### PR TITLE
fix: P1/P2 remaining - UX improvements and dropdown auto-select fix

### DIFF
--- a/frontend/lib/features/budget/presentation/pages/budget_form_page.dart
+++ b/frontend/lib/features/budget/presentation/pages/budget_form_page.dart
@@ -386,7 +386,10 @@ class _BudgetFormPageState extends State<BudgetFormPage> {
       final currentIds = currentState.categories.map((c) => c.id).toSet();
       final diff = currentIds.difference(oldIds);
       if (diff.isNotEmpty) {
-        setState(() => _selectedCategoryId = diff.first);
+        setState(() {
+          _selectedCategoryId = diff.first;
+          _dropdownResetKey++;
+        });
         return;
       }
     }
@@ -399,7 +402,12 @@ class _BudgetFormPageState extends State<BudgetFormPage> {
           final newIds = state.categories.map((c) => c.id).toSet();
           final diff = newIds.difference(oldIds);
           if (diff.isNotEmpty) {
-            if (mounted) setState(() => _selectedCategoryId = diff.first);
+            if (mounted) {
+              setState(() {
+                _selectedCategoryId = diff.first;
+                _dropdownResetKey++;
+              });
+            }
             return;
           }
         }

--- a/frontend/lib/features/statistics/presentation/widgets/category_breakdown_tab.dart
+++ b/frontend/lib/features/statistics/presentation/widgets/category_breakdown_tab.dart
@@ -59,7 +59,31 @@ class CategoryBreakdownTab extends StatelessWidget {
       );
     }
     if (categoryStats.isEmpty) {
-      return const Center(child: Text('데이터가 없습니다'));
+      return Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(
+              Icons.pie_chart_outline,
+              size: 64,
+              color: Theme.of(context)
+                  .colorScheme
+                  .onSurface
+                  .withValues(alpha: 0.3),
+            ),
+            const SizedBox(height: 16),
+            Text(
+              '이 달에 기록된 거래가 없습니다',
+              style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                    color: Theme.of(context)
+                        .colorScheme
+                        .onSurface
+                        .withValues(alpha: 0.5),
+                  ),
+            ),
+          ],
+        ),
+      );
     }
 
     return SingleChildScrollView(

--- a/frontend/lib/features/statistics/presentation/widgets/monthly_trend_tab.dart
+++ b/frontend/lib/features/statistics/presentation/widgets/monthly_trend_tab.dart
@@ -36,7 +36,31 @@ class MonthlyTrendTab extends StatelessWidget {
       );
     }
     if (trends.isEmpty) {
-      return const Center(child: Text('데이터가 없습니다'));
+      return Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(
+              Icons.show_chart,
+              size: 64,
+              color: Theme.of(context)
+                  .colorScheme
+                  .onSurface
+                  .withValues(alpha: 0.3),
+            ),
+            const SizedBox(height: 16),
+            Text(
+              '추이 데이터가 없습니다',
+              style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                    color: Theme.of(context)
+                        .colorScheme
+                        .onSurface
+                        .withValues(alpha: 0.5),
+                  ),
+            ),
+          ],
+        ),
+      );
     }
 
     return SingleChildScrollView(

--- a/frontend/lib/features/transaction/presentation/bloc/transaction_bloc.dart
+++ b/frontend/lib/features/transaction/presentation/bloc/transaction_bloc.dart
@@ -115,6 +115,7 @@ class TransactionBloc extends Bloc<TransactionEvent, TransactionState> {
             month: currentState.month,
             totalElements: currentState.totalElements - 1,
             hasMore: currentState.hasMore,
+            operationSuccess: '거래가 삭제되었습니다',
           ));
         }
       },

