### PR TITLE
fix: design verification - budget pop and AppBar cleanup

### DIFF
--- a/docs/sessions/2026-03-13_1_plan.md
+++ b/docs/sessions/2026-03-13_1_plan.md
@@ -1,0 +1,140 @@
+# 전체 기능 설계 검증 및 수정
+> 날짜: 2026-03-13 | 회차: 1 | 상태: 기획/검증완료
+
+## 요청 내용
+필드 테스트에서 발견된 심각한 버그들(커플 연결, 네비게이션, 폼 빈 화면, 카테고리)의 근본 원인은 기획/설계 단계에서 유저 플로우, 화면 전환, 상태 라이프사이클 검증이 부재했기 때문. 전체 앱을 5대 검증 기준으로 재검증하여 남은 문제를 모두 찾고 수정.
+
+---
+
+## 1. 유저 플로우 시뮬레이션
+
+### 플로우 A: 신규 가입 → 커플 연결 → 첫 거래
+```
+[앱 열기] → /login → [Google 로그인] → /auth/callback → coupleId=null → /couple
+→ [초대 코드 생성] → 코드 공유 → [파트너가 수락] → [연결 상태 확인] 클릭
+→ CoupleLinked → AuthRefreshUser 대기 → /home (대시보드)
+→ 하단 탭 "거래" → /transactions → [+] → /transactions/create → 폼 작성 → 저장 → pop
+→ 거래 목록에 새 항목 표시
+```
+
+**검증 결과:**
+- ✅ 로그인 → 콜백 → 커플 redirect: 정상
+- ✅ 커플 연결 후 AuthRefreshUser 대기 → 홈 이동: **수정 완료(PR #31)**
+- ✅ 거래 추가 → pop: BlocProvider.value 사용으로 **수정 완료(PR #31)**
+
+### 플로우 B: 커플 연결 후 설정에서 카테고리 관리
+```
+/settings → [카테고리 관리] → push /categories → [+] → 카테고리 추가 → [뒤로]
+→ /settings → [카테고리 관리] → push /categories → 이전에 추가한 카테고리 표시되어야 함
+```
+
+**검증 결과:**
+- ✅ CategoryBloc .value로 전환되어 pop 후에도 싱글턴 생존: **수정 완료(PR #31)**
+
+### 플로우 C: 예산 추가 플로우
+```
+하단 탭 "예산" → /budgets → [+] → /budgets/create → 폼 작성 → 저장 → ???
+```
+
+**🔴 발견된 버그: BudgetFormPage 생성 모드에서 pop 안 됨**
+- BudgetBloc.CreateBudget 성공 → LoadBudgets 재호출 → BudgetLoaded 상태 emit
+- BudgetFormPage listener: `state is BudgetLoaded && _initialized && _budget != null` 체크
+- 생성 모드에서 `_initialized = false`, `_budget = null` → 조건 불충족 → **pop 안 됨**
+- 사용자가 예산 생성 후 폼 페이지에 갇힘
+
+### 플로우 D: 거래 탭 AppBar에서 통계/예산/카테고리 push
+```
+/transactions (탭 1) → AppBar [통계] 버튼 → context.push('/statistics')
+→ 통계 페이지가 Shell 위에 push됨 (하단 네비 없음)
+→ [뒤로] → /transactions 복귀
+```
+
+**🟡 UX 이슈: 거래 탭 AppBar의 통계/예산/카테고리/커플 아이콘들**
+- 하단 탭에 이미 통계(탭3), 예산(탭2)이 있는데, 거래 탭 AppBar에도 동일 기능 아이콘 존재
+- `context.push('/statistics')`: Shell 밖에 push → 하단 탭 없음 → 탭 전환으로 통계 간 것과 다른 경험
+- `context.push('/budgets')`: 마찬가지 — 하단 탭의 예산 탭과 충돌
+- **탭 인덱스 불일치 원인**: 사용자가 거래 탭에서 AppBar 통계 아이콘을 누르면 Shell 위에 통계가 뜸. 뒤로 가면 하단 탭은 여전히 "거래"로 표시되지만 사용자는 "통계를 보고 왔는데 왜 거래가 선택되어 있지?" 혼란
+
+### 플로우 E: 웹 새로고침
+```
+/home에서 브라우저 새로고침 → 앱 재시작 → AuthCheckRequested
+→ 토큰이 secure storage에 있으면 복원 → /home 또는 /couple
+```
+
+**검증 결과:**
+- ✅ `AuthCheckRequested`가 `app.dart`에서 발동 → 토큰 확인 후 상태 복원
+- ✅ `initialLocation: '/login'`이지만 redirect가 인증 상태에 따라 처리
+
+---
+
+## 2. 화면 전환 매트릭스
+
+| 출발 화면 | 도착 화면 | 방식 | Shell 안 | 하단 탭 | 뒤로가기 |
+|----------|----------|------|---------|--------|---------|
+| /login | /home | go (redirect) | ✅ | ✅ | ❌ (로그인으로 못감) |
+| /login | /couple | go (redirect) | ❌ | ❌ | ❌ |
+| /couple | /home | go | ✅ | ✅ | ❌ |
+| /home | /couple | push | ❌ | ❌ | ✅ |
+| /home→거래 탭 | /transactions/create | push | ❌ | ❌ | ✅ |
+| /transactions | /statistics (AppBar) | push | ❌ | ❌ | ✅ 🟡 |
+| /transactions | /budgets (AppBar) | push | ❌ | ❌ | ✅ 🟡 |
+| /settings | /categories | push | ❌ | ❌ | ✅ |
+| /settings | /pockets | push | ❌ | ❌ | ✅ |
+
+🟡 = 하단 탭으로 갈 수 있는 화면을 push로 열어서 UX 혼란 발생
+
+---
+
+## 3. 상태 라이프사이클 검증
+
+| BLoC | DI | 생성 시점 | 소멸 시점 | 서브 라우트 제공 | 상태 |
+|------|-----|---------|---------|--------------|------|
+| AuthBloc | singleton | 앱 시작 | 앱 종료 | app.dart create: | ✅ 정상 |
+| TransactionBloc | singleton | 첫 탭 진입 | 앱 종료 | .value | ✅ 수정완료 |
+| BudgetBloc | singleton | 첫 탭 진입 | 앱 종료 | .value | ✅ 수정완료 |
+| CategoryBloc | singleton | 첫 접근 | 앱 종료 | .value | ✅ 수정완료 |
+| PaymentMethodBloc | singleton | 첫 접근 | 앱 종료 | .value | ✅ 수정완료 |
+| CategoryGroupBloc | singleton | 첫 접근 | 앱 종료 | .value | ✅ 수정완료 |
+| PocketBloc | singleton | 첫 접근 | 앱 종료 | .value | ✅ 수정완료 |
+| PocketTransferBloc | singleton | 첫 접근 | 앱 종료 | .value | ✅ 수정완료 |
+| CoupleBloc | factory | 매 방문 | pop 시 | create: | ✅ 정상 |
+| StatisticsBloc | factory | 매 탭 진입 | 탭 소멸 | create: | ✅ 정상 |
+| DashboardBloc | factory | 매 탭 진입 | 탭 소멸 | create: | ✅ 정상 |
+
+---
+
+## 4. 발견된 문제 목록
+
+### 🔴 P0 (필수 수정)
+
+| # | 문제 | 영향 | 수정 방법 |
+|---|------|------|----------|
+| 1 | **BudgetFormPage 생성 후 pop 안 됨** | 예산 추가 후 폼에 갇힘 | listener에 create 모드 pop 로직 추가 |
+
+### 🟡 P1 (UX 개선)
+
+| # | 문제 | 영향 | 수정 방법 |
+|---|------|------|----------|
+| 2 | **TransactionListPage AppBar에 통계/예산 push 아이콘** | 하단 탭과 중복, Shell 밖에 push되어 탭 인덱스 혼란 | AppBar에서 제거 (하단 탭이 담당) |
+| 3 | **TransactionListPage AppBar에 커플/카테고리 아이콘** | 설정 탭에서 접근 가능, AppBar 과밀 | 설정 탭으로 통합 (AppBar에서 제거) |
+
+### 🟢 P2 (비기능)
+
+| # | 문제 | 영향 | 수정 방법 |
+|---|------|------|----------|
+| 4 | **Pocket Summary API 미구현** | spec에 정의되었으나 BE 미구현, FE도 미호출 | spec에서 제거하거나 추후 구현 (현재 미사용) |
+
+---
+
+## 작업 계획
+
+| # | 작업 | 파일 | 난이도 |
+|---|------|------|--------|
+| 1 | BudgetFormPage create 모드 pop 수정 | `budget_form_page.dart` | S |
+| 2 | TransactionListPage AppBar 정리 | `transaction_list_page.dart` | S |
+
+## 검증 계획
+- [ ] `flutter analyze` — no issues
+- [ ] `flutter test` — all pass
+- [ ] `flutter build web` — success
+- [ ] 유저 플로우 A~E 재검증 (머릿속 시뮬레이션)

--- a/frontend/lib/features/budget/presentation/pages/budget_form_page.dart
+++ b/frontend/lib/features/budget/presentation/pages/budget_form_page.dart
@@ -40,6 +40,7 @@ class _BudgetFormPageState extends State<BudgetFormPage> {
   late String _budgetPeriod;
   Budget? _budget;
   bool _initialized = false;
+  bool _submitted = false;
 
   bool get isEditing => widget.budgetId != null;
 
@@ -87,12 +88,10 @@ class _BudgetFormPageState extends State<BudgetFormPage> {
                 backgroundColor: Colors.red,
               ),
             );
-          } else if (state is BudgetLoaded && _initialized && _budget != null) {
-            // After successful update/create, pop if budget list was refreshed
-            // The list reload happens after create/update success
-            if (!state.budgets.any((b) => b.id == _budget?.id && b.amount == _budget?.amount)) {
-              context.pop();
-            }
+          } else if (state is BudgetLoaded && _submitted) {
+            // After successful create or update, pop back to budget list
+            _submitted = false;
+            context.pop();
           } else if (state is BudgetError) {
             ScaffoldMessenger.of(context).showSnackBar(
               SnackBar(
@@ -337,6 +336,7 @@ class _BudgetFormPageState extends State<BudgetFormPage> {
 
   void _onSubmit() {
     if (_formKey.currentState?.validate() ?? false) {
+      setState(() => _submitted = true);
       final amount = int.parse(_amountController.text.trim());
       final weeklyAmount = _budgetPeriod == 'WEEKLY' &&
               _weeklyAmountController.text.trim().isNotEmpty

--- a/frontend/lib/features/transaction/presentation/pages/transaction_list_page.dart
+++ b/frontend/lib/features/transaction/presentation/pages/transaction_list_page.dart
@@ -15,29 +15,7 @@ class TransactionListPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Budget Book'),
-        actions: [
-          IconButton(
-            onPressed: () => context.push('/statistics'),
-            icon: const Icon(Icons.pie_chart),
-            tooltip: '통계',
-          ),
-          IconButton(
-            onPressed: () => context.push('/budgets'),
-            icon: const Icon(Icons.account_balance_wallet),
-            tooltip: '예산 관리',
-          ),
-          IconButton(
-            onPressed: () => context.push('/categories'),
-            icon: const Icon(Icons.category),
-            tooltip: '카테고리 관리',
-          ),
-          IconButton(
-            onPressed: () => context.push('/couple'),
-            icon: const Icon(Icons.favorite),
-            tooltip: '커플 연결',
-          ),
-        ],
+        title: const Text('거래'),
       ),
       body: BlocConsumer<TransactionBloc, TransactionState>(
         listener: (context, state) {


### PR DESCRIPTION
## Summary
- **P0 fix**: BudgetFormPage create mode에서 저장 후 pop 안 되던 버그 수정 (`_submitted` 플래그)
- **P1 fix**: TransactionListPage AppBar에서 하단 탭과 중복되는 push 아이콘 4개 제거 (통계/예산/카테고리/커플)
- 전체 기능 설계 검증 기획서 추가 (`docs/sessions/2026-03-13_1_plan.md`)

## Test plan
- [x] `flutter analyze` — No issues found
- [x] `flutter test` — 274 tests passed
- [x] `flutter build web` — Success
- [x] 유저 플로우 시뮬레이션 재검증 (플로우 A~E)

🤖 Generated with [Claude Code](https://claude.com/claude-code)