### PR TITLE
feat: Phase 5a - security hardening and SafeArea fixes

### DIFF
--- a/backend/src/main/kotlin/com/budgetbook/couple/controller/CoupleController.kt
+++ b/backend/src/main/kotlin/com/budgetbook/couple/controller/CoupleController.kt
@@ -27,7 +27,7 @@ class CoupleController(
 
     companion object {
         private const val INVITE_ACCEPT_MAX_REQUESTS = 5
-        private const val INVITE_ACCEPT_WINDOW_MILLIS = 60_000L // 1 minute
+        private const val INVITE_ACCEPT_WINDOW_MILLIS = 3_600_000L // 1 hour
     }
 
     @PostMapping("/invitations")

--- a/backend/src/main/kotlin/com/budgetbook/couple/domain/Couple.kt
+++ b/backend/src/main/kotlin/com/budgetbook/couple/domain/Couple.kt
@@ -11,6 +11,7 @@ import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
+import java.time.Instant
 import java.util.UUID
 
 @Entity
@@ -29,7 +30,10 @@ class Couple(
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)
-    var status: CoupleStatus = CoupleStatus.PENDING
+    var status: CoupleStatus = CoupleStatus.PENDING,
+
+    @Column(name = "dissolved_at")
+    var dissolvedAt: Instant? = null
 ) : BaseTimeEntity()
 
 enum class CoupleStatus { PENDING, ACTIVE, DISSOLVED }

--- a/backend/src/main/kotlin/com/budgetbook/couple/dto/CoupleDtos.kt
+++ b/backend/src/main/kotlin/com/budgetbook/couple/dto/CoupleDtos.kt
@@ -12,7 +12,8 @@ data class CoupleResponse(
     val id: UUID,
     val partner: UserSummary,
     val status: String,
-    val createdAt: Instant
+    val createdAt: Instant,
+    val dissolvedAt: Instant? = null
 )
 
 data class UserSummary(

--- a/backend/src/main/kotlin/com/budgetbook/couple/service/CoupleService.kt
+++ b/backend/src/main/kotlin/com/budgetbook/couple/service/CoupleService.kt
@@ -135,7 +135,8 @@ class CoupleService(
                 profileImageUrl = partner.profileImageUrl
             ),
             status = couple.status.name,
-            createdAt = couple.createdAt
+            createdAt = couple.createdAt,
+            dissolvedAt = couple.dissolvedAt
         )
     }
 
@@ -153,7 +154,8 @@ class CoupleService(
                 profileImageUrl = partner.profileImageUrl
             ),
             status = couple.status.name,
-            createdAt = couple.createdAt
+            createdAt = couple.createdAt,
+            dissolvedAt = couple.dissolvedAt
         )
     }
 
