### PR TITLE
fix: optimize JVM for Render free tier deployment

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -12,4 +12,8 @@ WORKDIR /app
 COPY --from=build /app/build/libs/*.jar app.jar
 USER app
 EXPOSE 8080
-ENTRYPOINT ["java", "-jar", "app.jar"]
+ENTRYPOINT ["java", \
+  "-Xms128m", "-Xmx384m", \
+  "-XX:+UseSerialGC", \
+  "-Dspring.jmx.enabled=false", \
+  "-jar", "app.jar"]

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -1,9 +1,15 @@
 spring:
+  main:
+    lazy-initialization: true
+
   datasource:
     url: jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT:5432}/${DB_NAME:postgres}?sslmode=require
     username: ${DB_USERNAME:postgres}
     password: ${DB_PASSWORD:}
     driver-class-name: org.postgresql.Driver
+    hikari:
+      connection-timeout: 20000
+      maximum-pool-size: 5
 
   jpa:
     show-sql: false
@@ -12,6 +18,8 @@ spring:
 
   flyway:
     enabled: ${FLYWAY_ENABLED:true}
+    connect-retries: 3
+    connect-retries-interval: 5
 
   security:
     oauth2:


### PR DESCRIPTION
## Summary
- Dockerfile: JVM memory limits (-Xms128m -Xmx384m), SerialGC, disable JMX for faster startup on Render free tier (512MB)
- application-prod.yml: lazy-initialization, Hikari connection-timeout 20s, pool-size 5, Flyway connect-retries 3

## Problem
Render deployment failing with "Port scan timeout reached, no open ports detected" - Spring Boot not starting within Render's port scan window on 512MB RAM.

## Test plan
- [ ] CI backend tests pass
- [ ] Merge to main triggers Render redeploy
- [ ] Verify Render deploy succeeds (no port scan timeout)
- [ ] Verify `/actuator/health` returns UP

🤖 Generated with [Claude Code](https://claude.com/claude-code)