### PR TITLE
feat: Phase 4-1 - Money Pockets

### DIFF
--- a/backend/src/main/kotlin/com/budgetbook/pocket/controller/MoneyPocketController.kt
+++ b/backend/src/main/kotlin/com/budgetbook/pocket/controller/MoneyPocketController.kt
@@ -1,0 +1,63 @@
+package com.budgetbook.pocket.controller
+
+import com.budgetbook.common.dto.ApiResponse
+import com.budgetbook.pocket.dto.CreatePocketRequest
+import com.budgetbook.pocket.dto.PocketResponse
+import com.budgetbook.pocket.dto.UpdatePocketRequest
+import com.budgetbook.pocket.service.MoneyPocketService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.Authentication
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@RestController
+@RequestMapping("/api/v1/pockets")
+class MoneyPocketController(
+    private val moneyPocketService: MoneyPocketService
+) {
+
+    @GetMapping
+    fun listPockets(authentication: Authentication): ApiResponse<List<PocketResponse>> {
+        val userId = authentication.principal as UUID
+        return ApiResponse.ok(moneyPocketService.getPockets(userId))
+    }
+
+    @PostMapping
+    fun createPocket(
+        authentication: Authentication,
+        @Valid @RequestBody request: CreatePocketRequest
+    ): ResponseEntity<ApiResponse<PocketResponse>> {
+        val userId = authentication.principal as UUID
+        val result = moneyPocketService.createPocket(userId, request)
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.ok(result))
+    }
+
+    @PutMapping("/{id}")
+    fun updatePocket(
+        authentication: Authentication,
+        @PathVariable id: UUID,
+        @Valid @RequestBody request: UpdatePocketRequest
+    ): ApiResponse<PocketResponse> {
+        val userId = authentication.principal as UUID
+        return ApiResponse.ok(moneyPocketService.updatePocket(userId, id, request))
+    }
+
+    @DeleteMapping("/{id}")
+    fun deletePocket(
+        authentication: Authentication,
+        @PathVariable id: UUID
+    ): ResponseEntity<Void> {
+        val userId = authentication.principal as UUID
+        moneyPocketService.deletePocket(userId, id)
+        return ResponseEntity.noContent().build()
+    }
+}

--- a/backend/src/main/kotlin/com/budgetbook/pocket/controller/PocketTransferController.kt
+++ b/backend/src/main/kotlin/com/budgetbook/pocket/controller/PocketTransferController.kt
@@ -1,0 +1,48 @@
+package com.budgetbook.pocket.controller
+
+import com.budgetbook.common.dto.ApiResponse
+import com.budgetbook.pocket.dto.CreateTransferRequest
+import com.budgetbook.pocket.dto.DistributeRequest
+import com.budgetbook.pocket.dto.DistributeResponse
+import com.budgetbook.pocket.dto.PocketTransferResponse
+import com.budgetbook.pocket.service.PocketTransferService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.Authentication
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@RestController
+class PocketTransferController(
+    private val pocketTransferService: PocketTransferService
+) {
+
+    @GetMapping("/api/v1/pocket-transfers")
+    fun listTransfers(authentication: Authentication): ApiResponse<List<PocketTransferResponse>> {
+        val userId = authentication.principal as UUID
+        return ApiResponse.ok(pocketTransferService.getTransfers(userId))
+    }
+
+    @PostMapping("/api/v1/pocket-transfers")
+    fun createTransfer(
+        authentication: Authentication,
+        @Valid @RequestBody request: CreateTransferRequest
+    ): ResponseEntity<ApiResponse<PocketTransferResponse>> {
+        val userId = authentication.principal as UUID
+        val result = pocketTransferService.createTransfer(userId, request)
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.ok(result))
+    }
+
+    @PostMapping("/api/v1/pockets/distribute")
+    fun distribute(
+        authentication: Authentication,
+        @Valid @RequestBody request: DistributeRequest
+    ): ApiResponse<DistributeResponse> {
+        val userId = authentication.principal as UUID
+        return ApiResponse.ok(pocketTransferService.distribute(userId, request))
+    }
+}

--- a/backend/src/main/kotlin/com/budgetbook/pocket/domain/MoneyPocket.kt
+++ b/backend/src/main/kotlin/com/budgetbook/pocket/domain/MoneyPocket.kt
@@ -1,0 +1,47 @@
+package com.budgetbook.pocket.domain
+
+import com.budgetbook.common.entity.BaseTimeEntity
+import com.budgetbook.couple.domain.Couple
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import java.util.UUID
+
+@Entity
+@Table(name = "money_pockets")
+class MoneyPocket(
+    @Id
+    val id: UUID = UUID.randomUUID(),
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "couple_id", nullable = false)
+    val couple: Couple,
+
+    @Column(nullable = false, length = 50)
+    var name: String,
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    val type: PocketType,
+
+    @Column(name = "allocated_amount", nullable = false)
+    var allocatedAmount: Long = 0,
+
+    @Column(length = 50)
+    var icon: String? = null,
+
+    @Column(length = 20)
+    var color: String? = null,
+
+    @Column(name = "display_order", nullable = false)
+    var displayOrder: Int = 0,
+
+    @Column(name = "is_active", nullable = false)
+    var isActive: Boolean = true
+) : BaseTimeEntity()

--- a/backend/src/main/kotlin/com/budgetbook/pocket/domain/PocketTransfer.kt
+++ b/backend/src/main/kotlin/com/budgetbook/pocket/domain/PocketTransfer.kt
@@ -1,0 +1,46 @@
+package com.budgetbook.pocket.domain
+
+import com.budgetbook.auth.domain.User
+import com.budgetbook.common.entity.BaseTimeEntity
+import com.budgetbook.couple.domain.Couple
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import java.time.LocalDate
+import java.util.UUID
+
+@Entity
+@Table(name = "pocket_transfers")
+class PocketTransfer(
+    @Id
+    val id: UUID = UUID.randomUUID(),
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "couple_id", nullable = false)
+    val couple: Couple,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "from_pocket_id", nullable = false)
+    val fromPocket: MoneyPocket,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "to_pocket_id", nullable = false)
+    val toPocket: MoneyPocket,
+
+    @Column(nullable = false)
+    val amount: Long,
+
+    @Column(length = 255)
+    var description: String? = null,
+
+    @Column(name = "transfer_date", nullable = false)
+    val transferDate: LocalDate,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "author_id", nullable = false)
+    val author: User
+) : BaseTimeEntity()

--- a/backend/src/main/kotlin/com/budgetbook/pocket/domain/PocketType.kt
+++ b/backend/src/main/kotlin/com/budgetbook/pocket/domain/PocketType.kt
@@ -1,0 +1,9 @@
+package com.budgetbook.pocket.domain
+
+enum class PocketType {
+    LIVING,
+    FIXED,
+    CARD_PENDING,
+    SAVINGS,
+    CUSTOM
+}

--- a/backend/src/main/kotlin/com/budgetbook/pocket/dto/PocketDtos.kt
+++ b/backend/src/main/kotlin/com/budgetbook/pocket/dto/PocketDtos.kt
@@ -1,0 +1,53 @@
+package com.budgetbook.pocket.dto
+
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Size
+import java.time.Instant
+import java.util.UUID
+
+data class CreatePocketRequest(
+    @field:NotBlank
+    @field:Size(max = 50)
+    val name: String,
+
+    @field:NotBlank
+    val type: String,
+
+    @field:NotNull
+    @field:Min(0)
+    val allocatedAmount: Long,
+
+    val icon: String? = null,
+
+    val color: String? = null
+)
+
+data class UpdatePocketRequest(
+    @field:Size(max = 50)
+    val name: String? = null,
+
+    @field:Min(0)
+    val allocatedAmount: Long? = null,
+
+    val icon: String? = null,
+
+    val color: String? = null,
+
+    val displayOrder: Int? = null
+)
+
+data class PocketResponse(
+    val id: UUID,
+    val name: String,
+    val type: String,
+    val allocatedAmount: Long,
+    val balance: Long,
+    val icon: String?,
+    val color: String?,
+    val displayOrder: Int,
+    val isActive: Boolean,
+    val createdAt: Instant,
+    val updatedAt: Instant
+)

--- a/backend/src/main/kotlin/com/budgetbook/pocket/dto/PocketTransferDtos.kt
+++ b/backend/src/main/kotlin/com/budgetbook/pocket/dto/PocketTransferDtos.kt
@@ -1,0 +1,74 @@
+package com.budgetbook.pocket.dto
+
+import jakarta.validation.Valid
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Size
+import java.time.Instant
+import java.time.LocalDate
+import java.util.UUID
+
+data class CreateTransferRequest(
+    @field:NotNull
+    val fromPocketId: UUID,
+
+    @field:NotNull
+    val toPocketId: UUID,
+
+    @field:NotNull
+    @field:Min(1)
+    val amount: Long,
+
+    @field:Size(max = 255)
+    val description: String? = null,
+
+    @field:NotNull
+    val transferDate: LocalDate
+)
+
+data class PocketTransferResponse(
+    val id: UUID,
+    val fromPocket: PocketSummary,
+    val toPocket: PocketSummary,
+    val amount: Long,
+    val description: String?,
+    val transferDate: LocalDate,
+    val authorId: UUID,
+    val createdAt: Instant,
+    val updatedAt: Instant
+)
+
+data class PocketSummary(
+    val id: UUID,
+    val name: String
+)
+
+data class DistributeRequest(
+    @field:NotNull
+    @field:Min(0)
+    val totalAmount: Long,
+
+    @field:NotNull
+    @field:Valid
+    val distributions: List<DistributionItem>
+)
+
+data class DistributionItem(
+    @field:NotNull
+    val pocketId: UUID,
+
+    @field:NotNull
+    @field:Min(0)
+    val amount: Long
+)
+
+data class DistributeResponse(
+    val distributions: List<DistributionResult>,
+    val totalDistributed: Long
+)
+
+data class DistributionResult(
+    val pocketId: UUID,
+    val pocketName: String,
+    val amount: Long
+)

--- a/backend/src/main/kotlin/com/budgetbook/pocket/repository/MoneyPocketRepository.kt
+++ b/backend/src/main/kotlin/com/budgetbook/pocket/repository/MoneyPocketRepository.kt
@@ -1,0 +1,26 @@
+package com.budgetbook.pocket.repository
+
+import com.budgetbook.pocket.domain.MoneyPocket
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import java.util.UUID
+
+interface MoneyPocketRepository : JpaRepository<MoneyPocket, UUID> {
+
+    @Query("""
+        SELECT p FROM MoneyPocket p
+        WHERE p.couple.id = :coupleId AND p.isActive = true
+        ORDER BY p.displayOrder ASC, p.createdAt ASC
+    """)
+    fun findByCoupleIdAndIsActiveTrue(@Param("coupleId") coupleId: UUID): List<MoneyPocket>
+
+    fun findByIdAndCoupleId(id: UUID, coupleId: UUID): MoneyPocket?
+
+    @Query("""
+        SELECT COALESCE(MAX(p.displayOrder), 0)
+        FROM MoneyPocket p
+        WHERE p.couple.id = :coupleId
+    """)
+    fun maxDisplayOrderByCoupleId(@Param("coupleId") coupleId: UUID): Int
+}

--- a/backend/src/main/kotlin/com/budgetbook/pocket/repository/PocketTransferRepository.kt
+++ b/backend/src/main/kotlin/com/budgetbook/pocket/repository/PocketTransferRepository.kt
@@ -1,0 +1,33 @@
+package com.budgetbook.pocket.repository
+
+import com.budgetbook.pocket.domain.PocketTransfer
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import java.util.UUID
+
+interface PocketTransferRepository : JpaRepository<PocketTransfer, UUID> {
+
+    @Query("""
+        SELECT t FROM PocketTransfer t
+        WHERE t.couple.id = :coupleId
+        ORDER BY t.transferDate DESC, t.createdAt DESC
+    """)
+    fun findByCoupleId(@Param("coupleId") coupleId: UUID): List<PocketTransfer>
+
+    fun findByFromPocketIdOrToPocketId(fromPocketId: UUID, toPocketId: UUID): List<PocketTransfer>
+
+    @Query("""
+        SELECT COALESCE(SUM(t.amount), 0)
+        FROM PocketTransfer t
+        WHERE t.toPocket.id = :pocketId
+    """)
+    fun sumAmountByToPocketId(@Param("pocketId") pocketId: UUID): Long
+
+    @Query("""
+        SELECT COALESCE(SUM(t.amount), 0)
+        FROM PocketTransfer t
+        WHERE t.fromPocket.id = :pocketId
+    """)
+    fun sumAmountByFromPocketId(@Param("pocketId") pocketId: UUID): Long
+}

--- a/backend/src/main/kotlin/com/budgetbook/pocket/service/MoneyPocketService.kt
+++ b/backend/src/main/kotlin/com/budgetbook/pocket/service/MoneyPocketService.kt
@@ -1,0 +1,171 @@
+package com.budgetbook.pocket.service
+
+import com.budgetbook.common.exception.BusinessException
+import com.budgetbook.common.exception.ForbiddenException
+import com.budgetbook.common.exception.NotFoundException
+import com.budgetbook.couple.domain.Couple
+import com.budgetbook.couple.domain.CoupleStatus
+import com.budgetbook.couple.repository.CoupleRepository
+import com.budgetbook.pocket.domain.MoneyPocket
+import com.budgetbook.pocket.domain.PocketType
+import com.budgetbook.pocket.dto.CreatePocketRequest
+import com.budgetbook.pocket.dto.PocketResponse
+import com.budgetbook.pocket.dto.UpdatePocketRequest
+import com.budgetbook.pocket.repository.MoneyPocketRepository
+import com.budgetbook.pocket.repository.PocketTransferRepository
+import com.budgetbook.sync.SyncEvent
+import com.budgetbook.sync.SyncEventPublisher
+import com.budgetbook.transaction.repository.TransactionRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+@Service
+class MoneyPocketService(
+    private val moneyPocketRepository: MoneyPocketRepository,
+    private val coupleRepository: CoupleRepository,
+    private val syncEventPublisher: SyncEventPublisher,
+    private val pocketTransferRepository: PocketTransferRepository,
+    private val transactionRepository: TransactionRepository
+) {
+
+    @Transactional(readOnly = true)
+    fun getPockets(userId: UUID): List<PocketResponse> {
+        val couple = getActiveCouple(userId)
+        val pockets = moneyPocketRepository.findByCoupleIdAndIsActiveTrue(couple.id)
+        return pockets.map { it.toResponse(calculateBalance(it)) }
+    }
+
+    @Transactional
+    fun createPocket(userId: UUID, request: CreatePocketRequest): PocketResponse {
+        val couple = getActiveCouple(userId)
+
+        val pocketType = try {
+            PocketType.valueOf(request.type)
+        } catch (e: IllegalArgumentException) {
+            throw BusinessException("VALIDATION_ERROR", "Invalid pocket type: ${request.type}")
+        }
+
+        val maxOrder = moneyPocketRepository.maxDisplayOrderByCoupleId(couple.id)
+
+        val pocket = MoneyPocket(
+            couple = couple,
+            name = request.name,
+            type = pocketType,
+            allocatedAmount = request.allocatedAmount,
+            icon = request.icon,
+            color = request.color,
+            displayOrder = maxOrder + 1
+        )
+
+        val saved = moneyPocketRepository.save(pocket)
+        syncEventPublisher.publish(SyncEvent(
+            type = "POCKET_CREATED",
+            entityType = "POCKET",
+            entityId = saved.id,
+            coupleId = couple.id,
+            authorId = userId
+        ))
+        return saved.toResponse(calculateBalance(saved))
+    }
+
+    @Transactional
+    fun updatePocket(userId: UUID, pocketId: UUID, request: UpdatePocketRequest): PocketResponse {
+        val couple = getActiveCouple(userId)
+        val pocket = moneyPocketRepository.findByIdAndCoupleId(pocketId, couple.id)
+            ?: throw NotFoundException("POCKET_NOT_FOUND", "Pocket does not exist.")
+
+        if (!pocket.isActive) {
+            throw NotFoundException("POCKET_NOT_FOUND", "Pocket does not exist.")
+        }
+
+        if (pocket.couple.id != couple.id) {
+            throw ForbiddenException("FORBIDDEN", "Pocket belongs to a different couple.")
+        }
+
+        request.name?.let { pocket.name = it }
+        request.allocatedAmount?.let { pocket.allocatedAmount = it }
+        request.icon?.let { pocket.icon = it }
+        request.color?.let { pocket.color = it }
+        request.displayOrder?.let { pocket.displayOrder = it }
+
+        val saved = moneyPocketRepository.save(pocket)
+        syncEventPublisher.publish(SyncEvent(
+            type = "POCKET_UPDATED",
+            entityType = "POCKET",
+            entityId = saved.id,
+            coupleId = couple.id,
+            authorId = userId
+        ))
+        return saved.toResponse(calculateBalance(saved))
+    }
+
+    @Transactional
+    fun deletePocket(userId: UUID, pocketId: UUID) {
+        val couple = getActiveCouple(userId)
+        val pocket = moneyPocketRepository.findByIdAndCoupleId(pocketId, couple.id)
+            ?: throw NotFoundException("POCKET_NOT_FOUND", "Pocket does not exist.")
+
+        if (!pocket.isActive) {
+            throw NotFoundException("POCKET_NOT_FOUND", "Pocket does not exist.")
+        }
+
+        pocket.isActive = false
+        moneyPocketRepository.save(pocket)
+        syncEventPublisher.publish(SyncEvent(
+            type = "POCKET_DELETED",
+            entityType = "POCKET",
+            entityId = pocketId,
+            coupleId = couple.id,
+            authorId = userId
+        ))
+    }
+
+    @Transactional
+    fun seedDefaultPockets(couple: Couple): List<MoneyPocket> {
+        val defaults = listOf(
+            Triple("생활비", PocketType.LIVING, "wallet"),
+            Triple("고정지출", PocketType.FIXED, "receipt_long"),
+            Triple("카드대기", PocketType.CARD_PENDING, "credit_card"),
+            Triple("저축", PocketType.SAVINGS, "savings")
+        )
+
+        return defaults.mapIndexed { index, (name, type, icon) ->
+            moneyPocketRepository.save(
+                MoneyPocket(
+                    couple = couple,
+                    name = name,
+                    type = type,
+                    icon = icon,
+                    displayOrder = index + 1
+                )
+            )
+        }
+    }
+
+    internal fun calculateBalance(pocket: MoneyPocket): Long {
+        val transfersIn = pocketTransferRepository.sumAmountByToPocketId(pocket.id)
+        val transfersOut = pocketTransferRepository.sumAmountByFromPocketId(pocket.id)
+        val expenses = transactionRepository.sumExpenseByPocketId(pocket.id)
+        return pocket.allocatedAmount + transfersIn - transfersOut - expenses
+    }
+
+    internal fun getActiveCouple(userId: UUID): Couple {
+        return coupleRepository.findByUserIdAndStatus(userId, CoupleStatus.ACTIVE)
+            ?: throw NotFoundException("COUPLE_NOT_FOUND", "User is not in an active couple.")
+    }
+
+    private fun MoneyPocket.toResponse(balance: Long) = PocketResponse(
+        id = id,
+        name = name,
+        type = type.name,
+        allocatedAmount = allocatedAmount,
+        balance = balance,
+        icon = icon,
+        color = color,
+        displayOrder = displayOrder,
+        isActive = isActive,
+        createdAt = createdAt,
+        updatedAt = updatedAt
+    )
+}

--- a/backend/src/main/kotlin/com/budgetbook/pocket/service/PocketTransferService.kt
+++ b/backend/src/main/kotlin/com/budgetbook/pocket/service/PocketTransferService.kt
@@ -1,0 +1,140 @@
+package com.budgetbook.pocket.service
+
+import com.budgetbook.auth.repository.UserRepository
+import com.budgetbook.common.exception.BusinessException
+import com.budgetbook.common.exception.NotFoundException
+import com.budgetbook.couple.domain.Couple
+import com.budgetbook.couple.domain.CoupleStatus
+import com.budgetbook.couple.repository.CoupleRepository
+import com.budgetbook.pocket.domain.PocketTransfer
+import com.budgetbook.pocket.dto.CreateTransferRequest
+import com.budgetbook.pocket.dto.DistributeRequest
+import com.budgetbook.pocket.dto.DistributeResponse
+import com.budgetbook.pocket.dto.DistributionResult
+import com.budgetbook.pocket.dto.PocketSummary
+import com.budgetbook.pocket.dto.PocketTransferResponse
+import com.budgetbook.pocket.repository.MoneyPocketRepository
+import com.budgetbook.pocket.repository.PocketTransferRepository
+import com.budgetbook.sync.SyncEvent
+import com.budgetbook.sync.SyncEventPublisher
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+@Service
+class PocketTransferService(
+    private val pocketTransferRepository: PocketTransferRepository,
+    private val moneyPocketRepository: MoneyPocketRepository,
+    private val coupleRepository: CoupleRepository,
+    private val userRepository: UserRepository,
+    private val syncEventPublisher: SyncEventPublisher
+) {
+
+    @Transactional(readOnly = true)
+    fun getTransfers(userId: UUID): List<PocketTransferResponse> {
+        val couple = getActiveCouple(userId)
+        val transfers = pocketTransferRepository.findByCoupleId(couple.id)
+        return transfers.map { it.toResponse() }
+    }
+
+    @Transactional
+    fun createTransfer(userId: UUID, request: CreateTransferRequest): PocketTransferResponse {
+        val couple = getActiveCouple(userId)
+        val user = userRepository.findById(userId)
+            .orElseThrow { NotFoundException("USER_NOT_FOUND", "User not found.") }
+
+        if (request.fromPocketId == request.toPocketId) {
+            throw BusinessException("VALIDATION_ERROR", "Cannot transfer to the same pocket.")
+        }
+
+        val fromPocket = moneyPocketRepository.findByIdAndCoupleId(request.fromPocketId, couple.id)
+            ?: throw NotFoundException("POCKET_NOT_FOUND", "Source pocket does not exist.")
+        if (!fromPocket.isActive) {
+            throw NotFoundException("POCKET_NOT_FOUND", "Source pocket does not exist.")
+        }
+
+        val toPocket = moneyPocketRepository.findByIdAndCoupleId(request.toPocketId, couple.id)
+            ?: throw NotFoundException("POCKET_NOT_FOUND", "Destination pocket does not exist.")
+        if (!toPocket.isActive) {
+            throw NotFoundException("POCKET_NOT_FOUND", "Destination pocket does not exist.")
+        }
+
+        val transfer = PocketTransfer(
+            couple = couple,
+            fromPocket = fromPocket,
+            toPocket = toPocket,
+            amount = request.amount,
+            description = request.description,
+            transferDate = request.transferDate,
+            author = user
+        )
+
+        val saved = pocketTransferRepository.save(transfer)
+        syncEventPublisher.publish(SyncEvent(
+            type = "POCKET_TRANSFER_CREATED",
+            entityType = "POCKET_TRANSFER",
+            entityId = saved.id,
+            coupleId = couple.id,
+            authorId = userId
+        ))
+        return saved.toResponse()
+    }
+
+    @Transactional
+    fun distribute(userId: UUID, request: DistributeRequest): DistributeResponse {
+        val couple = getActiveCouple(userId)
+
+        val distributionSum = request.distributions.sumOf { it.amount }
+        if (distributionSum != request.totalAmount) {
+            throw BusinessException("VALIDATION_ERROR",
+                "Sum of distributions ($distributionSum) does not match totalAmount (${request.totalAmount}).")
+        }
+
+        val results = request.distributions.map { item ->
+            val pocket = moneyPocketRepository.findByIdAndCoupleId(item.pocketId, couple.id)
+                ?: throw NotFoundException("POCKET_NOT_FOUND", "Pocket ${item.pocketId} does not exist.")
+            if (!pocket.isActive) {
+                throw NotFoundException("POCKET_NOT_FOUND", "Pocket ${item.pocketId} is not active.")
+            }
+
+            pocket.allocatedAmount += item.amount
+            moneyPocketRepository.save(pocket)
+
+            DistributionResult(
+                pocketId = pocket.id,
+                pocketName = pocket.name,
+                amount = item.amount
+            )
+        }
+
+        syncEventPublisher.publish(SyncEvent(
+            type = "POCKET_DISTRIBUTED",
+            entityType = "POCKET",
+            entityId = couple.id,
+            coupleId = couple.id,
+            authorId = userId
+        ))
+
+        return DistributeResponse(
+            distributions = results,
+            totalDistributed = distributionSum
+        )
+    }
+
+    private fun getActiveCouple(userId: UUID): Couple {
+        return coupleRepository.findByUserIdAndStatus(userId, CoupleStatus.ACTIVE)
+            ?: throw NotFoundException("COUPLE_NOT_FOUND", "User is not in an active couple.")
+    }
+
+    private fun PocketTransfer.toResponse() = PocketTransferResponse(
+        id = id,
+        fromPocket = PocketSummary(id = fromPocket.id, name = fromPocket.name),
+        toPocket = PocketSummary(id = toPocket.id, name = toPocket.name),
+        amount = amount,
+        description = description,
+        transferDate = transferDate,
+        authorId = author.id,
+        createdAt = createdAt,
+        updatedAt = updatedAt
+    )
+}

