### PR TITLE
perf: Render cold start optimization

### DIFF
--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -2,8 +2,9 @@ name: Keep Alive - Render Cold Start Prevention
 
 on:
   schedule:
-    # Every 14 minutes to prevent Render free tier 15-min sleep
-    - cron: '*/14 * * * *'
+    # Every 10 minutes to prevent Render free tier 15-min sleep
+    # (GitHub Actions cron can delay up to 5min, so 10min provides safety margin)
+    - cron: '*/10 * * * *'
   workflow_dispatch:
 
 jobs:

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -6,15 +6,33 @@ RUN gradle dependencies --no-daemon || true
 COPY src ./src
 RUN gradle bootJar --no-daemon
 
+# Extract Spring Boot jar for exploded layout (faster class loading)
+FROM eclipse-temurin:21-jre-alpine AS extract
+WORKDIR /app
+COPY --from=build /app/build/libs/*.jar app.jar
+RUN java -Djarmode=tools -jar app.jar extract --destination extracted
+
+# CDS training - captures JDK/Spring class metadata for faster JVM startup
+# DB/Redis connection failure is expected; archive is still created on JVM exit
+FROM eclipse-temurin:21-jre-alpine AS cds
+WORKDIR /app
+COPY --from=extract /app/extracted/ ./
+RUN java -XX:ArchiveClassesAtExit=app-cds.jsa \
+  -Dspring.context.exit=onRefresh \
+  -jar app.jar 2>/dev/null ; true
+
 FROM eclipse-temurin:21-jre-alpine
 RUN addgroup -S app && adduser -S app -G app
 WORKDIR /app
-COPY --from=build /app/build/libs/*.jar app.jar
+COPY --from=cds /app/lib/ ./lib/
+COPY --from=cds /app/app.jar ./
+COPY --from=cds /app/app-cds.jsa ./
 USER app
 EXPOSE 8080
 ENTRYPOINT ["java", \
   "-Xms128m", "-Xmx384m", \
   "-XX:+UseSerialGC", \
   "-XX:+TieredCompilation", "-XX:TieredStopAtLevel=1", \
+  "-XX:SharedArchiveFile=app-cds.jsa", \
   "-Dspring.jmx.enabled=false", \
   "-jar", "app.jar"]

--- a/frontend/lib/features/auth/presentation/pages/login_page.dart
+++ b/frontend/lib/features/auth/presentation/pages/login_page.dart
@@ -1,3 +1,4 @@
+import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -11,8 +12,16 @@ import 'package:budget_book/features/auth/presentation/bloc/auth_bloc.dart';
 import 'package:budget_book/features/auth/presentation/bloc/auth_state.dart';
 import 'package:budget_book/features/auth/presentation/widgets/social_login_button.dart';
 
-class LoginPage extends StatelessWidget {
+class LoginPage extends StatefulWidget {
   const LoginPage({super.key});
+
+  @override
+  State<LoginPage> createState() => _LoginPageState();
+}
+
+class _LoginPageState extends State<LoginPage> {
+  bool _isWakingServer = false;
+  String _statusMessage = '';
 
   @override
   Widget build(BuildContext context) {
@@ -68,6 +77,11 @@ class LoginPage extends StatelessWidget {
                           ),
                     ),
                     const SizedBox(height: 60),
+                    // Server wake-up status
+                    if (_isWakingServer) ...[
+                      _buildWakeUpIndicator(),
+                      const SizedBox(height: 24),
+                    ],
                     // Google login button
                     SocialLoginButton(
                       providerName: 'Google',
@@ -75,9 +89,11 @@ class LoginPage extends StatelessWidget {
                       backgroundColor: Colors.white,
                       textColor: Colors.black87,
                       iconColor: Colors.red,
-                      onPressed: () => _launchOAuth(
-                        '${ApiEndpoints.baseUrl}${ApiEndpoints.authGoogle}',
-                      ),
+                      onPressed: _isWakingServer
+                          ? () {}
+                          : () => _wakeAndLaunchOAuth(
+                                '${ApiEndpoints.baseUrl}${ApiEndpoints.authGoogle}',
+                              ),
                     ),
                     const SizedBox(height: 16),
                     // Kakao login button
@@ -87,9 +103,11 @@ class LoginPage extends StatelessWidget {
                       backgroundColor: const Color(0xFFFEE500),
                       textColor: const Color(0xFF3C1E1E),
                       iconColor: const Color(0xFF3C1E1E),
-                      onPressed: () => _launchOAuth(
-                        '${ApiEndpoints.baseUrl}${ApiEndpoints.authKakao}',
-                      ),
+                      onPressed: _isWakingServer
+                          ? () {}
+                          : () => _wakeAndLaunchOAuth(
+                                '${ApiEndpoints.baseUrl}${ApiEndpoints.authKakao}',
+                              ),
                     ),
                     const SizedBox(height: 40),
                     // Footer text
@@ -113,12 +131,112 @@ class LoginPage extends StatelessWidget {
     );
   }
 
-  Future<void> _launchOAuth(String url) async {
+  Widget _buildWakeUpIndicator() {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 14),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.primaryContainer.withValues(alpha: 0.3),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          SizedBox(
+            width: 18,
+            height: 18,
+            child: CircularProgressIndicator(
+              strokeWidth: 2,
+              color: Theme.of(context).colorScheme.primary,
+            ),
+          ),
+          const SizedBox(width: 12),
+          Flexible(
+            child: Text(
+              _statusMessage,
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: Theme.of(context).colorScheme.primary,
+                  ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _wakeAndLaunchOAuth(String oauthUrl) async {
+    setState(() {
+      _isWakingServer = true;
+      _statusMessage = '서버 연결 중...';
+    });
+
+    final dio = Dio(BaseOptions(
+      connectTimeout: const Duration(seconds: 60),
+      receiveTimeout: const Duration(seconds: 60),
+    ));
+
+    try {
+      // Quick health check first
+      final response = await dio.get(
+        '${ApiEndpoints.baseUrl}/actuator/health',
+      );
+
+      if (response.statusCode == 200) {
+        if (mounted) {
+          setState(() => _isWakingServer = false);
+          _launchOAuth(oauthUrl);
+        }
+        return;
+      }
+    } on DioException {
+      // Server is likely sleeping - start wake-up polling
+    }
+
+    if (!mounted) return;
+    setState(() => _statusMessage = '서버를 깨우고 있습니다...');
+
+    // Poll with retries (max 90 seconds)
+    for (int i = 0; i < 18; i++) {
+      await Future.delayed(const Duration(seconds: 5));
+      if (!mounted) return;
+
+      if (i >= 6) {
+        setState(() => _statusMessage = '거의 다 됐습니다... 잠시만 기다려주세요');
+      }
+
+      try {
+        final response = await dio.get(
+          '${ApiEndpoints.baseUrl}/actuator/health',
+          options: Options(
+            sendTimeout: const Duration(seconds: 10),
+            receiveTimeout: const Duration(seconds: 10),
+          ),
+        );
+
+        if (response.statusCode == 200) {
+          if (mounted) {
+            setState(() => _isWakingServer = false);
+            _launchOAuth(oauthUrl);
+          }
+          return;
+        }
+      } on DioException {
+        // Still waking up, continue polling
+      }
+    }
+
+    // Timeout - let user try anyway
+    if (mounted) {
+      setState(() => _isWakingServer = false);
+      _launchOAuth(oauthUrl);
+    }
+  }
+
+  void _launchOAuth(String url) {
     if (kIsWeb) {
       web_nav.setWindowLocation(url);
     } else {
       final uri = Uri.parse(url);
-      await launchUrl(uri, mode: LaunchMode.externalApplication);
+      launchUrl(uri, mode: LaunchMode.externalApplication);
     }
   }
 }


### PR DESCRIPTION
## Summary
- **CDS (Class Data Sharing)**: Dockerfile에 Spring Boot extract + CDS training stage 추가. JVM/Spring 클래스 메타데이터를 Docker 이미지에 미리 캐싱하여 부팅 15-30% 단축
- **Keep-alive 10분**: GitHub Actions cron 지연(최대 5분) 대비, 14분→10분으로 축소하여 Render sleep 방지 강화
- **서버 웨이크업 UI**: 로그인 버튼 클릭 시 health check 후 OAuth redirect. "서버 연결 중..." → "서버를 깨우고 있습니다..." → "거의 다 됐습니다..." 단계별 상태 메시지 표시

## Test plan
- [x] BE: `./gradlew test` — all passing
- [x] FE: `flutter test` — 274 tests passing
- [x] FE: `flutter analyze` — no issues
- [x] FE: `flutter build web` — successful

🤖 Generated with [Claude Code](https://claude.com/claude-code)