### PR TITLE
fix: resolve state synchronization bugs

### DIFF
--- a/docs/sessions/2026-03-13_3_plan.md
+++ b/docs/sessions/2026-03-13_3_plan.md
@@ -1,0 +1,82 @@
+# 상태 동기화 버그 전체 수정
+> 날짜: 2026-03-13 | 회차: 3 | 상태: 기획/검증완료
+
+## 요청 내용
+"결제수단 추가해도 적용이 안되고, 삭제한 걸 홈에 가면 띄어져있어서 새로고침하니 사라지는 등 버그. 존재하는 버그 전체 수정해. 결제 카드 등록하면 자동으로 선택되어야하고, 결제일 또는 이름 미입력시 검증되어야한다."
+
+## 근본 원인 분석
+
+### 1. DashboardBloc이 registerFactory (홈 탭 새로고침 안됨)
+- `DashboardBloc`은 `registerFactory`로 등록 → `getIt<DashboardBloc>()` 호출마다 새 인스턴스
+- StatefulShellBranch가 `/home` 페이지를 캐시 → builder 1회만 실행 → BLoC도 1회만 로드
+- SyncEventHandler에서 `getIt<DashboardBloc>()`하면 위젯 트리와 **다른 인스턴스** → refresh 불가
+- **삭제한 데이터가 홈에서 계속 보이는 이유**: DashboardBloc이 한번 로드 후 갱신 안됨
+
+### 2. 탭 전환 시 데이터 갱신 없음
+- `StatefulShellRoute.indexedStack`이 각 탭 페이지를 캐시
+- Tab 0~3 모두 builder가 1회만 실행 → 탭 재방문 시 BLoC 이벤트 미발생
+- 다른 탭에서 변경한 데이터가 이전 탭에 반영 안됨
+
+### 3. 폼 시트 race condition (인라인 생성 미반영)
+- `category_form_sheet`, `payment_method_form_sheet`, `pocket_form_sheet` 모두:
+  - `widget.onSubmit(...)` 호출 (BLoC 이벤트 발행)
+  - **즉시** `Navigator.of(context).pop()` 실행
+  - BLoC이 API 호출 완료 전에 시트 닫힘
+  - 부모 드롭다운이 아직 옛 데이터 표시
+
+### 4. 인라인 생성 후 자동 선택 없음
+- 결제수단/카테고리/포켓 인라인 생성 후 드롭다운에서 자동 선택 안됨
+- 새 아이템 ID를 추적하는 로직 없음
+
+### 5. 결제수단 CREDIT 타입 결제일 검증 누락
+- `payment_method_form_sheet.dart`: CREDIT 타입에서도 결제일이 optional
+
+---
+
+## 작업 계획
+
+### Phase A: DashboardBloc 싱글턴 전환 + SyncEventHandler 연동
+
+| # | 파일 | 작업 |
+|---|------|------|
+| A1 | `core/di/injection.dart` | `DashboardBloc` registerFactory → registerLazySingleton + dispose |
+| A2 | `core/router/app_router.dart` | `/home` 빌더: `BlocProvider.value` + `LoadDashboard` 이벤트 발행 |
+| A3 | `core/websocket/sync_event_handler.dart` | `_refreshDashboard()` 추가 → TRANSACTION, BUDGET, POCKET 케이스에서 호출 |
+
+### Phase B: 탭 전환 시 데이터 갱신
+
+| # | 파일 | 작업 |
+|---|------|------|
+| B1 | `core/widgets/main_shell_page.dart` | StatefulWidget 전환, 탭 변경 시 해당 BLoC refresh 이벤트 발행 |
+
+### Phase C: 인라인 생성 auto-select + race condition 해소
+
+| # | 파일 | 작업 |
+|---|------|------|
+| C1 | `transaction_form_page.dart` | `_showCreateCategorySheet`: await sheet → BLoC 상태 대기 → 새 아이템 auto-select |
+| C2 | `transaction_form_page.dart` | `_showCreatePaymentMethodSheet`: 동일 패턴 |
+| C3 | `transaction_form_page.dart` | `_showCreatePocketSheet`: 동일 패턴 |
+| C4 | `budget_form_page.dart` | `_showCreateCategorySheet`: 동일 패턴 |
+
+### Phase D: 결제수단 검증 강화
+
+| # | 파일 | 작업 |
+|---|------|------|
+| D1 | `payment_method_form_sheet.dart` | CREDIT 타입일 때 결제일(settlementDay) 필수 검증 추가 |
+
+---
+
+## 성능 설계
+- DashboardBloc 싱글턴 전환: 메모리 절약 (factory는 매번 새 인스턴스), 하나의 인스턴스 재사용
+- 탭 전환 refresh: 탭 변경 시에만 1회 API 호출, 중복 호출 없음
+- 인라인 생성 auto-select: BLoC stream 1회 대기 (timeout 10초), 추가 API 호출 없음
+- SyncEventHandler dashboard refresh: 기존 3개 API 병렬 호출 (statistics + transactions + budgets)
+
+## 검증 계획
+- [ ] `flutter analyze` — no issues
+- [ ] `flutter test` — all pass
+- [ ] `flutter build web` — success
+- [ ] 유저 플로우 검증: 인라인 생성 → auto-select, 탭 전환 → 데이터 갱신, 삭제 → 홈 반영
+
+## 팀 구성
+FE 전용 변경이므로 frontend-teammate 단독 작업 + code-reviewer 검증