--- a/backend/src/main/kotlin/com/budgetbook/transaction/domain/Transaction.kt
+++ b/backend/src/main/kotlin/com/budgetbook/transaction/domain/Transaction.kt
@@ -5,6 +5,7 @@ import com.budgetbook.category.domain.Category
 import com.budgetbook.common.entity.BaseTimeEntity
 import com.budgetbook.couple.domain.Couple
 import com.budgetbook.paymentmethod.domain.PaymentMethod
+import com.budgetbook.pocket.domain.MoneyPocket
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
@@ -55,7 +56,11 @@ class Transaction(
     var paymentMethod: PaymentMethod? = null,
 
     @Column(name = "settlement_date")
-    var settlementDate: LocalDate? = null
+    var settlementDate: LocalDate? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "pocket_id")
+    var pocket: MoneyPocket? = null
 ) : BaseTimeEntity()
 
 enum class TransactionType { INCOME, EXPENSE }

--- a/backend/src/main/kotlin/com/budgetbook/transaction/dto/TransactionDtos.kt
+++ b/backend/src/main/kotlin/com/budgetbook/transaction/dto/TransactionDtos.kt
@@ -27,6 +27,8 @@ data class TransactionResponse(
     val paymentMethodName: String? = null,
     val paymentMethodType: String? = null,
     val settlementDate: String? = null,
+    val pocketId: UUID? = null,
+    val pocketName: String? = null,
     val createdAt: Instant,
     val updatedAt: Instant
 )
