### PR TITLE
feat: Phase 5b - dashboard enhancements, profile edit

### DIFF
--- a/backend/src/main/kotlin/com/budgetbook/auth/controller/AuthController.kt
+++ b/backend/src/main/kotlin/com/budgetbook/auth/controller/AuthController.kt
@@ -3,12 +3,14 @@ package com.budgetbook.auth.controller
 import com.budgetbook.auth.dto.LogoutRequest
 import com.budgetbook.auth.dto.RefreshTokenRequest
 import com.budgetbook.auth.dto.TokenResponse
+import com.budgetbook.auth.dto.UpdateProfileRequest
 import com.budgetbook.auth.dto.UserResponse
 import com.budgetbook.auth.service.AuthService
 import com.budgetbook.common.dto.ApiResponse
 import jakarta.validation.Valid
 import org.springframework.security.core.Authentication
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -33,6 +35,16 @@ class AuthController(
     fun getCurrentUser(authentication: Authentication): ApiResponse<UserResponse> {
         val userId = authentication.principal as UUID
         val userResponse = authService.getCurrentUser(userId)
+        return ApiResponse.ok(userResponse)
+    }
+
+    @PatchMapping("/me")
+    fun updateProfile(
+        authentication: Authentication,
+        @Valid @RequestBody request: UpdateProfileRequest
+    ): ApiResponse<UserResponse> {
+        val userId = authentication.principal as UUID
+        val userResponse = authService.updateProfile(userId, request)
         return ApiResponse.ok(userResponse)
     }
 

--- a/backend/src/main/kotlin/com/budgetbook/auth/dto/AuthDtos.kt
+++ b/backend/src/main/kotlin/com/budgetbook/auth/dto/AuthDtos.kt
@@ -2,6 +2,7 @@ package com.budgetbook.auth.dto
 
 import com.budgetbook.auth.domain.User
 import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
 import java.time.Instant
 import java.util.UUID
 
@@ -19,6 +20,13 @@ data class RefreshTokenRequest(
 data class LogoutRequest(
     @field:NotBlank(message = "Refresh token is required")
     val refreshToken: String
+)
+
+data class UpdateProfileRequest(
+    @field:Size(min = 1, max = 50, message = "닉네임은 1~50자 이내로 입력해주세요")
+    val nickname: String? = null,
+    val profileImageUrl: String? = null,
+    val clearProfileImage: Boolean = false
 )
 
 data class UserResponse(

--- a/backend/src/main/kotlin/com/budgetbook/auth/service/AuthService.kt
+++ b/backend/src/main/kotlin/com/budgetbook/auth/service/AuthService.kt
@@ -4,6 +4,7 @@ import com.budgetbook.auth.domain.RefreshToken
 import com.budgetbook.auth.dto.LogoutRequest
 import com.budgetbook.auth.dto.RefreshTokenRequest
 import com.budgetbook.auth.dto.TokenResponse
+import com.budgetbook.auth.dto.UpdateProfileRequest
 import com.budgetbook.auth.dto.UserResponse
 import com.budgetbook.auth.repository.RefreshTokenRepository
 import com.budgetbook.auth.repository.UserRepository
@@ -87,5 +88,24 @@ class AuthService(
 
         val couple = coupleRepository.findByUserIdAndStatus(userId, CoupleStatus.ACTIVE)
         return UserResponse.from(user, couple?.id)
+    }
+
+    @Transactional
+    fun updateProfile(userId: UUID, request: UpdateProfileRequest): UserResponse {
+        val user = userRepository.findById(userId)
+            .orElseThrow { NotFoundException("USER_NOT_FOUND", "User not found") }
+
+        request.nickname?.let { user.nickname = it }
+        if (request.clearProfileImage) {
+            user.profileImageUrl = null
+        } else {
+            request.profileImageUrl?.let { user.profileImageUrl = it }
+        }
+
+        val savedUser = userRepository.save(user)
+        userCacheService.evict(userId)
+
+        val couple = coupleRepository.findByUserIdAndStatus(userId, CoupleStatus.ACTIVE)
+        return UserResponse.from(savedUser, couple?.id)
     }
 }

--- a/backend/src/test/kotlin/com/budgetbook/auth/controller/AuthControllerTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/auth/controller/AuthControllerTest.kt
@@ -3,6 +3,7 @@ package com.budgetbook.auth.controller
 import com.budgetbook.auth.dto.LogoutRequest
 import com.budgetbook.auth.dto.RefreshTokenRequest
 import com.budgetbook.auth.dto.TokenResponse
+import com.budgetbook.auth.dto.UpdateProfileRequest
 import com.budgetbook.auth.dto.UserResponse
 import com.budgetbook.auth.service.AuthService
 import io.kotest.core.spec.style.FunSpec
@@ -163,5 +164,77 @@ class AuthControllerTest : FunSpec({
         authController.logout(authentication, request)
 
         verify { authService.logout(specificUserId, request) }
+    }
+
+    test("updateProfile calls authService.updateProfile and returns ApiResponse.ok") {
+        val authentication = createAuthentication(testUserId)
+        val request = UpdateProfileRequest(nickname = "NewNickname")
+        val expectedUser = UserResponse(
+            id = testUserId,
+            email = "test@example.com",
+            nickname = "NewNickname",
+            profileImageUrl = "https://example.com/photo.png",
+            provider = "GOOGLE",
+            role = "USER",
+            coupleId = null,
+            createdAt = Instant.now()
+        )
+
+        every { authService.updateProfile(testUserId, request) } returns expectedUser
+
+        val result = authController.updateProfile(authentication, request)
+
+        result.success shouldBe true
+        result.data shouldBe expectedUser
+        result.data!!.nickname shouldBe "NewNickname"
+
+        verify(exactly = 1) { authService.updateProfile(testUserId, request) }
+    }
+
+    test("updateProfile with clearProfileImage returns null profileImageUrl") {
+        val authentication = createAuthentication(testUserId)
+        val request = UpdateProfileRequest(clearProfileImage = true)
+        val expectedUser = UserResponse(
+            id = testUserId,
+            email = "test@example.com",
+            nickname = "TestUser",
+            profileImageUrl = null,
+            provider = "GOOGLE",
+            role = "USER",
+            coupleId = null,
+            createdAt = Instant.now()
+        )
+
+        every { authService.updateProfile(testUserId, request) } returns expectedUser
+
+        val result = authController.updateProfile(authentication, request)
+
+        result.success shouldBe true
+        result.data!!.profileImageUrl shouldBe null
+
+        verify(exactly = 1) { authService.updateProfile(testUserId, request) }
+    }
+
+    test("updateProfile extracts UUID from authentication principal") {
+        val specificUserId = UUID.fromString("550e8400-e29b-41d4-a716-446655440000")
+        val authentication = createAuthentication(specificUserId)
+        val request = UpdateProfileRequest(nickname = "Updated")
+        val expectedUser = UserResponse(
+            id = specificUserId,
+            email = "specific@example.com",
+            nickname = "Updated",
+            profileImageUrl = null,
+            provider = "KAKAO",
+            role = "USER",
+            coupleId = null,
+            createdAt = Instant.now()
+        )
+
+        every { authService.updateProfile(specificUserId, request) } returns expectedUser
+
+        val result = authController.updateProfile(authentication, request)
+
+        result.data!!.id shouldBe specificUserId
+        verify { authService.updateProfile(specificUserId, request) }
     }
 })

--- a/backend/src/test/kotlin/com/budgetbook/auth/service/AuthServiceTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/auth/service/AuthServiceTest.kt
@@ -5,6 +5,7 @@ import com.budgetbook.auth.domain.RefreshToken
 import com.budgetbook.auth.domain.User
 import com.budgetbook.auth.dto.LogoutRequest
 import com.budgetbook.auth.dto.RefreshTokenRequest
+import com.budgetbook.auth.dto.UpdateProfileRequest
 import com.budgetbook.auth.repository.RefreshTokenRepository
 import com.budgetbook.auth.repository.UserRepository
 import com.budgetbook.common.exception.NotFoundException
@@ -244,6 +245,123 @@ class AuthServiceTest : BehaviorSpec({
                     authService.logout(testUser.id, request)
                 }
                 exception.code shouldBe "AUTH_TOKEN_MISMATCH"
+            }
+        }
+    }
+
+    Given("an updateProfile request with nickname only") {
+        val user = User(
+            email = "profile@example.com",
+            nickname = "OldNick",
+            profileImageUrl = "https://example.com/old.png",
+            provider = AuthProvider.GOOGLE,
+            providerId = "google-profile-1"
+        )
+
+        every { userRepository.findById(user.id) } returns Optional.of(user)
+        every { userRepository.save(any()) } returnsArgument 0
+        every { coupleRepository.findByUserIdAndStatus(user.id, CoupleStatus.ACTIVE) } returns null
+
+        When("updateProfile is called with a new nickname") {
+            val request = UpdateProfileRequest(nickname = "NewNick")
+            val result = authService.updateProfile(user.id, request)
+
+            Then("updates the nickname and keeps profileImageUrl") {
+                result.nickname shouldBe "NewNick"
+                result.profileImageUrl shouldBe "https://example.com/old.png"
+            }
+
+            Then("evicts the user cache") {
+                verify { userCacheService.evict(user.id) }
+            }
+        }
+    }
+
+    Given("an updateProfile request with profileImageUrl only") {
+        val user = User(
+            email = "profile2@example.com",
+            nickname = "KeepNick",
+            profileImageUrl = "https://example.com/old.png",
+            provider = AuthProvider.GOOGLE,
+            providerId = "google-profile-2"
+        )
+
+        every { userRepository.findById(user.id) } returns Optional.of(user)
+        every { userRepository.save(any()) } returnsArgument 0
+        every { coupleRepository.findByUserIdAndStatus(user.id, CoupleStatus.ACTIVE) } returns null
+
+        When("updateProfile is called with a new profileImageUrl") {
+            val request = UpdateProfileRequest(profileImageUrl = "https://example.com/new.png")
+            val result = authService.updateProfile(user.id, request)
+
+            Then("updates the profileImageUrl and keeps nickname") {
+                result.nickname shouldBe "KeepNick"
+                result.profileImageUrl shouldBe "https://example.com/new.png"
+            }
+        }
+    }
+
+    Given("an updateProfile request with clearProfileImage = true") {
+        val user = User(
+            email = "profile3@example.com",
+            nickname = "ClearImg",
+            profileImageUrl = "https://example.com/existing.png",
+            provider = AuthProvider.GOOGLE,
+            providerId = "google-profile-3"
+        )
+
+        every { userRepository.findById(user.id) } returns Optional.of(user)
+        every { userRepository.save(any()) } returnsArgument 0
+        every { coupleRepository.findByUserIdAndStatus(user.id, CoupleStatus.ACTIVE) } returns null
+
+        When("updateProfile is called with clearProfileImage = true") {
+            val request = UpdateProfileRequest(clearProfileImage = true)
+            val result = authService.updateProfile(user.id, request)
+
+            Then("clears the profileImageUrl") {
+                result.profileImageUrl shouldBe null
+            }
+        }
+    }
+
+    Given("an updateProfile request with clearProfileImage = true and profileImageUrl provided") {
+        val user = User(
+            email = "profile4@example.com",
+            nickname = "ClearWins",
+            profileImageUrl = "https://example.com/existing.png",
+            provider = AuthProvider.GOOGLE,
+            providerId = "google-profile-4"
+        )
+
+        every { userRepository.findById(user.id) } returns Optional.of(user)
+        every { userRepository.save(any()) } returnsArgument 0
+        every { coupleRepository.findByUserIdAndStatus(user.id, CoupleStatus.ACTIVE) } returns null
+
+        When("updateProfile is called") {
+            val request = UpdateProfileRequest(
+                profileImageUrl = "https://example.com/new.png",
+                clearProfileImage = true
+            )
+            val result = authService.updateProfile(user.id, request)
+
+            Then("clearProfileImage takes precedence and sets profileImageUrl to null") {
+                result.profileImageUrl shouldBe null
+            }
+        }
+    }
+
+    Given("an updateProfile request for a non-existent user") {
+        val unknownId = UUID.randomUUID()
+        every { userRepository.findById(unknownId) } returns Optional.empty()
+
+        When("updateProfile is called") {
+            val request = UpdateProfileRequest(nickname = "NewNick")
+
+            Then("throws NotFoundException") {
+                val exception = shouldThrow<NotFoundException> {
+                    authService.updateProfile(unknownId, request)
+                }
+                exception.code shouldBe "USER_NOT_FOUND"
             }
         }
     }

