### PR TITLE
fix: critical audit findings (Phase 1-3)

### DIFF
--- a/backend/src/main/kotlin/com/budgetbook/budget/service/BudgetService.kt
+++ b/backend/src/main/kotlin/com/budgetbook/budget/service/BudgetService.kt
@@ -169,10 +169,14 @@ class BudgetService(
             )
         }
 
+        // Calculate totalSpent independently as the direct sum of ALL expenses for the month,
+        // to avoid double-counting when both a "total" budget and category-specific budgets exist
+        val totalSpent = transactions.content.sumOf { it.amount }
+
         return BudgetSummaryResponse(
             yearMonth = yearMonth,
             totalBudget = budgets.sumOf { it.amount },
-            totalSpent = items.sumOf { it.spentAmount },
+            totalSpent = totalSpent,
             items = items
         )
     }

--- a/backend/src/main/kotlin/com/budgetbook/common/dto/PatchValue.kt
+++ b/backend/src/main/kotlin/com/budgetbook/common/dto/PatchValue.kt
@@ -3,6 +3,7 @@ package com.budgetbook.common.dto
 import com.fasterxml.jackson.core.JsonParser
 import com.fasterxml.jackson.databind.DeserializationContext
 import com.fasterxml.jackson.databind.JsonDeserializer