@@ -58,7 +60,9 @@ data class CreateTransactionRequest(
 
     val memo: String? = null,
 
-    val paymentMethodId: UUID? = null
+    val paymentMethodId: UUID? = null,
+
+    val pocketId: UUID? = null
 )
 
 data class UpdateTransactionRequest(
@@ -77,7 +81,10 @@ data class UpdateTransactionRequest(
     val memo: PatchValue<String>? = null,
 
     @JsonDeserialize(using = UUIDPatchValueDeserializer::class)
-    val paymentMethodId: PatchValue<UUID>? = null
+    val paymentMethodId: PatchValue<UUID>? = null,
+
+    @JsonDeserialize(using = UUIDPatchValueDeserializer::class)
+    val pocketId: PatchValue<UUID>? = null
 )
 
 data class PageResponse<T>(

--- a/backend/src/main/kotlin/com/budgetbook/transaction/repository/TransactionRepository.kt
+++ b/backend/src/main/kotlin/com/budgetbook/transaction/repository/TransactionRepository.kt
@@ -132,4 +132,12 @@ interface TransactionRepository : JpaRepository<Transaction, UUID> {
         @Param("startDate") startDate: LocalDate,
         @Param("endDate") endDate: LocalDate
     ): List<Array<Any>>
+
+    @Query("""
+        SELECT COALESCE(SUM(t.amount), 0)
+        FROM Transaction t
+        WHERE t.pocket.id = :pocketId
+        AND t.type = com.budgetbook.transaction.domain.TransactionType.EXPENSE
+    """)
+    fun sumExpenseByPocketId(@Param("pocketId") pocketId: UUID): Long
 }

--- a/backend/src/main/kotlin/com/budgetbook/transaction/service/TransactionService.kt
+++ b/backend/src/main/kotlin/com/budgetbook/transaction/service/TransactionService.kt
@@ -11,6 +11,7 @@ import com.budgetbook.couple.dto.UserSummary
 import com.budgetbook.couple.repository.CoupleRepository
 import com.budgetbook.paymentmethod.domain.PaymentMethodType
 import com.budgetbook.paymentmethod.repository.PaymentMethodRepository
+import com.budgetbook.pocket.repository.MoneyPocketRepository
 import com.budgetbook.transaction.domain.Transaction
 import com.budgetbook.transaction.domain.TransactionType
 import com.budgetbook.transaction.dto.CategorySummary
@@ -35,6 +36,7 @@ class TransactionService(
     private val userRepository: UserRepository,
     private val categoryRepository: CategoryRepository,
     private val paymentMethodRepository: PaymentMethodRepository,
+    private val moneyPocketRepository: MoneyPocketRepository,
     private val syncEventPublisher: SyncEventPublisher
 ) {
 
@@ -120,6 +122,18 @@ class TransactionService(
             calculateSettlementDate(it, request.transactionDate)
         }
 
+        val pocket = request.pocketId?.let { pocketId ->
+            val p = moneyPocketRepository.findById(pocketId)
+                .orElseThrow { NotFoundException("POCKET_NOT_FOUND", "Specified pocket does not exist.") }
+            if (p.couple.id != couple.id) {
+                throw ForbiddenException("FORBIDDEN", "Pocket belongs to a different couple.")
+            }
+            if (!p.isActive) {
+                throw NotFoundException("POCKET_NOT_FOUND", "Specified pocket is not active.")
+            }
+            p
+        }
+
         val transaction = Transaction(
             couple = couple,
             author = user,
@@ -130,7 +144,8 @@ class TransactionService(
             memo = request.memo,
             transactionDate = request.transactionDate,
             paymentMethod = paymentMethod,
-            settlementDate = settlementDate
+            settlementDate = settlementDate,
+            pocket = pocket
         )
 
         val saved = transactionRepository.save(transaction)
@@ -204,6 +219,24 @@ class TransactionService(
                 transaction.paymentMethod = null
                 transaction.settlementDate = null
                 paymentMethodChanged = true
+            }
+        }
+
+        // Handle pocketId with PatchValue
+        request.pocketId?.let { patchValue ->
+            val pocketIdVal = patchValue.value
+            if (pocketIdVal != null) {
+                val p = moneyPocketRepository.findById(pocketIdVal)
+                    .orElseThrow { NotFoundException("POCKET_NOT_FOUND", "Specified pocket does not exist.") }
+                if (p.couple.id != couple.id) {
+                    throw ForbiddenException("FORBIDDEN", "Pocket belongs to a different couple.")
+                }
+                if (!p.isActive) {
+                    throw NotFoundException("POCKET_NOT_FOUND", "Specified pocket is not active.")
+                }
+                transaction.pocket = p
+            } else {
+                transaction.pocket = null
             }
         }
 
@@ -297,6 +330,8 @@ class TransactionService(
         paymentMethodName = paymentMethod?.name,
         paymentMethodType = paymentMethod?.type?.name,
         settlementDate = settlementDate?.toString(),
+        pocketId = pocket?.id,
+        pocketName = pocket?.name,
         createdAt = createdAt,
         updatedAt = updatedAt
     )

--- a/backend/src/main/resources/db/migration/V11__create_money_pockets_table.sql
+++ b/backend/src/main/resources/db/migration/V11__create_money_pockets_table.sql
@@ -1,0 +1,14 @@
+CREATE TABLE money_pockets (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    couple_id UUID NOT NULL REFERENCES couples(id),
+    name VARCHAR(50) NOT NULL,
+    type VARCHAR(20) NOT NULL CHECK (type IN ('LIVING', 'FIXED', 'CARD_PENDING', 'SAVINGS', 'CUSTOM')),
+    allocated_amount BIGINT NOT NULL DEFAULT 0,
+    icon VARCHAR(50),
+    color VARCHAR(7),
+    display_order INTEGER NOT NULL DEFAULT 0,
+    is_active BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX idx_money_pockets_couple ON money_pockets(couple_id);

--- a/backend/src/main/resources/db/migration/V12__create_pocket_transfers_table.sql
+++ b/backend/src/main/resources/db/migration/V12__create_pocket_transfers_table.sql
@@ -1,0 +1,14 @@
+CREATE TABLE pocket_transfers (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    couple_id UUID NOT NULL REFERENCES couples(id),
+    from_pocket_id UUID NOT NULL REFERENCES money_pockets(id),
+    to_pocket_id UUID NOT NULL REFERENCES money_pockets(id),
+    amount BIGINT NOT NULL CHECK (amount > 0),
+    description VARCHAR(255),
+    transfer_date DATE NOT NULL,
+    author_id UUID NOT NULL REFERENCES users(id),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX idx_pocket_transfers_couple ON pocket_transfers(couple_id);
+CREATE INDEX idx_pocket_transfers_date ON pocket_transfers(transfer_date);

--- a/backend/src/main/resources/db/migration/V13__add_pocket_id_to_transactions.sql
+++ b/backend/src/main/resources/db/migration/V13__add_pocket_id_to_transactions.sql
@@ -1,0 +1,2 @@
+ALTER TABLE transactions ADD COLUMN pocket_id UUID REFERENCES money_pockets(id) ON DELETE SET NULL;
+CREATE INDEX idx_transactions_pocket ON transactions(pocket_id);

--- a/backend/src/test/kotlin/com/budgetbook/pocket/controller/MoneyPocketControllerTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/pocket/controller/MoneyPocketControllerTest.kt
@@ -1,0 +1,92 @@
+package com.budgetbook.pocket.controller
+
+import com.budgetbook.pocket.dto.CreatePocketRequest
+import com.budgetbook.pocket.dto.PocketResponse
+import com.budgetbook.pocket.dto.UpdatePocketRequest
+import com.budgetbook.pocket.service.MoneyPocketService
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.verify
+import org.springframework.http.HttpStatus
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.Authentication
+import java.time.Instant
+import java.util.UUID
+
+class MoneyPocketControllerTest : FunSpec({
+
+    val moneyPocketService = mockk<MoneyPocketService>()
+    val controller = MoneyPocketController(moneyPocketService)
+    val testUserId = UUID.randomUUID()
+
+    fun createAuth(userId: UUID): Authentication =
+        UsernamePasswordAuthenticationToken(userId, null, emptyList())
+
+    fun samplePocketResponse(name: String = "생활비") = PocketResponse(
+        id = UUID.randomUUID(),
+        name = name,
+        type = "LIVING",
+        allocatedAmount = 500000,
+        balance = 500000,
+        icon = "wallet",
+        color = "#FF5733",
+        displayOrder = 1,
+        isActive = true,
+        createdAt = Instant.now(),
+        updatedAt = Instant.now()
+    )
+
+    test("listPockets returns all active pockets") {
+        val auth = createAuth(testUserId)
+        val pockets = listOf(samplePocketResponse("생활비"), samplePocketResponse("저축"))
+        every { moneyPocketService.getPockets(testUserId) } returns pockets
+
+        val result = controller.listPockets(auth)
+
+        result.success shouldBe true
+        result.data!!.size shouldBe 2
+    }
+
+    test("createPocket returns 201") {
+        val auth = createAuth(testUserId)
+        val request = CreatePocketRequest(
+            name = "생활비",
+            type = "LIVING",
+            allocatedAmount = 500000,
+            icon = "wallet",
+            color = "#FF5733"
+        )
+        every { moneyPocketService.createPocket(testUserId, request) } returns samplePocketResponse()
+
+        val result = controller.createPocket(auth, request)
+
+        result.statusCode shouldBe HttpStatus.CREATED
+        result.body!!.success shouldBe true
+        result.body!!.data!!.name shouldBe "생활비"
+    }
+
+    test("updatePocket returns updated pocket") {
+        val auth = createAuth(testUserId)
+        val pocketId = UUID.randomUUID()
+        val request = UpdatePocketRequest(name = "생활비(수정)", allocatedAmount = 600000)
+        every { moneyPocketService.updatePocket(testUserId, pocketId, request) } returns samplePocketResponse("생활비(수정)")
+
+        val result = controller.updatePocket(auth, pocketId, request)
+
+        result.success shouldBe true
+    }
+
+    test("deletePocket returns 204") {
+        val auth = createAuth(testUserId)
+        val pocketId = UUID.randomUUID()
+        justRun { moneyPocketService.deletePocket(testUserId, pocketId) }
+
+        val result = controller.deletePocket(auth, pocketId)
+
+        result.statusCode shouldBe HttpStatus.NO_CONTENT
+        verify(exactly = 1) { moneyPocketService.deletePocket(testUserId, pocketId) }
+    }
+})

--- a/backend/src/test/kotlin/com/budgetbook/pocket/controller/PocketTransferControllerTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/pocket/controller/PocketTransferControllerTest.kt
@@ -1,0 +1,94 @@
+package com.budgetbook.pocket.controller
+
+import com.budgetbook.pocket.dto.CreateTransferRequest
+import com.budgetbook.pocket.dto.DistributeRequest
+import com.budgetbook.pocket.dto.DistributeResponse
+import com.budgetbook.pocket.dto.DistributionItem
+import com.budgetbook.pocket.dto.DistributionResult
+import com.budgetbook.pocket.dto.PocketSummary
+import com.budgetbook.pocket.dto.PocketTransferResponse
+import com.budgetbook.pocket.service.PocketTransferService
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import org.springframework.http.HttpStatus
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.Authentication
+import java.time.Instant
+import java.time.LocalDate
+import java.util.UUID
+
+class PocketTransferControllerTest : FunSpec({
+
+    val pocketTransferService = mockk<PocketTransferService>()
+    val controller = PocketTransferController(pocketTransferService)
+    val testUserId = UUID.randomUUID()
+
+    fun createAuth(userId: UUID): Authentication =
+        UsernamePasswordAuthenticationToken(userId, null, emptyList())
+
+    fun sampleTransferResponse() = PocketTransferResponse(
+        id = UUID.randomUUID(),
+        fromPocket = PocketSummary(UUID.randomUUID(), "생활비"),
+        toPocket = PocketSummary(UUID.randomUUID(), "저축"),
+        amount = 100000,
+        description = "이체",
+        transferDate = LocalDate.of(2024, 3, 1),
+        authorId = testUserId,
+        createdAt = Instant.now(),
+        updatedAt = Instant.now()
+    )
+
+    test("listTransfers returns transfers") {
+        val auth = createAuth(testUserId)
+        val transfers = listOf(sampleTransferResponse())
+        every { pocketTransferService.getTransfers(testUserId) } returns transfers
+
+        val result = controller.listTransfers(auth)
+
+        result.success shouldBe true
+        result.data!!.size shouldBe 1
+    }
+
+    test("createTransfer returns 201") {
+        val auth = createAuth(testUserId)
+        val request = CreateTransferRequest(
+            fromPocketId = UUID.randomUUID(),
+            toPocketId = UUID.randomUUID(),
+            amount = 50000,
+            transferDate = LocalDate.of(2024, 3, 1)
+        )
+        every { pocketTransferService.createTransfer(testUserId, request) } returns sampleTransferResponse()
+
+        val result = controller.createTransfer(auth, request)
+
+        result.statusCode shouldBe HttpStatus.CREATED
+        result.body!!.success shouldBe true
+    }
+
+    test("distribute returns distribution results") {
+        val auth = createAuth(testUserId)
+        val request = DistributeRequest(
+            totalAmount = 3000000,
+            distributions = listOf(
+                DistributionItem(pocketId = UUID.randomUUID(), amount = 2000000),
+                DistributionItem(pocketId = UUID.randomUUID(), amount = 1000000)
+            )
+        )
+        val response = DistributeResponse(
+            distributions = listOf(
+                DistributionResult(UUID.randomUUID(), "생활비", 2000000),
+                DistributionResult(UUID.randomUUID(), "저축", 1000000)
+            ),
+            totalDistributed = 3000000
+        )
+        every { pocketTransferService.distribute(testUserId, request) } returns response
+
+        val result = controller.distribute(auth, request)
+
+        result.success shouldBe true
+        result.data!!.totalDistributed shouldBe 3000000
+        result.data!!.distributions.size shouldBe 2
+    }
+})

--- a/backend/src/test/kotlin/com/budgetbook/pocket/service/MoneyPocketServiceTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/pocket/service/MoneyPocketServiceTest.kt
@@ -1,0 +1,232 @@
+package com.budgetbook.pocket.service
+
+import com.budgetbook.auth.domain.AuthProvider
+import com.budgetbook.auth.domain.User
+import com.budgetbook.common.exception.BusinessException
+import com.budgetbook.common.exception.NotFoundException
+import com.budgetbook.couple.domain.Couple
+import com.budgetbook.couple.domain.CoupleStatus
+import com.budgetbook.couple.repository.CoupleRepository
+import com.budgetbook.pocket.domain.MoneyPocket
+import com.budgetbook.pocket.domain.PocketType
+import com.budgetbook.pocket.dto.CreatePocketRequest
+import com.budgetbook.pocket.dto.UpdatePocketRequest
+import com.budgetbook.pocket.repository.MoneyPocketRepository
+import com.budgetbook.pocket.repository.PocketTransferRepository
+import com.budgetbook.sync.SyncEventPublisher
+import com.budgetbook.transaction.repository.TransactionRepository
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+
+class MoneyPocketServiceTest : BehaviorSpec({
+
+    isolationMode = IsolationMode.InstancePerLeaf
+
+    val moneyPocketRepository = mockk<MoneyPocketRepository>()
+    val coupleRepository = mockk<CoupleRepository>()
+    val syncEventPublisher = mockk<SyncEventPublisher>(relaxed = true)
+    val pocketTransferRepository = mockk<PocketTransferRepository> {
+        every { sumAmountByToPocketId(any()) } returns 0L
+        every { sumAmountByFromPocketId(any()) } returns 0L
+    }
+    val transactionRepository = mockk<TransactionRepository> {
+        every { sumExpenseByPocketId(any()) } returns 0L
+    }
+    val service = MoneyPocketService(moneyPocketRepository, coupleRepository, syncEventPublisher, pocketTransferRepository, transactionRepository)
+
+    val user1 = User(email = "u1@test.com", nickname = "U1", provider = AuthProvider.GOOGLE, providerId = "g1")
+    val user2 = User(email = "u2@test.com", nickname = "U2", provider = AuthProvider.KAKAO, providerId = "k2")
+    val couple = Couple(user1 = user1, user2 = user2, status = CoupleStatus.ACTIVE)
+
+    // --- getPockets ---
+
+    Given("a user in an active couple with pockets") {
+        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+
+        val pocket1 = MoneyPocket(couple = couple, name = "생활비", type = PocketType.LIVING, allocatedAmount = 500000, displayOrder = 1)
+        val pocket2 = MoneyPocket(couple = couple, name = "저축", type = PocketType.SAVINGS, allocatedAmount = 1000000, displayOrder = 2)
+        every { moneyPocketRepository.findByCoupleIdAndIsActiveTrue(couple.id) } returns listOf(pocket1, pocket2)
+
+        When("getPockets is called") {
+            val result = service.getPockets(user1.id)
+
+            Then("returns all active pockets") {
+                result shouldHaveSize 2
+                result[0].name shouldBe "생활비"
+                result[0].type shouldBe "LIVING"
+                result[0].allocatedAmount shouldBe 500000
+                result[0].balance shouldBe 500000
+                result[1].name shouldBe "저축"
+            }
+        }
+    }
+
+    // --- createPocket ---
+
+    Given("a user in an active couple") {
+        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { moneyPocketRepository.maxDisplayOrderByCoupleId(couple.id) } returns 2
+
+        When("creating a pocket with valid data") {
+            val request = CreatePocketRequest(
+                name = "용돈",
+                type = "CUSTOM",
+                allocatedAmount = 200000,
+                icon = "money",
+                color = "#00FF00"
+            )
+            val pocketSlot = slot<MoneyPocket>()
+            every { moneyPocketRepository.save(capture(pocketSlot)) } answers { pocketSlot.captured }
+
+            val result = service.createPocket(user1.id, request)
+
+            Then("creates pocket with correct fields") {
+                result.name shouldBe "용돈"
+                result.type shouldBe "CUSTOM"
+                result.allocatedAmount shouldBe 200000
+                result.icon shouldBe "money"
+                result.color shouldBe "#00FF00"
+                result.displayOrder shouldBe 3
+                result.isActive shouldBe true
+            }
+
+            Then("publishes POCKET_CREATED event") {
+                verify(exactly = 1) { syncEventPublisher.publish(match { it.type == "POCKET_CREATED" }) }
+            }
+        }
+
+        When("creating a pocket with invalid type") {
+            val request = CreatePocketRequest(
+                name = "Invalid",
+                type = "INVALID_TYPE",
+                allocatedAmount = 100000
+            )
+
+            Then("throws BusinessException") {
+                val ex = shouldThrow<BusinessException> {
+                    service.createPocket(user1.id, request)
+                }
+                ex.code shouldBe "VALIDATION_ERROR"
+            }
+        }
+    }
+
+    // --- updatePocket ---
+
+    Given("an existing active pocket") {
+        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        val pocket = MoneyPocket(couple = couple, name = "생활비", type = PocketType.LIVING, allocatedAmount = 500000, displayOrder = 1)
+        every { moneyPocketRepository.findByIdAndCoupleId(pocket.id, couple.id) } returns pocket
+        every { moneyPocketRepository.save(pocket) } returns pocket
+
+        When("updating name and allocatedAmount") {
+            val request = UpdatePocketRequest(name = "생활비(수정)", allocatedAmount = 600000)
+            val result = service.updatePocket(user1.id, pocket.id, request)
+
+            Then("updates the fields") {
+                result.name shouldBe "생활비(수정)"
+                result.allocatedAmount shouldBe 600000
+            }
+
+            Then("publishes POCKET_UPDATED event") {
+                verify(exactly = 1) { syncEventPublisher.publish(match { it.type == "POCKET_UPDATED" }) }
+            }
+        }
+    }
+
+    Given("a non-existent pocket") {
+        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        val fakeId = java.util.UUID.randomUUID()
+        every { moneyPocketRepository.findByIdAndCoupleId(fakeId, couple.id) } returns null
+
+        When("updatePocket is called") {
+            Then("throws NotFoundException") {
+                val ex = shouldThrow<NotFoundException> {
+                    service.updatePocket(user1.id, fakeId, UpdatePocketRequest(name = "test"))
+                }
+                ex.code shouldBe "POCKET_NOT_FOUND"
+            }
+        }
+    }
+
+    Given("an inactive pocket") {
+        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        val pocket = MoneyPocket(couple = couple, name = "삭제됨", type = PocketType.CUSTOM, allocatedAmount = 0, isActive = false)
+        every { moneyPocketRepository.findByIdAndCoupleId(pocket.id, couple.id) } returns pocket
+
+        When("updatePocket is called") {
+            Then("throws NotFoundException") {
+                shouldThrow<NotFoundException> {
+                    service.updatePocket(user1.id, pocket.id, UpdatePocketRequest(name = "test"))
+                }
+            }
+        }
+    }
+
+    // --- deletePocket ---
+
+    Given("an active pocket to delete") {
+        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        val pocket = MoneyPocket(couple = couple, name = "삭제할거", type = PocketType.CUSTOM, allocatedAmount = 100000, displayOrder = 1)
+        every { moneyPocketRepository.findByIdAndCoupleId(pocket.id, couple.id) } returns pocket
+        every { moneyPocketRepository.save(pocket) } returns pocket
+
+        When("deletePocket is called") {
+            service.deletePocket(user1.id, pocket.id)
+
+            Then("soft deletes the pocket") {
+                pocket.isActive shouldBe false
+                verify(exactly = 1) { moneyPocketRepository.save(pocket) }
+            }
+
+            Then("publishes POCKET_DELETED event") {
+                verify(exactly = 1) { syncEventPublisher.publish(match { it.type == "POCKET_DELETED" }) }
+            }
+        }
+    }
+
+    // --- seedDefaultPockets ---
+
+    Given("a couple needing default pockets") {
+        val pocketSlot = slot<MoneyPocket>()
+        every { moneyPocketRepository.save(capture(pocketSlot)) } answers { pocketSlot.captured }
+
+        When("seedDefaultPockets is called") {
+            val result = service.seedDefaultPockets(couple)
+
+            Then("creates 4 default pockets") {
+                result shouldHaveSize 4
+                result[0].name shouldBe "생활비"
+                result[0].type shouldBe PocketType.LIVING
+                result[1].name shouldBe "고정지출"
+                result[1].type shouldBe PocketType.FIXED
+                result[2].name shouldBe "카드대기"
+                result[2].type shouldBe PocketType.CARD_PENDING
+                result[3].name shouldBe "저축"
+                result[3].type shouldBe PocketType.SAVINGS
+            }
+        }
+    }
+
+    // --- getActiveCouple error ---
+
+    Given("a user not in any active couple") {
+        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns null
+
+        When("getPockets is called") {
+            Then("throws NotFoundException") {
+                val ex = shouldThrow<NotFoundException> {
+                    service.getPockets(user1.id)
+                }
+                ex.code shouldBe "COUPLE_NOT_FOUND"
+            }
+        }
+    }
+})

--- a/backend/src/test/kotlin/com/budgetbook/pocket/service/PocketTransferServiceTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/pocket/service/PocketTransferServiceTest.kt
@@ -1,0 +1,213 @@
+package com.budgetbook.pocket.service
+
+import com.budgetbook.auth.domain.AuthProvider
+import com.budgetbook.auth.domain.User
+import com.budgetbook.auth.repository.UserRepository
+import com.budgetbook.common.exception.BusinessException
+import com.budgetbook.common.exception.NotFoundException
+import com.budgetbook.couple.domain.Couple
+import com.budgetbook.couple.domain.CoupleStatus
+import com.budgetbook.couple.repository.CoupleRepository
+import com.budgetbook.pocket.domain.MoneyPocket
+import com.budgetbook.pocket.domain.PocketTransfer
+import com.budgetbook.pocket.domain.PocketType
+import com.budgetbook.pocket.dto.CreateTransferRequest
+import com.budgetbook.pocket.dto.DistributeRequest
+import com.budgetbook.pocket.dto.DistributionItem
+import com.budgetbook.pocket.repository.MoneyPocketRepository
+import com.budgetbook.pocket.repository.PocketTransferRepository
+import com.budgetbook.sync.SyncEventPublisher
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import java.time.LocalDate
+import java.util.Optional
+
+class PocketTransferServiceTest : BehaviorSpec({
+
+    isolationMode = IsolationMode.InstancePerLeaf
+
+    val pocketTransferRepository = mockk<PocketTransferRepository>()
+    val moneyPocketRepository = mockk<MoneyPocketRepository>()
+    val coupleRepository = mockk<CoupleRepository>()
+    val userRepository = mockk<UserRepository>()
+    val syncEventPublisher = mockk<SyncEventPublisher>(relaxed = true)
+    val service = PocketTransferService(pocketTransferRepository, moneyPocketRepository, coupleRepository, userRepository, syncEventPublisher)
+
+    val user1 = User(email = "u1@test.com", nickname = "U1", provider = AuthProvider.GOOGLE, providerId = "g1")
+    val user2 = User(email = "u2@test.com", nickname = "U2", provider = AuthProvider.KAKAO, providerId = "k2")
+    val couple = Couple(user1 = user1, user2 = user2, status = CoupleStatus.ACTIVE)
+    val pocket1 = MoneyPocket(couple = couple, name = "생활비", type = PocketType.LIVING, allocatedAmount = 500000, displayOrder = 1)
+    val pocket2 = MoneyPocket(couple = couple, name = "저축", type = PocketType.SAVINGS, allocatedAmount = 1000000, displayOrder = 2)
+
+    // --- getTransfers ---
+
+    Given("a user with transfers") {
+        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        val transfer = PocketTransfer(
+            couple = couple, fromPocket = pocket1, toPocket = pocket2,
+            amount = 100000, description = "저축 이동", transferDate = LocalDate.of(2024, 3, 1), author = user1
+        )
+        every { pocketTransferRepository.findByCoupleId(couple.id) } returns listOf(transfer)
+
+        When("getTransfers is called") {
+            val result = service.getTransfers(user1.id)
+
+            Then("returns list of transfers") {
+                result shouldHaveSize 1
+                result[0].amount shouldBe 100000
+                result[0].fromPocket.name shouldBe "생활비"
+                result[0].toPocket.name shouldBe "저축"
+                result[0].authorId shouldBe user1.id
+            }
+        }
+    }
+
+    // --- createTransfer ---
+
+    Given("a user creating a transfer") {
+        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { userRepository.findById(user1.id) } returns Optional.of(user1)
+        every { moneyPocketRepository.findByIdAndCoupleId(pocket1.id, couple.id) } returns pocket1
+        every { moneyPocketRepository.findByIdAndCoupleId(pocket2.id, couple.id) } returns pocket2
+
+        When("creating a valid transfer") {
+            val request = CreateTransferRequest(
+                fromPocketId = pocket1.id,
+                toPocketId = pocket2.id,
+                amount = 50000,
+                description = "저축 이동",
+                transferDate = LocalDate.of(2024, 3, 1)
+            )
+            val transferSlot = slot<PocketTransfer>()
+            every { pocketTransferRepository.save(capture(transferSlot)) } answers { transferSlot.captured }
+
+            val result = service.createTransfer(user1.id, request)
+
+            Then("creates the transfer") {
+                result.amount shouldBe 50000
+                result.fromPocket.id shouldBe pocket1.id
+                result.toPocket.id shouldBe pocket2.id
+                result.description shouldBe "저축 이동"
+            }
+
+            Then("publishes sync event") {
+                verify(exactly = 1) { syncEventPublisher.publish(match { it.type == "POCKET_TRANSFER_CREATED" }) }
+            }
+        }
+
+        When("creating a transfer to the same pocket") {
+            val request = CreateTransferRequest(
+                fromPocketId = pocket1.id,
+                toPocketId = pocket1.id,
+                amount = 50000,
+                transferDate = LocalDate.of(2024, 3, 1)
+            )
+
+            Then("throws BusinessException") {
+                val ex = shouldThrow<BusinessException> {
+                    service.createTransfer(user1.id, request)
+                }
+                ex.code shouldBe "VALIDATION_ERROR"
+            }
+        }
+    }
+
+    Given("a user creating a transfer with non-existent source pocket") {
+        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { userRepository.findById(user1.id) } returns Optional.of(user1)
+        val fakeId = java.util.UUID.randomUUID()
+        every { moneyPocketRepository.findByIdAndCoupleId(fakeId, couple.id) } returns null
+
+        When("createTransfer is called") {
+            val request = CreateTransferRequest(
+                fromPocketId = fakeId,
+                toPocketId = pocket2.id,
+                amount = 50000,
+                transferDate = LocalDate.of(2024, 3, 1)
+            )
+
+            Then("throws NotFoundException") {
+                shouldThrow<NotFoundException> {
+                    service.createTransfer(user1.id, request)
+                }
+            }
+        }
+    }
+
+    // --- distribute ---
+
+    Given("a user distributing income") {
+        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { moneyPocketRepository.findByIdAndCoupleId(pocket1.id, couple.id) } returns pocket1
+        every { moneyPocketRepository.findByIdAndCoupleId(pocket2.id, couple.id) } returns pocket2
+        every { moneyPocketRepository.save(any()) } answers { firstArg() }
+
+        When("distributing with matching total") {
+            val request = DistributeRequest(
+                totalAmount = 3000000,
+                distributions = listOf(
+                    DistributionItem(pocketId = pocket1.id, amount = 2000000),
+                    DistributionItem(pocketId = pocket2.id, amount = 1000000)
+                )
+            )
+
+            val result = service.distribute(user1.id, request)
+
+            Then("distributes to each pocket") {
+                result.totalDistributed shouldBe 3000000
+                result.distributions shouldHaveSize 2
+                result.distributions[0].pocketName shouldBe "생활비"
+                result.distributions[0].amount shouldBe 2000000
+                result.distributions[1].pocketName shouldBe "저축"
+                result.distributions[1].amount shouldBe 1000000
+            }
+
+            Then("adds to pocket allocatedAmount") {
+                pocket1.allocatedAmount shouldBe 2500000 // 500000 + 2000000
+                pocket2.allocatedAmount shouldBe 2000000 // 1000000 + 1000000
+            }
+        }
+    }
+
+    Given("a user distributing with mismatched total") {
+        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+
+        When("distribute is called with wrong total") {
+            val request = DistributeRequest(
+                totalAmount = 3000000,
+                distributions = listOf(
+                    DistributionItem(pocketId = pocket1.id, amount = 1000000),
+                    DistributionItem(pocketId = pocket2.id, amount = 1000000)
+                )
+            )
+
+            Then("throws BusinessException") {
+                val ex = shouldThrow<BusinessException> {
+                    service.distribute(user1.id, request)
+                }
+                ex.code shouldBe "VALIDATION_ERROR"
+            }
+        }
+    }
+
+    // --- getActiveCouple error ---
+
+    Given("a user not in any active couple") {
+        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns null
+
+        When("getTransfers is called") {
+            Then("throws NotFoundException") {
+                shouldThrow<NotFoundException> {
+                    service.getTransfers(user1.id)
+                }
+            }
+        }
+    }
+})

--- a/backend/src/test/kotlin/com/budgetbook/transaction/service/TransactionServiceTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/transaction/service/TransactionServiceTest.kt
@@ -15,6 +15,7 @@ import com.budgetbook.couple.repository.CoupleRepository
 import com.budgetbook.paymentmethod.domain.PaymentMethod
 import com.budgetbook.paymentmethod.domain.PaymentMethodType
 import com.budgetbook.paymentmethod.repository.PaymentMethodRepository
+import com.budgetbook.pocket.repository.MoneyPocketRepository
 import com.budgetbook.transaction.domain.Transaction
 import com.budgetbook.sync.SyncEventPublisher
 import com.budgetbook.transaction.domain.TransactionType
@@ -44,8 +45,9 @@ class TransactionServiceTest : BehaviorSpec({
     val userRepository = mockk<UserRepository>()
     val categoryRepository = mockk<CategoryRepository>()
     val paymentMethodRepository = mockk<PaymentMethodRepository>()
+    val moneyPocketRepository = mockk<MoneyPocketRepository>()
     val syncEventPublisher = mockk<SyncEventPublisher>(relaxed = true)
-    val service = TransactionService(transactionRepository, coupleRepository, userRepository, categoryRepository, paymentMethodRepository, syncEventPublisher)
+    val service = TransactionService(transactionRepository, coupleRepository, userRepository, categoryRepository, paymentMethodRepository, moneyPocketRepository, syncEventPublisher)
 
     val user1 = User(email = "u1@test.com", nickname = "U1", provider = AuthProvider.GOOGLE, providerId = "g1")
     val user2 = User(email = "u2@test.com", nickname = "U2", provider = AuthProvider.KAKAO, providerId = "k2")

--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -62,6 +62,16 @@
   - [Create Recurring Transaction](#2-create-recurring-transaction)
   - [Update Recurring Transaction](#3-update-recurring-transaction)
   - [Delete Recurring Transaction](#4-delete-recurring-transaction)
+- [Money Pockets](#money-pockets)
+  - [List Pockets](#1-list-pockets)
+  - [Create Pocket](#2-create-pocket)
+  - [Update Pocket](#3-update-pocket)
+  - [Delete Pocket](#4-delete-pocket)
+  - [Pocket Summary](#5-pocket-summary)
+  - [Distribute Income](#6-distribute-income)
+- [Pocket Transfers](#pocket-transfers)
+  - [List Pocket Transfers](#1-list-pocket-transfers)
+  - [Create Pocket Transfer](#2-create-pocket-transfer)
 - [Infrastructure](#infrastructure)
   - [Health Check](#1-health-check)
   - [Actuator Health](#2-actuator-health)
@@ -2095,6 +2105,375 @@ All endpoints require the `Authorization: Bearer {accessToken}` header.
 | `totalExpense` | `long`   | Sum of all expense transactions      |
 | `balance`      | `long`   | `totalIncome - totalExpense`         |
 
+### PocketResponse
+
+| Field             | Type      | Nullable | Description                                              |
+|:------------------|:----------|:--------:|:---------------------------------------------------------|
+| `id`              | `UUID`    | No       | Pocket unique identifier                                 |
+| `name`            | `string`  | No       | Pocket display name                                      |
+| `type`            | `enum`    | No       | `LIVING`, `FIXED`, `CARD_PENDING`, `SAVINGS`, `CUSTOM`  |
+| `allocatedAmount` | `long`    | No       | Allocated budget in KRW                                  |
+| `balance`         | `long`    | No       | Computed balance: `allocatedAmount + transferIn - transferOut - expense` |
+| `icon`            | `string`  | Yes      | Material icon name                                       |
+| `color`           | `string`  | Yes      | Hex color code (e.g. `#FF5733`)                          |
+| `displayOrder`    | `integer` | No       | Sort order                                               |
+| `isActive`        | `boolean` | No       | Whether this pocket is active                            |
+
+### PocketSummaryResponse
+
+| Field              | Type              | Nullable | Description                                   |
+|:-------------------|:------------------|:--------:|:----------------------------------------------|
+| `pocket`           | `PocketResponse`  | No       | The pocket detail                             |
+| `totalIncome`      | `long`            | No       | Sum of INCOME transactions linked to pocket   |
+| `totalExpense`     | `long`            | No       | Sum of EXPENSE transactions linked to pocket  |
+| `totalTransferIn`  | `long`            | No       | Sum of incoming pocket transfers              |
+| `totalTransferOut` | `long`            | No       | Sum of outgoing pocket transfers              |
+| `balance`          | `long`            | No       | `allocatedAmount + transferIn - transferOut - expense` |
+
+### PocketSummary
+
+Abbreviated pocket reference used within transfer responses.
+
+| Field  | Type     | Nullable | Description          |
+|:-------|:---------|:--------:|:---------------------|
+| `id`   | `UUID`   | No       | Pocket unique identifier |
+| `name` | `string` | No       | Pocket display name  |
+
+### PocketTransferResponse
+
+| Field          | Type            | Nullable | Description                            |
+|:---------------|:----------------|:--------:|:---------------------------------------|
+| `id`           | `UUID`          | No       | Transfer unique identifier             |
+| `fromPocket`   | `PocketSummary` | No       | Source pocket (id and name)            |
+| `toPocket`     | `PocketSummary` | No       | Destination pocket (id and name)       |
+| `amount`       | `long`          | No       | Transfer amount in KRW (always > 0)    |
+| `description`  | `string`        | Yes      | Optional transfer note                 |
+| `transferDate` | `string`        | No       | ISO 8601 date: `YYYY-MM-DD`            |
+| `authorId`     | `UUID`          | No       | ID of user who created the transfer    |
+
+### DistributeResponse
+
+| Field                         | Type     | Nullable | Description                                    |
+|:------------------------------|:---------|:--------:|:-----------------------------------------------|
+| `distributions`               | `array`  | No       | List of pocket allocation entries              |
+| `distributions[].pocketId`   | `UUID`   | No       | Pocket unique identifier                       |
+| `distributions[].pocketName` | `string` | No       | Pocket display name                            |
+| `distributions[].amount`     | `long`   | No       | Amount allocated to this pocket                |
+| `totalDistributed`            | `long`   | No       | Sum of all distribution amounts                |
+
+---
+
+## Money Pockets
+
+Base path: `/api/v1/pockets`
+
+All endpoints require the `Authorization: Bearer {accessToken}` header.
+
+Money Pockets represent named budget envelopes for a couple (e.g., living expenses, fixed costs, savings). Each pocket tracks allocated amounts and actual spending via linked transactions and transfers.
+
+**Pocket types**: `LIVING` (생활비), `FIXED` (고정지출), `CARD_PENDING` (카드미결제), `SAVINGS` (저축), `CUSTOM` (직접입력)
+
+**Balance formula**: `allocatedAmount + totalTransferIn - totalTransferOut - totalExpense`
+where `totalExpense` is the sum of `EXPENSE` transactions linked to this pocket via `pocket_id`.
+
+---
+
+### 1. List Pockets
+
+Returns all active pockets for the authenticated couple with balance summary.
+
+| Item        | Value                     |
+|:------------|:--------------------------|
+| **Method**  | `GET`                     |
+| **Path**    | `/api/v1/pockets`         |
+| **Auth**    | Required                  |
+
+**Response `200 OK`**: `ApiResponse<List<PocketResponse>>`
+
+```json
+{
+  "success": true,
+  "data": [
+    {
+      "id": "550e8400-e29b-41d4-a716-446655440100",
+      "name": "생활비",
+      "type": "LIVING",
+      "allocatedAmount": 1000000,
+      "balance": 750000,
+      "icon": "home",
+      "color": "#4CAF50",
+      "displayOrder": 0,
+      "isActive": true
+    }
+  ],
+  "timestamp": "2026-03-12T10:00:00Z"
+}
+```
+
+---
+
+### 2. Create Pocket
+
+| Item        | Value                     |
+|:------------|:--------------------------|
+| **Method**  | `POST`                    |
+| **Path**    | `/api/v1/pockets`         |
+| **Auth**    | Required                  |
+
+**Request Body**
+
+| Field             | Type      | Required | Description                                              |
+|:------------------|:----------|:--------:|:---------------------------------------------------------|
+| `name`            | `string`  | Yes      | Pocket display name (max 50 chars)                       |
+| `type`            | `enum`    | Yes      | `LIVING`, `FIXED`, `CARD_PENDING`, `SAVINGS`, `CUSTOM`  |
+| `allocatedAmount` | `long`    | Yes      | Allocated budget amount in KRW (>= 0)                    |
+| `icon`            | `string`  | No       | Material icon name                                       |
+| `color`           | `string`  | No       | Hex color code (e.g. `#FF5733`)                          |
+
+**Response `201 Created`**: `ApiResponse<PocketResponse>`
+
+**Error Responses**
+
+| Status | Error Code          | Description                    |
+|:------:|:--------------------|:-------------------------------|
+| `400`  | `VALIDATION_ERROR`  | Missing required fields         |
+| `404`  | `COUPLE_NOT_FOUND`  | User is not in an active couple |
+
+---
+
+### 3. Update Pocket
+
+| Item        | Value                         |
+|:------------|:------------------------------|
+| **Method**  | `PUT`                         |
+| **Path**    | `/api/v1/pockets/{id}`        |
+| **Auth**    | Required                      |
+
+**Request Body** (all fields optional)
+
+| Field             | Type      | Description                                              |
+|:------------------|:----------|:---------------------------------------------------------|
+| `name`            | `string`  | Pocket display name (max 50 chars)                       |
+| `type`            | `enum`    | `LIVING`, `FIXED`, `CARD_PENDING`, `SAVINGS`, `CUSTOM`  |
+| `allocatedAmount` | `long`    | Allocated budget amount in KRW (>= 0)                    |
+| `icon`            | `string`  | Material icon name                                       |
+| `color`           | `string`  | Hex color code                                           |
+| `displayOrder`    | `integer` | Sort order                                               |
+
+**Response `200 OK`**: `ApiResponse<PocketResponse>`
+
+**Error Responses**
+
+| Status | Error Code          | Description                       |
+|:------:|:--------------------|:----------------------------------|
+| `404`  | `POCKET_NOT_FOUND`  | Requested pocket does not exist   |
+| `403`  | `FORBIDDEN`         | Pocket belongs to another couple  |
+
+---
+
+### 4. Delete Pocket
+
+Soft-deletes the pocket by setting `is_active = false`. The pocket's historical data is preserved.
+
+| Item        | Value                         |
+|:------------|:------------------------------|
+| **Method**  | `DELETE`                      |
+| **Path**    | `/api/v1/pockets/{id}`        |
+| **Auth**    | Required                      |
+
+**Response `204 No Content`**
+
+**Error Responses**
+
+| Status | Error Code          | Description                       |
+|:------:|:--------------------|:----------------------------------|
+| `404`  | `POCKET_NOT_FOUND`  | Requested pocket does not exist   |
+| `403`  | `FORBIDDEN`         | Pocket belongs to another couple  |
+
+---
+
+### 5. Pocket Summary
+
+Returns full balance breakdown for a single pocket.
+
+| Item        | Value                             |
+|:------------|:----------------------------------|
+| **Method**  | `GET`                             |
+| **Path**    | `/api/v1/pockets/{id}/summary`    |
+| **Auth**    | Required                          |
+
+**Response `200 OK`**: `ApiResponse<PocketSummaryResponse>`
+
+```json
+{
+  "success": true,
+  "data": {
+    "pocket": {
+      "id": "550e8400-e29b-41d4-a716-446655440100",
+      "name": "생활비",
+      "type": "LIVING",
+      "allocatedAmount": 1000000,
+      "balance": 750000,
+      "icon": "home",
+      "color": "#4CAF50",
+      "displayOrder": 0,
+      "isActive": true
+    },
+    "totalIncome": 0,
+    "totalExpense": 250000,
+    "totalTransferIn": 0,
+    "totalTransferOut": 0,
+    "balance": 750000
+  },
+  "timestamp": "2026-03-12T10:00:00Z"
+}
+```
+
+**Error Responses**
+
+| Status | Error Code          | Description                       |
+|:------:|:--------------------|:----------------------------------|
+| `404`  | `POCKET_NOT_FOUND`  | Requested pocket does not exist   |
+
+---
+
+### 6. Distribute Income
+
+Distributes a total income amount across multiple pockets by updating each pocket's `allocatedAmount`.
+
+| Item        | Value                             |
+|:------------|:----------------------------------|
+| **Method**  | `POST`                            |
+| **Path**    | `/api/v1/pockets/distribute`      |
+| **Auth**    | Required                          |
+
+**Request Body**
+
+| Field                       | Type    | Required | Description                                 |
+|:----------------------------|:--------|:--------:|:--------------------------------------------|
+| `totalAmount`               | `long`  | Yes      | Total income amount to distribute (> 0)     |
+| `distributions`             | `array` | Yes      | List of pocket allocation entries           |
+| `distributions[].pocketId`  | `UUID`  | Yes      | Target pocket ID                            |
+| `distributions[].amount`    | `long`  | Yes      | Amount to allocate to this pocket (> 0)     |
+
+**Response `200 OK`**: `ApiResponse<DistributeResponse>`
+
+```json
+{
+  "success": true,
+  "data": {
+    "distributions": [
+      {
+        "pocketId": "550e8400-e29b-41d4-a716-446655440100",
+        "pocketName": "생활비",
+        "amount": 600000
+      },
+      {
+        "pocketId": "550e8400-e29b-41d4-a716-446655440101",
+        "pocketName": "저축",
+        "amount": 400000
+      }
+    ],
+    "totalDistributed": 1000000
+  },
+  "timestamp": "2026-03-12T10:00:00Z"
+}
+```
+
+**Error Responses**
+
+| Status | Error Code          | Description                                              |
+|:------:|:--------------------|:---------------------------------------------------------|
+| `400`  | `VALIDATION_ERROR`  | Missing required fields or amounts not positive          |
+| `404`  | `POCKET_NOT_FOUND`  | One or more target pockets do not exist                  |
+
+---
+
+## Pocket Transfers
+
+Base path: `/api/v1/pocket-transfers`
+
+All endpoints require the `Authorization: Bearer {accessToken}` header.
+
+Records money moved between pockets (e.g., surplus from living expenses moved to savings).
+
+---
+
+### 1. List Pocket Transfers
+
+Returns pocket transfer history for the couple. Supports optional filtering.
+
+| Item        | Value                         |
+|:------------|:------------------------------|
+| **Method**  | `GET`                         |
+| **Path**    | `/api/v1/pocket-transfers`    |
+| **Auth**    | Required                      |
+
+**Query Parameters**
+
+| Parameter      | Type     | Required | Description                              |
+|:---------------|:---------|:--------:|:-----------------------------------------|
+| `fromPocketId` | `UUID`   | No       | Filter by source pocket                  |
+| `toPocketId`   | `UUID`   | No       | Filter by destination pocket             |
+| `startDate`    | `string` | No       | Start date inclusive (`YYYY-MM-DD`)      |
+| `endDate`      | `string` | No       | End date inclusive (`YYYY-MM-DD`)        |
+
+**Response `200 OK`**: `ApiResponse<List<PocketTransferResponse>>`
+
+```json
+{
+  "success": true,
+  "data": [
+    {
+      "id": "550e8400-e29b-41d4-a716-446655440200",
+      "fromPocket": {
+        "id": "550e8400-e29b-41d4-a716-446655440100",
+        "name": "생활비"
+      },
+      "toPocket": {
+        "id": "550e8400-e29b-41d4-a716-446655440101",
+        "name": "저축"
+      },
+      "amount": 100000,
+      "description": "이월 저축",
+      "transferDate": "2026-03-12",
+      "authorId": "550e8400-e29b-41d4-a716-446655440000"
+    }
+  ],
+  "timestamp": "2026-03-12T10:00:00Z"
+}
+```
+
+---
+
+### 2. Create Pocket Transfer
+
+| Item        | Value                         |
+|:------------|:------------------------------|
+| **Method**  | `POST`                        |
+| **Path**    | `/api/v1/pocket-transfers`    |
+| **Auth**    | Required                      |
+
+**Request Body**
+
+| Field          | Type     | Required | Description                            |
+|:---------------|:---------|:--------:|:---------------------------------------|
+| `fromPocketId` | `UUID`   | Yes      | Source pocket ID                       |
+| `toPocketId`   | `UUID`   | Yes      | Destination pocket ID                  |
+| `amount`       | `long`   | Yes      | Transfer amount in KRW (> 0)           |
+| `description`  | `string` | No       | Optional transfer note (max 255 chars) |
+| `transferDate` | `string` | Yes      | Transfer date (`YYYY-MM-DD`)           |
+
+**Response `201 Created`**: `ApiResponse<PocketTransferResponse>`
+
+**Error Responses**
+
+| Status | Error Code          | Description                                            |
+|:------:|:--------------------|:-------------------------------------------------------|
+| `400`  | `VALIDATION_ERROR`  | Missing required fields, amount <= 0, or same pocket   |
+| `404`  | `POCKET_NOT_FOUND`  | Source or destination pocket does not exist            |
+| `403`  | `FORBIDDEN`         | Pocket belongs to another couple                       |
+
 ---
 
 ## Infrastructure
@@ -2245,6 +2624,8 @@ All messages published to a couple topic share the following JSON structure:
 | `CATEGORY`       | `CATEGORY_CREATED`, `CATEGORY_UPDATED`, `CATEGORY_DELETED`                                        |
 | `CATEGORY_GROUP` | `CATEGORY_GROUP_CREATED`, `CATEGORY_GROUP_UPDATED`, `CATEGORY_GROUP_DELETED`                      |
 | `PAYMENT_METHOD` | `PAYMENT_METHOD_CREATED`, `PAYMENT_METHOD_UPDATED`, `PAYMENT_METHOD_DELETED`                      |
+| `POCKET`         | `POCKET_CREATED`, `POCKET_UPDATED`, `POCKET_DELETED`                                              |
+| `POCKET_TRANSFER`| `POCKET_TRANSFER_CREATED`, `POCKET_DISTRIBUTED`                                                   |
 
 Upon receiving an event, the frontend client should:
 1. Check `coupleId` matches the authenticated session's couple.
@@ -2319,3 +2700,5 @@ spring:
 | `PAYMENT_METHOD_NOT_FOUND`        | `404`       | Requested payment method does not exist              |
 | `CANNOT_DELETE_DEFAULT_PAYMENT_METHOD` | `400`  | Default payment methods cannot be deleted            |
 | `RECURRING_NOT_FOUND`             | `404`       | Requested recurring transaction does not exist       |
+| `POCKET_NOT_FOUND`                | `404`       | Requested money pocket does not exist                |
+| `POCKET_TRANSFER_NOT_FOUND`       | `404`       | Requested pocket transfer does not exist             |

--- a/docs/erd.md
+++ b/docs/erd.md
@@ -97,6 +97,7 @@ erDiagram
         UUID author_id FK "NOT NULL, FK -> users(id) ON DELETE RESTRICT"
         UUID category_id FK "Nullable, FK -> categories(id) ON DELETE SET NULL"
         UUID payment_method_id FK "Nullable, FK -> payment_methods(id) ON DELETE SET NULL"
+        UUID pocket_id FK "Nullable, FK -> money_pockets(id) ON DELETE SET NULL"
         VARCHAR(20) type "NOT NULL (INCOME, EXPENSE)"
         BIGINT amount "NOT NULL, > 0, in KRW"
         VARCHAR(255) description "NOT NULL"
@@ -154,6 +155,33 @@ erDiagram
         TIMESTAMP updated_at "NOT NULL"
     }
 
+    money_pockets {
+        UUID id PK "Primary Key, auto-generated"
+        UUID couple_id FK "NOT NULL, FK -> couples(id)"
+        VARCHAR(50) name "NOT NULL"
+        VARCHAR(20) type "NOT NULL (LIVING, FIXED, CARD_PENDING, SAVINGS, CUSTOM)"
+        BIGINT allocated_amount "NOT NULL, DEFAULT 0"
+        VARCHAR(50) icon "Nullable"
+        VARCHAR(7) color "Nullable, hex code"
+        INTEGER display_order "NOT NULL, DEFAULT 0"
+        BOOLEAN is_active "NOT NULL, DEFAULT TRUE"
+        TIMESTAMP created_at "NOT NULL"
+        TIMESTAMP updated_at "NOT NULL"
+    }
+
+    pocket_transfers {
+        UUID id PK "Primary Key, auto-generated"
+        UUID couple_id FK "NOT NULL, FK -> couples(id)"
+        UUID from_pocket_id FK "NOT NULL, FK -> money_pockets(id)"
+        UUID to_pocket_id FK "NOT NULL, FK -> money_pockets(id)"
+        BIGINT amount "NOT NULL, > 0"
+        VARCHAR(255) description "Nullable"
+        DATE transfer_date "NOT NULL"
+        UUID author_id FK "NOT NULL, FK -> users(id)"
+        TIMESTAMP created_at "NOT NULL"
+        TIMESTAMP updated_at "NOT NULL"
+    }
+
     users ||--o{ refresh_tokens : "has"
     users ||--o{ couple_invitations : "creates"
     users ||--o{ couples : "member of (user1)"
@@ -165,8 +193,11 @@ erDiagram
     couples ||--o{ weekly_budget_snapshots : "owns"
     couples ||--o{ payment_methods : "owns"
     couples ||--o{ recurring_transactions : "owns"
+    couples ||--o{ money_pockets : "owns"
+    couples ||--o{ pocket_transfers : "owns"
     users ||--o{ transactions : "authors"
     users ||--o{ recurring_transactions : "authors"
+    users ||--o{ pocket_transfers : "authors"
     category_groups ||--o{ categories : "groups"
     category_groups ||--o{ weekly_budget_snapshots : "tracks"
     categories ||--o{ transactions : "categorizes"
@@ -174,6 +205,9 @@ erDiagram
     categories ||--o{ recurring_transactions : "categorizes"
     payment_methods ||--o{ transactions : "used in"
     payment_methods ||--o{ recurring_transactions : "used in"
+    money_pockets ||--o{ transactions : "tracks"
+    money_pockets ||--o{ pocket_transfers : "source of"
+    money_pockets ||--o{ pocket_transfers : "destination of"
 ```
 
 ---
@@ -331,6 +365,7 @@ Individual income and expense records belonging to a couple.
 | `couple_id`        | `UUID`        | `FK NOT NULL`                       | References `couples(id)` ON DELETE CASCADE           |
 | `author_id`        | `UUID`        | `FK NOT NULL`                       | References `users(id)` ON DELETE RESTRICT            |
 | `category_id`      | `UUID`        | `FK NULLABLE`                       | References `categories(id)` ON DELETE SET NULL       |
+| `pocket_id`        | `UUID`        | `FK NULLABLE`                       | References `money_pockets(id)` ON DELETE SET NULL    |
 | `type`             | `VARCHAR(20)` | `NOT NULL`                          | `INCOME` or `EXPENSE`                                |
 | `amount`           | `BIGINT`      | `NOT NULL CHECK (amount > 0)`       | Amount in KRW (Korean Won, no decimals)              |
 | `description`      | `VARCHAR(255)`| `NOT NULL`                          | Short description                                    |
@@ -350,6 +385,9 @@ Individual income and expense records belonging to a couple.
 | `idx_transactions_couple_type`    | Index | `(couple_id, type)`              |
 | `idx_transactions_category_id`    | Index | `category_id`                    |
 | `idx_transactions_author_id`      | Index | `author_id`                      |
+| `idx_transactions_pocket`         | Index | `pocket_id`                      |
+
+**Note**: `transactions.pocket_id` (FK → `money_pockets(id) ON DELETE SET NULL`) added in V13.
 
 ### `category_groups` (V7)
 
@@ -505,6 +543,62 @@ Monthly budget targets per couple, optionally scoped to a category. A `null` `ca
 
 ---
 
+### `money_pockets` (V11)
+
+Named budget envelopes per couple. Each pocket has an allocated amount and tracks spending through linked transactions and transfers.
+
+| Column             | Type           | Constraints                           | Description                                              |
+|:-------------------|:---------------|:--------------------------------------|:---------------------------------------------------------|
+| `id`               | `UUID`         | `PK`                                 | Auto-generated primary key                               |
+| `couple_id`        | `UUID`         | `FK NOT NULL`                        | References `couples(id)`                                 |
+| `name`             | `VARCHAR(50)`  | `NOT NULL`                           | Pocket display name                                      |
+| `type`             | `VARCHAR(20)`  | `NOT NULL`                           | `LIVING`, `FIXED`, `CARD_PENDING`, `SAVINGS`, `CUSTOM`  |
+| `allocated_amount` | `BIGINT`       | `NOT NULL DEFAULT 0`                 | Allocated budget in KRW                                  |
+| `icon`             | `VARCHAR(50)`  | `NULLABLE`                           | Material icon name                                       |
+| `color`            | `VARCHAR(7)`   | `NULLABLE`                           | Hex color code (e.g. `#FF5733`)                          |
+| `display_order`    | `INTEGER`      | `NOT NULL DEFAULT 0`                 | Sort order                                               |
+| `is_active`        | `BOOLEAN`      | `NOT NULL DEFAULT TRUE`              | Soft-delete flag                                         |
+| `created_at`       | `TIMESTAMPTZ`  | `NOT NULL`                           | Creation timestamp                                       |
+| `updated_at`       | `TIMESTAMPTZ`  | `NOT NULL`                           | Last update timestamp                                    |
+
+**Check Constraints**: `type IN ('LIVING','FIXED','CARD_PENDING','SAVINGS','CUSTOM')`
+
+**Indexes**
+
+| Name                        | Type  | Columns    |
+|:----------------------------|:------|:-----------|
+| `idx_money_pockets_couple`  | Index | `couple_id`|
+
+---
+
+### `pocket_transfers` (V12)
+
+Records transfers of funds between pockets. Affects balance calculation for both source and destination pockets.
+
+| Column           | Type           | Constraints              | Description                                          |
+|:-----------------|:---------------|:-------------------------|:-----------------------------------------------------|
+| `id`             | `UUID`         | `PK`                    | Auto-generated primary key                           |
+| `couple_id`      | `UUID`         | `FK NOT NULL`           | References `couples(id)`                             |
+| `from_pocket_id` | `UUID`         | `FK NOT NULL`           | References `money_pockets(id)` — source pocket       |
+| `to_pocket_id`   | `UUID`         | `FK NOT NULL`           | References `money_pockets(id)` — destination pocket  |
+| `amount`         | `BIGINT`       | `NOT NULL CHECK (> 0)`  | Transfer amount in KRW                               |
+| `description`    | `VARCHAR(255)` | `NULLABLE`              | Optional transfer note                               |
+| `transfer_date`  | `DATE`         | `NOT NULL`              | Date the transfer was made                           |
+| `author_id`      | `UUID`         | `FK NOT NULL`           | References `users(id)` — user who made the transfer  |
+| `created_at`     | `TIMESTAMPTZ`  | `NOT NULL`              | Creation timestamp                                   |
+| `updated_at`     | `TIMESTAMPTZ`  | `NOT NULL`              | Last update timestamp                                |
+
+**Check Constraints**: `amount > 0`
+
+**Indexes**
+
+| Name                          | Type  | Columns         |
+|:------------------------------|:------|:----------------|
+| `idx_pocket_transfers_couple` | Index | `couple_id`     |
+| `idx_pocket_transfers_date`   | Index | `transfer_date` |
+
+---
+
 ## Relationships
 
 | From                      | To                          | Cardinality | Description                                                |
@@ -519,8 +613,11 @@ Monthly budget targets per couple, optionally scoped to a category. A `null` `ca
 | `couples`                 | `weekly_budget_snapshots`   | One-to-Many | A couple owns all their weekly snapshots                   |
 | `couples`                 | `payment_methods`           | One-to-Many | A couple owns all their payment methods                    |
 | `couples`                 | `recurring_transactions`    | One-to-Many | A couple owns all their recurring transaction rules        |
+| `couples`                 | `money_pockets`             | One-to-Many | A couple owns all their money pockets                      |
+| `couples`                 | `pocket_transfers`          | One-to-Many | A couple owns all their pocket transfers                   |
 | `users`                   | `transactions`              | One-to-Many | A user authors transactions on behalf of the couple        |
 | `users`                   | `recurring_transactions`    | One-to-Many | A user creates recurring transaction rules                 |
+| `users`                   | `pocket_transfers`          | One-to-Many | A user authors pocket transfers                            |
 | `category_groups`         | `categories`                | One-to-Many | A group contains multiple categories (nullable)            |
 | `category_groups`         | `weekly_budget_snapshots`   | One-to-Many | Weekly snapshots are scoped to a group (nullable)          |
 | `categories`              | `transactions`              | One-to-Many | Transactions are categorized (category_id can be null)     |
@@ -528,6 +625,9 @@ Monthly budget targets per couple, optionally scoped to a category. A `null` `ca
 | `categories`              | `recurring_transactions`    | One-to-Many | Recurring rules are optionally categorized                 |
 | `payment_methods`         | `transactions`              | One-to-Many | Transactions may reference a payment method (nullable)     |
 | `payment_methods`         | `recurring_transactions`    | One-to-Many | Recurring rules may reference a payment method (nullable)  |
+| `money_pockets`           | `transactions`              | One-to-Many | Transactions may be linked to a pocket (pocket_id nullable)|
+| `money_pockets`           | `pocket_transfers`          | One-to-Many | A pocket can be the source of transfers                    |
+| `money_pockets`           | `pocket_transfers`          | One-to-Many | A pocket can be the destination of transfers               |
 
 ---
 
@@ -545,3 +645,6 @@ Monthly budget targets per couple, optionally scoped to a category. A `null` `ca
 | V8      | `V8__create_payment_methods_table.sql`           | Payment methods + `transactions.payment_method_id` column|
 | V9      | `V9__create_weekly_budget_snapshots_table.sql`   | Weekly budget snapshots + `monthly_budgets` period fields|
 | V10     | `V10__create_recurring_transactions_table.sql`   | Recurring transaction rules with scheduler support       |
+| V11     | `V11__create_money_pockets_table.sql`            | Money pockets (budget envelopes) per couple              |
+| V12     | `V12__create_pocket_transfers_table.sql`         | Pocket transfers between money pockets                   |
+| V13     | `V13__add_pocket_id_to_transactions.sql`         | `transactions.pocket_id` FK to money pockets             |

--- a/frontend/lib/core/constants/api_endpoints.dart
+++ b/frontend/lib/core/constants/api_endpoints.dart
@@ -50,4 +50,11 @@ class ApiEndpoints {
   // Recurring Transactions
   static const String recurringTransactions = '/api/v1/recurring-transactions';
 
+  // Money Pockets
+  static const String pockets = '/api/v1/pockets';
+  static const String pocketsDistribute = '/api/v1/pockets/distribute';
+
+  // Pocket Transfers
+  static const String pocketTransfers = '/api/v1/pocket-transfers';
+
 }

--- a/frontend/lib/core/di/injection.dart
+++ b/frontend/lib/core/di/injection.dart
@@ -45,6 +45,14 @@ import 'package:budget_book/features/recurring/data/datasources/recurring_remote
 import 'package:budget_book/features/recurring/data/repositories/recurring_repository_impl.dart';
 import 'package:budget_book/features/recurring/domain/repositories/recurring_repository.dart';
 import 'package:budget_book/features/recurring/presentation/bloc/recurring_bloc.dart';
+import 'package:budget_book/features/pocket/data/datasources/pocket_remote_datasource.dart';
+import 'package:budget_book/features/pocket/data/repositories/pocket_repository_impl.dart';
+import 'package:budget_book/features/pocket/domain/repositories/pocket_repository.dart';
+import 'package:budget_book/features/pocket/presentation/bloc/pocket_bloc.dart';
+import 'package:budget_book/features/pocket/data/datasources/pocket_transfer_remote_datasource.dart';
+import 'package:budget_book/features/pocket/data/repositories/pocket_transfer_repository_impl.dart';
+import 'package:budget_book/features/pocket/domain/repositories/pocket_transfer_repository.dart';
+import 'package:budget_book/features/pocket/presentation/bloc/pocket_transfer_bloc.dart';
 import 'package:budget_book/features/home/presentation/bloc/dashboard_bloc.dart';
 import 'package:budget_book/core/websocket/websocket_service.dart';
 import 'package:budget_book/core/websocket/sync_event_handler.dart';
@@ -204,6 +212,33 @@ Future<void> configureDependencies() async {
   );
   getIt.registerFactory<RecurringBloc>(
     () => RecurringBloc(recurringRepository: getIt<RecurringRepository>()),
+  );
+
+  // Money Pocket feature
+  getIt.registerLazySingleton<PocketRemoteDataSource>(
+    () => PocketRemoteDataSourceImpl(apiClient: getIt<ApiClient>()),
+  );
+  getIt.registerLazySingleton<PocketRepository>(
+    () => PocketRepositoryImpl(
+        remoteDataSource: getIt<PocketRemoteDataSource>()),
+  );
+  getIt.registerLazySingleton<PocketBloc>(
+    () => PocketBloc(pocketRepository: getIt<PocketRepository>()),
+    dispose: (bloc) => bloc.close(),
+  );
+
+  // Pocket Transfer feature
+  getIt.registerLazySingleton<PocketTransferRemoteDataSource>(
+    () => PocketTransferRemoteDataSourceImpl(apiClient: getIt<ApiClient>()),
+  );
+  getIt.registerLazySingleton<PocketTransferRepository>(
+    () => PocketTransferRepositoryImpl(
+        remoteDataSource: getIt<PocketTransferRemoteDataSource>()),
+  );
+  getIt.registerLazySingleton<PocketTransferBloc>(
+    () => PocketTransferBloc(
+        pocketTransferRepository: getIt<PocketTransferRepository>()),
+    dispose: (bloc) => bloc.close(),
   );
 
   // WebSocket / Real-time sync

--- a/frontend/lib/core/router/app_router.dart
+++ b/frontend/lib/core/router/app_router.dart
@@ -44,6 +44,13 @@ import 'package:budget_book/features/home/presentation/bloc/dashboard_bloc.dart'
 import 'package:budget_book/features/home/presentation/bloc/dashboard_event.dart';
 import 'package:budget_book/features/home/presentation/pages/dashboard_page.dart';
 import 'package:budget_book/features/settings/presentation/pages/settings_page.dart';
+import 'package:budget_book/features/pocket/presentation/bloc/pocket_bloc.dart';
+import 'package:budget_book/features/pocket/presentation/bloc/pocket_event.dart';
+import 'package:budget_book/features/pocket/presentation/bloc/pocket_transfer_bloc.dart';
+import 'package:budget_book/features/pocket/presentation/bloc/pocket_transfer_event.dart';
+import 'package:budget_book/features/pocket/presentation/pages/pocket_page.dart';
+import 'package:budget_book/features/pocket/presentation/pages/distribute_wizard_page.dart';
+import 'package:budget_book/features/pocket/presentation/pages/pocket_transfer_page.dart';
 import 'package:budget_book/core/websocket/websocket_bloc.dart';
 
 final _rootNavigatorKey = GlobalKey<NavigatorState>();
@@ -213,6 +220,9 @@ final appRouter = GoRouter(
             create: (_) =>
                 getIt<PaymentMethodBloc>()..add(const LoadPaymentMethods()),
           ),
+          BlocProvider<PocketBloc>.value(
+            value: getIt<PocketBloc>()..add(const LoadPockets()),
+          ),
         ],
         child: const TransactionFormPage(),
       ),
@@ -234,6 +244,9 @@ final appRouter = GoRouter(
             BlocProvider<PaymentMethodBloc>(
               create: (_) =>
                   getIt<PaymentMethodBloc>()..add(const LoadPaymentMethods()),
+            ),
+            BlocProvider<PocketBloc>.value(
+              value: getIt<PocketBloc>()..add(const LoadPockets()),
             ),
           ],
           child: TransactionFormPage(
@@ -398,6 +411,39 @@ final appRouter = GoRouter(
           child: RecurringFormPage(recurringId: recurringId),
         );
       },
+    ),
+    // Money Pockets
+    GoRoute(
+      path: '/pockets',
+      parentNavigatorKey: _rootNavigatorKey,
+      builder: (context, state) => BlocProvider<PocketBloc>.value(
+        value: getIt<PocketBloc>()..add(const LoadPockets()),
+        child: const PocketPage(),
+      ),
+    ),
+    GoRoute(
+      path: '/pockets/distribute',
+      parentNavigatorKey: _rootNavigatorKey,
+      builder: (context, state) => BlocProvider<PocketBloc>.value(
+        value: getIt<PocketBloc>()..add(const LoadPockets()),
+        child: const DistributeWizardPage(),
+      ),
+    ),
+    GoRoute(
+      path: '/pocket-transfers',
+      parentNavigatorKey: _rootNavigatorKey,
+      builder: (context, state) => MultiBlocProvider(
+        providers: [
+          BlocProvider<PocketBloc>.value(
+            value: getIt<PocketBloc>()..add(const LoadPockets()),
+          ),
+          BlocProvider<PocketTransferBloc>.value(
+            value: getIt<PocketTransferBloc>()
+              ..add(const LoadPocketTransfers()),
+          ),
+        ],
+        child: const PocketTransferPage(),
+      ),
     ),
   ],
 );

--- a/frontend/lib/core/websocket/sync_event_handler.dart
+++ b/frontend/lib/core/websocket/sync_event_handler.dart
@@ -11,6 +11,8 @@ import 'package:budget_book/features/payment_method/presentation/bloc/payment_me
 import 'package:budget_book/features/payment_method/presentation/bloc/payment_method_event.dart';
 import 'package:budget_book/features/category_group/presentation/bloc/category_group_bloc.dart';
 import 'package:budget_book/features/category_group/presentation/bloc/category_group_event.dart';
+import 'package:budget_book/features/pocket/presentation/bloc/pocket_bloc.dart';
+import 'package:budget_book/features/pocket/presentation/bloc/pocket_event.dart';
 
 import 'sync_event.dart';
 
@@ -49,6 +51,9 @@ class SyncEventHandler {
         _refreshPaymentMethods();
       case 'CATEGORY_GROUP':
         _refreshCategoryGroups();
+      case 'POCKET':
+      case 'POCKET_TRANSFER':
+        _refreshPockets();
       default:
         _logger.w('Unknown entity type: ${event.entityType}');
     }
@@ -103,6 +108,16 @@ class SyncEventHandler {
       _logger.d('Dispatched LoadCategoryGroups refresh');
     } catch (e) {
       _logger.e('Failed to refresh category groups: $e');
+    }
+  }
+
+  void _refreshPockets() {
+    try {
+      final bloc = _getIt<PocketBloc>();
+      bloc.add(const LoadPockets());
+      _logger.d('Dispatched LoadPockets refresh');
+    } catch (e) {
+      _logger.e('Failed to refresh pockets: $e');
     }
   }
 }

--- a/frontend/lib/features/pocket/data/datasources/pocket_remote_datasource.dart
+++ b/frontend/lib/features/pocket/data/datasources/pocket_remote_datasource.dart
@@ -1,0 +1,67 @@
+import 'package:budget_book/core/network/api_client.dart';
+import 'package:budget_book/core/constants/api_endpoints.dart';
+import 'package:budget_book/features/pocket/data/models/pocket_model.dart';
+import 'package:budget_book/features/pocket/data/models/distribute_result_model.dart';
+
+abstract class PocketRemoteDataSource {
+  Future<List<PocketModel>> getPockets();
+  Future<PocketModel> createPocket(Map<String, dynamic> data);
+  Future<PocketModel> updatePocket(String id, Map<String, dynamic> data);
+  Future<void> deletePocket(String id);
+  Future<DistributeResultModel> distributeIncome(Map<String, dynamic> data);
+}
+
+class PocketRemoteDataSourceImpl implements PocketRemoteDataSource {
+  final ApiClient apiClient;
+
+  PocketRemoteDataSourceImpl({required this.apiClient});
+
+  @override
+  Future<List<PocketModel>> getPockets() async {
+    final response = await apiClient.dio.get(ApiEndpoints.pockets);
+    final list = response.data['data'] as List<dynamic>;
+    return list
+        .map((e) => PocketModel.fromJson(e as Map<String, dynamic>))
+        .toList();
+  }
+
+  @override
+  Future<PocketModel> createPocket(Map<String, dynamic> data) async {
+    final response = await apiClient.dio.post(
+      ApiEndpoints.pockets,
+      data: data,
+    );
+    return PocketModel.fromJson(
+      response.data['data'] as Map<String, dynamic>,
+    );
+  }
+
+  @override
+  Future<PocketModel> updatePocket(
+      String id, Map<String, dynamic> data) async {
+    final response = await apiClient.dio.put(
+      '${ApiEndpoints.pockets}/$id',
+      data: data,
+    );
+    return PocketModel.fromJson(
+      response.data['data'] as Map<String, dynamic>,
+    );
+  }
+
+  @override
+  Future<void> deletePocket(String id) async {
+    await apiClient.dio.delete('${ApiEndpoints.pockets}/$id');
+  }
+
+  @override
+  Future<DistributeResultModel> distributeIncome(
+      Map<String, dynamic> data) async {
+    final response = await apiClient.dio.post(
+      ApiEndpoints.pocketsDistribute,
+      data: data,
+    );
+    return DistributeResultModel.fromJson(
+      response.data['data'] as Map<String, dynamic>,
+    );
+  }
+}

--- a/frontend/lib/features/pocket/data/datasources/pocket_transfer_remote_datasource.dart
+++ b/frontend/lib/features/pocket/data/datasources/pocket_transfer_remote_datasource.dart
@@ -1,0 +1,57 @@
+import 'package:budget_book/core/network/api_client.dart';
+import 'package:budget_book/core/constants/api_endpoints.dart';
+import 'package:budget_book/features/pocket/data/models/pocket_transfer_model.dart';
+
+abstract class PocketTransferRemoteDataSource {
+  Future<List<PocketTransferModel>> getPocketTransfers({
+    String? fromPocketId,
+    String? toPocketId,
+    String? startDate,
+    String? endDate,
+  });
+  Future<PocketTransferModel> createPocketTransfer(
+      Map<String, dynamic> data);
+}
+
+class PocketTransferRemoteDataSourceImpl
+    implements PocketTransferRemoteDataSource {
+  final ApiClient apiClient;
+
+  PocketTransferRemoteDataSourceImpl({required this.apiClient});
+
+  @override
+  Future<List<PocketTransferModel>> getPocketTransfers({
+    String? fromPocketId,
+    String? toPocketId,
+    String? startDate,
+    String? endDate,
+  }) async {
+    final queryParams = <String, dynamic>{};
+    if (fromPocketId != null) queryParams['fromPocketId'] = fromPocketId;
+    if (toPocketId != null) queryParams['toPocketId'] = toPocketId;
+    if (startDate != null) queryParams['startDate'] = startDate;
+    if (endDate != null) queryParams['endDate'] = endDate;
+
+    final response = await apiClient.dio.get(
+      ApiEndpoints.pocketTransfers,
+      queryParameters: queryParams.isNotEmpty ? queryParams : null,
+    );
+    final list = response.data['data'] as List<dynamic>;
+    return list
+        .map((e) =>
+            PocketTransferModel.fromJson(e as Map<String, dynamic>))
+        .toList();
+  }
+
+  @override
+  Future<PocketTransferModel> createPocketTransfer(
+      Map<String, dynamic> data) async {
+    final response = await apiClient.dio.post(
+      ApiEndpoints.pocketTransfers,
+      data: data,
+    );
+    return PocketTransferModel.fromJson(
+      response.data['data'] as Map<String, dynamic>,
+    );
+  }
+}

--- a/frontend/lib/features/pocket/data/models/distribute_result_model.dart
+++ b/frontend/lib/features/pocket/data/models/distribute_result_model.dart
@@ -1,0 +1,34 @@
+import 'package:budget_book/features/pocket/domain/entities/distribute_result.dart';
+
+class DistributeResultModel extends DistributeResult {
+  const DistributeResultModel({
+    required super.distributions,
+    required super.totalDistributed,
+  });
+
+  factory DistributeResultModel.fromJson(Map<String, dynamic> json) {
+    final entries = (json['distributions'] as List<dynamic>)
+        .map((e) => DistributionEntryModel.fromJson(e as Map<String, dynamic>))
+        .toList();
+    return DistributeResultModel(
+      distributions: entries,
+      totalDistributed: json['totalDistributed'] as int,
+    );
+  }
+}
+
+class DistributionEntryModel extends DistributionEntry {
+  const DistributionEntryModel({
+    required super.pocketId,
+    required super.pocketName,
+    required super.amount,
+  });
+
+  factory DistributionEntryModel.fromJson(Map<String, dynamic> json) {
+    return DistributionEntryModel(
+      pocketId: json['pocketId'] as String,
+      pocketName: json['pocketName'] as String,
+      amount: json['amount'] as int,
+    );
+  }
+}

--- a/frontend/lib/features/pocket/data/models/pocket_model.dart
+++ b/frontend/lib/features/pocket/data/models/pocket_model.dart
@@ -1,0 +1,29 @@
+import 'package:budget_book/features/pocket/domain/entities/money_pocket.dart';
+
+class PocketModel extends MoneyPocket {
+  const PocketModel({
+    required super.id,
+    required super.name,
+    required super.type,
+    required super.allocatedAmount,
+    required super.balance,
+    super.icon,
+    super.color,
+    required super.displayOrder,
+    required super.isActive,
+  });
+
+  factory PocketModel.fromJson(Map<String, dynamic> json) {
+    return PocketModel(
+      id: json['id'] as String,
+      name: json['name'] as String,
+      type: json['type'] as String,
+      allocatedAmount: json['allocatedAmount'] as int,
+      balance: json['balance'] as int,
+      icon: json['icon'] as String?,
+      color: json['color'] as String?,
+      displayOrder: json['displayOrder'] as int? ?? 0,
+      isActive: json['isActive'] as bool? ?? true,
+    );
+  }
+}

--- a/frontend/lib/features/pocket/data/models/pocket_transfer_model.dart
+++ b/frontend/lib/features/pocket/data/models/pocket_transfer_model.dart
@@ -1,0 +1,38 @@
+import 'package:budget_book/features/pocket/domain/entities/pocket_transfer.dart';
+
+class PocketTransferModel extends PocketTransfer {
+  const PocketTransferModel({
+    required super.id,
+    required super.fromPocket,
+    required super.toPocket,
+    required super.amount,
+    super.description,
+    required super.transferDate,
+    required super.authorId,
+  });
+
+  factory PocketTransferModel.fromJson(Map<String, dynamic> json) {
+    return PocketTransferModel(
+      id: json['id'] as String,
+      fromPocket: PocketRefModel.fromJson(
+          json['fromPocket'] as Map<String, dynamic>),
+      toPocket: PocketRefModel.fromJson(
+          json['toPocket'] as Map<String, dynamic>),
+      amount: json['amount'] as int,
+      description: json['description'] as String?,
+      transferDate: json['transferDate'] as String,
+      authorId: json['authorId'] as String,
+    );
+  }
+}
+
+class PocketRefModel extends PocketRef {
+  const PocketRefModel({required super.id, required super.name});
+
+  factory PocketRefModel.fromJson(Map<String, dynamic> json) {
+    return PocketRefModel(
+      id: json['id'] as String,
+      name: json['name'] as String,
+    );
+  }
+}

--- a/frontend/lib/features/pocket/data/repositories/pocket_repository_impl.dart
+++ b/frontend/lib/features/pocket/data/repositories/pocket_repository_impl.dart
@@ -1,0 +1,108 @@
+import 'package:dartz/dartz.dart';
+import 'package:dio/dio.dart';
+import 'package:budget_book/core/error/failure.dart';
+import 'package:budget_book/features/pocket/data/datasources/pocket_remote_datasource.dart';
+import 'package:budget_book/features/pocket/domain/entities/money_pocket.dart';
+import 'package:budget_book/features/pocket/domain/entities/distribute_result.dart';
+import 'package:budget_book/features/pocket/domain/repositories/pocket_repository.dart';
+
+class PocketRepositoryImpl implements PocketRepository {
+  final PocketRemoteDataSource remoteDataSource;
+
+  PocketRepositoryImpl({required this.remoteDataSource});
+
+  @override
+  Future<Either<Failure, List<MoneyPocket>>> getPockets() async {
+    try {
+      final result = await remoteDataSource.getPockets();
+      return Right(result);
+    } on DioException catch (e) {
+      return Left(_mapDioError(e, 'Failed to load pockets'));
+    }
+  }
+
+  @override
+  Future<Either<Failure, MoneyPocket>> createPocket({
+    required String name,
+    required String type,
+    required int allocatedAmount,
+    String? icon,
+    String? color,
+  }) async {
+    try {
+      final data = <String, dynamic>{
+        'name': name,
+        'type': type,
+        'allocatedAmount': allocatedAmount,
+        if (icon != null) 'icon': icon,
+        if (color != null) 'color': color,
+      };
+      final result = await remoteDataSource.createPocket(data);
+      return Right(result);
+    } on DioException catch (e) {
+      return Left(_mapDioError(e, 'Failed to create pocket'));
+    }
+  }
+
+  @override
+  Future<Either<Failure, MoneyPocket>> updatePocket({
+    required String id,
+    String? name,
+    String? type,
+    int? allocatedAmount,
+    String? icon,
+    String? color,
+    int? displayOrder,
+  }) async {
+    try {
+      final data = <String, dynamic>{
+        if (name != null) 'name': name,
+        if (type != null) 'type': type,
+        if (allocatedAmount != null) 'allocatedAmount': allocatedAmount,
+        if (icon != null) 'icon': icon,
+        if (color != null) 'color': color,
+        if (displayOrder != null) 'displayOrder': displayOrder,
+      };
+      final result = await remoteDataSource.updatePocket(id, data);
+      return Right(result);
+    } on DioException catch (e) {
+      return Left(_mapDioError(e, 'Failed to update pocket'));
+    }
+  }
+
+  @override
+  Future<Either<Failure, void>> deletePocket(String id) async {
+    try {
+      await remoteDataSource.deletePocket(id);
+      return const Right(null);
+    } on DioException catch (e) {
+      return Left(_mapDioError(e, 'Failed to delete pocket'));
+    }
+  }
+
+  @override
+  Future<Either<Failure, DistributeResult>> distributeIncome({
+    required int totalAmount,
+    required List<Map<String, dynamic>> distributions,
+  }) async {
+    try {
+      final data = <String, dynamic>{
+        'totalAmount': totalAmount,
+        'distributions': distributions,
+      };
+      final result = await remoteDataSource.distributeIncome(data);
+      return Right(result);
+    } on DioException catch (e) {
+      return Left(_mapDioError(e, 'Failed to distribute income'));
+    }
+  }
+
+  Failure _mapDioError(DioException e, String defaultMessage) {
+    final errorData = e.response?.data?['error'];
+    return ServerFailure(
+      errorData?['message'] as String? ?? defaultMessage,
+      errorData?['code'] as String?,
+      e.response?.statusCode,
+    );
+  }
+}

--- a/frontend/lib/features/pocket/data/repositories/pocket_transfer_repository_impl.dart
+++ b/frontend/lib/features/pocket/data/repositories/pocket_transfer_repository_impl.dart
@@ -1,0 +1,64 @@
+import 'package:dartz/dartz.dart';
+import 'package:dio/dio.dart';
+import 'package:budget_book/core/error/failure.dart';
+import 'package:budget_book/features/pocket/data/datasources/pocket_transfer_remote_datasource.dart';
+import 'package:budget_book/features/pocket/domain/entities/pocket_transfer.dart';
+import 'package:budget_book/features/pocket/domain/repositories/pocket_transfer_repository.dart';
+
+class PocketTransferRepositoryImpl implements PocketTransferRepository {
+  final PocketTransferRemoteDataSource remoteDataSource;
+
+  PocketTransferRepositoryImpl({required this.remoteDataSource});
+
+  @override
+  Future<Either<Failure, List<PocketTransfer>>> getPocketTransfers({
+    String? fromPocketId,
+    String? toPocketId,
+    String? startDate,
+    String? endDate,
+  }) async {
+    try {
+      final result = await remoteDataSource.getPocketTransfers(
+        fromPocketId: fromPocketId,
+        toPocketId: toPocketId,
+        startDate: startDate,
+        endDate: endDate,
+      );
+      return Right(result);
+    } on DioException catch (e) {
+      return Left(_mapDioError(e, 'Failed to load pocket transfers'));
+    }
+  }
+
+  @override
+  Future<Either<Failure, PocketTransfer>> createPocketTransfer({
+    required String fromPocketId,
+    required String toPocketId,
+    required int amount,
+    String? description,
+    required String transferDate,
+  }) async {
+    try {
+      final data = <String, dynamic>{
+        'fromPocketId': fromPocketId,
+        'toPocketId': toPocketId,
+        'amount': amount,
+        'transferDate': transferDate,
+        if (description != null) 'description': description,
+      };
+      final result = await remoteDataSource.createPocketTransfer(data);
+      return Right(result);
+    } on DioException catch (e) {
+      return Left(_mapDioError(e, 'Failed to create pocket transfer'));
+    }
+  }
+
+  Failure _mapDioError(DioException e, String defaultMessage) {
+    final errorData = e.response?.data?['error'];
+    return ServerFailure(
+      errorData?['message'] as String? ?? defaultMessage,
+      errorData?['code'] as String?,
+      e.response?.statusCode,
+    );
+  }
+}

--- a/frontend/lib/features/pocket/domain/entities/distribute_result.dart
+++ b/frontend/lib/features/pocket/domain/entities/distribute_result.dart
@@ -1,0 +1,29 @@
+import 'package:equatable/equatable.dart';
+
+class DistributeResult extends Equatable {
+  final List<DistributionEntry> distributions;
+  final int totalDistributed;
+
+  const DistributeResult({
+    required this.distributions,
+    required this.totalDistributed,
+  });
+
+  @override
+  List<Object?> get props => [distributions, totalDistributed];
+}
+
+class DistributionEntry extends Equatable {
+  final String pocketId;
+  final String pocketName;
+  final int amount;
+
+  const DistributionEntry({
+    required this.pocketId,
+    required this.pocketName,
+    required this.amount,
+  });
+
+  @override
+  List<Object?> get props => [pocketId, pocketName, amount];
+}

--- a/frontend/lib/features/pocket/domain/entities/money_pocket.dart
+++ b/frontend/lib/features/pocket/domain/entities/money_pocket.dart
@@ -1,0 +1,44 @@
+import 'package:equatable/equatable.dart';
+
+class MoneyPocket extends Equatable {
+  final String id;
+  final String name;
+  final String type;
+  final int allocatedAmount;
+  final int balance;
+  final String? icon;
+  final String? color;
+  final int displayOrder;
+  final bool isActive;
+
+  const MoneyPocket({
+    required this.id,
+    required this.name,
+    required this.type,
+    required this.allocatedAmount,
+    required this.balance,
+    this.icon,
+    this.color,
+    required this.displayOrder,
+    required this.isActive,
+  });
+
+  bool get isLiving => type == 'LIVING';
+  bool get isFixed => type == 'FIXED';
+  bool get isCardPending => type == 'CARD_PENDING';
+  bool get isSavings => type == 'SAVINGS';
+  bool get isCustom => type == 'CUSTOM';
+
+  @override
+  List<Object?> get props => [
+        id,
+        name,
+        type,
+        allocatedAmount,
+        balance,
+        icon,
+        color,
+        displayOrder,
+        isActive,
+      ];
+}

--- a/frontend/lib/features/pocket/domain/entities/pocket_summary.dart
+++ b/frontend/lib/features/pocket/domain/entities/pocket_summary.dart
@@ -1,0 +1,30 @@
+import 'package:equatable/equatable.dart';
+import 'money_pocket.dart';
+
+class PocketSummary extends Equatable {
+  final MoneyPocket pocket;
+  final int totalIncome;
+  final int totalExpense;
+  final int totalTransferIn;
+  final int totalTransferOut;
+  final int balance;
+
+  const PocketSummary({
+    required this.pocket,
+    required this.totalIncome,
+    required this.totalExpense,
+    required this.totalTransferIn,
+    required this.totalTransferOut,
+    required this.balance,
+  });
+
+  @override
+  List<Object?> get props => [
+        pocket,
+        totalIncome,
+        totalExpense,
+        totalTransferIn,
+        totalTransferOut,
+        balance,
+      ];
+}

--- a/frontend/lib/features/pocket/domain/entities/pocket_transfer.dart
+++ b/frontend/lib/features/pocket/domain/entities/pocket_transfer.dart
@@ -1,0 +1,42 @@
+import 'package:equatable/equatable.dart';
+
+class PocketTransfer extends Equatable {
+  final String id;
+  final PocketRef fromPocket;
+  final PocketRef toPocket;
+  final int amount;
+  final String? description;
+  final String transferDate;
+  final String authorId;
+
+  const PocketTransfer({
+    required this.id,
+    required this.fromPocket,
+    required this.toPocket,
+    required this.amount,
+    this.description,
+    required this.transferDate,
+    required this.authorId,
+  });
+
+  @override
+  List<Object?> get props => [
+        id,
+        fromPocket,
+        toPocket,
+        amount,
+        description,
+        transferDate,
+        authorId,
+      ];
+}
+
+class PocketRef extends Equatable {
+  final String id;
+  final String name;
+
+  const PocketRef({required this.id, required this.name});
+
+  @override
+  List<Object?> get props => [id, name];
+}

--- a/frontend/lib/features/pocket/domain/repositories/pocket_repository.dart
+++ b/frontend/lib/features/pocket/domain/repositories/pocket_repository.dart
@@ -1,0 +1,29 @@
+import 'package:dartz/dartz.dart';
+import 'package:budget_book/core/error/failure.dart';
+import 'package:budget_book/features/pocket/domain/entities/money_pocket.dart';
+import 'package:budget_book/features/pocket/domain/entities/distribute_result.dart';
+
+abstract class PocketRepository {
+  Future<Either<Failure, List<MoneyPocket>>> getPockets();
+  Future<Either<Failure, MoneyPocket>> createPocket({
+    required String name,
+    required String type,
+    required int allocatedAmount,
+    String? icon,
+    String? color,
+  });
+  Future<Either<Failure, MoneyPocket>> updatePocket({
+    required String id,
+    String? name,
+    String? type,
+    int? allocatedAmount,
+    String? icon,
+    String? color,
+    int? displayOrder,
+  });
+  Future<Either<Failure, void>> deletePocket(String id);
+  Future<Either<Failure, DistributeResult>> distributeIncome({
+    required int totalAmount,
+    required List<Map<String, dynamic>> distributions,
+  });
+}

--- a/frontend/lib/features/pocket/domain/repositories/pocket_transfer_repository.dart
+++ b/frontend/lib/features/pocket/domain/repositories/pocket_transfer_repository.dart
@@ -1,0 +1,19 @@
+import 'package:dartz/dartz.dart';
+import 'package:budget_book/core/error/failure.dart';
+import 'package:budget_book/features/pocket/domain/entities/pocket_transfer.dart';
+
+abstract class PocketTransferRepository {
+  Future<Either<Failure, List<PocketTransfer>>> getPocketTransfers({
+    String? fromPocketId,
+    String? toPocketId,
+    String? startDate,
+    String? endDate,
+  });
+  Future<Either<Failure, PocketTransfer>> createPocketTransfer({
+    required String fromPocketId,
+    required String toPocketId,
+    required int amount,
+    String? description,
+    required String transferDate,
+  });
+}

--- a/frontend/lib/features/pocket/presentation/bloc/pocket_bloc.dart
+++ b/frontend/lib/features/pocket/presentation/bloc/pocket_bloc.dart
@@ -1,0 +1,131 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:budget_book/features/pocket/domain/entities/money_pocket.dart';
+import 'package:budget_book/features/pocket/domain/repositories/pocket_repository.dart';
+import 'pocket_event.dart';
+import 'pocket_state.dart';
+
+class PocketBloc extends Bloc<PocketEvent, PocketState> {
+  final PocketRepository pocketRepository;
+
+  PocketBloc({required this.pocketRepository})
+      : super(const PocketInitial()) {
+    on<LoadPockets>(_onLoadPockets);
+    on<CreatePocket>(_onCreatePocket);
+    on<UpdatePocket>(_onUpdatePocket);
+    on<DeletePocket>(_onDeletePocket);
+    on<DistributeIncome>(_onDistributeIncome);
+  }
+
+  Future<void> _onLoadPockets(
+    LoadPockets event,
+    Emitter<PocketState> emit,
+  ) async {
+    emit(const PocketLoading());
+    final result = await pocketRepository.getPockets();
+    result.fold(
+      (failure) => emit(PocketError(failure.message)),
+      (pockets) => emit(PocketLoaded(pockets)),
+    );
+  }
+
+  Future<void> _onCreatePocket(
+    CreatePocket event,
+    Emitter<PocketState> emit,
+  ) async {
+    final currentPockets = state is PocketLoaded
+        ? (state as PocketLoaded).pockets
+        : <MoneyPocket>[];
+
+    final result = await pocketRepository.createPocket(
+      name: event.name,
+      type: event.type,
+      allocatedAmount: event.allocatedAmount,
+      icon: event.icon,
+      color: event.color,
+    );
+    result.fold(
+      (failure) => emit(PocketLoaded(
+        currentPockets,
+        operationError: failure.message,
+      )),
+      (pocket) => emit(PocketLoaded([...currentPockets, pocket])),
+    );
+  }
+
+  Future<void> _onUpdatePocket(
+    UpdatePocket event,
+    Emitter<PocketState> emit,
+  ) async {
+    final currentPockets = state is PocketLoaded
+        ? (state as PocketLoaded).pockets
+        : <MoneyPocket>[];
+
+    final result = await pocketRepository.updatePocket(
+      id: event.id,
+      name: event.name,
+      type: event.type,
+      allocatedAmount: event.allocatedAmount,
+      icon: event.icon,
+      color: event.color,
+      displayOrder: event.displayOrder,
+    );
+    result.fold(
+      (failure) => emit(PocketLoaded(
+        currentPockets,
+        operationError: failure.message,
+      )),
+      (updated) {
+        final updatedList = currentPockets
+            .map((p) => p.id == updated.id ? updated : p)
+            .toList();
+        emit(PocketLoaded(updatedList));
+      },
+    );
+  }
+
+  Future<void> _onDeletePocket(
+    DeletePocket event,
+    Emitter<PocketState> emit,
+  ) async {
+    final currentPockets = state is PocketLoaded
+        ? (state as PocketLoaded).pockets
+        : <MoneyPocket>[];
+
+    final result = await pocketRepository.deletePocket(event.id);
+    result.fold(
+      (failure) => emit(PocketLoaded(
+        currentPockets,
+        operationError: failure.message,
+      )),
+      (_) {
+        final updatedList =
+            currentPockets.where((p) => p.id != event.id).toList();
+        emit(PocketLoaded(updatedList));
+      },
+    );
+  }
+
+  Future<void> _onDistributeIncome(
+    DistributeIncome event,
+    Emitter<PocketState> emit,
+  ) async {
+    final currentPockets = state is PocketLoaded
+        ? (state as PocketLoaded).pockets
+        : <MoneyPocket>[];
+
+    final result = await pocketRepository.distributeIncome(
+      totalAmount: event.totalAmount,
+      distributions: event.distributions,
+    );
+    result.fold(
+      (failure) => emit(PocketLoaded(
+        currentPockets,
+        operationError: failure.message,
+      )),
+      (_) {
+        // Reload pockets after distribution to get fresh balances
+        add(const LoadPockets());
+      },
+    );
+  }
+}

--- a/frontend/lib/features/pocket/presentation/bloc/pocket_event.dart
+++ b/frontend/lib/features/pocket/presentation/bloc/pocket_event.dart
@@ -1,0 +1,77 @@
+import 'package:equatable/equatable.dart';
+
+sealed class PocketEvent extends Equatable {
+  const PocketEvent();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class LoadPockets extends PocketEvent {
+  const LoadPockets();
+}
+
+class CreatePocket extends PocketEvent {
+  final String name;
+  final String type;
+  final int allocatedAmount;
+  final String? icon;
+  final String? color;
+
+  const CreatePocket({
+    required this.name,
+    required this.type,
+    required this.allocatedAmount,
+    this.icon,
+    this.color,
+  });
+
+  @override
+  List<Object?> get props => [name, type, allocatedAmount, icon, color];
+}
+
+class UpdatePocket extends PocketEvent {
+  final String id;
+  final String? name;
+  final String? type;
+  final int? allocatedAmount;
+  final String? icon;
+  final String? color;
+  final int? displayOrder;
+
+  const UpdatePocket({
+    required this.id,
+    this.name,
+    this.type,
+    this.allocatedAmount,
+    this.icon,
+    this.color,
+    this.displayOrder,
+  });
+
+  @override
+  List<Object?> get props =>
+      [id, name, type, allocatedAmount, icon, color, displayOrder];
+}
+
+class DeletePocket extends PocketEvent {
+  final String id;
+
+  const DeletePocket(this.id);
+
+  @override
+  List<Object?> get props => [id];
+}
+
+class DistributeIncome extends PocketEvent {
+  final int totalAmount;
+  final List<Map<String, dynamic>> distributions;
+
+  const DistributeIncome({
+    required this.totalAmount,
+    required this.distributions,
+  });
+
+  @override
+  List<Object?> get props => [totalAmount, distributions];
+}

--- a/frontend/lib/features/pocket/presentation/bloc/pocket_state.dart
+++ b/frontend/lib/features/pocket/presentation/bloc/pocket_state.dart
@@ -1,0 +1,44 @@
+import 'package:equatable/equatable.dart';
+import 'package:budget_book/features/pocket/domain/entities/money_pocket.dart';
+
+sealed class PocketState extends Equatable {
+  const PocketState();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class PocketInitial extends PocketState {
+  const PocketInitial();
+}
+
+class PocketLoading extends PocketState {
+  const PocketLoading();
+}
+
+class PocketLoaded extends PocketState {
+  final List<MoneyPocket> pockets;
+  final String? operationError;
+
+  const PocketLoaded(this.pockets, {this.operationError});
+
+  List<MoneyPocket> get activePockets =>
+      pockets.where((p) => p.isActive).toList();
+
+  int get totalBalance => pockets.fold(0, (sum, p) => sum + p.balance);
+
+  int get totalAllocated =>
+      pockets.fold(0, (sum, p) => sum + p.allocatedAmount);
+
+  @override
+  List<Object?> get props => [pockets, operationError];
+}
+
+class PocketError extends PocketState {
+  final String message;
+
+  const PocketError(this.message);
+
+  @override
+  List<Object?> get props => [message];
+}

--- a/frontend/lib/features/pocket/presentation/bloc/pocket_transfer_bloc.dart
+++ b/frontend/lib/features/pocket/presentation/bloc/pocket_transfer_bloc.dart
@@ -1,0 +1,59 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:budget_book/features/pocket/domain/entities/pocket_transfer.dart';
+import 'package:budget_book/features/pocket/domain/repositories/pocket_transfer_repository.dart';
+import 'pocket_transfer_event.dart';
+import 'pocket_transfer_state.dart';
+
+class PocketTransferBloc
+    extends Bloc<PocketTransferEvent, PocketTransferState> {
+  final PocketTransferRepository pocketTransferRepository;
+
+  PocketTransferBloc({required this.pocketTransferRepository})
+      : super(const PocketTransferInitial()) {
+    on<LoadPocketTransfers>(_onLoadPocketTransfers);
+    on<CreatePocketTransfer>(_onCreatePocketTransfer);
+  }
+
+  Future<void> _onLoadPocketTransfers(
+    LoadPocketTransfers event,
+    Emitter<PocketTransferState> emit,
+  ) async {
+    emit(const PocketTransferLoading());
+    final result = await pocketTransferRepository.getPocketTransfers(
+      fromPocketId: event.fromPocketId,
+      toPocketId: event.toPocketId,
+      startDate: event.startDate,
+      endDate: event.endDate,
+    );
+    result.fold(
+      (failure) => emit(PocketTransferError(failure.message)),
+      (transfers) => emit(PocketTransferLoaded(transfers)),
+    );
+  }
+
+  Future<void> _onCreatePocketTransfer(
+    CreatePocketTransfer event,
+    Emitter<PocketTransferState> emit,
+  ) async {
+    final currentTransfers = state is PocketTransferLoaded
+        ? (state as PocketTransferLoaded).transfers
+        : <PocketTransfer>[];
+
+    final result = await pocketTransferRepository.createPocketTransfer(
+      fromPocketId: event.fromPocketId,
+      toPocketId: event.toPocketId,
+      amount: event.amount,
+      description: event.description,
+      transferDate: event.transferDate,
+    );
+    result.fold(
+      (failure) => emit(PocketTransferLoaded(
+        currentTransfers,
+        operationError: failure.message,
+      )),
+      (transfer) => emit(PocketTransferLoaded(
+        [transfer, ...currentTransfers],
+      )),
+    );
+  }
+}

--- a/frontend/lib/features/pocket/presentation/bloc/pocket_transfer_event.dart
+++ b/frontend/lib/features/pocket/presentation/bloc/pocket_transfer_event.dart
@@ -1,0 +1,45 @@
+import 'package:equatable/equatable.dart';
+
+sealed class PocketTransferEvent extends Equatable {
+  const PocketTransferEvent();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class LoadPocketTransfers extends PocketTransferEvent {
+  final String? fromPocketId;
+  final String? toPocketId;
+  final String? startDate;
+  final String? endDate;
+
+  const LoadPocketTransfers({
+    this.fromPocketId,
+    this.toPocketId,
+    this.startDate,
+    this.endDate,
+  });
+
+  @override
+  List<Object?> get props => [fromPocketId, toPocketId, startDate, endDate];
+}
+
+class CreatePocketTransfer extends PocketTransferEvent {
+  final String fromPocketId;
+  final String toPocketId;
+  final int amount;
+  final String? description;
+  final String transferDate;
+
+  const CreatePocketTransfer({
+    required this.fromPocketId,
+    required this.toPocketId,
+    required this.amount,
+    this.description,
+    required this.transferDate,
+  });
+
+  @override
+  List<Object?> get props =>
+      [fromPocketId, toPocketId, amount, description, transferDate];
+}

--- a/frontend/lib/features/pocket/presentation/bloc/pocket_transfer_state.dart
+++ b/frontend/lib/features/pocket/presentation/bloc/pocket_transfer_state.dart
@@ -1,0 +1,36 @@
+import 'package:equatable/equatable.dart';
+import 'package:budget_book/features/pocket/domain/entities/pocket_transfer.dart';
+
+sealed class PocketTransferState extends Equatable {
+  const PocketTransferState();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class PocketTransferInitial extends PocketTransferState {
+  const PocketTransferInitial();
+}
+
+class PocketTransferLoading extends PocketTransferState {
+  const PocketTransferLoading();
+}
+
+class PocketTransferLoaded extends PocketTransferState {
+  final List<PocketTransfer> transfers;
+  final String? operationError;
+
+  const PocketTransferLoaded(this.transfers, {this.operationError});
+
+  @override
+  List<Object?> get props => [transfers, operationError];
+}
+
+class PocketTransferError extends PocketTransferState {
+  final String message;
+
+  const PocketTransferError(this.message);
+
+  @override
+  List<Object?> get props => [message];
+}

--- a/frontend/lib/features/pocket/presentation/pages/distribute_wizard_page.dart
+++ b/frontend/lib/features/pocket/presentation/pages/distribute_wizard_page.dart
@@ -1,0 +1,319 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
+import 'package:intl/intl.dart';
+import 'package:budget_book/features/pocket/domain/entities/money_pocket.dart';
+import 'package:budget_book/features/pocket/presentation/bloc/pocket_bloc.dart';
+import 'package:budget_book/features/pocket/presentation/bloc/pocket_event.dart';
+import 'package:budget_book/features/pocket/presentation/bloc/pocket_state.dart';
+
+class DistributeWizardPage extends StatefulWidget {
+  const DistributeWizardPage({super.key});
+
+  @override
+  State<DistributeWizardPage> createState() => _DistributeWizardPageState();
+}
+
+class _DistributeWizardPageState extends State<DistributeWizardPage> {
+  int _currentStep = 0;
+  final _totalAmountController = TextEditingController();
+  final Map<String, TextEditingController> _allocationControllers = {};
+  final _formatter = NumberFormat('#,###');
+
+  int get _totalAmount =>
+      int.tryParse(_totalAmountController.text.replaceAll(',', '')) ?? 0;
+
+  int get _totalAllocated {
+    int sum = 0;
+    for (final controller in _allocationControllers.values) {
+      sum += int.tryParse(controller.text.replaceAll(',', '')) ?? 0;
+    }
+    return sum;
+  }
+
+  int get _remaining => _totalAmount - _totalAllocated;
+
+  @override
+  void dispose() {
+    _totalAmountController.dispose();
+    for (final c in _allocationControllers.values) {
+      c.dispose();
+    }
+    super.dispose();
+  }
+
+  void _ensureControllers(List<MoneyPocket> pockets) {
+    for (final pocket in pockets) {
+      _allocationControllers.putIfAbsent(
+        pocket.id,
+        () => TextEditingController(text: '0'),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('월급 분배'),
+      ),
+      body: BlocConsumer<PocketBloc, PocketState>(
+        listener: (context, state) {
+          if (state is PocketLoaded && state.operationError != null) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(
+                content: Text(state.operationError!),
+                backgroundColor: Colors.red,
+              ),
+            );
+          }
+        },
+        builder: (context, state) {
+          if (state is! PocketLoaded) {
+            return const Center(child: CircularProgressIndicator());
+          }
+
+          final pockets = state.pockets;
+          _ensureControllers(pockets);
+
+          return Stepper(
+            currentStep: _currentStep,
+            onStepContinue: () {
+              if (_currentStep == 0 && _totalAmount <= 0) {
+                ScaffoldMessenger.of(context).showSnackBar(
+                  const SnackBar(content: Text('금액을 입력하세요')),
+                );
+                return;
+              }
+              if (_currentStep == 1 && _remaining != 0) {
+                ScaffoldMessenger.of(context).showSnackBar(
+                  SnackBar(
+                    content: Text(
+                      '남은 금액이 ${_formatter.format(_remaining)}원 있습니다. 모두 분배해주세요.',
+                    ),
+                  ),
+                );
+                return;
+              }
+              if (_currentStep < 2) {
+                setState(() => _currentStep++);
+              } else {
+                _submitDistribution(context, pockets);
+              }
+            },
+            onStepCancel: () {
+              if (_currentStep > 0) {
+                setState(() => _currentStep--);
+              } else {
+                context.pop();
+              }
+            },
+            controlsBuilder: (context, details) {
+              return Padding(
+                padding: const EdgeInsets.only(top: 16),
+                child: Row(
+                  children: [
+                    FilledButton(
+                      onPressed: details.onStepContinue,
+                      child: Text(_currentStep == 2 ? '확정' : '다음'),
+                    ),
+                    const SizedBox(width: 12),
+                    TextButton(
+                      onPressed: details.onStepCancel,
+                      child: Text(_currentStep == 0 ? '취소' : '이전'),
+                    ),
+                  ],
+                ),
+              );
+            },
+            steps: [
+              Step(
+                title: const Text('총 금액 입력'),
+                content: _buildStep1(),
+                isActive: _currentStep >= 0,
+                state: _currentStep > 0
+                    ? StepState.complete
+                    : StepState.indexed,
+              ),
+              Step(
+                title: const Text('포켓별 금액 할당'),
+                content: _buildStep2(pockets),
+                isActive: _currentStep >= 1,
+                state: _currentStep > 1
+                    ? StepState.complete
+                    : StepState.indexed,
+              ),
+              Step(
+                title: const Text('확인'),
+                content: _buildStep3(pockets),
+                isActive: _currentStep >= 2,
+                state: StepState.indexed,
+              ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildStep1() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        const Text('분배할 총 금액을 입력하세요'),
+        const SizedBox(height: 16),
+        TextFormField(
+          controller: _totalAmountController,
+          decoration: const InputDecoration(
+            labelText: '총 금액',
+            suffixText: '원',
+            prefixIcon: Icon(Icons.payments),
+          ),
+          keyboardType: TextInputType.number,
+          inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+          onChanged: (_) => setState(() {}),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildStep2(List<MoneyPocket> pockets) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Card(
+          color: _remaining == 0
+              ? Colors.green.shade50
+              : _remaining < 0
+                  ? Colors.red.shade50
+                  : Colors.orange.shade50,
+          child: Padding(
+            padding: const EdgeInsets.all(12),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                const Text('남은 금액'),
+                Text(
+                  '${_formatter.format(_remaining)}원',
+                  style: TextStyle(
+                    fontWeight: FontWeight.bold,
+                    color: _remaining == 0
+                        ? Colors.green
+                        : _remaining < 0
+                            ? Colors.red
+                            : Colors.orange,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+        const SizedBox(height: 12),
+        ...pockets.map((pocket) {
+          final controller = _allocationControllers[pocket.id]!;
+          return Padding(
+            padding: const EdgeInsets.only(bottom: 12),
+            child: TextFormField(
+              controller: controller,
+              decoration: InputDecoration(
+                labelText: pocket.name,
+                suffixText: '원',
+                prefixIcon: const Icon(Icons.account_balance_wallet),
+              ),
+              keyboardType: TextInputType.number,
+              inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+              onChanged: (_) => setState(() {}),
+            ),
+          );
+        }),
+      ],
+    );
+  }
+
+  Widget _buildStep3(List<MoneyPocket> pockets) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Card(
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  '분배 요약',
+                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.bold,
+                      ),
+                ),
+                const SizedBox(height: 12),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    const Text('총 금액'),
+                    Text(
+                      '${_formatter.format(_totalAmount)}원',
+                      style: const TextStyle(fontWeight: FontWeight.bold),
+                    ),
+                  ],
+                ),
+                const Divider(),
+                ...pockets.map((pocket) {
+                  final amount = int.tryParse(
+                        _allocationControllers[pocket.id]
+                                ?.text
+                                .replaceAll(',', '') ??
+                            '0',
+                      ) ??
+                      0;
+                  if (amount <= 0) return const SizedBox.shrink();
+                  return Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 4),
+                    child: Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: [
+                        Text(pocket.name),
+                        Text('${_formatter.format(amount)}원'),
+                      ],
+                    ),
+                  );
+                }),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  void _submitDistribution(
+      BuildContext context, List<MoneyPocket> pockets) {
+    final distributions = <Map<String, dynamic>>[];
+    for (final pocket in pockets) {
+      final amount = int.tryParse(
+            _allocationControllers[pocket.id]
+                    ?.text
+                    .replaceAll(',', '') ??
+                '0',
+          ) ??
+          0;
+      if (amount > 0) {
+        distributions.add({
+          'pocketId': pocket.id,
+          'amount': amount,
+        });
+      }
+    }
+
+    context.read<PocketBloc>().add(DistributeIncome(
+          totalAmount: _totalAmount,
+          distributions: distributions,
+        ));
+
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('분배가 완료되었습니다')),
+    );
+    context.pop();
+  }
+}

--- a/frontend/lib/features/pocket/presentation/pages/pocket_page.dart
+++ b/frontend/lib/features/pocket/presentation/pages/pocket_page.dart
@@ -1,0 +1,382 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
+import 'package:intl/intl.dart';
+import 'package:budget_book/features/pocket/domain/entities/money_pocket.dart';
+import 'package:budget_book/features/pocket/presentation/bloc/pocket_bloc.dart';
+import 'package:budget_book/features/pocket/presentation/bloc/pocket_event.dart';
+import 'package:budget_book/features/pocket/presentation/bloc/pocket_state.dart';
+import 'package:budget_book/features/pocket/presentation/widgets/pocket_form_sheet.dart';
+
+class PocketPage extends StatelessWidget {
+  const PocketPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('머니 포켓'),
+        actions: [
+          IconButton(
+            onPressed: () => context.push('/pockets/distribute'),
+            icon: const Icon(Icons.account_balance_wallet),
+            tooltip: '월급 분배',
+          ),
+          IconButton(
+            onPressed: () => context.push('/pocket-transfers'),
+            icon: const Icon(Icons.swap_horiz),
+            tooltip: '포켓 이체',
+          ),
+        ],
+      ),
+      body: BlocConsumer<PocketBloc, PocketState>(
+        listener: (context, state) {
+          if (state is PocketError) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(
+                content: Text(state.message),
+                backgroundColor: Colors.red,
+              ),
+            );
+          } else if (state is PocketLoaded && state.operationError != null) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(
+                content: Text(state.operationError!),
+                backgroundColor: Colors.red,
+              ),
+            );
+          }
+        },
+        builder: (context, state) {
+          return switch (state) {
+            PocketInitial() || PocketLoading() =>
+              const Center(child: CircularProgressIndicator()),
+            PocketLoaded(pockets: final pockets) =>
+              _buildContent(context, pockets, state),
+            PocketError() => _buildError(context),
+          };
+        },
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => _showAddPocket(context),
+        tooltip: '포켓 추가',
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+
+  Widget _buildContent(
+    BuildContext context,
+    List<MoneyPocket> pockets,
+    PocketLoaded state,
+  ) {
+    if (pockets.isEmpty) {
+      return Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(
+              Icons.account_balance_wallet_outlined,
+              size: 64,
+              color: Theme.of(context)
+                  .colorScheme
+                  .onSurface
+                  .withValues(alpha: 0.3),
+            ),
+            const SizedBox(height: 16),
+            Text(
+              '등록된 포켓이 없습니다',
+              style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                    color: Theme.of(context)
+                        .colorScheme
+                        .onSurface
+                        .withValues(alpha: 0.5),
+                  ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              '+ 버튼을 눌러 첫 포켓을 만드세요',
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: Theme.of(context)
+                        .colorScheme
+                        .onSurface
+                        .withValues(alpha: 0.4),
+                  ),
+            ),
+          ],
+        ),
+      );
+    }
+
+    return ListView(
+      padding: const EdgeInsets.all(16),
+      children: [
+        // Total balance card
+        _TotalBalanceCard(totalBalance: state.totalBalance),
+        const SizedBox(height: 16),
+        // Pocket cards
+        ...pockets.map((pocket) => Padding(
+              padding: const EdgeInsets.only(bottom: 8),
+              child: _PocketCard(
+                pocket: pocket,
+                onTap: () => _showEditPocket(context, pocket),
+                onLongPress: () => _showDeleteDialog(context, pocket),
+              ),
+            )),
+      ],
+    );
+  }
+
+  Widget _buildError(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          const Icon(Icons.error_outline, size: 48, color: Colors.red),
+          const SizedBox(height: 16),
+          const Text('포켓을 불러오지 못했습니다'),
+          const SizedBox(height: 16),
+          FilledButton(
+            onPressed: () {
+              context.read<PocketBloc>().add(const LoadPockets());
+            },
+            child: const Text('다시 시도'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _showAddPocket(BuildContext context) {
+    final bloc = context.read<PocketBloc>();
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      builder: (_) => PocketFormSheet(
+        onSubmit: (name, type, allocatedAmount, icon, color) {
+          bloc.add(CreatePocket(
+            name: name,
+            type: type,
+            allocatedAmount: allocatedAmount,
+            icon: icon,
+            color: color,
+          ));
+        },
+      ),
+    );
+  }
+
+  void _showEditPocket(BuildContext context, MoneyPocket pocket) {
+    final bloc = context.read<PocketBloc>();
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      builder: (_) => PocketFormSheet(
+        pocket: pocket,
+        onSubmit: (name, type, allocatedAmount, icon, color) {
+          bloc.add(UpdatePocket(
+            id: pocket.id,
+            name: name,
+            type: type,
+            allocatedAmount: allocatedAmount,
+            icon: icon,
+            color: color,
+          ));
+        },
+      ),
+    );
+  }
+
+  Future<void> _showDeleteDialog(
+      BuildContext context, MoneyPocket pocket) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('포켓 삭제'),
+        content: Text("'${pocket.name}' 포켓을 삭제하시겠습니까?"),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(false),
+            child: const Text('취소'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(true),
+            style: TextButton.styleFrom(foregroundColor: Colors.red),
+            child: const Text('삭제'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed == true && context.mounted) {
+      context.read<PocketBloc>().add(DeletePocket(pocket.id));
+    }
+  }
+}
+
+class _TotalBalanceCard extends StatelessWidget {
+  final int totalBalance;
+
+  const _TotalBalanceCard({required this.totalBalance});
+
+  @override
+  Widget build(BuildContext context) {
+    final formatter = NumberFormat('#,###');
+    final isPositive = totalBalance >= 0;
+
+    return Card(
+      color: Theme.of(context).colorScheme.primaryContainer,
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          children: [
+            Text(
+              '진짜 남은 돈',
+              style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.bold,
+                    color:
+                        Theme.of(context).colorScheme.onPrimaryContainer,
+                  ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              '${formatter.format(totalBalance)}원',
+              style: Theme.of(context).textTheme.headlineMedium?.copyWith(
+                    fontWeight: FontWeight.bold,
+                    color: isPositive ? Colors.green : Colors.red,
+                  ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _PocketCard extends StatelessWidget {
+  final MoneyPocket pocket;
+  final VoidCallback? onTap;
+  final VoidCallback? onLongPress;
+
+  const _PocketCard({
+    required this.pocket,
+    this.onTap,
+    this.onLongPress,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final formatter = NumberFormat('#,###');
+    final color = _parseColor(pocket.color);
+    final isPositive = pocket.balance >= 0;
+
+    final typeLabel = switch (pocket.type) {
+      'LIVING' => '생활비',
+      'FIXED' => '고정지출',
+      'CARD_PENDING' => '카드미결제',
+      'SAVINGS' => '저축',
+      'CUSTOM' => '직접입력',
+      _ => pocket.type,
+    };
+
+    return Card(
+      child: InkWell(
+        onTap: onTap,
+        onLongPress: onLongPress,
+        borderRadius: BorderRadius.circular(12),
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Row(
+            children: [
+              CircleAvatar(
+                backgroundColor: color.withValues(alpha: 0.15),
+                child: Icon(
+                  _resolveIcon(pocket.icon),
+                  color: color,
+                  size: 20,
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        Text(
+                          pocket.name,
+                          style: Theme.of(context)
+                              .textTheme
+                              .titleSmall
+                              ?.copyWith(fontWeight: FontWeight.bold),
+                        ),
+                        const SizedBox(width: 8),
+                        Container(
+                          padding: const EdgeInsets.symmetric(
+                              horizontal: 6, vertical: 2),
+                          decoration: BoxDecoration(
+                            color: color.withValues(alpha: 0.1),
+                            borderRadius: BorderRadius.circular(4),
+                          ),
+                          child: Text(
+                            typeLabel,
+                            style: TextStyle(
+                              fontSize: 10,
+                              fontWeight: FontWeight.bold,
+                              color: color,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      '할당: ${formatter.format(pocket.allocatedAmount)}원',
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                            color: Theme.of(context)
+                                .colorScheme
+                                .onSurface
+                                .withValues(alpha: 0.6),
+                          ),
+                    ),
+                  ],
+                ),
+              ),
+              Text(
+                '${formatter.format(pocket.balance)}원',
+                style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                      color: isPositive ? Colors.green : Colors.red,
+                      fontWeight: FontWeight.bold,
+                    ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Color _parseColor(String? hex) {
+    if (hex == null || hex.isEmpty) return Colors.grey;
+    try {
+      final colorStr = hex.replaceFirst('#', '');
+      return Color(int.parse('FF$colorStr', radix: 16));
+    } catch (_) {
+      return Colors.grey;
+    }
+  }
+
+  IconData _resolveIcon(String? iconName) {
+    if (iconName == null) return Icons.account_balance_wallet;
+    const iconMap = <String, IconData>{
+      'home': Icons.home,
+      'restaurant': Icons.restaurant,
+      'shopping_cart': Icons.shopping_cart,
+      'directions_bus': Icons.directions_bus,
+      'savings': Icons.savings,
+      'payments': Icons.payments,
+      'account_balance': Icons.account_balance,
+      'card_giftcard': Icons.card_giftcard,
+    };
+    return iconMap[iconName] ?? Icons.account_balance_wallet;
+  }
+}

--- a/frontend/lib/features/pocket/presentation/pages/pocket_transfer_page.dart
+++ b/frontend/lib/features/pocket/presentation/pages/pocket_transfer_page.dart
@@ -1,0 +1,185 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:intl/intl.dart';
+import 'package:budget_book/features/pocket/domain/entities/pocket_transfer.dart';
+import 'package:budget_book/features/pocket/presentation/bloc/pocket_bloc.dart';
+import 'package:budget_book/features/pocket/presentation/bloc/pocket_state.dart';
+import 'package:budget_book/features/pocket/presentation/bloc/pocket_transfer_bloc.dart';
+import 'package:budget_book/features/pocket/presentation/bloc/pocket_transfer_event.dart';
+import 'package:budget_book/features/pocket/presentation/bloc/pocket_transfer_state.dart';
+import 'package:budget_book/features/pocket/presentation/widgets/pocket_transfer_form_sheet.dart';
+
+class PocketTransferPage extends StatelessWidget {
+  const PocketTransferPage({super.key});
+
+  static final _formatter = NumberFormat('#,###');
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('포켓 이체 내역'),
+      ),
+      body: BlocConsumer<PocketTransferBloc, PocketTransferState>(
+        listener: (context, state) {
+          if (state is PocketTransferError) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(
+                content: Text(state.message),
+                backgroundColor: Colors.red,
+              ),
+            );
+          } else if (state is PocketTransferLoaded &&
+              state.operationError != null) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(
+                content: Text(state.operationError!),
+                backgroundColor: Colors.red,
+              ),
+            );
+          }
+        },
+        builder: (context, state) {
+          return switch (state) {
+            PocketTransferInitial() ||
+            PocketTransferLoading() =>
+              const Center(child: CircularProgressIndicator()),
+            PocketTransferLoaded(transfers: final transfers) =>
+              _buildContent(context, transfers),
+            PocketTransferError() => _buildError(context),
+          };
+        },
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => _showAddTransfer(context),
+        tooltip: '이체 추가',
+        child: const Icon(Icons.swap_horiz),
+      ),
+    );
+  }
+
+  Widget _buildContent(
+      BuildContext context, List<PocketTransfer> transfers) {
+    if (transfers.isEmpty) {
+      return Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(
+              Icons.swap_horiz,
+              size: 64,
+              color: Theme.of(context)
+                  .colorScheme
+                  .onSurface
+                  .withValues(alpha: 0.3),
+            ),
+            const SizedBox(height: 16),
+            Text(
+              '이체 내역이 없습니다',
+              style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                    color: Theme.of(context)
+                        .colorScheme
+                        .onSurface
+                        .withValues(alpha: 0.5),
+                  ),
+            ),
+          ],
+        ),
+      );
+    }
+
+    return ListView.builder(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      itemCount: transfers.length,
+      itemBuilder: (context, index) {
+        final transfer = transfers[index];
+        return _buildTransferTile(context, transfer);
+      },
+    );
+  }
+
+  Widget _buildTransferTile(BuildContext context, PocketTransfer transfer) {
+    return ListTile(
+      leading: CircleAvatar(
+        backgroundColor: Colors.blue.withValues(alpha: 0.15),
+        child: const Icon(Icons.swap_horiz, color: Colors.blue, size: 20),
+      ),
+      title: Text(
+        '${transfer.fromPocket.name} -> ${transfer.toPocket.name}',
+        style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+              fontWeight: FontWeight.w600,
+            ),
+      ),
+      subtitle: Text(
+        '${transfer.transferDate}${transfer.description != null ? ' - ${transfer.description}' : ''}',
+        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+              color: Theme.of(context)
+                  .colorScheme
+                  .onSurface
+                  .withValues(alpha: 0.6),
+            ),
+      ),
+      trailing: Text(
+        '${_formatter.format(transfer.amount)}원',
+        style: Theme.of(context).textTheme.titleSmall?.copyWith(
+              fontWeight: FontWeight.bold,
+              color: Colors.blue,
+            ),
+      ),
+    );
+  }
+
+  Widget _buildError(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          const Icon(Icons.error_outline, size: 48, color: Colors.red),
+          const SizedBox(height: 16),
+          const Text('이체 내역을 불러오지 못했습니다'),
+          const SizedBox(height: 16),
+          FilledButton(
+            onPressed: () {
+              context
+                  .read<PocketTransferBloc>()
+                  .add(const LoadPocketTransfers());
+            },
+            child: const Text('다시 시도'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _showAddTransfer(BuildContext context) {
+    final pocketState = context.read<PocketBloc>().state;
+    final pockets =
+        pocketState is PocketLoaded ? pocketState.pockets : [];
+
+    if (pockets.length < 2) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('이체하려면 최소 2개의 포켓이 필요합니다')),
+      );
+      return;
+    }
+
+    final transferBloc = context.read<PocketTransferBloc>();
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      builder: (_) => PocketTransferFormSheet(
+        pockets: pockets.cast(),
+        onSubmit: (fromPocketId, toPocketId, amount, description,
+            transferDate) {
+          transferBloc.add(CreatePocketTransfer(
+            fromPocketId: fromPocketId,
+            toPocketId: toPocketId,
+            amount: amount,
+            description: description,
+            transferDate: transferDate,
+          ));
+        },
+      ),
+    );
+  }
+}

--- a/frontend/lib/features/pocket/presentation/widgets/pocket_form_sheet.dart
+++ b/frontend/lib/features/pocket/presentation/widgets/pocket_form_sheet.dart
@@ -1,0 +1,296 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:budget_book/features/pocket/domain/entities/money_pocket.dart';
+
+class PocketFormSheet extends StatefulWidget {
+  final MoneyPocket? pocket;
+  final void Function(
+    String name,
+    String type,
+    int allocatedAmount,
+    String? icon,
+    String? color,
+  ) onSubmit;
+
+  const PocketFormSheet({
+    super.key,
+    this.pocket,
+    required this.onSubmit,
+  });
+
+  @override
+  State<PocketFormSheet> createState() => _PocketFormSheetState();
+}
+
+class _PocketFormSheetState extends State<PocketFormSheet> {
+  final _formKey = GlobalKey<FormState>();
+  late final TextEditingController _nameController;
+  late final TextEditingController _amountController;
+  late String _selectedType;
+  late String _selectedIcon;
+  late String _selectedColor;
+
+  bool get isEditing => widget.pocket != null;
+
+  static const _typeLabels = {
+    'LIVING': '생활비',
+    'FIXED': '고정지출',
+    'CARD_PENDING': '카드미결제',
+    'SAVINGS': '저축',
+    'CUSTOM': '직접입력',
+  };
+
+  static const _iconOptions = [
+    'home',
+    'restaurant',
+    'shopping_cart',
+    'directions_bus',
+    'savings',
+    'payments',
+    'account_balance',
+    'card_giftcard',
+  ];
+
+  static const _colorOptions = [
+    '#4CAF50',
+    '#2196F3',
+    '#FF9800',
+    '#E91E63',
+    '#9C27B0',
+    '#00BCD4',
+    '#795548',
+    '#607D8B',
+  ];
+
+  @override
+  void initState() {
+    super.initState();
+    final p = widget.pocket;
+    _nameController = TextEditingController(text: p?.name ?? '');
+    _amountController = TextEditingController(
+      text: p != null ? p.allocatedAmount.toString() : '',
+    );
+    _selectedType = p?.type ?? 'LIVING';
+    _selectedIcon = p?.icon ?? 'home';
+    _selectedColor = p?.color ?? '#4CAF50';
+  }
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _amountController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.only(
+        left: 24,
+        right: 24,
+        top: 24,
+        bottom: MediaQuery.of(context).viewInsets.bottom + 24,
+      ),
+      child: Form(
+        key: _formKey,
+        child: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Center(
+                child: Container(
+                  width: 40,
+                  height: 4,
+                  decoration: BoxDecoration(
+                    color: Theme.of(context)
+                        .colorScheme
+                        .onSurface
+                        .withValues(alpha: 0.3),
+                    borderRadius: BorderRadius.circular(2),
+                  ),
+                ),
+              ),
+              const SizedBox(height: 16),
+              Text(
+                isEditing ? '포켓 수정' : '포켓 추가',
+                style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                      fontWeight: FontWeight.bold,
+                    ),
+              ),
+              const SizedBox(height: 24),
+              // Name field
+              TextFormField(
+                controller: _nameController,
+                decoration: const InputDecoration(
+                  labelText: '포켓 이름',
+                  hintText: '예: 생활비, 저축',
+                ),
+                maxLength: 50,
+                validator: (value) {
+                  if (value == null || value.trim().isEmpty) {
+                    return '포켓 이름을 입력하세요';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 16),
+              // Type dropdown
+              DropdownButtonFormField<String>(
+                initialValue: _selectedType,
+                decoration: const InputDecoration(
+                  labelText: '유형',
+                  prefixIcon: Icon(Icons.label),
+                ),
+                items: _typeLabels.entries
+                    .map((e) => DropdownMenuItem<String>(
+                          value: e.key,
+                          child: Text(e.value),
+                        ))
+                    .toList(),
+                onChanged: (value) {
+                  if (value != null) {
+                    setState(() {
+                      _selectedType = value;
+                    });
+                  }
+                },
+              ),
+              const SizedBox(height: 16),
+              // Amount field
+              TextFormField(
+                controller: _amountController,
+                decoration: const InputDecoration(
+                  labelText: '할당 금액',
+                  suffixText: '원',
+                  prefixIcon: Icon(Icons.payments),
+                ),
+                keyboardType: TextInputType.number,
+                inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+                validator: (value) {
+                  if (value == null || value.trim().isEmpty) {
+                    return '금액을 입력하세요';
+                  }
+                  final amount = int.tryParse(value);
+                  if (amount == null || amount < 0) {
+                    return '0 이상의 금액을 입력하세요';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 16),
+              // Icon selector
+              Text(
+                '아이콘',
+                style: Theme.of(context).textTheme.titleSmall,
+              ),
+              const SizedBox(height: 8),
+              Wrap(
+                spacing: 8,
+                children: _iconOptions.map((iconName) {
+                  final isSelected = _selectedIcon == iconName;
+                  return ChoiceChip(
+                    selected: isSelected,
+                    label: Icon(
+                      _resolveIcon(iconName),
+                      size: 20,
+                      color: isSelected
+                          ? Theme.of(context).colorScheme.onPrimary
+                          : null,
+                    ),
+                    onSelected: (_) {
+                      setState(() {
+                        _selectedIcon = iconName;
+                      });
+                    },
+                  );
+                }).toList(),
+              ),
+              const SizedBox(height: 16),
+              // Color selector
+              Text(
+                '색상',
+                style: Theme.of(context).textTheme.titleSmall,
+              ),
+              const SizedBox(height: 8),
+              Wrap(
+                spacing: 8,
+                children: _colorOptions.map((hex) {
+                  final isSelected = _selectedColor == hex;
+                  final color = _parseColor(hex);
+                  return GestureDetector(
+                    onTap: () {
+                      setState(() {
+                        _selectedColor = hex;
+                      });
+                    },
+                    child: Container(
+                      width: 36,
+                      height: 36,
+                      decoration: BoxDecoration(
+                        color: color,
+                        shape: BoxShape.circle,
+                        border: isSelected
+                            ? Border.all(
+                                color:
+                                    Theme.of(context).colorScheme.onSurface,
+                                width: 3,
+                              )
+                            : null,
+                      ),
+                    ),
+                  );
+                }).toList(),
+              ),
+              const SizedBox(height: 24),
+              FilledButton(
+                onPressed: _onSubmit,
+                style: FilledButton.styleFrom(
+                  padding: const EdgeInsets.symmetric(vertical: 16),
+                ),
+                child: Text(isEditing ? '수정' : '추가'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  void _onSubmit() {
+    if (_formKey.currentState?.validate() ?? false) {
+      final amount = int.parse(_amountController.text.trim());
+      widget.onSubmit(
+        _nameController.text.trim(),
+        _selectedType,
+        amount,
+        _selectedIcon,
+        _selectedColor,
+      );
+      Navigator.of(context).pop();
+    }
+  }
+
+  Color _parseColor(String hex) {
+    try {
+      final colorStr = hex.replaceFirst('#', '');
+      return Color(int.parse('FF$colorStr', radix: 16));
+    } catch (_) {
+      return Colors.grey;
+    }
+  }
+
+  IconData _resolveIcon(String iconName) {
+    const iconMap = <String, IconData>{
+      'home': Icons.home,
+      'restaurant': Icons.restaurant,
+      'shopping_cart': Icons.shopping_cart,
+      'directions_bus': Icons.directions_bus,
+      'savings': Icons.savings,
+      'payments': Icons.payments,
+      'account_balance': Icons.account_balance,
+      'card_giftcard': Icons.card_giftcard,
+    };
+    return iconMap[iconName] ?? Icons.account_balance_wallet;
+  }
+}

--- a/frontend/lib/features/pocket/presentation/widgets/pocket_transfer_form_sheet.dart
+++ b/frontend/lib/features/pocket/presentation/widgets/pocket_transfer_form_sheet.dart
@@ -1,0 +1,218 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:intl/intl.dart';
+import 'package:budget_book/features/pocket/domain/entities/money_pocket.dart';
+
+class PocketTransferFormSheet extends StatefulWidget {
+  final List<MoneyPocket> pockets;
+  final void Function(
+    String fromPocketId,
+    String toPocketId,
+    int amount,
+    String? description,
+    String transferDate,
+  ) onSubmit;
+
+  const PocketTransferFormSheet({
+    super.key,
+    required this.pockets,
+    required this.onSubmit,
+  });
+
+  @override
+  State<PocketTransferFormSheet> createState() =>
+      _PocketTransferFormSheetState();
+}
+
+class _PocketTransferFormSheetState extends State<PocketTransferFormSheet> {
+  final _formKey = GlobalKey<FormState>();
+  final _amountController = TextEditingController();
+  final _descriptionController = TextEditingController();
+  String? _fromPocketId;
+  String? _toPocketId;
+  late DateTime _selectedDate;
+
+  @override
+  void initState() {
+    super.initState();
+    _selectedDate = DateTime.now();
+  }
+
+  @override
+  void dispose() {
+    _amountController.dispose();
+    _descriptionController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.only(
+        left: 24,
+        right: 24,
+        top: 24,
+        bottom: MediaQuery.of(context).viewInsets.bottom + 24,
+      ),
+      child: Form(
+        key: _formKey,
+        child: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Center(
+                child: Container(
+                  width: 40,
+                  height: 4,
+                  decoration: BoxDecoration(
+                    color: Theme.of(context)
+                        .colorScheme
+                        .onSurface
+                        .withValues(alpha: 0.3),
+                    borderRadius: BorderRadius.circular(2),
+                  ),
+                ),
+              ),
+              const SizedBox(height: 16),
+              Text(
+                '포켓 이체',
+                style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                      fontWeight: FontWeight.bold,
+                    ),
+              ),
+              const SizedBox(height: 24),
+              // From pocket
+              DropdownButtonFormField<String>(
+                initialValue: _fromPocketId,
+                decoration: const InputDecoration(
+                  labelText: '보내는 포켓',
+                  prefixIcon: Icon(Icons.arrow_upward),
+                ),
+                items: widget.pockets
+                    .map((p) => DropdownMenuItem<String>(
+                          value: p.id,
+                          child: Text(p.name),
+                        ))
+                    .toList(),
+                validator: (value) {
+                  if (value == null) return '보내는 포켓을 선택하세요';
+                  return null;
+                },
+                onChanged: (value) {
+                  setState(() => _fromPocketId = value);
+                },
+              ),
+              const SizedBox(height: 16),
+              // To pocket
+              DropdownButtonFormField<String>(
+                initialValue: _toPocketId,
+                decoration: const InputDecoration(
+                  labelText: '받는 포켓',
+                  prefixIcon: Icon(Icons.arrow_downward),
+                ),
+                items: widget.pockets
+                    .map((p) => DropdownMenuItem<String>(
+                          value: p.id,
+                          child: Text(p.name),
+                        ))
+                    .toList(),
+                validator: (value) {
+                  if (value == null) return '받는 포켓을 선택하세요';
+                  if (value == _fromPocketId) return '같은 포켓으로 이체할 수 없습니다';
+                  return null;
+                },
+                onChanged: (value) {
+                  setState(() => _toPocketId = value);
+                },
+              ),
+              const SizedBox(height: 16),
+              // Amount
+              TextFormField(
+                controller: _amountController,
+                decoration: const InputDecoration(
+                  labelText: '금액',
+                  suffixText: '원',
+                  prefixIcon: Icon(Icons.payments),
+                ),
+                keyboardType: TextInputType.number,
+                inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+                validator: (value) {
+                  if (value == null || value.trim().isEmpty) {
+                    return '금액을 입력하세요';
+                  }
+                  final amount = int.tryParse(value);
+                  if (amount == null || amount <= 0) {
+                    return '0보다 큰 금액을 입력하세요';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 16),
+              // Description
+              TextFormField(
+                controller: _descriptionController,
+                decoration: const InputDecoration(
+                  labelText: '메모 (선택)',
+                  hintText: '예: 이월 저축',
+                  prefixIcon: Icon(Icons.note),
+                ),
+                maxLength: 255,
+              ),
+              const SizedBox(height: 16),
+              // Date
+              InkWell(
+                onTap: () async {
+                  final picked = await showDatePicker(
+                    context: context,
+                    initialDate: _selectedDate,
+                    firstDate: DateTime(2020),
+                    lastDate: DateTime(2030, 12, 31),
+                  );
+                  if (picked != null) {
+                    setState(() => _selectedDate = picked);
+                  }
+                },
+                child: InputDecorator(
+                  decoration: const InputDecoration(
+                    labelText: '날짜',
+                    prefixIcon: Icon(Icons.calendar_today),
+                  ),
+                  child: Text(
+                      DateFormat('yyyy-MM-dd').format(_selectedDate)),
+                ),
+              ),
+              const SizedBox(height: 24),
+              FilledButton(
+                onPressed: _onSubmit,
+                style: FilledButton.styleFrom(
+                  padding: const EdgeInsets.symmetric(vertical: 16),
+                ),
+                child: const Text('이체'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  void _onSubmit() {
+    if (_formKey.currentState?.validate() ?? false) {
+      final amount = int.parse(_amountController.text.trim());
+      final description = _descriptionController.text.trim().isEmpty
+          ? null
+          : _descriptionController.text.trim();
+      final dateStr = DateFormat('yyyy-MM-dd').format(_selectedDate);
+
+      widget.onSubmit(
+        _fromPocketId!,
+        _toPocketId!,
+        amount,
+        description,
+        dateStr,
+      );
+      Navigator.of(context).pop();
+    }
+  }
+}

--- a/frontend/lib/features/settings/presentation/pages/settings_page.dart
+++ b/frontend/lib/features/settings/presentation/pages/settings_page.dart
@@ -51,6 +51,13 @@ class SettingsPage extends StatelessWidget {
               trailing: const Icon(Icons.chevron_right),
               onTap: () => context.push('/payment-methods'),
             ),
+            // Money Pockets
+            ListTile(
+              leading: const Icon(Icons.account_balance_wallet),
+              title: const Text('머니 포켓'),
+              trailing: const Icon(Icons.chevron_right),
+              onTap: () => context.push('/pockets'),
+            ),
             // Recurring Transactions
             ListTile(
               leading: const Icon(Icons.repeat),

--- a/frontend/lib/features/transaction/data/models/transaction_model.dart
+++ b/frontend/lib/features/transaction/data/models/transaction_model.dart
@@ -17,6 +17,8 @@ class TransactionModel extends Transaction {
     super.paymentMethodName,
     super.paymentMethodType,
     super.settlementDate,
+    super.pocketId,
+    super.pocketName,
     required super.createdAt,
     required super.updatedAt,
   });
@@ -40,6 +42,8 @@ class TransactionModel extends Transaction {
       paymentMethodName: json['paymentMethodName'] as String?,
       paymentMethodType: json['paymentMethodType'] as String?,
       settlementDate: json['settlementDate'] as String?,
+      pocketId: json['pocketId'] as String?,
+      pocketName: json['pocketName'] as String?,
       createdAt: DateTime.parse(json['createdAt'] as String),
       updatedAt: DateTime.parse(json['updatedAt'] as String),
     );

--- a/frontend/lib/features/transaction/data/repositories/transaction_repository_impl.dart
+++ b/frontend/lib/features/transaction/data/repositories/transaction_repository_impl.dart
@@ -54,6 +54,7 @@ class TransactionRepositoryImpl implements TransactionRepository {
     required String transactionDate,
     String? memo,
     String? paymentMethodId,
+    String? pocketId,
   }) async {
     try {
       final data = <String, dynamic>{
@@ -64,6 +65,7 @@ class TransactionRepositoryImpl implements TransactionRepository {
         if (categoryId != null) 'categoryId': categoryId,
         if (memo != null) 'memo': memo,
         if (paymentMethodId != null) 'paymentMethodId': paymentMethodId,
+        if (pocketId != null) 'pocketId': pocketId,
       };
       final result = await remoteDataSource.createTransaction(data);
       return Right(result);
@@ -82,6 +84,7 @@ class TransactionRepositoryImpl implements TransactionRepository {
     String? memo,
     bool clearMemo = false,
     String? paymentMethodId,
+    String? pocketId,
   }) async {
     try {
       final data = <String, dynamic>{
@@ -91,6 +94,7 @@ class TransactionRepositoryImpl implements TransactionRepository {
         if (transactionDate != null) 'transactionDate': transactionDate,
         if (memo != null) 'memo': memo else if (clearMemo) 'memo': null,
         if (paymentMethodId != null) 'paymentMethodId': paymentMethodId,
+        if (pocketId != null) 'pocketId': pocketId,
       };
       final result = await remoteDataSource.updateTransaction(id, data);
       return Right(result);

--- a/frontend/lib/features/transaction/domain/entities/transaction.dart
+++ b/frontend/lib/features/transaction/domain/entities/transaction.dart
@@ -16,6 +16,8 @@ class Transaction extends Equatable {
   final String? paymentMethodName;
   final String? paymentMethodType;
   final String? settlementDate;
+  final String? pocketId;
+  final String? pocketName;
   final DateTime createdAt;
   final DateTime updatedAt;
 
@@ -33,6 +35,8 @@ class Transaction extends Equatable {
     this.paymentMethodName,
     this.paymentMethodType,
     this.settlementDate,
+    this.pocketId,
+    this.pocketName,
     required this.createdAt,
     required this.updatedAt,
   });
@@ -55,6 +59,8 @@ class Transaction extends Equatable {
         paymentMethodName,
         paymentMethodType,
         settlementDate,
+        pocketId,
+        pocketName,
         createdAt,
         updatedAt,
       ];

--- a/frontend/lib/features/transaction/domain/repositories/transaction_repository.dart
+++ b/frontend/lib/features/transaction/domain/repositories/transaction_repository.dart
@@ -23,6 +23,7 @@ abstract class TransactionRepository {
     required String transactionDate,
     String? memo,
     String? paymentMethodId,
+    String? pocketId,
   });
 
   Future<Either<Failure, Transaction>> updateTransaction({
@@ -34,6 +35,7 @@ abstract class TransactionRepository {
     String? memo,
     bool clearMemo = false,
     String? paymentMethodId,
+    String? pocketId,
   });
 
   Future<Either<Failure, void>> deleteTransaction(String id);

--- a/frontend/lib/features/transaction/presentation/bloc/transaction_bloc.dart
+++ b/frontend/lib/features/transaction/presentation/bloc/transaction_bloc.dart
@@ -54,6 +54,7 @@ class TransactionBloc extends Bloc<TransactionEvent, TransactionState> {
       transactionDate: event.transactionDate,
       memo: event.memo,
       paymentMethodId: event.paymentMethodId,
+      pocketId: event.pocketId,
     );
     result.fold(
       (failure) => emit(TransactionError(failure.message)),
@@ -74,6 +75,7 @@ class TransactionBloc extends Bloc<TransactionEvent, TransactionState> {
       memo: event.memo,
       clearMemo: event.clearMemo,
       paymentMethodId: event.paymentMethodId,
+      pocketId: event.pocketId,
     );
     result.fold(
       (failure) => emit(TransactionError(failure.message)),

--- a/frontend/lib/features/transaction/presentation/bloc/transaction_event.dart
+++ b/frontend/lib/features/transaction/presentation/bloc/transaction_event.dart
@@ -25,6 +25,7 @@ class CreateTransaction extends TransactionEvent {
   final String transactionDate;
   final String? memo;
   final String? paymentMethodId;
+  final String? pocketId;
 
   const CreateTransaction({
     required this.type,
@@ -34,11 +35,12 @@ class CreateTransaction extends TransactionEvent {
     required this.transactionDate,
     this.memo,
     this.paymentMethodId,
+    this.pocketId,
   });
 
   @override
   List<Object?> get props =>
-      [type, amount, description, categoryId, transactionDate, memo, paymentMethodId];
+      [type, amount, description, categoryId, transactionDate, memo, paymentMethodId, pocketId];
 }
 
 class UpdateTransaction extends TransactionEvent {
@@ -50,6 +52,7 @@ class UpdateTransaction extends TransactionEvent {
   final String? memo;
   final bool clearMemo;
   final String? paymentMethodId;
+  final String? pocketId;
 
   const UpdateTransaction({
     required this.id,
@@ -60,11 +63,12 @@ class UpdateTransaction extends TransactionEvent {
     this.memo,
     this.clearMemo = false,
     this.paymentMethodId,
+    this.pocketId,
   });
 
   @override
   List<Object?> get props =>
-      [id, amount, description, categoryId, transactionDate, memo, clearMemo, paymentMethodId];
+      [id, amount, description, categoryId, transactionDate, memo, clearMemo, paymentMethodId, pocketId];
 }
 
 class DeleteTransaction extends TransactionEvent {

--- a/frontend/lib/features/transaction/presentation/pages/transaction_form_page.dart
+++ b/frontend/lib/features/transaction/presentation/pages/transaction_form_page.dart
@@ -9,6 +9,9 @@ import 'package:budget_book/features/category/presentation/bloc/category_state.d
 import 'package:budget_book/features/payment_method/domain/entities/payment_method.dart';
 import 'package:budget_book/features/payment_method/presentation/bloc/payment_method_bloc.dart';
 import 'package:budget_book/features/payment_method/presentation/bloc/payment_method_state.dart';
+import 'package:budget_book/features/pocket/domain/entities/money_pocket.dart';
+import 'package:budget_book/features/pocket/presentation/bloc/pocket_bloc.dart';
+import 'package:budget_book/features/pocket/presentation/bloc/pocket_state.dart';
 import 'package:budget_book/features/transaction/presentation/bloc/transaction_bloc.dart';
 import 'package:budget_book/features/transaction/presentation/bloc/transaction_event.dart';
 import 'package:budget_book/features/transaction/presentation/bloc/transaction_state.dart';
@@ -32,6 +35,7 @@ class _TransactionFormPageState extends State<TransactionFormPage> {
   late String _selectedType;
   String? _selectedCategoryId;
   String? _selectedPaymentMethodId;
+  String? _selectedPocketId;
   late DateTime _selectedDate;
   bool _isLoadingTransaction = false;
 
@@ -81,6 +85,7 @@ class _TransactionFormPageState extends State<TransactionFormPage> {
             _selectedType = transaction.type;
             _selectedCategoryId = transaction.category?.id;
             _selectedPaymentMethodId = transaction.paymentMethodId;
+            _selectedPocketId = transaction.pocketId;
             _selectedDate = DateTime.parse(transaction.transactionDate);
           });
         }
@@ -197,6 +202,9 @@ class _TransactionFormPageState extends State<TransactionFormPage> {
                 // Payment method picker
                 _buildPaymentMethodPicker(context),
                 const SizedBox(height: 16),
+                // Pocket picker
+                _buildPocketPicker(context),
+                const SizedBox(height: 16),
                 // Date picker
                 _buildDatePicker(context),
                 const SizedBox(height: 16),
@@ -295,6 +303,39 @@ class _TransactionFormPageState extends State<TransactionFormPage> {
     );
   }
 
+  Widget _buildPocketPicker(BuildContext context) {
+    return BlocBuilder<PocketBloc, PocketState>(
+      builder: (context, pocketState) {
+        final pockets = pocketState is PocketLoaded
+            ? pocketState.pockets
+            : <MoneyPocket>[];
+
+        return DropdownButtonFormField<String>(
+          initialValue: _selectedPocketId,
+          decoration: const InputDecoration(
+            labelText: '포켓 (선택)',
+            prefixIcon: Icon(Icons.account_balance_wallet),
+          ),
+          items: [
+            const DropdownMenuItem<String>(
+              value: null,
+              child: Text('포켓 미지정'),
+            ),
+            ...pockets.map((p) => DropdownMenuItem<String>(
+                  value: p.id,
+                  child: Text(p.name),
+                )),
+          ],
+          onChanged: (value) {
+            setState(() {
+              _selectedPocketId = value;
+            });
+          },
+        );
+      },
+    );
+  }
+
   Widget _buildDatePicker(BuildContext context) {
     final formattedDate = DateFormat('yyyy-MM-dd').format(_selectedDate);
     return InkWell(
@@ -340,6 +381,7 @@ class _TransactionFormPageState extends State<TransactionFormPage> {
           memo: memo,
           clearMemo: memo == null,
           paymentMethodId: _selectedPaymentMethodId,
+          pocketId: _selectedPocketId,
         ));
       } else {
         bloc.add(CreateTransaction(
@@ -350,6 +392,7 @@ class _TransactionFormPageState extends State<TransactionFormPage> {
           transactionDate: dateStr,
           memo: memo,
           paymentMethodId: _selectedPaymentMethodId,
+          pocketId: _selectedPocketId,
         ));
       }
     }

--- a/frontend/lib/features/transaction/presentation/widgets/transaction_list_tile.dart
+++ b/frontend/lib/features/transaction/presentation/widgets/transaction_list_tile.dart
@@ -54,15 +54,40 @@ class TransactionListTile extends StatelessWidget {
           maxLines: 1,
           overflow: TextOverflow.ellipsis,
         ),
-        subtitle: Text(
-          category?.name ?? '미분류',
-          style: TextStyle(
-            color: Theme.of(context)
-                .colorScheme
-                .onSurface
-                .withValues(alpha: 0.5),
-            fontSize: 12,
-          ),
+        subtitle: Row(
+          children: [
+            Text(
+              category?.name ?? '미분류',
+              style: TextStyle(
+                color: Theme.of(context)
+                    .colorScheme
+                    .onSurface
+                    .withValues(alpha: 0.5),
+                fontSize: 12,
+              ),
+            ),
+            if (transaction.pocketName != null) ...[
+              const SizedBox(width: 6),
+              Container(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 5, vertical: 1),
+                decoration: BoxDecoration(
+                  color: Theme.of(context)
+                      .colorScheme
+                      .primaryContainer
+                      .withValues(alpha: 0.6),
+                  borderRadius: BorderRadius.circular(4),
+                ),
+                child: Text(
+                  transaction.pocketName!,
+                  style: TextStyle(
+                    fontSize: 10,
+                    color: Theme.of(context).colorScheme.onPrimaryContainer,
+                  ),
+                ),
+              ),
+            ],
+          ],
         ),
         trailing: Column(
           mainAxisAlignment: MainAxisAlignment.center,

--- a/frontend/test/features/pocket/presentation/bloc/pocket_bloc_test.dart
+++ b/frontend/test/features/pocket/presentation/bloc/pocket_bloc_test.dart
@@ -1,0 +1,446 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:dartz/dartz.dart';
+import 'package:budget_book/features/pocket/presentation/bloc/pocket_bloc.dart';
+import 'package:budget_book/features/pocket/presentation/bloc/pocket_event.dart';
+import 'package:budget_book/features/pocket/presentation/bloc/pocket_state.dart';
+import 'package:budget_book/features/pocket/domain/repositories/pocket_repository.dart';
+import 'package:budget_book/features/pocket/domain/entities/money_pocket.dart';
+import 'package:budget_book/features/pocket/domain/entities/distribute_result.dart';
+import 'package:budget_book/core/error/failure.dart';
+
+class MockPocketRepository extends Mock implements PocketRepository {
+  @override
+  Future<Either<Failure, List<MoneyPocket>>> getPockets() =>
+      super.noSuchMethod(
+        Invocation.method(#getPockets, []),
+        returnValue: Future.value(
+          const Right<Failure, List<MoneyPocket>>([]),
+        ),
+      ) as Future<Either<Failure, List<MoneyPocket>>>;
+
+  @override
+  Future<Either<Failure, MoneyPocket>> createPocket({
+    required String name,
+    required String type,
+    required int allocatedAmount,
+    String? icon,
+    String? color,
+  }) =>
+      super.noSuchMethod(
+        Invocation.method(#createPocket, [], {
+          #name: name,
+          #type: type,
+          #allocatedAmount: allocatedAmount,
+          #icon: icon,
+          #color: color,
+        }),
+        returnValue: Future.value(
+          const Right<Failure, MoneyPocket>(MoneyPocket(
+            id: '',
+            name: '',
+            type: 'LIVING',
+            allocatedAmount: 0,
+            balance: 0,
+            displayOrder: 0,
+            isActive: true,
+          )),
+        ),
+      ) as Future<Either<Failure, MoneyPocket>>;
+
+  @override
+  Future<Either<Failure, MoneyPocket>> updatePocket({
+    required String id,
+    String? name,
+    String? type,
+    int? allocatedAmount,
+    String? icon,
+    String? color,
+    int? displayOrder,
+  }) =>
+      super.noSuchMethod(
+        Invocation.method(#updatePocket, [], {
+          #id: id,
+          #name: name,
+          #type: type,
+          #allocatedAmount: allocatedAmount,
+          #icon: icon,
+          #color: color,
+          #displayOrder: displayOrder,
+        }),
+        returnValue: Future.value(
+          const Right<Failure, MoneyPocket>(MoneyPocket(
+            id: '',
+            name: '',
+            type: 'LIVING',
+            allocatedAmount: 0,
+            balance: 0,
+            displayOrder: 0,
+            isActive: true,
+          )),
+        ),
+      ) as Future<Either<Failure, MoneyPocket>>;
+
+  @override
+  Future<Either<Failure, void>> deletePocket(String id) =>
+      super.noSuchMethod(
+        Invocation.method(#deletePocket, [id]),
+        returnValue: Future.value(const Right<Failure, void>(null)),
+      ) as Future<Either<Failure, void>>;
+
+  @override
+  Future<Either<Failure, DistributeResult>> distributeIncome({
+    required int totalAmount,
+    required List<Map<String, dynamic>> distributions,
+  }) =>
+      super.noSuchMethod(
+        Invocation.method(#distributeIncome, [], {
+          #totalAmount: totalAmount,
+          #distributions: distributions,
+        }),
+        returnValue: Future.value(
+          const Right<Failure, DistributeResult>(DistributeResult(
+            distributions: [],
+            totalDistributed: 0,
+          )),
+        ),
+      ) as Future<Either<Failure, DistributeResult>>;
+}
+
+void main() {
+  late PocketBloc bloc;
+  late MockPocketRepository mockRepository;
+
+  const tLivingPocket = MoneyPocket(
+    id: 'pocket-1',
+    name: '생활비',
+    type: 'LIVING',
+    allocatedAmount: 1000000,
+    balance: 750000,
+    icon: 'home',
+    color: '#4CAF50',
+    displayOrder: 0,
+    isActive: true,
+  );
+
+  const tSavingsPocket = MoneyPocket(
+    id: 'pocket-2',
+    name: '저축',
+    type: 'SAVINGS',
+    allocatedAmount: 500000,
+    balance: 500000,
+    icon: 'savings',
+    color: '#2196F3',
+    displayOrder: 1,
+    isActive: true,
+  );
+
+  const tNewPocket = MoneyPocket(
+    id: 'pocket-3',
+    name: '고정지출',
+    type: 'FIXED',
+    allocatedAmount: 300000,
+    balance: 300000,
+    icon: 'payments',
+    color: '#FF9800',
+    displayOrder: 2,
+    isActive: true,
+  );
+
+  final tPockets = [tLivingPocket, tSavingsPocket];
+
+  setUp(() {
+    mockRepository = MockPocketRepository();
+    bloc = PocketBloc(pocketRepository: mockRepository);
+  });
+
+  tearDown(() {
+    bloc.close();
+  });
+
+  group('PocketBloc', () {
+    test('initial state is PocketInitial', () {
+      expect(bloc.state, const PocketInitial());
+    });
+
+    group('LoadPockets', () {
+      blocTest<PocketBloc, PocketState>(
+        'emits [PocketLoading, PocketLoaded] on success',
+        build: () {
+          when(mockRepository.getPockets())
+              .thenAnswer((_) async => Right(tPockets));
+          return bloc;
+        },
+        act: (bloc) => bloc.add(const LoadPockets()),
+        expect: () => [
+          const PocketLoading(),
+          PocketLoaded(tPockets),
+        ],
+      );
+
+      blocTest<PocketBloc, PocketState>(
+        'emits [PocketLoading, PocketError] on failure',
+        build: () {
+          when(mockRepository.getPockets()).thenAnswer(
+              (_) async => const Left(ServerFailure('Failed to load pockets')));
+          return bloc;
+        },
+        act: (bloc) => bloc.add(const LoadPockets()),
+        expect: () => [
+          const PocketLoading(),
+          const PocketError('Failed to load pockets'),
+        ],
+      );
+    });
+
+    group('CreatePocket', () {
+      blocTest<PocketBloc, PocketState>(
+        'emits [PocketLoaded] with new pocket appended',
+        build: () {
+          when(mockRepository.createPocket(
+            name: '고정지출',
+            type: 'FIXED',
+            allocatedAmount: 300000,
+            icon: 'payments',
+            color: '#FF9800',
+          )).thenAnswer((_) async => const Right(tNewPocket));
+          return bloc;
+        },
+        seed: () => PocketLoaded(tPockets),
+        act: (bloc) => bloc.add(const CreatePocket(
+          name: '고정지출',
+          type: 'FIXED',
+          allocatedAmount: 300000,
+          icon: 'payments',
+          color: '#FF9800',
+        )),
+        expect: () => [
+          PocketLoaded([...tPockets, tNewPocket]),
+        ],
+      );
+
+      blocTest<PocketBloc, PocketState>(
+        'emits [PocketLoaded with operationError] on failure',
+        build: () {
+          when(mockRepository.createPocket(
+            name: '고정지출',
+            type: 'FIXED',
+            allocatedAmount: 300000,
+            icon: 'payments',
+            color: '#FF9800',
+          )).thenAnswer(
+              (_) async => const Left(ServerFailure('Failed to create pocket')));
+          return bloc;
+        },
+        seed: () => PocketLoaded(tPockets),
+        act: (bloc) => bloc.add(const CreatePocket(
+          name: '고정지출',
+          type: 'FIXED',
+          allocatedAmount: 300000,
+          icon: 'payments',
+          color: '#FF9800',
+        )),
+        expect: () => [
+          PocketLoaded(tPockets,
+              operationError: 'Failed to create pocket'),
+        ],
+      );
+    });
+
+    group('UpdatePocket', () {
+      const tUpdatedPocket = MoneyPocket(
+        id: 'pocket-1',
+        name: '생활비 (변경)',
+        type: 'LIVING',
+        allocatedAmount: 1200000,
+        balance: 950000,
+        icon: 'home',
+        color: '#4CAF50',
+        displayOrder: 0,
+        isActive: true,
+      );
+
+      blocTest<PocketBloc, PocketState>(
+        'emits [PocketLoaded] with updated pocket in list',
+        build: () {
+          when(mockRepository.updatePocket(
+            id: 'pocket-1',
+            name: '생활비 (변경)',
+            allocatedAmount: 1200000,
+          )).thenAnswer((_) async => const Right(tUpdatedPocket));
+          return bloc;
+        },
+        seed: () => PocketLoaded(tPockets),
+        act: (bloc) => bloc.add(const UpdatePocket(
+          id: 'pocket-1',
+          name: '생활비 (변경)',
+          allocatedAmount: 1200000,
+        )),
+        expect: () => [
+          const PocketLoaded([tUpdatedPocket, tSavingsPocket]),
+        ],
+      );
+
+      blocTest<PocketBloc, PocketState>(
+        'emits [PocketLoaded with operationError] on failure',
+        build: () {
+          when(mockRepository.updatePocket(
+            id: 'pocket-1',
+            name: '생활비 (변경)',
+          )).thenAnswer(
+              (_) async => const Left(ServerFailure('Failed to update pocket')));
+          return bloc;
+        },
+        seed: () => PocketLoaded(tPockets),
+        act: (bloc) => bloc.add(const UpdatePocket(
+          id: 'pocket-1',
+          name: '생활비 (변경)',
+        )),
+        expect: () => [
+          PocketLoaded(tPockets,
+              operationError: 'Failed to update pocket'),
+        ],
+      );
+    });
+
+    group('DeletePocket', () {
+      blocTest<PocketBloc, PocketState>(
+        'emits [PocketLoaded] with pocket removed',
+        build: () {
+          when(mockRepository.deletePocket('pocket-2'))
+              .thenAnswer((_) async => const Right(null));
+          return bloc;
+        },
+        seed: () => PocketLoaded(tPockets),
+        act: (bloc) => bloc.add(const DeletePocket('pocket-2')),
+        expect: () => [
+          const PocketLoaded([tLivingPocket]),
+        ],
+      );
+
+      blocTest<PocketBloc, PocketState>(
+        'emits [PocketLoaded with operationError] on failure',
+        build: () {
+          when(mockRepository.deletePocket('pocket-1')).thenAnswer(
+              (_) async =>
+                  const Left(ServerFailure('Failed to delete pocket')));
+          return bloc;
+        },
+        seed: () => PocketLoaded(tPockets),
+        act: (bloc) => bloc.add(const DeletePocket('pocket-1')),
+        expect: () => [
+          PocketLoaded(tPockets,
+              operationError: 'Failed to delete pocket'),
+        ],
+      );
+    });
+
+    group('DistributeIncome', () {
+      const tDistributeResult = DistributeResult(
+        distributions: [
+          DistributionEntry(
+              pocketId: 'pocket-1', pocketName: '생활비', amount: 600000),
+          DistributionEntry(
+              pocketId: 'pocket-2', pocketName: '저축', amount: 400000),
+        ],
+        totalDistributed: 1000000,
+      );
+
+      blocTest<PocketBloc, PocketState>(
+        'emits LoadPockets after successful distribution (reloads)',
+        build: () {
+          when(mockRepository.distributeIncome(
+            totalAmount: 1000000,
+            distributions: [
+              {'pocketId': 'pocket-1', 'amount': 600000},
+              {'pocketId': 'pocket-2', 'amount': 400000},
+            ],
+          )).thenAnswer((_) async => const Right(tDistributeResult));
+          when(mockRepository.getPockets())
+              .thenAnswer((_) async => Right(tPockets));
+          return bloc;
+        },
+        seed: () => PocketLoaded(tPockets),
+        act: (bloc) => bloc.add(const DistributeIncome(
+          totalAmount: 1000000,
+          distributions: [
+            {'pocketId': 'pocket-1', 'amount': 600000},
+            {'pocketId': 'pocket-2', 'amount': 400000},
+          ],
+        )),
+        expect: () => [
+          const PocketLoading(),
+          PocketLoaded(tPockets),
+        ],
+      );
+
+      blocTest<PocketBloc, PocketState>(
+        'emits [PocketLoaded with operationError] on distribution failure',
+        build: () {
+          when(mockRepository.distributeIncome(
+            totalAmount: 1000000,
+            distributions: [
+              {'pocketId': 'pocket-1', 'amount': 600000},
+            ],
+          )).thenAnswer((_) async =>
+              const Left(ServerFailure('Failed to distribute income')));
+          return bloc;
+        },
+        seed: () => PocketLoaded(tPockets),
+        act: (bloc) => bloc.add(const DistributeIncome(
+          totalAmount: 1000000,
+          distributions: [
+            {'pocketId': 'pocket-1', 'amount': 600000},
+          ],
+        )),
+        expect: () => [
+          PocketLoaded(tPockets,
+              operationError: 'Failed to distribute income'),
+        ],
+      );
+    });
+  });
+
+  group('PocketLoaded helpers', () {
+    test('totalBalance sums all pocket balances', () {
+      final state = PocketLoaded(tPockets);
+      expect(state.totalBalance, 1250000);
+    });
+
+    test('totalAllocated sums all allocated amounts', () {
+      final state = PocketLoaded(tPockets);
+      expect(state.totalAllocated, 1500000);
+    });
+
+    test('activePockets returns only active pockets', () {
+      const inactivePocket = MoneyPocket(
+        id: 'pocket-4',
+        name: '비활성',
+        type: 'CUSTOM',
+        allocatedAmount: 0,
+        balance: 0,
+        displayOrder: 4,
+        isActive: false,
+      );
+      final state = PocketLoaded([...tPockets, inactivePocket]);
+      expect(state.activePockets, tPockets);
+    });
+  });
+
+  group('MoneyPocket entity', () {
+    test('isLiving returns true for LIVING type', () {
+      expect(tLivingPocket.isLiving, true);
+      expect(tLivingPocket.isSavings, false);
+    });
+
+    test('isSavings returns true for SAVINGS type', () {
+      expect(tSavingsPocket.isSavings, true);
+      expect(tSavingsPocket.isLiving, false);
+    });
+
+    test('isFixed returns true for FIXED type', () {
+      expect(tNewPocket.isFixed, true);
+    });
+  });
+}

--- a/frontend/test/features/pocket/presentation/bloc/pocket_transfer_bloc_test.dart
+++ b/frontend/test/features/pocket/presentation/bloc/pocket_transfer_bloc_test.dart
@@ -1,0 +1,183 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:dartz/dartz.dart';
+import 'package:budget_book/features/pocket/presentation/bloc/pocket_transfer_bloc.dart';
+import 'package:budget_book/features/pocket/presentation/bloc/pocket_transfer_event.dart';
+import 'package:budget_book/features/pocket/presentation/bloc/pocket_transfer_state.dart';
+import 'package:budget_book/features/pocket/domain/repositories/pocket_transfer_repository.dart';
+import 'package:budget_book/features/pocket/domain/entities/pocket_transfer.dart';
+import 'package:budget_book/core/error/failure.dart';
+
+class MockPocketTransferRepository extends Mock
+    implements PocketTransferRepository {
+  @override
+  Future<Either<Failure, List<PocketTransfer>>> getPocketTransfers({
+    String? fromPocketId,
+    String? toPocketId,
+    String? startDate,
+    String? endDate,
+  }) =>
+      super.noSuchMethod(
+        Invocation.method(#getPocketTransfers, [], {
+          #fromPocketId: fromPocketId,
+          #toPocketId: toPocketId,
+          #startDate: startDate,
+          #endDate: endDate,
+        }),
+        returnValue: Future.value(
+          const Right<Failure, List<PocketTransfer>>([]),
+        ),
+      ) as Future<Either<Failure, List<PocketTransfer>>>;
+
+  @override
+  Future<Either<Failure, PocketTransfer>> createPocketTransfer({
+    required String fromPocketId,
+    required String toPocketId,
+    required int amount,
+    String? description,
+    required String transferDate,
+  }) =>
+      super.noSuchMethod(
+        Invocation.method(#createPocketTransfer, [], {
+          #fromPocketId: fromPocketId,
+          #toPocketId: toPocketId,
+          #amount: amount,
+          #description: description,
+          #transferDate: transferDate,
+        }),
+        returnValue: Future.value(
+          const Right<Failure, PocketTransfer>(PocketTransfer(
+            id: '',
+            fromPocket: PocketRef(id: '', name: ''),
+            toPocket: PocketRef(id: '', name: ''),
+            amount: 0,
+            transferDate: '',
+            authorId: '',
+          )),
+        ),
+      ) as Future<Either<Failure, PocketTransfer>>;
+}
+
+void main() {
+  late PocketTransferBloc bloc;
+  late MockPocketTransferRepository mockRepository;
+
+  const tTransfer = PocketTransfer(
+    id: 'transfer-1',
+    fromPocket: PocketRef(id: 'pocket-1', name: '생활비'),
+    toPocket: PocketRef(id: 'pocket-2', name: '저축'),
+    amount: 100000,
+    description: '이월 저축',
+    transferDate: '2026-03-12',
+    authorId: 'user-1',
+  );
+
+  const tTransfer2 = PocketTransfer(
+    id: 'transfer-2',
+    fromPocket: PocketRef(id: 'pocket-2', name: '저축'),
+    toPocket: PocketRef(id: 'pocket-1', name: '생활비'),
+    amount: 50000,
+    transferDate: '2026-03-13',
+    authorId: 'user-1',
+  );
+
+  final tTransfers = [tTransfer];
+
+  setUp(() {
+    mockRepository = MockPocketTransferRepository();
+    bloc = PocketTransferBloc(pocketTransferRepository: mockRepository);
+  });
+
+  tearDown(() {
+    bloc.close();
+  });
+
+  group('PocketTransferBloc', () {
+    test('initial state is PocketTransferInitial', () {
+      expect(bloc.state, const PocketTransferInitial());
+    });
+
+    group('LoadPocketTransfers', () {
+      blocTest<PocketTransferBloc, PocketTransferState>(
+        'emits [Loading, Loaded] on success',
+        build: () {
+          when(mockRepository.getPocketTransfers())
+              .thenAnswer((_) async => Right(tTransfers));
+          return bloc;
+        },
+        act: (bloc) => bloc.add(const LoadPocketTransfers()),
+        expect: () => [
+          const PocketTransferLoading(),
+          PocketTransferLoaded(tTransfers),
+        ],
+      );
+
+      blocTest<PocketTransferBloc, PocketTransferState>(
+        'emits [Loading, Error] on failure',
+        build: () {
+          when(mockRepository.getPocketTransfers()).thenAnswer((_) async =>
+              const Left(ServerFailure('Failed to load pocket transfers')));
+          return bloc;
+        },
+        act: (bloc) => bloc.add(const LoadPocketTransfers()),
+        expect: () => [
+          const PocketTransferLoading(),
+          const PocketTransferError('Failed to load pocket transfers'),
+        ],
+      );
+    });
+
+    group('CreatePocketTransfer', () {
+      blocTest<PocketTransferBloc, PocketTransferState>(
+        'emits [Loaded] with new transfer prepended',
+        build: () {
+          when(mockRepository.createPocketTransfer(
+            fromPocketId: 'pocket-2',
+            toPocketId: 'pocket-1',
+            amount: 50000,
+            description: null,
+            transferDate: '2026-03-13',
+          )).thenAnswer((_) async => const Right(tTransfer2));
+          return bloc;
+        },
+        seed: () => PocketTransferLoaded(tTransfers),
+        act: (bloc) => bloc.add(const CreatePocketTransfer(
+          fromPocketId: 'pocket-2',
+          toPocketId: 'pocket-1',
+          amount: 50000,
+          transferDate: '2026-03-13',
+        )),
+        expect: () => [
+          PocketTransferLoaded([tTransfer2, ...tTransfers]),
+        ],
+      );
+
+      blocTest<PocketTransferBloc, PocketTransferState>(
+        'emits [Loaded with operationError] on failure',
+        build: () {
+          when(mockRepository.createPocketTransfer(
+            fromPocketId: 'pocket-1',
+            toPocketId: 'pocket-1',
+            amount: 50000,
+            description: null,
+            transferDate: '2026-03-13',
+          )).thenAnswer((_) async =>
+              const Left(ServerFailure('Cannot transfer to same pocket')));
+          return bloc;
+        },
+        seed: () => PocketTransferLoaded(tTransfers),
+        act: (bloc) => bloc.add(const CreatePocketTransfer(
+          fromPocketId: 'pocket-1',
+          toPocketId: 'pocket-1',
+          amount: 50000,
+          transferDate: '2026-03-13',
+        )),
+        expect: () => [
+          PocketTransferLoaded(tTransfers,
+              operationError: 'Cannot transfer to same pocket'),
+        ],
+      );
+    });
+  });
+}

--- a/frontend/test/features/transaction/presentation/bloc/transaction_bloc_test.dart
+++ b/frontend/test/features/transaction/presentation/bloc/transaction_bloc_test.dart
@@ -65,6 +65,7 @@ class MockTransactionRepository extends Mock
     required String transactionDate,
     String? memo,
     String? paymentMethodId,
+    String? pocketId,
   }) =>
       super.noSuchMethod(
         Invocation.method(#createTransaction, [], {
@@ -75,6 +76,7 @@ class MockTransactionRepository extends Mock
           #transactionDate: transactionDate,
           #memo: memo,
           #paymentMethodId: paymentMethodId,
+          #pocketId: pocketId,
         }),
         returnValue: Future.value(
           Right<Failure, Transaction>(_dummyTransaction),
@@ -91,6 +93,7 @@ class MockTransactionRepository extends Mock
     String? memo,
     bool clearMemo = false,
     String? paymentMethodId,
+    String? pocketId,
   }) =>
       super.noSuchMethod(
         Invocation.method(#updateTransaction, [], {
@@ -102,6 +105,7 @@ class MockTransactionRepository extends Mock
           #memo: memo,
           #clearMemo: clearMemo,
           #paymentMethodId: paymentMethodId,
+          #pocketId: pocketId,
         }),
         returnValue: Future.value(
           Right<Failure, Transaction>(_dummyTransaction),


### PR DESCRIPTION
## Summary
- Complete Money Pockets feature: BE CRUD + balance calculation, FE Clean Architecture with BLoC
- 5 pocket types (LIVING/FIXED/CARD_PENDING/SAVINGS/CUSTOM) with distribute wizard
- Pocket transfers, transaction-pocket linking, real-time WebSocket sync
- Flyway V11-V13 migrations, 65 files, all tests passing (BE 274+, FE 274+)

## Test plan
- [x] BE: `./gradlew test` — all passing
- [x] FE: `flutter test` — 274 tests passing
- [x] FE: `flutter build web` — successful
- [x] Cross-validation: SyncEventHandler routes POCKET + POCKET_TRANSFER events
- [x] api-spec.md aligned with BE entityType naming

🤖 Generated with [Claude Code](https://claude.com/claude-code)