--- a/frontend/lib/core/di/injection.dart
+++ b/frontend/lib/core/di/injection.dart
@@ -258,11 +258,12 @@ Future<void> configureDependencies() async {
   );
 
   // Dashboard feature
-  getIt.registerFactory<DashboardBloc>(
+  getIt.registerLazySingleton<DashboardBloc>(
     () => DashboardBloc(
       statisticsRepository: getIt<StatisticsRepository>(),
       transactionRepository: getIt<TransactionRepository>(),
       budgetRepository: getIt<BudgetRepository>(),
     ),
+    dispose: (bloc) => bloc.close(),
   );
 }

--- a/frontend/lib/core/router/app_router.dart
+++ b/frontend/lib/core/router/app_router.dart
@@ -144,9 +144,10 @@ GoRouter createAppRouter(AuthBloc authBloc) => GoRouter(
               path: '/home',
               builder: (context, state) {
                 final now = DateTime.now();
-                return BlocProvider<DashboardBloc>(
-                  create: (_) => getIt<DashboardBloc>()
-                    ..add(LoadDashboard(year: now.year, month: now.month)),
+                getIt<DashboardBloc>()
+                    .add(LoadDashboard(year: now.year, month: now.month));
+                return BlocProvider<DashboardBloc>.value(
+                  value: getIt<DashboardBloc>(),
                   child: const DashboardPage(),
                 );
               },

--- a/frontend/lib/core/websocket/sync_event_handler.dart
+++ b/frontend/lib/core/websocket/sync_event_handler.dart
@@ -13,6 +13,10 @@ import 'package:budget_book/features/category_group/presentation/bloc/category_g
 import 'package:budget_book/features/category_group/presentation/bloc/category_group_event.dart';
 import 'package:budget_book/features/pocket/presentation/bloc/pocket_bloc.dart';
 import 'package:budget_book/features/pocket/presentation/bloc/pocket_event.dart';
+import 'package:budget_book/features/pocket/presentation/bloc/pocket_transfer_bloc.dart';
+import 'package:budget_book/features/pocket/presentation/bloc/pocket_transfer_event.dart';
+import 'package:budget_book/features/home/presentation/bloc/dashboard_bloc.dart';
+import 'package:budget_book/features/home/presentation/bloc/dashboard_event.dart';
 
 import 'sync_event.dart';
 
@@ -43,8 +47,10 @@ class SyncEventHandler {
     switch (event.entityType) {
       case 'TRANSACTION':
         _refreshTransactions();
+        _refreshDashboard();
       case 'BUDGET':
         _refreshBudgets();
+        _refreshDashboard();
       case 'CATEGORY':
         _refreshCategories();
       case 'PAYMENT_METHOD':
@@ -52,8 +58,12 @@ class SyncEventHandler {
       case 'CATEGORY_GROUP':
         _refreshCategoryGroups();
       case 'POCKET':
+        _refreshPockets();
+        _refreshDashboard();
       case 'POCKET_TRANSFER':
         _refreshPockets();
+        _refreshPocketTransfers();
+        _refreshDashboard();
       default:
         _logger.w('Unknown entity type: ${event.entityType}');
     }
@@ -118,6 +128,27 @@ class SyncEventHandler {
       _logger.d('Dispatched LoadPockets refresh');
     } catch (e) {
       _logger.e('Failed to refresh pockets: $e');
+    }
+  }
+
+  void _refreshPocketTransfers() {
+    try {
+      final bloc = _getIt<PocketTransferBloc>();
+      bloc.add(const LoadPocketTransfers());
+      _logger.d('Dispatched LoadPocketTransfers refresh');
+    } catch (e) {
+      _logger.e('Failed to refresh pocket transfers: $e');
+    }
+  }
+
+  void _refreshDashboard() {
+    try {
+      final now = DateTime.now();
+      final bloc = _getIt<DashboardBloc>();
+      bloc.add(LoadDashboard(year: now.year, month: now.month));
+      _logger.d('Dispatched LoadDashboard refresh');
+    } catch (e) {
+      _logger.e('Failed to refresh dashboard: $e');
     }
   }
 }

--- a/frontend/lib/core/widgets/main_shell_page.dart
+++ b/frontend/lib/core/widgets/main_shell_page.dart
@@ -2,14 +2,56 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 
+import 'package:budget_book/core/di/injection.dart';
 import 'package:budget_book/core/websocket/websocket_bloc.dart';
 import 'package:budget_book/core/websocket/websocket_state.dart';
 import 'package:budget_book/core/websocket/websocket_service.dart';
+import 'package:budget_book/features/home/presentation/bloc/dashboard_bloc.dart';
+import 'package:budget_book/features/home/presentation/bloc/dashboard_event.dart';
+import 'package:budget_book/features/transaction/presentation/bloc/transaction_bloc.dart';
+import 'package:budget_book/features/transaction/presentation/bloc/transaction_event.dart';
+import 'package:budget_book/features/budget/presentation/bloc/budget_bloc.dart';
+import 'package:budget_book/features/budget/presentation/bloc/budget_event.dart';
 
-class MainShellPage extends StatelessWidget {
+class MainShellPage extends StatefulWidget {
   final StatefulNavigationShell navigationShell;
 
   const MainShellPage({super.key, required this.navigationShell});
+
+  @override
+  State<MainShellPage> createState() => _MainShellPageState();
+}
+
+class _MainShellPageState extends State<MainShellPage> {
+  int _previousIndex = 0;
+
+  void _onDestinationSelected(int index) {
+    final previousIndex = _previousIndex;
+    _previousIndex = index;
+
+    // Refresh data when switching to a different tab
+    if (index != previousIndex) {
+      final now = DateTime.now();
+      switch (index) {
+        case 0:
+          getIt<DashboardBloc>()
+              .add(LoadDashboard(year: now.year, month: now.month));
+        case 1:
+          getIt<TransactionBloc>()
+              .add(LoadTransactions(year: now.year, month: now.month));
+        case 2:
+          getIt<BudgetBloc>()
+              .add(LoadBudgets(year: now.year, month: now.month));
+        // Tab 3 (Statistics) uses factory, loaded fresh by its builder
+        // Tab 4 (Settings) needs no refresh
+      }
+    }
+
+    widget.navigationShell.goBranch(
+      index,
+      initialLocation: index == widget.navigationShell.currentIndex,
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -17,17 +59,12 @@ class MainShellPage extends StatelessWidget {
       body: Column(
         children: [
           const _ConnectionStatusBanner(),
-          Expanded(child: navigationShell),
+          Expanded(child: widget.navigationShell),
         ],
       ),
       bottomNavigationBar: NavigationBar(
-        selectedIndex: navigationShell.currentIndex,
-        onDestinationSelected: (index) {
-          navigationShell.goBranch(
-            index,
-            initialLocation: index == navigationShell.currentIndex,
-          );
-        },
+        selectedIndex: widget.navigationShell.currentIndex,
+        onDestinationSelected: _onDestinationSelected,
         destinations: const [
           NavigationDestination(
             icon: Icon(Icons.home_outlined),

--- a/frontend/lib/features/budget/presentation/pages/budget_form_page.dart
+++ b/frontend/lib/features/budget/presentation/pages/budget_form_page.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -356,9 +358,13 @@ class _BudgetFormPageState extends State<BudgetFormPage> {
     );
   }
 
-  void _showCreateCategorySheet(BuildContext context) {
+  Future<void> _showCreateCategorySheet(BuildContext context) async {
     final bloc = context.read<CategoryBloc>();
-    showModalBottomSheet(
+    final oldIds = (bloc.state is CategoryLoaded)
+        ? (bloc.state as CategoryLoaded).categories.map((c) => c.id).toSet()
+        : <String>{};
+
+    await showModalBottomSheet(
       context: context,
       isScrollControlled: true,
       builder: (_) => CategoryFormSheet(
@@ -372,6 +378,35 @@ class _BudgetFormPageState extends State<BudgetFormPage> {
         },
       ),
     );
+
+    if (!mounted) return;
+    // Check if already updated
+    final currentState = bloc.state;
+    if (currentState is CategoryLoaded) {
+      final currentIds = currentState.categories.map((c) => c.id).toSet();
+      final diff = currentIds.difference(oldIds);
+      if (diff.isNotEmpty) {
+        setState(() => _selectedCategoryId = diff.first);
+        return;
+      }
+    }
+
+    // Wait for next state with new item
+    try {
+      await for (final state
+          in bloc.stream.timeout(const Duration(seconds: 10))) {
+        if (state is CategoryLoaded) {
+          final newIds = state.categories.map((c) => c.id).toSet();
+          final diff = newIds.difference(oldIds);
+          if (diff.isNotEmpty) {
+            if (mounted) setState(() => _selectedCategoryId = diff.first);
+            return;
+          }
+        }
+      }
+    } catch (_) {
+      // Timeout
+    }
   }
 
   void _onSubmit() {

--- a/frontend/lib/features/payment_method/presentation/widgets/payment_method_form_sheet.dart
+++ b/frontend/lib/features/payment_method/presentation/widgets/payment_method_form_sheet.dart
@@ -154,6 +154,11 @@ class _PaymentMethodFormSheetState extends State<PaymentMethodFormSheet> {
                   keyboardType: TextInputType.number,
                   inputFormatters: [FilteringTextInputFormatter.digitsOnly],
                   validator: (value) {
+                    if (_selectedType == 'CREDIT') {
+                      if (value == null || value.trim().isEmpty) {
+                        return '신용카드는 결제일을 입력해야 합니다';
+                      }
+                    }
                     if (value != null && value.isNotEmpty) {
                       final day = int.tryParse(value);
                       if (day == null || day < 1 || day > 31) {

--- a/frontend/lib/features/transaction/presentation/pages/transaction_form_page.dart
+++ b/frontend/lib/features/transaction/presentation/pages/transaction_form_page.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -416,9 +418,13 @@ class _TransactionFormPageState extends State<TransactionFormPage> {
     );
   }
 
-  void _showCreateCategorySheet(BuildContext context) {
+  Future<void> _showCreateCategorySheet(BuildContext context) async {
     final bloc = context.read<CategoryBloc>();
-    showModalBottomSheet(
+    final oldIds = (bloc.state is CategoryLoaded)
+        ? (bloc.state as CategoryLoaded).categories.map((c) => c.id).toSet()
+        : <String>{};
+
+    await showModalBottomSheet(
       context: context,
       isScrollControlled: true,
       builder: (_) => CategoryFormSheet(
@@ -432,11 +438,28 @@ class _TransactionFormPageState extends State<TransactionFormPage> {
         },
       ),
     );
+
+    if (!mounted) return;
+    await _autoSelectNewItem<CategoryBloc, CategoryState>(
+      bloc: bloc,
+      getIds: (s) => s is CategoryLoaded
+          ? s.categories.map((c) => c.id).toSet()
+          : <String>{},
+      oldIds: oldIds,
+      onSelect: (newId) => setState(() => _selectedCategoryId = newId),
+    );
   }
 
-  void _showCreatePaymentMethodSheet(BuildContext context) {
+  Future<void> _showCreatePaymentMethodSheet(BuildContext context) async {
     final bloc = context.read<PaymentMethodBloc>();
-    showModalBottomSheet(
+    final oldIds = (bloc.state is PaymentMethodLoaded)
+        ? (bloc.state as PaymentMethodLoaded)
+            .paymentMethods
+            .map((pm) => pm.id)
+            .toSet()
+        : <String>{};
+
+    await showModalBottomSheet(
       context: context,
       isScrollControlled: true,
       builder: (_) => PaymentMethodFormSheet(
@@ -450,11 +473,25 @@ class _TransactionFormPageState extends State<TransactionFormPage> {
         },
       ),
     );
+
+    if (!mounted) return;
+    await _autoSelectNewItem<PaymentMethodBloc, PaymentMethodState>(
+      bloc: bloc,
+      getIds: (s) => s is PaymentMethodLoaded
+          ? s.paymentMethods.map((pm) => pm.id).toSet()
+          : <String>{},
+      oldIds: oldIds,
+      onSelect: (newId) => setState(() => _selectedPaymentMethodId = newId),
+    );
   }
 
-  void _showCreatePocketSheet(BuildContext context) {
+  Future<void> _showCreatePocketSheet(BuildContext context) async {
     final bloc = context.read<PocketBloc>();
-    showModalBottomSheet(
+    final oldIds = (bloc.state is PocketLoaded)
+        ? (bloc.state as PocketLoaded).pockets.map((p) => p.id).toSet()
+        : <String>{};
+
+    await showModalBottomSheet(
       context: context,
       isScrollControlled: true,
       builder: (_) => PocketFormSheet(
@@ -469,6 +506,45 @@ class _TransactionFormPageState extends State<TransactionFormPage> {
         },
       ),
     );
+
+    if (!mounted) return;
+    await _autoSelectNewItem<PocketBloc, PocketState>(
+      bloc: bloc,
+      getIds: (s) => s is PocketLoaded
+          ? s.pockets.map((p) => p.id).toSet()
+          : <String>{},
+      oldIds: oldIds,
+      onSelect: (newId) => setState(() => _selectedPocketId = newId),
+    );
+  }
+
+  Future<void> _autoSelectNewItem<B extends BlocBase<S>, S>({
+    required B bloc,
+    required Set<String> Function(S state) getIds,
+    required Set<String> oldIds,
+    required void Function(String newId) onSelect,
+  }) async {
+    // Check if already updated
+    final currentIds = getIds(bloc.state);
+    final diff = currentIds.difference(oldIds);
+    if (diff.isNotEmpty) {
+      onSelect(diff.first);
+      return;
+    }
+
+    // Wait for next state with new item
+    try {
+      await for (final state in bloc.stream.timeout(const Duration(seconds: 10))) {
+        final newIds = getIds(state);
+        final newDiff = newIds.difference(oldIds);
+        if (newDiff.isNotEmpty) {
+          if (mounted) onSelect(newDiff.first);
+          return;
+        }
+      }
+    } catch (_) {
+      // Timeout — user can manually select
+    }
   }
 
   void _confirmDelete(BuildContext context) {


### PR DESCRIPTION
## Summary
- **DashboardBloc singleton**: `registerFactory` → `registerLazySingleton` so SyncEventHandler and tab-switch can refresh the same instance used by the widget tree
- **Tab-switch refresh**: MainShellPage converted to StatefulWidget, dispatches BLoC refresh on tab change (home/transactions/budgets)
- **SyncEventHandler**: Dashboard refresh on TRANSACTION/BUDGET/POCKET/POCKET_TRANSFER events; PocketTransferBloc refresh on POCKET_TRANSFER
- **Inline creation auto-select**: Category/PaymentMethod/Pocket dropdowns await BLoC update after creation and auto-select the new item
- **CREDIT settlement day required**: Payment method form now requires settlement day for credit card type

## Root causes fixed
| Bug | Root cause |
|-----|-----------|
| 삭제한 데이터가 홈에서 계속 보임 | DashboardBloc이 factory → SyncEventHandler가 다른 인스턴스 refresh |
| 탭 전환해도 데이터 안바뀜 | StatefulShellBranch 캐시, builder 1회만 실행 |
| 인라인 생성해도 드롭다운 미반영 | Form sheet pop → BLoC 완료 전 닫힘, auto-select 없음 |
| CREDIT 결제일 없이 저장 가능 | Validator에 required 조건 누락 |

## Test plan
- [x] `flutter analyze` — No issues
- [x] `flutter test` — 274/274 passed
- [x] `flutter build web` — Success
- [ ] 실사용 검증: 인라인 생성 → auto-select, 탭 전환 → 최신 데이터, 삭제 → 홈 반영

🤖 Generated with [Claude Code](https://claude.com/claude-code)