--- a/frontend/lib/features/transaction/presentation/bloc/transaction_state.dart
+++ b/frontend/lib/features/transaction/presentation/bloc/transaction_state.dart
@@ -23,6 +23,7 @@ class TransactionLoaded extends TransactionState {
   final int totalElements;
   final bool hasMore;
   final String? operationError;
+  final String? operationSuccess;
 
   const TransactionLoaded({
     required this.transactions,
@@ -31,6 +32,7 @@ class TransactionLoaded extends TransactionState {
     required this.totalElements,
     required this.hasMore,
     this.operationError,
+    this.operationSuccess,
   });
 
   int get totalIncome => transactions
@@ -53,7 +55,7 @@ class TransactionLoaded extends TransactionState {
 
   @override
   List<Object?> get props =>
-      [transactions, year, month, totalElements, hasMore, operationError];
+      [transactions, year, month, totalElements, hasMore, operationError, operationSuccess];
 }
 
 class TransactionError extends TransactionState {

--- a/frontend/lib/features/transaction/presentation/pages/transaction_form_page.dart
+++ b/frontend/lib/features/transaction/presentation/pages/transaction_form_page.dart
@@ -153,29 +153,49 @@ class _TransactionFormPageState extends State<TransactionFormPage> {
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
                 // Type toggle
-                SegmentedButton<String>(
-                  segments: const [
-                    ButtonSegment(
-                      value: 'EXPENSE',
-                      label: Text('지출'),
-                      icon: Icon(Icons.arrow_downward),
+                if (isEditing)
+                  ListTile(
+                    leading: Icon(
+                      _selectedType == 'INCOME'
+                          ? Icons.arrow_upward
+                          : Icons.arrow_downward,
+                      color: _selectedType == 'INCOME'
+                          ? Colors.green
+                          : Colors.red,
                     ),
-                    ButtonSegment(
-                      value: 'INCOME',
-                      label: Text('수입'),
-                      icon: Icon(Icons.arrow_upward),
+                    title: Text(
+                        _selectedType == 'INCOME' ? '수입' : '지출'),
+                    subtitle: const Text('유형은 수정할 수 없습니다'),
+                    tileColor: Theme.of(context)
+                        .colorScheme
+                        .surfaceContainerHighest
+                        .withValues(alpha: 0.3),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(12),
                     ),
-                  ],
-                  selected: {_selectedType},
-                  onSelectionChanged: isEditing
-                      ? null
-                      : (value) {
-                          setState(() {
-                            _selectedType = value.first;
-                            _selectedCategoryId = null;
-                          });
-                        },
-                ),
+                  )
+                else
+                  SegmentedButton<String>(
+                    segments: const [
+                      ButtonSegment(
+                        value: 'EXPENSE',
+                        label: Text('지출'),
+                        icon: Icon(Icons.arrow_downward),
+                      ),
+                      ButtonSegment(
+                        value: 'INCOME',
+                        label: Text('수입'),
+                        icon: Icon(Icons.arrow_upward),
+                      ),
+                    ],
+                    selected: {_selectedType},
+                    onSelectionChanged: (value) {
+                      setState(() {
+                        _selectedType = value.first;
+                        _selectedCategoryId = null;
+                      });
+                    },
+                  ),
                 const SizedBox(height: 24),
                 // Amount
                 TextFormField(
@@ -446,7 +466,10 @@ class _TransactionFormPageState extends State<TransactionFormPage> {
           ? s.categories.map((c) => c.id).toSet()
           : <String>{},
       oldIds: oldIds,
-      onSelect: (newId) => setState(() => _selectedCategoryId = newId),
+      onSelect: (newId) => setState(() {
+        _selectedCategoryId = newId;
+        _dropdownResetKey++;
+      }),
     );
   }
 
@@ -481,7 +504,10 @@ class _TransactionFormPageState extends State<TransactionFormPage> {
           ? s.paymentMethods.map((pm) => pm.id).toSet()
           : <String>{},
       oldIds: oldIds,
-      onSelect: (newId) => setState(() => _selectedPaymentMethodId = newId),
+      onSelect: (newId) => setState(() {
+        _selectedPaymentMethodId = newId;
+        _dropdownResetKey++;
+      }),
     );
   }
 
@@ -514,7 +540,10 @@ class _TransactionFormPageState extends State<TransactionFormPage> {
           ? s.pockets.map((p) => p.id).toSet()
           : <String>{},
       oldIds: oldIds,
-      onSelect: (newId) => setState(() => _selectedPocketId = newId),
+      onSelect: (newId) => setState(() {
+        _selectedPocketId = newId;
+        _dropdownResetKey++;
+      }),
     );
   }
 

--- a/frontend/lib/features/transaction/presentation/pages/transaction_list_page.dart
+++ b/frontend/lib/features/transaction/presentation/pages/transaction_list_page.dart
@@ -34,6 +34,13 @@ class TransactionListPage extends StatelessWidget {
                 backgroundColor: Colors.red,
               ),
             );
+          } else if (state is TransactionLoaded &&
+              state.operationSuccess != null) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(
+                content: Text(state.operationSuccess!),
+              ),
+            );
           }
         },
         builder: (context, state) {

--- a/frontend/test/features/transaction/presentation/bloc/transaction_bloc_test.dart
+++ b/frontend/test/features/transaction/presentation/bloc/transaction_bloc_test.dart
@@ -339,6 +339,7 @@ void main() {
             month: 1,
             totalElements: 1,
             hasMore: false,
+            operationSuccess: '거래가 삭제되었습니다',
           ),
         ],
       );


### PR DESCRIPTION
## Summary
- Delete transaction success snackbar feedback
- Statistics empty state with icons for category breakdown and trend tabs
- Transaction edit: type field shows clear read-only ListTile
- **Dropdown auto-select fix**: increment `_dropdownResetKey` after inline creation to force fresh widget (fixes payment method not appearing after creation)

## Test plan
- [x] `flutter analyze` — No issues
- [x] `flutter test` — 274/274 passed
- [x] `flutter build web` — Success

🤖 Generated with [Claude Code](https://claude.com/claude-code)