### PR TITLE
fix: critical navigation and BLoC lifecycle bugs

### DIFF
--- a/frontend/lib/core/router/app_router.dart
+++ b/frontend/lib/core/router/app_router.dart
@@ -69,13 +69,15 @@ final appRouter = GoRouter(
     if (isOnCallbackPage) return null;
 
     if (authState is AuthAuthenticated && isOnLoginPage) {
-      // Check if user has a couple
       return authState.user.coupleId != null ? '/home' : '/couple';
     }
 
     if (authState is AuthAuthenticated) {
       // If no couple and trying to access couple-required pages, redirect to /couple
-      if (authState.user.coupleId == null && !isOnCouplePage) {
+      // But allow /couple itself and /settings to pass through
+      if (authState.user.coupleId == null &&
+          !isOnCouplePage &&
+          state.matchedLocation != '/settings') {
         return '/couple';
       }
       return null;
@@ -142,9 +144,10 @@ final appRouter = GoRouter(
               path: '/transactions',
               builder: (context, state) {
                 final now = DateTime.now();
-                return BlocProvider<TransactionBloc>(
-                  create: (_) => getIt<TransactionBloc>()
-                    ..add(LoadTransactions(year: now.year, month: now.month)),
+                getIt<TransactionBloc>()
+                    .add(LoadTransactions(year: now.year, month: now.month));
+                return BlocProvider<TransactionBloc>.value(
+                  value: getIt<TransactionBloc>(),
                   child: const TransactionListPage(),
                 );
               },
@@ -158,9 +161,10 @@ final appRouter = GoRouter(
               path: '/budgets',
               builder: (context, state) {
                 final now = DateTime.now();
-                return BlocProvider<BudgetBloc>(
-                  create: (_) => getIt<BudgetBloc>()
-                    ..add(LoadBudgets(year: now.year, month: now.month)),
+                getIt<BudgetBloc>()
+                    .add(LoadBudgets(year: now.year, month: now.month));
+                return BlocProvider<BudgetBloc>.value(
+                  value: getIt<BudgetBloc>(),
                   child: const BudgetListPage(),
                 );
               },
@@ -195,58 +199,66 @@ final appRouter = GoRouter(
       ],
     ),
     // Sub-pages (pushed on top of shell, no bottom nav)
+    // IMPORTANT: Use BlocProvider.value() for singleton BLoCs to avoid
+    // auto-close on pop which would permanently kill the singleton.
     GoRoute(
       path: '/categories',
       parentNavigatorKey: _rootNavigatorKey,
-      builder: (context, state) => BlocProvider<CategoryBloc>(
-        create: (context) =>
-            getIt<CategoryBloc>()..add(const LoadCategories()),
-        child: const CategoryPage(),
-      ),
+      builder: (context, state) {
+        getIt<CategoryBloc>().add(const LoadCategories());
+        return BlocProvider<CategoryBloc>.value(
+          value: getIt<CategoryBloc>(),
+          child: const CategoryPage(),
+        );
+      },
     ),
     GoRoute(
       path: '/transactions/create',
       parentNavigatorKey: _rootNavigatorKey,
-      builder: (context, state) => MultiBlocProvider(
-        providers: [
-          BlocProvider<TransactionBloc>(
-            create: (_) => getIt<TransactionBloc>(),
-          ),
-          BlocProvider<CategoryBloc>(
-            create: (_) =>
-                getIt<CategoryBloc>()..add(const LoadCategories()),
-          ),
-          BlocProvider<PaymentMethodBloc>(
-            create: (_) =>
-                getIt<PaymentMethodBloc>()..add(const LoadPaymentMethods()),
-          ),
-          BlocProvider<PocketBloc>.value(
-            value: getIt<PocketBloc>()..add(const LoadPockets()),
-          ),
-        ],
-        child: const TransactionFormPage(),
-      ),
+      builder: (context, state) {
+        getIt<CategoryBloc>().add(const LoadCategories());
+        getIt<PaymentMethodBloc>().add(const LoadPaymentMethods());
+        getIt<PocketBloc>().add(const LoadPockets());
+        return MultiBlocProvider(
+          providers: [
+            BlocProvider<TransactionBloc>.value(
+              value: getIt<TransactionBloc>(),
+            ),
+            BlocProvider<CategoryBloc>.value(
+              value: getIt<CategoryBloc>(),
+            ),
+            BlocProvider<PaymentMethodBloc>.value(
+              value: getIt<PaymentMethodBloc>(),
+            ),
+            BlocProvider<PocketBloc>.value(
+              value: getIt<PocketBloc>(),
+            ),
+          ],
+          child: const TransactionFormPage(),
+        );
+      },
     ),
     GoRoute(
       path: '/transactions/edit/:id',
       parentNavigatorKey: _rootNavigatorKey,
       builder: (context, state) {
         final transactionId = state.pathParameters['id']!;
+        getIt<CategoryBloc>().add(const LoadCategories());
+        getIt<PaymentMethodBloc>().add(const LoadPaymentMethods());
+        getIt<PocketBloc>().add(const LoadPockets());
         return MultiBlocProvider(
           providers: [
-            BlocProvider<TransactionBloc>(
-              create: (_) => getIt<TransactionBloc>(),
+            BlocProvider<TransactionBloc>.value(
+              value: getIt<TransactionBloc>(),
             ),
-            BlocProvider<CategoryBloc>(
-              create: (_) =>
-                  getIt<CategoryBloc>()..add(const LoadCategories()),
+            BlocProvider<CategoryBloc>.value(
+              value: getIt<CategoryBloc>(),
             ),
-            BlocProvider<PaymentMethodBloc>(
-              create: (_) =>
-                  getIt<PaymentMethodBloc>()..add(const LoadPaymentMethods()),
+            BlocProvider<PaymentMethodBloc>.value(
+              value: getIt<PaymentMethodBloc>(),
             ),
             BlocProvider<PocketBloc>.value(
-              value: getIt<PocketBloc>()..add(const LoadPockets()),
+              value: getIt<PocketBloc>(),
             ),
           ],
           child: TransactionFormPage(
@@ -265,15 +277,15 @@ final appRouter = GoRouter(
         final month = int.tryParse(
                 state.uri.queryParameters['month'] ?? '') ??
             DateTime.now().month;
+        getIt<BudgetBloc>().add(LoadBudgets(year: year, month: month));
+        getIt<CategoryBloc>().add(const LoadCategories());
         return MultiBlocProvider(
           providers: [
-            BlocProvider<BudgetBloc>(
-              create: (_) => getIt<BudgetBloc>()
-                ..add(LoadBudgets(year: year, month: month)),
+            BlocProvider<BudgetBloc>.value(
+              value: getIt<BudgetBloc>(),
             ),
-            BlocProvider<CategoryBloc>(
-              create: (_) =>
-                  getIt<CategoryBloc>()..add(const LoadCategories()),
+            BlocProvider<CategoryBloc>.value(
+              value: getIt<CategoryBloc>(),
             ),
           ],
           child: BudgetFormPage(year: year, month: month),
@@ -290,15 +302,15 @@ final appRouter = GoRouter(
         final month = int.tryParse(
                 state.uri.queryParameters['month'] ?? '') ??
             DateTime.now().month;
+        getIt<BudgetBloc>().add(LoadBudgets(year: year, month: month));
+        getIt<CategoryBloc>().add(const LoadCategories());
         return MultiBlocProvider(
           providers: [
-            BlocProvider<BudgetBloc>(
-              create: (_) => getIt<BudgetBloc>()
-                ..add(LoadBudgets(year: year, month: month)),
+            BlocProvider<BudgetBloc>.value(
+              value: getIt<BudgetBloc>(),
             ),
-            BlocProvider<CategoryBloc>(
-              create: (_) =>
-                  getIt<CategoryBloc>()..add(const LoadCategories()),
+            BlocProvider<CategoryBloc>.value(
+              value: getIt<CategoryBloc>(),
             ),
           ],
           child: BudgetFormPage(
@@ -314,10 +326,11 @@ final appRouter = GoRouter(
       parentNavigatorKey: _rootNavigatorKey,
       builder: (context, state) {
         final now = DateTime.now();
-        return BlocProvider<PaymentMethodBloc>(
-          create: (context) => getIt<PaymentMethodBloc>()
-            ..add(const LoadPaymentMethods())
-            ..add(LoadCardPending(year: now.year, month: now.month)),
+        getIt<PaymentMethodBloc>()
+          ..add(const LoadPaymentMethods())
+          ..add(LoadCardPending(year: now.year, month: now.month));
+        return BlocProvider<PaymentMethodBloc>.value(
+          value: getIt<PaymentMethodBloc>(),
           child: const PaymentMethodPage(),
         );
       },
@@ -325,11 +338,13 @@ final appRouter = GoRouter(
     GoRoute(
       path: '/category-groups',
       parentNavigatorKey: _rootNavigatorKey,
-      builder: (context, state) => BlocProvider<CategoryGroupBloc>(
-        create: (context) =>
-            getIt<CategoryGroupBloc>()..add(const LoadCategoryGroups()),
-        child: const CategoryGroupPage(),
-      ),
+      builder: (context, state) {
+        getIt<CategoryGroupBloc>().add(const LoadCategoryGroups());
+        return BlocProvider<CategoryGroupBloc>.value(
+          value: getIt<CategoryGroupBloc>(),
+          child: const CategoryGroupPage(),
+        );
+      },
     ),
     GoRoute(
       path: '/weekly-budgets',
@@ -370,42 +385,44 @@ final appRouter = GoRouter(
     GoRoute(
       path: '/recurring/create',
       parentNavigatorKey: _rootNavigatorKey,
-      builder: (context, state) => MultiBlocProvider(
-        providers: [
-          BlocProvider<RecurringBloc>(
-            create: (_) =>
-                getIt<RecurringBloc>()..add(const LoadRecurringTransactions()),
-          ),
-          BlocProvider<CategoryBloc>(
-            create: (_) =>
-                getIt<CategoryBloc>()..add(const LoadCategories()),
-          ),
-          BlocProvider<PaymentMethodBloc>(
-            create: (_) =>
-                getIt<PaymentMethodBloc>()..add(const LoadPaymentMethods()),
-          ),
-        ],
-        child: const RecurringFormPage(),
-      ),
-    ),
-    GoRoute(
-      path: '/recurring/edit/:id',
-      parentNavigatorKey: _rootNavigatorKey,
       builder: (context, state) {
-        final recurringId = state.pathParameters['id']!;
+        getIt<CategoryBloc>().add(const LoadCategories());
+        getIt<PaymentMethodBloc>().add(const LoadPaymentMethods());
         return MultiBlocProvider(
           providers: [
             BlocProvider<RecurringBloc>(
               create: (_) => getIt<RecurringBloc>()
                 ..add(const LoadRecurringTransactions()),
             ),
-            BlocProvider<CategoryBloc>(
-              create: (_) =>
-                  getIt<CategoryBloc>()..add(const LoadCategories()),
+            BlocProvider<CategoryBloc>.value(
+              value: getIt<CategoryBloc>(),
             ),
-            BlocProvider<PaymentMethodBloc>(
-              create: (_) =>
-                  getIt<PaymentMethodBloc>()..add(const LoadPaymentMethods()),
+            BlocProvider<PaymentMethodBloc>.value(
+              value: getIt<PaymentMethodBloc>(),
+            ),
+          ],
+          child: const RecurringFormPage(),
+        );
+      },
+    ),
+    GoRoute(
+      path: '/recurring/edit/:id',
+      parentNavigatorKey: _rootNavigatorKey,
+      builder: (context, state) {
+        final recurringId = state.pathParameters['id']!;
+        getIt<CategoryBloc>().add(const LoadCategories());
+        getIt<PaymentMethodBloc>().add(const LoadPaymentMethods());
+        return MultiBlocProvider(
+          providers: [
+            BlocProvider<RecurringBloc>(
+              create: (_) => getIt<RecurringBloc>()
+                ..add(const LoadRecurringTransactions()),
+            ),
+            BlocProvider<CategoryBloc>.value(
+              value: getIt<CategoryBloc>(),
+            ),
+            BlocProvider<PaymentMethodBloc>.value(
+              value: getIt<PaymentMethodBloc>(),
             ),
           ],
           child: RecurringFormPage(recurringId: recurringId),
@@ -416,34 +433,43 @@ final appRouter = GoRouter(
     GoRoute(
       path: '/pockets',
       parentNavigatorKey: _rootNavigatorKey,
-      builder: (context, state) => BlocProvider<PocketBloc>.value(
-        value: getIt<PocketBloc>()..add(const LoadPockets()),
-        child: const PocketPage(),
-      ),
+      builder: (context, state) {
+        getIt<PocketBloc>().add(const LoadPockets());
+        return BlocProvider<PocketBloc>.value(
+          value: getIt<PocketBloc>(),
+          child: const PocketPage(),
+        );
+      },
     ),
     GoRoute(
       path: '/pockets/distribute',
       parentNavigatorKey: _rootNavigatorKey,
-      builder: (context, state) => BlocProvider<PocketBloc>.value(
-        value: getIt<PocketBloc>()..add(const LoadPockets()),
-        child: const DistributeWizardPage(),
-      ),
+      builder: (context, state) {
+        getIt<PocketBloc>().add(const LoadPockets());
+        return BlocProvider<PocketBloc>.value(
+          value: getIt<PocketBloc>(),
+          child: const DistributeWizardPage(),
+        );
+      },
     ),
     GoRoute(
       path: '/pocket-transfers',
       parentNavigatorKey: _rootNavigatorKey,
-      builder: (context, state) => MultiBlocProvider(
-        providers: [
-          BlocProvider<PocketBloc>.value(
-            value: getIt<PocketBloc>()..add(const LoadPockets()),
-          ),
-          BlocProvider<PocketTransferBloc>.value(
-            value: getIt<PocketTransferBloc>()
-              ..add(const LoadPocketTransfers()),
-          ),
-        ],
-        child: const PocketTransferPage(),
-      ),
+      builder: (context, state) {
+        getIt<PocketBloc>().add(const LoadPockets());
+        getIt<PocketTransferBloc>().add(const LoadPocketTransfers());
+        return MultiBlocProvider(
+          providers: [
+            BlocProvider<PocketBloc>.value(
+              value: getIt<PocketBloc>(),
+            ),
+            BlocProvider<PocketTransferBloc>.value(
+              value: getIt<PocketTransferBloc>(),
+            ),
+          ],
+          child: const PocketTransferPage(),
+        );
+      },
     ),
   ],
 );

--- a/frontend/lib/features/couple/presentation/pages/couple_page.dart
+++ b/frontend/lib/features/couple/presentation/pages/couple_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 import 'package:budget_book/features/auth/presentation/bloc/auth_bloc.dart';
 import 'package:budget_book/features/auth/presentation/bloc/auth_event.dart';
+import 'package:budget_book/features/auth/presentation/bloc/auth_state.dart';
 import 'package:budget_book/features/couple/presentation/bloc/couple_bloc.dart';
 import 'package:budget_book/features/couple/presentation/bloc/couple_event.dart';
 import 'package:budget_book/features/couple/presentation/bloc/couple_state.dart';
@@ -18,6 +19,7 @@ class CouplePage extends StatefulWidget {
 
 class _CouplePageState extends State<CouplePage> {
   final _codeController = TextEditingController();
+  bool _waitingForAuthRefresh = false;
 
   @override
   void dispose() {
@@ -27,42 +29,72 @@ class _CouplePageState extends State<CouplePage> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('커플 연결'),
-        automaticallyImplyLeading: Navigator.canPop(context),
-      ),
-      body: BlocConsumer<CoupleBloc, CoupleState>(
-        listener: (context, state) {
-          if (state is CoupleError) {
-            ScaffoldMessenger.of(context).showSnackBar(
-              SnackBar(
-                content: Text(state.message),
-                backgroundColor: Colors.red,
-              ),
-            );
-          } else if (state is CoupleLinked) {
-            // Refresh auth state to update coupleId
-            context.read<AuthBloc>().add(const AuthRefreshUser());
-            ScaffoldMessenger.of(context).showSnackBar(
-              const SnackBar(content: Text('커플이 연결되었습니다!')),
-            );
-            // Navigate to home after couple linking
-            context.go('/home');
-          }
-        },
-        builder: (context, state) {
-          return switch (state) {
-            CoupleInitial() || CoupleLoading() => const Center(
-                child: CircularProgressIndicator(),
-              ),
-            CoupleNotLinked() => _buildNotLinked(context),
-            CoupleInvitationPending(invitation: final inv) =>
-              _buildInvitationPending(context, inv),
-            CoupleLinked(couple: final couple) => _buildLinked(context, couple),
-            CoupleError() => _buildNotLinked(context),
-          };
-        },
+    return MultiBlocListener(
+      listeners: [
+        BlocListener<CoupleBloc, CoupleState>(
+          listener: (context, state) {
+            if (state is CoupleError) {
+              ScaffoldMessenger.of(context).showSnackBar(
+                SnackBar(
+                  content: Text(state.message),
+                  backgroundColor: Colors.red,
+                ),
+              );
+            } else if (state is CoupleLinked) {
+              // Refresh auth state to update coupleId, then navigate
+              setState(() => _waitingForAuthRefresh = true);
+              context.read<AuthBloc>().add(const AuthRefreshUser());
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(content: Text('커플이 연결되었습니다!')),
+              );
+            }
+          },
+        ),
+        // Wait for auth refresh to complete before navigating to home
+        BlocListener<AuthBloc, AuthState>(
+          listener: (context, state) {
+            if (_waitingForAuthRefresh &&
+                state is AuthAuthenticated &&
+                state.user.coupleId != null) {
+              _waitingForAuthRefresh = false;
+              context.go('/home');
+            }
+          },
+        ),
+      ],
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('커플 연결'),
+          automaticallyImplyLeading: Navigator.canPop(context),
+        ),
+        body: BlocBuilder<CoupleBloc, CoupleState>(
+          builder: (context, state) {
+            if (_waitingForAuthRefresh) {
+              return const Center(
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    CircularProgressIndicator(),
+                    SizedBox(height: 16),
+                    Text('홈으로 이동 중...'),
+                  ],
+                ),
+              );
+            }
+
+            return switch (state) {
+              CoupleInitial() || CoupleLoading() => const Center(
+                  child: CircularProgressIndicator(),
+                ),
+              CoupleNotLinked() => _buildNotLinked(context),
+              CoupleInvitationPending(invitation: final inv) =>
+                _buildInvitationPending(context, inv),
+              CoupleLinked(couple: final couple) =>
+                _buildLinked(context, couple),
+              CoupleError() => _buildNotLinked(context),
+            };
+          },
+        ),
       ),
     );
   }
@@ -168,11 +200,15 @@ class _CouplePageState extends State<CouplePage> {
                 ),
           ),
           const SizedBox(height: 32),
-          OutlinedButton(
+          FilledButton.icon(
             onPressed: () {
               context.read<CoupleBloc>().add(const LoadCouple());
             },
-            child: const Text('상태 새로고침'),
+            icon: const Icon(Icons.refresh),
+            label: const Text('연결 상태 확인'),
+            style: FilledButton.styleFrom(
+              padding: const EdgeInsets.symmetric(vertical: 16),
+            ),
           ),
           const SizedBox(height: 12),
           TextButton(
@@ -207,7 +243,21 @@ class _CouplePageState extends State<CouplePage> {
           ),
           const SizedBox(height: 24),
           CoupleInfoWidget(partner: couple.partner),
-          const SizedBox(height: 40),
+          const SizedBox(height: 32),
+          // Navigate to home
+          FilledButton.icon(
+            onPressed: () {
+              // Ensure auth state is fresh, then navigate
+              context.read<AuthBloc>().add(const AuthRefreshUser());
+              context.go('/home');
+            },
+            icon: const Icon(Icons.home),
+            label: const Text('홈으로 이동'),
+            style: FilledButton.styleFrom(
+              padding: const EdgeInsets.symmetric(vertical: 16),
+            ),
+          ),
+          const SizedBox(height: 16),
           OutlinedButton.icon(
             onPressed: () => _showDissolveDialog(context),
             icon: const Icon(Icons.link_off, color: Colors.red),


### PR DESCRIPTION
## Summary
- **BlocProvider 싱글턴 auto-close 버그 수정**: 서브 라우트에서 `BlocProvider(create:)`로 싱글턴 BLoC을 감싸면 pop 시 영구 close됨 → `.value()` 전환
- **커플 연결 후 네비게이션 수정**: AuthRefreshUser 완료 대기 후 홈 이동, "홈으로 이동" 버튼 추가
- 거래/예산 폼, 카테고리 관리 등 모든 서브 페이지 정상 동작 복구

## Test plan
- [x] `flutter analyze` — no issues
- [x] `flutter test` — 274 tests passing
- [x] `flutter build web` — successful
- [ ] 필드 테스트: 커플 연결 → 홈 이동 → 거래 추가 → pop → 재진입

🤖 Generated with [Claude Code](https://claude.com/claude-code)