--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -13,7 +13,8 @@
   - [OAuth2 Login Redirect](#1-oauth2-login-redirect)
   - [Refresh Token](#2-refresh-token)
   - [Get Current User](#3-get-current-user)
-  - [Logout](#4-logout)
+  - [Update Profile](#4-update-profile)
+  - [Logout](#5-logout)
 - [Couple](#couple)
   - [Create Invitation Code](#1-create-invitation-code)
   - [Accept Invitation](#2-accept-invitation)
@@ -304,7 +305,63 @@ Note: `coupleId` is omitted from the response when the user is not in an active 
 
 ---
 
-### 4. Logout
+### 4. Update Profile
+
+Updates the current user's profile information (nickname, profile image).
+
+| Item        | Value                        |
+|:------------|:-----------------------------|
+| **Method**  | `PATCH`                      |
+| **Path**    | `/api/v1/auth/me`            |
+| **Auth**    | Required                     |
+
+**Headers**
+
+| Header          | Value                    | Required |
+|:----------------|:-------------------------|:--------:|
+| `Authorization` | `Bearer {accessToken}`   | Yes      |
+| `Content-Type`  | `application/json`       | Yes      |
+
+**Request Body**
+
+| Field               | Type      | Required | Description                        |
+|:--------------------|:----------|:--------:|:-----------------------------------|
+| `nickname`          | `string`  | No       | New nickname (1-50 chars)          |
+| `profileImageUrl`   | `string`  | No       | New profile image URL              |
+| `clearProfileImage` | `boolean` | No       | Set true to remove profile image   |
+
+```json
+{
+  "nickname": "새닉네임",
+  "profileImageUrl": null,
+  "clearProfileImage": false
+}
+```
+
+**Response `200 OK`**: `ApiResponse<UserResponse>`
+
+```json
+{
+  "success": true,
+  "data": {
+    "id": "550e8400-e29b-41d4-a716-446655440000",
+    "email": "user@example.com",
+    "nickname": "새닉네임",
+    "profileImageUrl": "https://lh3.googleusercontent.com/...",
+    "provider": "GOOGLE",
+    "role": "USER",
+    "coupleId": "550e8400-e29b-41d4-a716-446655440001",
+    "createdAt": "2024-01-01T12:00:00Z"
+  },
+  "timestamp": "2024-01-01T12:00:00Z"
+}
+```
+
+**Response `400 Bad Request`**: Validation error (e.g., nickname too long)
+
+---
+
+### 5. Logout
 
 Revokes the refresh token and invalidates the current session.
 

--- a/frontend/lib/core/router/app_router.dart
+++ b/frontend/lib/core/router/app_router.dart
@@ -46,6 +46,7 @@ import 'package:budget_book/features/home/presentation/bloc/dashboard_bloc.dart'
 import 'package:budget_book/features/home/presentation/bloc/dashboard_event.dart';
 import 'package:budget_book/features/home/presentation/pages/dashboard_page.dart';
 import 'package:budget_book/features/settings/presentation/pages/settings_page.dart';
+import 'package:budget_book/features/settings/presentation/pages/profile_edit_page.dart';
 import 'package:budget_book/features/pocket/presentation/bloc/pocket_bloc.dart';
 import 'package:budget_book/features/pocket/presentation/bloc/pocket_event.dart';
 import 'package:budget_book/features/pocket/presentation/bloc/pocket_transfer_bloc.dart';
@@ -445,6 +446,12 @@ GoRouter createAppRouter(AuthBloc authBloc) => GoRouter(
           child: RecurringFormPage(recurringId: recurringId),
         );
       },
+    ),
+    // Profile Edit
+    GoRoute(
+      path: '/settings/profile-edit',
+      parentNavigatorKey: _rootNavigatorKey,
+      builder: (context, state) => const ProfileEditPage(),
     ),
     // Money Pockets
     GoRoute(

--- a/frontend/lib/features/auth/data/datasources/auth_remote_datasource.dart
+++ b/frontend/lib/features/auth/data/datasources/auth_remote_datasource.dart
@@ -6,6 +6,11 @@ import 'package:budget_book/features/auth/data/models/auth_token_model.dart';
 abstract class AuthRemoteDataSource {
   Future<AuthTokenModel> refreshToken(String refreshToken);
   Future<UserModel> getCurrentUser();
+  Future<UserModel> updateProfile({
+    String? nickname,
+    String? profileImageUrl,
+    bool clearProfileImage = false,
+  });
   Future<void> logout(String refreshToken);
 }
 
@@ -28,6 +33,26 @@ class AuthRemoteDataSourceImpl implements AuthRemoteDataSource {
   @override
   Future<UserModel> getCurrentUser() async {
     final response = await apiClient.dio.get(ApiEndpoints.authMe);
+    return UserModel.fromJson(
+      response.data['data'] as Map<String, dynamic>,
+    );
+  }
+
+  @override
+  Future<UserModel> updateProfile({
+    String? nickname,
+    String? profileImageUrl,
+    bool clearProfileImage = false,
+  }) async {
+    final data = <String, dynamic>{};
+    if (nickname != null) data['nickname'] = nickname;
+    if (profileImageUrl != null) data['profileImageUrl'] = profileImageUrl;
+    if (clearProfileImage) data['clearProfileImage'] = true;
+
+    final response = await apiClient.dio.patch(
+      ApiEndpoints.authMe,
+      data: data,
+    );
     return UserModel.fromJson(
       response.data['data'] as Map<String, dynamic>,
     );

--- a/frontend/lib/features/auth/data/repositories/auth_repository_impl.dart
+++ b/frontend/lib/features/auth/data/repositories/auth_repository_impl.dart
@@ -42,6 +42,29 @@ class AuthRepositoryImpl implements AuthRepository {
   }
 
   @override
+  Future<Either<Failure, User>> updateProfile({
+    String? nickname,
+    String? profileImageUrl,
+    bool clearProfileImage = false,
+  }) async {
+    try {
+      final result = await remoteDataSource.updateProfile(
+        nickname: nickname,
+        profileImageUrl: profileImageUrl,
+        clearProfileImage: clearProfileImage,
+      );
+      return Right(result);
+    } on DioException catch (e) {
+      return Left(
+        ServerFailure(
+          e.response?.data?['error']?['message'] as String? ??
+              'Failed to update profile',
+        ),
+      );
+    }
+  }
+
+  @override
   Future<Either<Failure, void>> logout(String refreshToken) async {
     try {
       await remoteDataSource.logout(refreshToken);

--- a/frontend/lib/features/auth/domain/repositories/auth_repository.dart
+++ b/frontend/lib/features/auth/domain/repositories/auth_repository.dart
@@ -6,5 +6,10 @@ import 'package:budget_book/features/auth/domain/entities/auth_token.dart';
 abstract class AuthRepository {
   Future<Either<Failure, AuthToken>> refreshToken(String refreshToken);
   Future<Either<Failure, User>> getCurrentUser();
+  Future<Either<Failure, User>> updateProfile({
+    String? nickname,
+    String? profileImageUrl,
+    bool clearProfileImage = false,
+  });
   Future<Either<Failure, void>> logout(String refreshToken);
 }

--- a/frontend/lib/features/auth/presentation/bloc/auth_bloc.dart
+++ b/frontend/lib/features/auth/presentation/bloc/auth_bloc.dart
@@ -18,6 +18,7 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
     on<AuthTokenRefreshRequested>(_onTokenRefreshRequested);
     on<AuthRefreshUser>(_onRefreshUser);
     on<AuthSessionExpired>(_onSessionExpired);
+    on<UpdateProfile>(_onUpdateProfile);
   }
 
   Future<void> _onCheckRequested(
@@ -85,6 +86,21 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
     emit(const AuthUnauthenticated(
       message: '세션이 만료되었습니다. 다시 로그인해주세요.',
     ));
+  }
+
+  Future<void> _onUpdateProfile(
+    UpdateProfile event,
+    Emitter<AuthState> emit,
+  ) async {
+    final result = await authRepository.updateProfile(
+      nickname: event.nickname,
+      profileImageUrl: event.profileImageUrl,
+      clearProfileImage: event.clearProfileImage,
+    );
+    result.fold(
+      (failure) => emit(AuthError(failure.message)),
+      (user) => emit(AuthAuthenticated(user)),
+    );
   }
 
   Future<void> _onTokenRefreshRequested(

--- a/frontend/lib/features/auth/presentation/bloc/auth_event.dart
+++ b/frontend/lib/features/auth/presentation/bloc/auth_event.dart
@@ -41,3 +41,19 @@ class AuthRefreshUser extends AuthEvent {
 class AuthSessionExpired extends AuthEvent {
   const AuthSessionExpired();
 }
+
+/// Updates the current user's profile (nickname, profile image).
+class UpdateProfile extends AuthEvent {
+  final String? nickname;
+  final String? profileImageUrl;
+  final bool clearProfileImage;
+
+  const UpdateProfile({
+    this.nickname,
+    this.profileImageUrl,
+    this.clearProfileImage = false,
+  });
+
+  @override
+  List<Object?> get props => [nickname, profileImageUrl, clearProfileImage];
+}

--- a/frontend/lib/features/home/presentation/pages/dashboard_page.dart
+++ b/frontend/lib/features/home/presentation/pages/dashboard_page.dart
@@ -64,8 +64,11 @@ class DashboardPage extends StatelessWidget {
               child: ListView(
                 padding: const EdgeInsets.all(16),
                 children: [
-                  // Month/Year header
+                  // Month/Year header with navigation
                   _MonthHeader(year: state.year, month: state.month),
+                  const SizedBox(height: 16),
+                  // Quick action buttons
+                  const _QuickActions(),
                   const SizedBox(height: 16),
                   // Summary card
                   _SummaryCard(state: state),
@@ -97,13 +100,147 @@ class _MonthHeader extends StatelessWidget {
 
   const _MonthHeader({required this.year, required this.month});
 
+  void _goToPreviousMonth(BuildContext context) {
+    int newYear = year;
+    int newMonth = month - 1;
+    if (newMonth < 1) {
+      newMonth = 12;
+      newYear -= 1;
+    }
+    context.read<DashboardBloc>().add(
+          LoadDashboard(year: newYear, month: newMonth),
+        );
+  }
+
+  void _goToNextMonth(BuildContext context) {
+    int newYear = year;
+    int newMonth = month + 1;
+    if (newMonth > 12) {
+      newMonth = 1;
+      newYear += 1;
+    }
+    context.read<DashboardBloc>().add(
+          LoadDashboard(year: newYear, month: newMonth),
+        );
+  }
+
   @override
   Widget build(BuildContext context) {
-    return Text(
-      '$year년 $month월',
-      style: Theme.of(context).textTheme.headlineSmall?.copyWith(
-            fontWeight: FontWeight.bold,
-          ),
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        IconButton(
+          icon: const Icon(Icons.chevron_left),
+          onPressed: () => _goToPreviousMonth(context),
+          tooltip: '이전 달',
+        ),
+        Text(
+          '$year년 $month월',
+          style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                fontWeight: FontWeight.bold,
+              ),
+        ),
+        IconButton(
+          icon: const Icon(Icons.chevron_right),
+          onPressed: () => _goToNextMonth(context),
+          tooltip: '다음 달',
+        ),
+      ],
+    );
+  }
+}
+
+class _QuickActions extends StatelessWidget {
+  const _QuickActions();
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+      children: [
+        _QuickActionButton(
+          icon: Icons.arrow_downward,
+          label: '지출',
+          color: Colors.red,
+          onTap: () => context.push('/transactions/create'),
+        ),
+        _QuickActionButton(
+          icon: Icons.arrow_upward,
+          label: '수입',
+          color: Colors.blue,
+          onTap: () => context.push('/transactions/create'),
+        ),
+        _QuickActionButton(
+          icon: Icons.bar_chart,
+          label: '통계',
+          color: Colors.purple,
+          onTap: () {
+            // Navigate to statistics tab (index 3)
+            final shell = StatefulNavigationShell.maybeOf(context);
+            if (shell != null) {
+              shell.goBranch(3);
+            } else {
+              context.go('/statistics');
+            }
+          },
+        ),
+        _QuickActionButton(
+          icon: Icons.settings,
+          label: '설정',
+          color: Colors.grey,
+          onTap: () {
+            // Navigate to settings tab (index 4)
+            final shell = StatefulNavigationShell.maybeOf(context);
+            if (shell != null) {
+              shell.goBranch(4);
+            } else {
+              context.go('/settings');
+            }
+          },
+        ),
+      ],
+    );
+  }
+}
+
+class _QuickActionButton extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final Color color;
+  final VoidCallback onTap;
+
+  const _QuickActionButton({
+    required this.icon,
+    required this.label,
+    required this.color,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(12),
+      child: Padding(
+        padding: const EdgeInsets.all(8),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            CircleAvatar(
+              radius: 24,
+              backgroundColor: color.withValues(alpha: 0.15),
+              child: Icon(icon, color: color, size: 24),
+            ),
+            const SizedBox(height: 6),
+            Text(
+              label,
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    fontWeight: FontWeight.w500,
+                  ),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }
@@ -319,11 +456,27 @@ class _RecentTransactionsCard extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text(
-              '최근 거래',
-              style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                    fontWeight: FontWeight.bold,
-                  ),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text(
+                  '최근 거래',
+                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.bold,
+                      ),
+                ),
+                TextButton(
+                  onPressed: () {
+                    final shell = StatefulNavigationShell.maybeOf(context);
+                    if (shell != null) {
+                      shell.goBranch(1);
+                    } else {
+                      context.go('/transactions');
+                    }
+                  },
+                  child: const Text('더보기'),
+                ),
+              ],
             ),
             const SizedBox(height: 12),
             if (error != null)

--- a/frontend/lib/features/settings/presentation/pages/profile_edit_page.dart
+++ b/frontend/lib/features/settings/presentation/pages/profile_edit_page.dart
@@ -1,0 +1,150 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:budget_book/features/auth/presentation/bloc/auth_bloc.dart';
+import 'package:budget_book/features/auth/presentation/bloc/auth_event.dart';
+import 'package:budget_book/features/auth/presentation/bloc/auth_state.dart';
+
+class ProfileEditPage extends StatefulWidget {
+  const ProfileEditPage({super.key});
+
+  @override
+  State<ProfileEditPage> createState() => _ProfileEditPageState();
+}
+
+class _ProfileEditPageState extends State<ProfileEditPage> {
+  final _formKey = GlobalKey<FormState>();
+  late final TextEditingController _nicknameController;
+  bool _isSubmitting = false;
+
+  @override
+  void initState() {
+    super.initState();
+    final authState = context.read<AuthBloc>().state;
+    final currentNickname =
+        authState is AuthAuthenticated ? authState.user.nickname : '';
+    _nicknameController = TextEditingController(text: currentNickname);
+  }
+
+  @override
+  void dispose() {
+    _nicknameController.dispose();
+    super.dispose();
+  }
+
+  void _onSubmit() {
+    if (!_formKey.currentState!.validate()) return;
+    setState(() => _isSubmitting = true);
+    context.read<AuthBloc>().add(
+          UpdateProfile(nickname: _nicknameController.text.trim()),
+        );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocListener<AuthBloc, AuthState>(
+      listener: (context, state) {
+        if (state is AuthAuthenticated && _isSubmitting) {
+          setState(() => _isSubmitting = false);
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('프로필이 수정되었습니다')),
+          );
+          Navigator.of(context).pop();
+        } else if (state is AuthError && _isSubmitting) {
+          setState(() => _isSubmitting = false);
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text('프로필 수정 실패: ${state.message}')),
+          );
+        }
+      },
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('프로필 수정'),
+        ),
+        body: BlocBuilder<AuthBloc, AuthState>(
+          builder: (context, state) {
+            final user =
+                state is AuthAuthenticated ? state.user : null;
+            return Padding(
+              padding: const EdgeInsets.all(16),
+              child: Form(
+                key: _formKey,
+                child: Column(
+                  children: [
+                    // Avatar
+                    CircleAvatar(
+                      radius: 48,
+                      backgroundImage: user?.profileImageUrl != null
+                          ? NetworkImage(user!.profileImageUrl!)
+                          : null,
+                      child: user?.profileImageUrl == null
+                          ? const Icon(Icons.person, size: 48)
+                          : null,
+                    ),
+                    const SizedBox(height: 8),
+                    Text(
+                      user?.email ?? '',
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                            color: Theme.of(context)
+                                .colorScheme
+                                .onSurface
+                                .withValues(alpha: 0.6),
+                          ),
+                    ),
+                    Text(
+                      '${user?.provider ?? ''} 계정',
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                            color: Theme.of(context)
+                                .colorScheme
+                                .onSurface
+                                .withValues(alpha: 0.4),
+                          ),
+                    ),
+                    const SizedBox(height: 32),
+                    // Nickname field
+                    TextFormField(
+                      controller: _nicknameController,
+                      decoration: const InputDecoration(
+                        labelText: '닉네임',
+                        hintText: '닉네임을 입력하세요',
+                        border: OutlineInputBorder(),
+                        prefixIcon: Icon(Icons.person_outline),
+                      ),
+                      maxLength: 50,
+                      validator: (value) {
+                        if (value == null || value.trim().isEmpty) {
+                          return '닉네임을 입력해주세요';
+                        }
+                        if (value.trim().length > 50) {
+                          return '닉네임은 50자 이내로 입력해주세요';
+                        }
+                        return null;
+                      },
+                    ),
+                    const SizedBox(height: 24),
+                    // Submit button
+                    SizedBox(
+                      width: double.infinity,
+                      child: FilledButton(
+                        onPressed: _isSubmitting ? null : _onSubmit,
+                        child: _isSubmitting
+                            ? const SizedBox(
+                                height: 20,
+                                width: 20,
+                                child: CircularProgressIndicator(
+                                  strokeWidth: 2,
+                                  color: Colors.white,
+                                ),
+                              )
+                            : const Text('저장'),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/lib/features/settings/presentation/pages/settings_page.dart
+++ b/frontend/lib/features/settings/presentation/pages/settings_page.dart
@@ -22,6 +22,36 @@ class SettingsPage extends StatelessWidget {
         ),
         body: ListView(
           children: [
+            // Profile card
+            BlocBuilder<AuthBloc, AuthState>(
+              builder: (context, state) {
+                if (state is AuthAuthenticated) {
+                  final user = state.user;
+                  return Card(
+                    margin: const EdgeInsets.all(16),
+                    child: ListTile(
+                      leading: CircleAvatar(
+                        radius: 24,
+                        backgroundImage: user.profileImageUrl != null
+                            ? NetworkImage(user.profileImageUrl!)
+                            : null,
+                        child: user.profileImageUrl == null
+                            ? const Icon(Icons.person)
+                            : null,
+                      ),
+                      title: Text(user.nickname),
+                      subtitle: Text(user.email),
+                      trailing: IconButton(
+                        icon: const Icon(Icons.edit),
+                        onPressed: () => context.push('/settings/profile-edit'),
+                        tooltip: '프로필 수정',
+                      ),
+                    ),
+                  );
+                }
+                return const SizedBox.shrink();
+              },
+            ),
             // Couple management
             ListTile(
               leading: const Icon(Icons.favorite),


### PR DESCRIPTION
## Summary
- Dashboard: month navigation, quick action buttons, recent transactions "더보기"
- Profile Edit: PATCH /api/v1/auth/me (BE), ProfileEditPage (FE), Settings profile card
- API spec updated with Update Profile endpoint
- 8 new BE tests, all 274 FE tests pass

## Test plan
- [ ] BE tests pass in CI
- [ ] FE tests pass in CI
- [ ] Dashboard month navigation works
- [ ] Profile edit updates nickname

🤖 Generated with [Claude Code](https://claude.com/claude-code)