@@ -163,6 +165,7 @@ class CoupleService(
             ?: throw NotFoundException("COUPLE_NOT_FOUND", "User is not currently in an active couple.")
 
         couple.status = CoupleStatus.DISSOLVED
+        couple.dissolvedAt = Instant.now()
         coupleRepository.save(couple)
 
         // Evict couple cache for both users

--- a/backend/src/main/resources/db/migration/V16__add_dissolved_at_to_couples.sql
+++ b/backend/src/main/resources/db/migration/V16__add_dissolved_at_to_couples.sql
@@ -1,0 +1,7 @@
+-- Add dissolved_at timestamp for soft-delete dissolution tracking
+ALTER TABLE couples ADD COLUMN dissolved_at TIMESTAMPTZ;
+
+-- Backfill dissolved_at for already dissolved couples using updated_at as approximation
+UPDATE couples SET dissolved_at = updated_at WHERE status = 'DISSOLVED' AND dissolved_at IS NULL;
+
+CREATE INDEX idx_couples_dissolved_at ON couples (dissolved_at) WHERE dissolved_at IS NOT NULL;

--- a/backend/src/test/kotlin/com/budgetbook/couple/controller/CoupleControllerTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/couple/controller/CoupleControllerTest.kt
@@ -95,7 +95,7 @@ class CoupleControllerTest : FunSpec({
             status = "ACTIVE",
             createdAt = Instant.now()
         )
-        every { rateLimiter.tryAcquire("invite-accept:203.0.113.50", 5, 60000L) } returns true
+        every { rateLimiter.tryAcquire("invite-accept:203.0.113.50", 5, 3_600_000L) } returns true
         every { coupleService.acceptInvitation(testUserId, "CODE1234") } returns expectedResponse
 
         val result = controller.acceptInvitation(auth, "CODE1234", request)

--- a/backend/src/test/kotlin/com/budgetbook/couple/service/CoupleServiceTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/couple/service/CoupleServiceTest.kt
@@ -21,6 +21,7 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldHaveLength
 import io.mockk.every
 import io.mockk.justRun
@@ -291,11 +292,18 @@ class CoupleServiceTest : BehaviorSpec({
         every { coupleRepository.save(couple) } returns couple
 
         When("dissolveCouple is called") {
+            val beforeDissolve = Instant.now()
             coupleService.dissolveCouple(user1.id)
 
             Then("sets couple status to DISSOLVED") {
                 couple.status shouldBe CoupleStatus.DISSOLVED
                 verify { coupleRepository.save(couple) }
+            }
+
+            Then("sets dissolvedAt timestamp") {
+                couple.dissolvedAt shouldNotBe null
+                couple.dissolvedAt!!.isAfter(beforeDissolve.minusSeconds(1)) shouldBe true
+                couple.dissolvedAt!!.isBefore(Instant.now().plusSeconds(1)) shouldBe true
             }
         }
     }

--- a/frontend/lib/core/widgets/main_shell_page.dart
+++ b/frontend/lib/core/widgets/main_shell_page.dart
@@ -56,11 +56,14 @@ class _MainShellPageState extends State<MainShellPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: Column(
-        children: [
-          const _ConnectionStatusBanner(),
-          Expanded(child: widget.navigationShell),
-        ],
+      body: SafeArea(
+        bottom: false, // Bottom is handled by NavigationBar
+        child: Column(
+          children: [
+            const _ConnectionStatusBanner(),
+            Expanded(child: widget.navigationShell),
+          ],
+        ),
       ),
       bottomNavigationBar: NavigationBar(
         selectedIndex: widget.navigationShell.currentIndex,

--- a/frontend/lib/features/auth/presentation/pages/auth_callback_page.dart
+++ b/frontend/lib/features/auth/presentation/pages/auth_callback_page.dart
@@ -66,17 +66,19 @@ class _AuthCallbackPageState extends State<AuthCallbackPage> {
         }
       },
       child: const Scaffold(
-        body: Center(
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              CircularProgressIndicator(),
-              SizedBox(height: 24),
-              Text(
-                '로그인 처리 중...',
-                style: TextStyle(fontSize: 16),
-              ),
-            ],
+        body: SafeArea(
+          child: Center(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                CircularProgressIndicator(),
+                SizedBox(height: 24),
+                Text(
+                  '로그인 처리 중...',
+                  style: TextStyle(fontSize: 16),
+                ),
+              ],
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
## Summary
- Increase invitation code rate limit window from 1min to 1hr for brute-force protection
- Add `dissolved_at` timestamp to couples table (V16 migration) for soft-delete tracking
- Add SafeArea coverage to MainShellPage and AuthCallbackPage for notch devices
- CoupleResponse DTO now includes `dissolvedAt` field

## Verification
- BE: 284+ tests passed (`./gradlew test`)
- FE: 274 tests passed, `flutter analyze` clean
- OAuth account linking already secured (account_exists error)
- GoRouter state.extra already fixed (path params used)
- StatisticsBloc already parallelized (Future.wait)

## Test plan
- [ ] BE tests pass in CI
- [ ] FE tests pass in CI
- [ ] Verify rate limiting on couple invitation endpoint
- [ ] Verify dissolved_at is set on couple dissolution

🤖 Generated with [Claude Code](https://claude.com/claude-code)