### PR TITLE
fix: remove duplicate web dependency in pubspec.yaml

### DIFF
--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -53,10 +53,9 @@ dependencies:
   uuid: ^4.5.1
   logger: ^2.4.0
   url_launcher: ^6.3.0
-  web: ^1.1.1
 
   # Web platform
-  web: ^1.1.0
+  web: ^1.1.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- Remove duplicate `web:` entry in pubspec.yaml that caused yaml parsing error in CI

## Test plan
- [x] `flutter pub get` succeeds
- [x] `flutter analyze` — 0 issues  
- [x] `flutter test` — 108 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)