+import java.util.UUID
 
 /**
  * Wrapper to distinguish "field absent" from "field explicitly set to null" in PUT/PATCH requests.
@@ -20,6 +21,17 @@ class StringPatchValueDeserializer : JsonDeserializer<PatchValue<String>>() {
     }
 
     override fun getNullValue(ctxt: DeserializationContext): PatchValue<String> {
+        return PatchValue(null)
+    }
+}
+
+class UUIDPatchValueDeserializer : JsonDeserializer<PatchValue<UUID>>() {
+    override fun deserialize(p: JsonParser, ctxt: DeserializationContext): PatchValue<UUID> {
+        val text = p.valueAsString
+        return PatchValue(if (text != null) UUID.fromString(text) else null)
+    }
+
+    override fun getNullValue(ctxt: DeserializationContext): PatchValue<UUID> {
         return PatchValue(null)
     }
 }

--- a/backend/src/main/kotlin/com/budgetbook/couple/service/CoupleService.kt
+++ b/backend/src/main/kotlin/com/budgetbook/couple/service/CoupleService.kt
@@ -1,7 +1,9 @@
 package com.budgetbook.couple.service
 
 import com.budgetbook.auth.repository.UserRepository
+import com.budgetbook.category.service.CategoryGroupService
 import com.budgetbook.category.service.CategoryService
+import com.budgetbook.paymentmethod.service.PaymentMethodService
 import com.budgetbook.common.exception.BusinessException
 import com.budgetbook.common.exception.ConflictException
 import com.budgetbook.common.exception.GoneException
@@ -25,7 +27,9 @@ class CoupleService(
     private val coupleRepository: CoupleRepository,
     private val coupleInvitationRepository: CoupleInvitationRepository,
     private val userRepository: UserRepository,
-    private val categoryService: CategoryService
+    private val categoryService: CategoryService,
+    private val categoryGroupService: CategoryGroupService,
+    private val paymentMethodService: PaymentMethodService
 ) {
 
     @Transactional
@@ -104,8 +108,10 @@ class CoupleService(
         )
         coupleRepository.save(couple)
 
-        // Seed default categories for the new couple
+        // Seed default data for the new couple (order matters: categories first, then groups that reference them)
         categoryService.seedDefaultCategories(couple)
+        categoryGroupService.seedDefaultCategoryGroups(couple)
+        paymentMethodService.seedDefaultPaymentMethods(couple)
 
         val partner = invitation.inviter
         return CoupleResponse(

--- a/backend/src/main/kotlin/com/budgetbook/report/service/ReportService.kt
+++ b/backend/src/main/kotlin/com/budgetbook/report/service/ReportService.kt
@@ -440,19 +440,13 @@ class ReportService(
         var cardsWithPending = 0
 
         for (card in creditCards) {
-            // Find transactions with this payment method that have no settlement date or settlement date is after endDate
-            val results = transactionRepository.findByCoupleIdAndFilters(
-                coupleId = coupleId,
+            // Find transactions settling in this month (aligned with PaymentMethodService.getCardPendingSummary)
+            val results = transactionRepository.sumByPaymentMethodAndSettlementDateRange(
+                paymentMethodId = card.id,
                 startDate = startDate,
-                endDate = endDate,
-                type = TransactionType.EXPENSE,
-                categoryId = null,
-                pageable = Pageable.unpaged()
-            ).content.filter { tx ->
-                tx.paymentMethod?.id == card.id && tx.settlementDate == null
-            }
-
-            val pendingAmount = results.sumOf { it.amount }
+                endDate = endDate
+            )
+            val pendingAmount = results.firstOrNull()?.let { (it[0] as? Number)?.toLong() } ?: 0L
             if (pendingAmount > 0) {
                 totalPending += pendingAmount
                 cardsWithPending++

--- a/backend/src/main/kotlin/com/budgetbook/transaction/dto/TransactionDtos.kt
+++ b/backend/src/main/kotlin/com/budgetbook/transaction/dto/TransactionDtos.kt
@@ -2,6 +2,7 @@ package com.budgetbook.transaction.dto
 
 import com.budgetbook.common.dto.PatchValue
 import com.budgetbook.common.dto.StringPatchValueDeserializer
+import com.budgetbook.common.dto.UUIDPatchValueDeserializer
 import com.budgetbook.couple.dto.UserSummary
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import jakarta.validation.constraints.Min
@@ -67,14 +68,16 @@ data class UpdateTransactionRequest(
     @field:Size(max = 255)
     val description: String? = null,
 
-    val categoryId: UUID? = null,
+    @JsonDeserialize(using = UUIDPatchValueDeserializer::class)
+    val categoryId: PatchValue<UUID>? = null,
 
     val transactionDate: LocalDate? = null,
 
     @JsonDeserialize(using = StringPatchValueDeserializer::class)
     val memo: PatchValue<String>? = null,
 
-    val paymentMethodId: UUID? = null
+    @JsonDeserialize(using = UUIDPatchValueDeserializer::class)
+    val paymentMethodId: PatchValue<UUID>? = null
 )
 
 data class PageResponse<T>(

--- a/backend/src/main/kotlin/com/budgetbook/transaction/service/TransactionService.kt
+++ b/backend/src/main/kotlin/com/budgetbook/transaction/service/TransactionService.kt
@@ -161,23 +161,44 @@ class TransactionService(
         request.transactionDate?.let { transaction.transactionDate = it }
         request.memo?.let { transaction.memo = it.value }
 
-        if (request.categoryId != null) {
-            val cat = categoryRepository.findById(request.categoryId)
-                .orElseThrow { NotFoundException("CATEGORY_NOT_FOUND", "Specified category does not exist.") }
-            if (cat.couple.id != couple.id) {
-                throw ForbiddenException("FORBIDDEN", "Category belongs to a different couple.")
+        // Handle categoryId with PatchValue: null = absent (no change), PatchValue(null) = clear, PatchValue(uuid) = set
+        request.categoryId?.let { patchValue ->
+            val catId = patchValue.value
+            if (catId != null) {
+                val cat = categoryRepository.findById(catId)
+                    .orElseThrow { NotFoundException("CATEGORY_NOT_FOUND", "Specified category does not exist.") }
+                if (cat.couple.id != couple.id) {
+                    throw ForbiddenException("FORBIDDEN", "Category belongs to a different couple.")
+                }
+                transaction.category = cat
+            } else {
+                transaction.category = null
             }
-            transaction.category = cat
         }
 
-        if (request.paymentMethodId != null) {
-            val pm = paymentMethodRepository.findById(request.paymentMethodId)
-                .orElseThrow { NotFoundException("PAYMENT_METHOD_NOT_FOUND", "Specified payment method does not exist.") }
-            if (pm.couple.id != couple.id) {
-                throw ForbiddenException("FORBIDDEN", "Payment method belongs to a different couple.")
+        // Handle paymentMethodId with PatchValue
+        var paymentMethodChanged = false
+        request.paymentMethodId?.let { patchValue ->
+            val pmId = patchValue.value
+            if (pmId != null) {
+                val pm = paymentMethodRepository.findById(pmId)
+                    .orElseThrow { NotFoundException("PAYMENT_METHOD_NOT_FOUND", "Specified payment method does not exist.") }
+                if (pm.couple.id != couple.id) {
+                    throw ForbiddenException("FORBIDDEN", "Payment method belongs to a different couple.")
+                }
+                transaction.paymentMethod = pm
+                transaction.settlementDate = calculateSettlementDate(pm, transaction.transactionDate)
+                paymentMethodChanged = true
+            } else {
+                transaction.paymentMethod = null
+                transaction.settlementDate = null
+                paymentMethodChanged = true
             }
-            transaction.paymentMethod = pm
-            transaction.settlementDate = calculateSettlementDate(pm, transaction.transactionDate)
+        }
+
+        // If transactionDate changed but paymentMethod was not changed, recalculate settlement date
+        if (request.transactionDate != null && !paymentMethodChanged && transaction.paymentMethod != null) {
+            transaction.settlementDate = calculateSettlementDate(transaction.paymentMethod!!, transaction.transactionDate)
         }
 
         return transactionRepository.save(transaction).toResponse()

--- a/backend/src/test/kotlin/com/budgetbook/budget/service/BudgetServiceTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/budget/service/BudgetServiceTest.kt
@@ -260,10 +260,12 @@ class BudgetServiceTest : BehaviorSpec({
         When("getBudgetSummary is called") {
             val result = service.getBudgetSummary(user1.id, 2026, 3)
 
-            Then("returns correct summary") {
+            Then("returns correct summary with no double-counting") {
                 result.yearMonth shouldBe "2026-03"
                 result.totalBudget shouldBe 3150000
                 result.items.size shouldBe 2
+                // totalSpent is calculated independently as the direct sum of ALL expenses (95000 + 50000)
+                result.totalSpent shouldBe 145000
             }
 
             Then("calculates category budget correctly") {

--- a/backend/src/test/kotlin/com/budgetbook/couple/service/CoupleServiceTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/couple/service/CoupleServiceTest.kt
@@ -3,7 +3,9 @@ package com.budgetbook.couple.service
 import com.budgetbook.auth.domain.AuthProvider
 import com.budgetbook.auth.domain.User
 import com.budgetbook.auth.repository.UserRepository
+import com.budgetbook.category.service.CategoryGroupService
 import com.budgetbook.category.service.CategoryService
+import com.budgetbook.paymentmethod.service.PaymentMethodService
 import com.budgetbook.common.exception.BusinessException
 import com.budgetbook.common.exception.ConflictException
 import com.budgetbook.common.exception.GoneException
@@ -36,7 +38,9 @@ class CoupleServiceTest : BehaviorSpec({
     val coupleInvitationRepository = mockk<CoupleInvitationRepository>()
     val userRepository = mockk<UserRepository>()
     val categoryService = mockk<CategoryService>(relaxed = true)
-    val coupleService = CoupleService(coupleRepository, coupleInvitationRepository, userRepository, categoryService)
+    val categoryGroupService = mockk<CategoryGroupService>(relaxed = true)
+    val paymentMethodService = mockk<PaymentMethodService>(relaxed = true)
+    val coupleService = CoupleService(coupleRepository, coupleInvitationRepository, userRepository, categoryService, categoryGroupService, paymentMethodService)
 
     val user1 = User(
         email = "user1@example.com",
@@ -120,6 +124,12 @@ class CoupleServiceTest : BehaviorSpec({
 
             Then("marks invitation as accepted") {
                 invitation.status shouldBe InvitationStatus.ACCEPTED
+            }
+
+            Then("seeds default categories, category groups, and payment methods") {
+                verify(exactly = 1) { categoryService.seedDefaultCategories(any()) }
+                verify(exactly = 1) { categoryGroupService.seedDefaultCategoryGroups(any()) }
+                verify(exactly = 1) { paymentMethodService.seedDefaultPaymentMethods(any()) }
             }
         }
     }

--- a/backend/src/test/kotlin/com/budgetbook/report/service/ReportServiceTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/report/service/ReportServiceTest.kt
@@ -340,15 +340,24 @@ class ReportServiceTest : BehaviorSpec({
                 arrayOf(280000L, 6L, transportCategory.id, "Transport", CategoryType.EXPENSE, "directions_car", "#2196F3")
             )
 
-            // Card pending summary
+            // Card pending summary (uses sumByPaymentMethodAndSettlementDateRange, aligned with PaymentMethodService)
             val creditCard = PaymentMethod(couple = couple, name = "Card1", type = PaymentMethodType.CREDIT)
             every {
                 paymentMethodRepository.findByCoupleIdAndTypeAndIsActiveTrue(couple.id, PaymentMethodType.CREDIT)
             } returns listOf(creditCard)
 
-            val unsettledTx = Transaction(
+            every {
+                transactionRepository.sumByPaymentMethodAndSettlementDateRange(
+                    paymentMethodId = creditCard.id,
+                    startDate = LocalDate.of(2026, 3, 1),
+                    endDate = LocalDate.of(2026, 3, 31)
+                )
+            } returns listOf(arrayOf<Any?>(150000L, 1L))
+
+            // Day of week pattern needs expense transactions for the month
+            val expenseTx = Transaction(
                 couple = couple, author = user1, category = foodCategory,
-                type = TransactionType.EXPENSE, amount = 150000, description = "Unsettled",
+                type = TransactionType.EXPENSE, amount = 150000, description = "Expense",
                 transactionDate = LocalDate.of(2026, 3, 15),
                 paymentMethod = creditCard, settlementDate = null
             )
@@ -361,7 +370,7 @@ class ReportServiceTest : BehaviorSpec({
                     categoryId = null,
                     pageable = Pageable.unpaged()
                 )
-            } returns PageImpl(listOf(unsettledTx))
+            } returns PageImpl(listOf(expenseTx))
 
             val result = service.getMonthlyReport(user1.id, 2026, 3)
 

--- a/backend/src/test/kotlin/com/budgetbook/transaction/service/TransactionServiceTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/transaction/service/TransactionServiceTest.kt
@@ -12,6 +12,8 @@ import com.budgetbook.common.exception.NotFoundException
 import com.budgetbook.couple.domain.Couple
 import com.budgetbook.couple.domain.CoupleStatus
 import com.budgetbook.couple.repository.CoupleRepository
+import com.budgetbook.paymentmethod.domain.PaymentMethod
+import com.budgetbook.paymentmethod.domain.PaymentMethodType
 import com.budgetbook.paymentmethod.repository.PaymentMethodRepository
 import com.budgetbook.transaction.domain.Transaction
 import com.budgetbook.transaction.domain.TransactionType
@@ -206,6 +208,84 @@ class TransactionServiceTest : BehaviorSpec({
 
             Then("keeps the existing memo") {
                 result.memo shouldBe "기존 메모"
+            }
+        }
+    }
+
+    Given("an existing transaction with a category to clear") {
+        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        val tx = Transaction(
+            couple = couple, author = user1, type = TransactionType.EXPENSE,
+            amount = 15000, description = "점심", category = category,
+            transactionDate = LocalDate.of(2024, 1, 15)
+        )
+        every { transactionRepository.findById(tx.id) } returns Optional.of(tx)
+        every { transactionRepository.save(tx) } returns tx
+
+        When("updateTransaction is called with categoryId = PatchValue(null)") {
+            val request = UpdateTransactionRequest(categoryId = PatchValue(null))
+            val result = service.updateTransaction(user1.id, tx.id, request)
+
+            Then("clears the category") {
+                result.category shouldBe null
+            }
+        }
+
+        When("updateTransaction is called with categoryId absent") {
+            val request = UpdateTransactionRequest(amount = 20000)
+            val result = service.updateTransaction(user1.id, tx.id, request)
+
+            Then("keeps the existing category") {
+                result.category shouldBe com.budgetbook.transaction.dto.CategorySummary(
+                    id = category.id, name = "식비", type = "EXPENSE", icon = "restaurant", color = "#FF5733"
+                )
+            }
+        }
+    }
+
+    Given("an existing transaction with a payment method to clear") {
+        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        val pm = PaymentMethod(couple = couple, name = "신한카드", type = PaymentMethodType.CREDIT, settlementDay = 15, closingDay = 25)
+        val tx = Transaction(
+            couple = couple, author = user1, type = TransactionType.EXPENSE,
+            amount = 15000, description = "점심", paymentMethod = pm,
+            settlementDate = LocalDate.of(2024, 2, 15),
+            transactionDate = LocalDate.of(2024, 1, 15)
+        )
+        every { transactionRepository.findById(tx.id) } returns Optional.of(tx)
+        every { transactionRepository.save(tx) } returns tx
+
+        When("updateTransaction is called with paymentMethodId = PatchValue(null)") {
+            val request = UpdateTransactionRequest(paymentMethodId = PatchValue(null))
+            val result = service.updateTransaction(user1.id, tx.id, request)
+
+            Then("clears the payment method and settlement date") {
+                result.paymentMethodId shouldBe null
+                result.settlementDate shouldBe null
+            }
+        }
+    }
+
+    Given("a transaction with a credit card where transactionDate changes") {
+        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        val pm = PaymentMethod(couple = couple, name = "신한카드", type = PaymentMethodType.CREDIT, settlementDay = 15, closingDay = 25)
+        val tx = Transaction(
+            couple = couple, author = user1, type = TransactionType.EXPENSE,
+            amount = 15000, description = "점심", paymentMethod = pm,
+            settlementDate = LocalDate.of(2024, 2, 15),
+            transactionDate = LocalDate.of(2024, 1, 15)
+        )
+        every { transactionRepository.findById(tx.id) } returns Optional.of(tx)
+        every { transactionRepository.save(tx) } returns tx
+
+        When("updateTransaction changes transactionDate without changing paymentMethod") {
+            // Moving transaction date to after closing day (25th) should push settlement to month+2
+            val request = UpdateTransactionRequest(transactionDate = LocalDate.of(2024, 1, 26))
+            val result = service.updateTransaction(user1.id, tx.id, request)
+
+            Then("recalculates the settlement date") {
+                // transactionDate = Jan 26, closingDay = 25, dayOfMonth(26) > 25 -> settlement month+2 = March 15
+                result.settlementDate shouldBe "2024-03-15"
             }
         }
     }

--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -75,7 +75,6 @@ All API responses are wrapped in `ApiResponse<T>`:
 {
   "success": true,
   "data": T,
-  "error": null,
   "timestamp": "2024-01-01T00:00:00Z"
 }
 ```
@@ -89,7 +88,6 @@ All API responses are wrapped in `ApiResponse<T>`:
     "id": "550e8400-e29b-41d4-a716-446655440000",
     "email": "user@example.com"
   },
-  "error": null,
   "timestamp": "2024-01-01T12:00:00Z"
 }
 ```
@@ -99,7 +97,6 @@ All API responses are wrapped in `ApiResponse<T>`:
 ```json
 {
   "success": false,
-  "data": null,
   "error": {
     "code": "ERROR_CODE",
     "message": "Human-readable error message"
@@ -107,6 +104,8 @@ All API responses are wrapped in `ApiResponse<T>`:
   "timestamp": "2024-01-01T12:00:00Z"
 }
 ```
+
+> **Note on null fields**: The API uses `@JsonInclude(NON_NULL)`. Fields that are `null` are **omitted entirely** from the JSON response rather than serialized as `"field": null`. For example, a success response will not include an `"error"` key, and an error response will not include a `"data"` key.
 
 ### HTTP Status Code Conventions
 
@@ -213,7 +212,6 @@ Issues a new access token using a valid refresh token.
     "refreshToken": "dGhpcyBpcyBhIHJlZnJlc2ggdG9rZW4...",
     "expiresIn": 3600
   },
-  "error": null,
   "timestamp": "2024-01-01T12:00:00Z"
 }
 ```
@@ -223,7 +221,6 @@ Issues a new access token using a valid refresh token.
 ```json
 {
   "success": false,
-  "data": null,
   "error": {
     "code": "INVALID_REFRESH_TOKEN",
     "message": "The refresh token is invalid or has been revoked."
@@ -267,19 +264,17 @@ Retrieves the profile of the currently authenticated user.
     "coupleId": "550e8400-e29b-41d4-a716-446655440001",
     "createdAt": "2024-01-01T12:00:00Z"
   },
-  "error": null,
   "timestamp": "2024-01-01T12:00:00Z"
 }
 ```
 
-Note: `coupleId` is `null` when the user is not in an active couple. This allows the frontend to decide routing immediately after login.
+Note: `coupleId` is omitted from the response when the user is not in an active couple (NON_NULL serialization). This allows the frontend to decide routing immediately after login.
 
 **Response `401 Unauthorized`**: `ApiResponse<null>`
 
 ```json
 {
   "success": false,
-  "data": null,
   "error": {
     "code": "INVALID_TOKEN",
     "message": "The access token is invalid or has expired."
@@ -323,8 +318,6 @@ Revokes the refresh token and invalidates the current session.
 ```json
 {
   "success": true,
-  "data": null,
-  "error": null,
   "timestamp": "2024-01-01T12:00:00Z"
 }
 ```
@@ -334,7 +327,6 @@ Revokes the refresh token and invalidates the current session.
 ```json
 {
   "success": false,
-  "data": null,
   "error": {
     "code": "INVALID_TOKEN",
     "message": "The access token is invalid or has expired."
@@ -376,7 +368,6 @@ Generates a new 8-character invitation code. The previous pending invitation for
     "code": "A3F9K2BX",
     "expiresAt": "2024-01-02T12:00:00Z"
   },
-  "error": null,
   "timestamp": "2024-01-01T12:00:00Z"
 }
 ```
@@ -386,7 +377,6 @@ Generates a new 8-character invitation code. The previous pending invitation for
 ```json
 {
   "success": false,
-  "data": null,
   "error": {
     "code": "COUPLE_ALREADY_EXISTS",
     "message": "User is already in an active couple."
@@ -430,7 +420,6 @@ Accepts an invitation code and links the two users as a couple. Default categori
     "status": "ACTIVE",
     "createdAt": "2024-01-01T12:00:00Z"
   },
-  "error": null,
   "timestamp": "2024-01-01T12:00:00Z"
 }
 ```
@@ -473,7 +462,6 @@ Retrieves the current user's couple information including the partner's profile.
     "status": "ACTIVE",
     "createdAt": "2024-01-01T12:00:00Z"
   },
-  "error": null,
   "timestamp": "2024-01-01T12:00:00Z"
 }
 ```
@@ -483,7 +471,6 @@ Retrieves the current user's couple information including the partner's profile.
 ```json
 {
   "success": false,
-  "data": null,
   "error": {
     "code": "COUPLE_NOT_FOUND",
     "message": "User is not currently in a couple."
@@ -549,6 +536,7 @@ Retrieves all categories for the caller's couple.
       "type": "EXPENSE",
       "icon": "restaurant",
       "color": "#FF5733",
+      "groupId": "550e8400-e29b-41d4-a716-446655440060",
       "isDefault": true,
       "displayOrder": 1,
       "createdAt": "2024-01-01T12:00:00Z"
@@ -564,7 +552,6 @@ Retrieves all categories for the caller's couple.
       "createdAt": "2024-01-01T12:00:00Z"
     }
   ],
-  "error": null,
   "timestamp": "2024-01-01T12:00:00Z"
 }
 ```
@@ -588,16 +575,18 @@ Creates a new custom category for the caller's couple.
   "name": "반려동물",
   "type": "EXPENSE",
   "icon": "pets",
-  "color": "#9C27B0"
+  "color": "#9C27B0",
+  "groupId": "550e8400-e29b-41d4-a716-446655440060"
 }
 ```
 
-| Field    | Type     | Required | Description                        |
-|:---------|:---------|:--------:|:-----------------------------------|
-| `name`   | `string` | Yes      | Category name (max 50 chars)       |
-| `type`   | `string` | Yes      | `INCOME` or `EXPENSE`              |
-| `icon`   | `string` | No       | Material icon name                 |
-| `color`  | `string` | No       | Hex color code (e.g., `#FF5733`)   |
+| Field     | Type     | Required | Description                              |
+|:----------|:---------|:--------:|:-----------------------------------------|
+| `name`    | `string` | Yes      | Category name (max 50 chars)             |
+| `type`    | `string` | Yes      | `INCOME` or `EXPENSE`                    |
+| `icon`    | `string` | No       | Material icon name                       |
+| `color`   | `string` | No       | Hex color code (e.g., `#FF5733`)         |
+| `groupId` | `UUID`   | No       | Category group ID (null = uncategorized) |
 
 **Response `201 Created`**: `ApiResponse<CategoryResponse>`
 
@@ -610,11 +599,11 @@ Creates a new custom category for the caller's couple.
     "type": "EXPENSE",
     "icon": "pets",
     "color": "#9C27B0",
+    "groupId": "550e8400-e29b-41d4-a716-446655440060",
     "isDefault": false,
     "displayOrder": 10,
     "createdAt": "2024-01-01T12:00:00Z"
   },
-  "error": null,
   "timestamp": "2024-01-01T12:00:00Z"
 }
 ```
@@ -651,16 +640,18 @@ Updates an existing category. Default categories cannot have their `type` change
   "name": "식비/외식",
   "icon": "restaurant_menu",
   "color": "#E91E63",
-  "displayOrder": 2
+  "displayOrder": 2,
+  "groupId": "550e8400-e29b-41d4-a716-446655440060"
 }
 ```
 
-| Field          | Type      | Required | Description                      |
-|:---------------|:----------|:--------:|:---------------------------------|
-| `name`         | `string`  | No       | Updated name (max 50 chars)      |
-| `icon`         | `string`  | No       | Updated icon name                |
-| `color`        | `string`  | No       | Updated hex color                |
-| `displayOrder` | `integer` | No       | Sort order within type group     |
+| Field          | Type      | Required | Description                              |
+|:---------------|:----------|:--------:|:-----------------------------------------|
+| `name`         | `string`  | No       | Updated name (max 50 chars)              |
+| `icon`         | `string`  | No       | Updated icon name                        |
+| `color`        | `string`  | No       | Updated hex color                        |
+| `displayOrder` | `integer` | No       | Sort order within type group             |
+| `groupId`      | `UUID`    | No       | Updated group ID (null = uncategorized)  |
 
 **Response `200 OK`**: `ApiResponse<CategoryResponse>`
 
@@ -756,8 +747,10 @@ Retrieves paginated transactions for the caller's couple. Default sort: `transac
         "type": "EXPENSE",
         "amount": 15000,
         "description": "점심 식사",
-        "memo": null,
         "transactionDate": "2024-01-15",
+        "paymentMethodId": "550e8400-e29b-41d4-a716-446655440031",
+        "paymentMethodName": "신한카드",
+        "paymentMethodType": "CREDIT",
         "createdAt": "2024-01-15T12:30:00Z",
         "updatedAt": "2024-01-15T12:30:00Z"
       }
@@ -769,7 +762,6 @@ Retrieves paginated transactions for the caller's couple. Default sort: `transac
     "first": true,
     "last": false
   },
-  "error": null,
   "timestamp": "2024-01-15T12:00:00Z"
 }
 ```
@@ -795,18 +787,20 @@ Creates a new income or expense transaction.
   "description": "점심 식사",
   "categoryId": "550e8400-e29b-41d4-a716-446655440010",
   "transactionDate": "2024-01-15",
-  "memo": "팀 점심"
+  "memo": "팀 점심",
+  "paymentMethodId": "550e8400-e29b-41d4-a716-446655440031"
 }
 ```
 
-| Field             | Type     | Required | Description                           |
-|:------------------|:---------|:--------:|:--------------------------------------|
-| `type`            | `string` | Yes      | `INCOME` or `EXPENSE`                 |
-| `amount`          | `long`   | Yes      | Amount in KRW (must be > 0)           |
-| `description`     | `string` | Yes      | Short description (max 255 chars)     |
-| `categoryId`      | `UUID`   | No       | Category ID (must belong to couple)   |
-| `transactionDate` | `string` | Yes      | ISO 8601 date: `YYYY-MM-DD`           |
-| `memo`            | `string` | No       | Optional longer note                  |
+| Field             | Type     | Required | Description                                    |
+|:------------------|:---------|:--------:|:-----------------------------------------------|
+| `type`            | `string` | Yes      | `INCOME` or `EXPENSE`                          |
+| `amount`          | `long`   | Yes      | Amount in KRW (must be > 0)                    |
+| `description`     | `string` | Yes      | Short description (max 255 chars)              |
+| `categoryId`      | `UUID`   | No       | Category ID (must belong to couple)            |
+| `transactionDate` | `string` | Yes      | ISO 8601 date: `YYYY-MM-DD`                    |
+| `memo`            | `string` | No       | Optional longer note                           |
+| `paymentMethodId` | `UUID`   | No       | Payment method ID (must belong to couple)      |
 
 **Response `201 Created`**: `ApiResponse<TransactionResponse>`
 
@@ -833,10 +827,12 @@ Creates a new income or expense transaction.
     "description": "점심 식사",
     "memo": "팀 점심",
     "transactionDate": "2024-01-15",
+    "paymentMethodId": "550e8400-e29b-41d4-a716-446655440031",
+    "paymentMethodName": "신한카드",
+    "paymentMethodType": "CREDIT",
     "createdAt": "2024-01-15T12:30:00Z",
     "updatedAt": "2024-01-15T12:30:00Z"
   },
-  "error": null,
   "timestamp": "2024-01-15T12:30:00Z"
 }
 ```
@@ -903,17 +899,19 @@ Updates an existing transaction. Only the author or the partner can update it.
   "description": "점심 + 커피",
   "categoryId": "550e8400-e29b-41d4-a716-446655440010",
   "transactionDate": "2024-01-15",
-  "memo": null
+  "memo": null,
+  "paymentMethodId": "550e8400-e29b-41d4-a716-446655440031"
 }
 ```
 
-| Field             | Type     | Required | Description                         |
-|:------------------|:---------|:--------:|:------------------------------------|
-| `amount`          | `long`   | No       | Updated amount (must be > 0)        |
-| `description`     | `string` | No       | Updated description (max 255 chars) |
-| `categoryId`      | `UUID`   | No       | Updated category (null to unset)    |
-| `transactionDate` | `string` | No       | Updated date: `YYYY-MM-DD`          |
-| `memo`            | `string` | No       | Updated memo (null to clear)        |
+| Field             | Type     | Required | Description                                    |
+|:------------------|:---------|:--------:|:-----------------------------------------------|
+| `amount`          | `long`   | No       | Updated amount (must be > 0)                   |
+| `description`     | `string` | No       | Updated description (max 255 chars)            |
+| `categoryId`      | `UUID`   | No       | Updated category (null to unset)               |
+| `transactionDate` | `string` | No       | Updated date: `YYYY-MM-DD`                     |
+| `memo`            | `string` | No       | Updated memo (null to clear)                   |
+| `paymentMethodId` | `UUID`   | No       | Updated payment method (null to unset)         |
 
 **Response `200 OK`**: `ApiResponse<TransactionResponse>`
 
@@ -978,15 +976,17 @@ Creates a monthly budget for the couple. Set `categoryId` to `null` for a total 
 {
   "categoryId": "550e8400-e29b-41d4-a716-446655440010",
   "yearMonth": "2026-03",
-  "amount": 150000
+  "amount": 150000,
+  "budgetPeriod": "MONTHLY"
 }
 ```
 
-| Field        | Type     | Required | Description                                               |
-|:-------------|:---------|:--------:|:----------------------------------------------------------|
-| `categoryId` | `UUID`   | No       | Category ID; `null` = total budget for the month         |
-| `yearMonth`  | `string` | Yes      | Target month in `YYYY-MM` format (e.g., `2026-03`)       |
-| `amount`     | `long`   | Yes      | Budget amount in KRW (must be > 0)                       |
+| Field          | Type     | Required | Description                                                            |
+|:---------------|:---------|:--------:|:-----------------------------------------------------------------------|
+| `categoryId`   | `UUID`   | No       | Category ID; `null` = total budget for the month                      |
+| `yearMonth`    | `string` | Yes      | Target month in `YYYY-MM` format (e.g., `2026-03`)                    |
+| `amount`       | `long`   | Yes      | Budget amount in KRW (must be > 0)                                    |
+| `budgetPeriod` | `string` | No       | Budget period type: `MONTHLY` (default) or `WEEKLY`                   |
 
 **Response `201 Created`**: `ApiResponse<BudgetResponse>`
 
@@ -1005,10 +1005,10 @@ Creates a monthly budget for the couple. Set `categoryId` to `null` for a total 
     },
     "yearMonth": "2026-03",
     "amount": 150000,
+    "budgetPeriod": "MONTHLY",
     "createdAt": "2026-03-01T12:00:00Z",
     "updatedAt": "2026-03-01T12:00:00Z"
   },
-  "error": null,
   "timestamp": "2026-03-01T12:00:00Z"
 }
 ```
@@ -1058,20 +1058,21 @@ Retrieves all budgets for the couple for a given month.
       },
       "yearMonth": "2026-03",
       "amount": 150000,
+      "budgetPeriod": "MONTHLY",
       "createdAt": "2026-03-01T12:00:00Z",
       "updatedAt": "2026-03-01T12:00:00Z"
     },
     {
       "id": "550e8400-e29b-41d4-a716-446655440051",
       "coupleId": "550e8400-e29b-41d4-a716-446655440001",
-      "category": null,
       "yearMonth": "2026-03",
-      "amount": 3000000,
+      "amount": 800000,
+      "budgetPeriod": "WEEKLY",
+      "weeklyAmount": 200000,
       "createdAt": "2026-03-01T12:00:00Z",
       "updatedAt": "2026-03-01T12:00:00Z"
     }
   ],
-  "error": null,
   "timestamp": "2026-03-01T12:00:00Z"
 }
 ```
@@ -1186,7 +1187,6 @@ Returns per-category budget vs actual spending summary for a given month.
         "usageRate": 63.3
       },
       {
-        "category": null,
         "budgetAmount": 3000000,
         "spentAmount": 1705000,
         "remainingAmount": 1295000,
@@ -1194,7 +1194,6 @@ Returns per-category budget vs actual spending summary for a given month.
       }
     ]
   },
-  "error": null,
   "timestamp": "2026-03-01T12:00:00Z"
 }
 ```
@@ -1239,7 +1238,6 @@ Returns total income, total expense, balance, and transaction count for a given 
     "balance": 1800000,
     "transactionCount": 45
   },
-  "error": null,
   "timestamp": "2026-03-01T12:00:00Z"
 }
 ```
@@ -1295,7 +1293,6 @@ Returns spending (or income) broken down by category for a given month, sorted b
       "transactionCount": 8
     }
   ],
-  "error": null,
   "timestamp": "2026-03-01T12:00:00Z"
 }
 ```
@@ -1361,7 +1358,6 @@ Returns month-over-month income, expense, and balance for the last N months incl
       "balance": 1800000
     }
   ],
-  "error": null,
   "timestamp": "2026-03-01T12:00:00Z"
 }
 ```
@@ -1999,15 +1995,17 @@ All endpoints require the `Authorization: Bearer {accessToken}` header.
 
 ### BudgetResponse
 
-| Field       | Type              | Nullable | Description                                  |
-|:------------|:------------------|:--------:|:---------------------------------------------|
-| `id`        | `UUID`            | No       | Budget unique identifier                     |
-| `coupleId`  | `UUID`            | No       | Owning couple ID                             |
-| `category`  | `CategorySummary` | Yes      | Category (null = total monthly budget)       |
-| `yearMonth` | `string`          | No       | Target month in `YYYY-MM` format             |
-| `amount`    | `long`            | No       | Budget amount in KRW (always > 0)            |
-| `createdAt` | `string`          | No       | ISO 8601 timestamp                           |
-| `updatedAt` | `string`          | No       | ISO 8601 timestamp                           |
+| Field          | Type              | Nullable | Description                                                    |
+|:---------------|:------------------|:--------:|:---------------------------------------------------------------|
+| `id`           | `UUID`            | No       | Budget unique identifier                                       |
+| `coupleId`     | `UUID`            | No       | Owning couple ID                                               |
+| `category`     | `CategorySummary` | Yes      | Category (omitted when null — total budget with no category)   |
+| `yearMonth`    | `string`          | No       | Target month in `YYYY-MM` format                               |
+| `amount`       | `long`            | No       | Budget amount in KRW (always > 0)                              |
+| `budgetPeriod` | `string`          | No       | Budget period type: `MONTHLY` or `WEEKLY`                      |
+| `weeklyAmount` | `long`            | Yes      | Per-week amount (omitted unless `budgetPeriod` is `WEEKLY`)    |
+| `createdAt`    | `string`          | No       | ISO 8601 timestamp                                             |
+| `updatedAt`    | `string`          | No       | ISO 8601 timestamp                                             |
 
 ### BudgetSummaryResponse
 
@@ -2087,3 +2085,4 @@ All endpoints require the `Authorization: Bearer {accessToken}` header.
 | `CANNOT_DELETE_DEFAULT_GROUP`     | `400`       | Default category groups cannot be deleted            |
 | `PAYMENT_METHOD_NOT_FOUND`        | `404`       | Requested payment method does not exist              |
 | `CANNOT_DELETE_DEFAULT_PAYMENT_METHOD` | `400`  | Default payment methods cannot be deleted            |
+| `RECURRING_NOT_FOUND`             | `404`       | Requested recurring transaction does not exist       |

--- a/frontend/lib/core/constants/api_endpoints.dart
+++ b/frontend/lib/core/constants/api_endpoints.dart
@@ -51,6 +51,4 @@ class ApiEndpoints {
   // Recurring Transactions
   static const String recurringTransactions = '/api/v1/recurring-transactions';
 
-  // Export
-  static const String exportCsv = '/api/v1/export/csv';
 }

--- a/frontend/lib/core/router/app_router.dart
+++ b/frontend/lib/core/router/app_router.dart
@@ -40,6 +40,7 @@ import 'package:budget_book/features/recurring/presentation/bloc/recurring_event
 import 'package:budget_book/features/recurring/presentation/pages/recurring_list_page.dart';
 import 'package:budget_book/features/recurring/presentation/pages/recurring_form_page.dart';
 import 'package:budget_book/features/recurring/domain/entities/recurring_transaction.dart';
+import 'package:budget_book/features/transaction/domain/entities/transaction.dart';
 
 final appRouter = GoRouter(
   initialLocation: '/login',
@@ -156,7 +157,7 @@ final appRouter = GoRouter(
             ),
           ],
           child: TransactionFormPage(
-            transaction: state.extra as dynamic,
+            transaction: state.extra as Transaction?,
           ),
         );
       },

--- a/frontend/lib/features/budget/data/models/budget_model.dart
+++ b/frontend/lib/features/budget/data/models/budget_model.dart
@@ -8,6 +8,8 @@ class BudgetModel extends Budget {
     super.category,
     required super.yearMonth,
     required super.amount,
+    super.budgetPeriod,
+    super.weeklyAmount,
     required super.createdAt,
     required super.updatedAt,
   });
@@ -22,6 +24,8 @@ class BudgetModel extends Budget {
           : null,
       yearMonth: json['yearMonth'] as String,
       amount: json['amount'] as int,
+      budgetPeriod: json['budgetPeriod'] as String? ?? 'MONTHLY',
+      weeklyAmount: json['weeklyAmount'] as int?,
       createdAt: DateTime.parse(json['createdAt'] as String),
       updatedAt: DateTime.parse(json['updatedAt'] as String),
     );

--- a/frontend/lib/features/budget/domain/entities/budget.dart
+++ b/frontend/lib/features/budget/domain/entities/budget.dart
@@ -7,6 +7,8 @@ class Budget extends Equatable {
   final TransactionCategory? category;
   final String yearMonth;
   final int amount;
+  final String budgetPeriod;
+  final int? weeklyAmount;
   final DateTime createdAt;
   final DateTime updatedAt;
 
@@ -16,13 +18,15 @@ class Budget extends Equatable {
     this.category,
     required this.yearMonth,
     required this.amount,
+    this.budgetPeriod = 'MONTHLY',
+    this.weeklyAmount,
     required this.createdAt,
     required this.updatedAt,
   });
 
   @override
   List<Object?> get props =>
-      [id, coupleId, category, yearMonth, amount, createdAt, updatedAt];
+      [id, coupleId, category, yearMonth, amount, budgetPeriod, weeklyAmount, createdAt, updatedAt];
 }
 
 class BudgetSummary extends Equatable {


### PR DESCRIPTION
## Summary
- **CoupleService**: seedDefaultCategoryGroups/PaymentMethods 호출 추가 (신규 커플 데이터 누락 수정)
- **TransactionService**: PatchValue로 categoryId/paymentMethodId null 설정 가능, settlementDate 재계산
- **BudgetService**: totalSpent 이중합산 버그 수정
- **ReportService**: 카드 미결제 쿼리 로직 통일
- **API Spec**: 누락 필드/에러코드 문서화, NON_NULL 동작 반영
- **Frontend**: dead code 제거, unsafe cast 수정, Budget 엔티티 보강

## Test plan
- [x] Backend: ./gradlew test — BUILD SUCCESSFUL
- [x] Frontend: flutter test — 228 tests passed
- [ ] Post-deploy: /actuator/health DB UP
- [ ] Post-deploy: Frontend page load

🤖 Generated with [Claude Code](https://claude.com/claude-code)