### PR TITLE
feat: Phase 5e - dark mode, language, default payment, app info

### DIFF
--- a/frontend/lib/app.dart
+++ b/frontend/lib/app.dart
@@ -8,6 +8,8 @@ import 'package:budget_book/core/router/app_router.dart';
 import 'package:budget_book/core/theme/app_theme.dart';
 import 'package:budget_book/features/auth/presentation/bloc/auth_bloc.dart';
 import 'package:budget_book/features/auth/presentation/bloc/auth_event.dart';
+import 'package:budget_book/features/settings/presentation/cubit/theme_cubit.dart';
+import 'package:budget_book/features/settings/presentation/cubit/locale_cubit.dart';
 
 class BudgetBookApp extends StatefulWidget {
   const BudgetBookApp({super.key});
@@ -29,26 +31,38 @@ class _BudgetBookAppState extends State<BudgetBookApp> {
 
   @override
   Widget build(BuildContext context) {
-    return BlocProvider<AuthBloc>.value(
-      value: _authBloc,
-      child: MaterialApp.router(
-        title: 'Budget Book',
-        theme: AppTheme.light,
-        darkTheme: AppTheme.dark,
-        themeMode: ThemeMode.system,
-        scaffoldMessengerKey: rootScaffoldMessengerKey,
-        routerConfig: _router,
-        localizationsDelegates: const [
-          GlobalMaterialLocalizations.delegate,
-          GlobalWidgetsLocalizations.delegate,
-          GlobalCupertinoLocalizations.delegate,
-        ],
-        supportedLocales: const [
-          Locale('ko'),
-          Locale('en'),
-        ],
-        locale: const Locale('ko'),
-        debugShowCheckedModeBanner: false,
+    return MultiBlocProvider(
+      providers: [
+        BlocProvider<AuthBloc>.value(value: _authBloc),
+        BlocProvider<ThemeCubit>.value(value: getIt<ThemeCubit>()),
+        BlocProvider<LocaleCubit>.value(value: getIt<LocaleCubit>()),
+      ],
+      child: BlocBuilder<ThemeCubit, ThemeMode>(
+        builder: (context, themeMode) {
+          return BlocBuilder<LocaleCubit, Locale?>(
+            builder: (context, locale) {
+              return MaterialApp.router(
+                title: 'Budget Book',
+                theme: AppTheme.light,
+                darkTheme: AppTheme.dark,
+                themeMode: themeMode,
+                scaffoldMessengerKey: rootScaffoldMessengerKey,
+                routerConfig: _router,
+                localizationsDelegates: const [
+                  GlobalMaterialLocalizations.delegate,
+                  GlobalWidgetsLocalizations.delegate,
+                  GlobalCupertinoLocalizations.delegate,
+                ],
+                supportedLocales: const [
+                  Locale('ko'),
+                  Locale('en'),
+                ],
+                locale: locale,
+                debugShowCheckedModeBanner: false,
+              );
+            },
+          );
+        },
       ),
     );
   }

--- a/frontend/lib/core/di/injection.dart
+++ b/frontend/lib/core/di/injection.dart
@@ -57,6 +57,8 @@ import 'package:budget_book/features/home/presentation/bloc/dashboard_bloc.dart'
 import 'package:budget_book/core/websocket/websocket_service.dart';
 import 'package:budget_book/core/websocket/sync_event_handler.dart';
 import 'package:budget_book/core/websocket/websocket_bloc.dart';
+import 'package:budget_book/features/settings/presentation/cubit/theme_cubit.dart';
+import 'package:budget_book/features/settings/presentation/cubit/locale_cubit.dart';
 
 final getIt = GetIt.instance;
 
@@ -255,6 +257,16 @@ Future<void> configureDependencies() async {
       syncEventHandler: getIt<SyncEventHandler>(),
     ),
     dispose: (bloc) => bloc.close(),
+  );
+
+  // Settings cubits
+  getIt.registerLazySingleton<ThemeCubit>(
+    () => ThemeCubit(),
+    dispose: (cubit) => cubit.close(),
+  );
+  getIt.registerLazySingleton<LocaleCubit>(
+    () => LocaleCubit(),
+    dispose: (cubit) => cubit.close(),
   );
 
   // Dashboard feature

--- a/frontend/lib/core/router/app_router.dart
+++ b/frontend/lib/core/router/app_router.dart
@@ -47,6 +47,7 @@ import 'package:budget_book/features/home/presentation/bloc/dashboard_event.dart
 import 'package:budget_book/features/home/presentation/pages/dashboard_page.dart';
 import 'package:budget_book/features/settings/presentation/pages/settings_page.dart';
 import 'package:budget_book/features/settings/presentation/pages/profile_edit_page.dart';
+import 'package:budget_book/features/settings/presentation/pages/app_info_page.dart';
 import 'package:budget_book/features/pocket/presentation/bloc/pocket_bloc.dart';
 import 'package:budget_book/features/pocket/presentation/bloc/pocket_event.dart';
 import 'package:budget_book/features/pocket/presentation/bloc/pocket_transfer_bloc.dart';
@@ -452,6 +453,12 @@ GoRouter createAppRouter(AuthBloc authBloc) => GoRouter(
       path: '/settings/profile-edit',
       parentNavigatorKey: _rootNavigatorKey,
       builder: (context, state) => const ProfileEditPage(),
+    ),
+    // App Info
+    GoRoute(
+      path: '/settings/app-info',
+      parentNavigatorKey: _rootNavigatorKey,
+      builder: (context, state) => const AppInfoPage(),
     ),
     // Money Pockets
     GoRoute(

--- a/frontend/lib/features/settings/presentation/cubit/locale_cubit.dart
+++ b/frontend/lib/features/settings/presentation/cubit/locale_cubit.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Stores user's locale preference.
+/// Emits `null` for "follow system", or a specific [Locale].
+class LocaleCubit extends Cubit<Locale?> {
+  static const _key = 'locale';
+
+  LocaleCubit() : super(null) {
+    _load();
+  }
+
+  Future<void> _load() async {
+    final prefs = await SharedPreferences.getInstance();
+    final value = prefs.getString(_key);
+    if (value != null && value != 'system') {
+      emit(Locale(value));
+    }
+    // null means system default
+  }
+
+  Future<void> setLocale(Locale? locale) async {
+    emit(locale);
+    final prefs = await SharedPreferences.getInstance();
+    if (locale == null) {
+      await prefs.setString(_key, 'system');
+    } else {
+      await prefs.setString(_key, locale.languageCode);
+    }
+  }
+}

--- a/frontend/lib/features/settings/presentation/cubit/theme_cubit.dart
+++ b/frontend/lib/features/settings/presentation/cubit/theme_cubit.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class ThemeCubit extends Cubit<ThemeMode> {
+  static const _key = 'theme_mode';
+
+  ThemeCubit() : super(ThemeMode.system) {
+    _load();
+  }
+
+  Future<void> _load() async {
+    final prefs = await SharedPreferences.getInstance();
+    final value = prefs.getString(_key);
+    if (value != null) {
+      emit(_fromString(value));
+    }
+  }
+
+  Future<void> setThemeMode(ThemeMode mode) async {
+    emit(mode);
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_key, _toString(mode));
+  }
+
+  static ThemeMode _fromString(String value) {
+    switch (value) {
+      case 'light':
+        return ThemeMode.light;
+      case 'dark':
+        return ThemeMode.dark;
+      default:
+        return ThemeMode.system;
+    }
+  }
+
+  static String _toString(ThemeMode mode) {
+    switch (mode) {
+      case ThemeMode.light:
+        return 'light';
+      case ThemeMode.dark:
+        return 'dark';
+      case ThemeMode.system:
+        return 'system';
+    }
+  }
+}

--- a/frontend/lib/features/settings/presentation/pages/app_info_page.dart
+++ b/frontend/lib/features/settings/presentation/pages/app_info_page.dart
@@ -1,0 +1,112 @@
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+class AppInfoPage extends StatelessWidget {
+  const AppInfoPage({super.key});
+
+  static const _version = '1.0.0';
+  static const _privacyUrl = 'https://budget-book.app/privacy';
+  static const _termsUrl = 'https://budget-book.app/terms';
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('앱 정보'),
+      ),
+      body: ListView(
+        children: [
+          const SizedBox(height: 32),
+          // App icon / logo
+          Center(
+            child: Container(
+              width: 80,
+              height: 80,
+              decoration: BoxDecoration(
+                color: theme.colorScheme.primaryContainer,
+                borderRadius: BorderRadius.circular(20),
+              ),
+              child: Icon(
+                Icons.account_balance_wallet,
+                size: 40,
+                color: theme.colorScheme.primary,
+              ),
+            ),
+          ),
+          const SizedBox(height: 16),
+          Center(
+            child: Text(
+              'Budget Book',
+              style: theme.textTheme.headlineSmall?.copyWith(
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ),
+          const SizedBox(height: 4),
+          Center(
+            child: Text(
+              'v$_version',
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ),
+          const SizedBox(height: 16),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 32),
+            child: Text(
+              '부부가 함께 사용하는 공유 가계부 앱입니다. '
+              '수입/지출 관리, 카테고리별 예산 계획, 통계/분석, '
+              '실시간 동기화를 제공합니다.',
+              textAlign: TextAlign.center,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ),
+          const SizedBox(height: 32),
+          const Divider(),
+          ListTile(
+            leading: const Icon(Icons.privacy_tip_outlined),
+            title: const Text('개인정보 처리방침'),
+            trailing: const Icon(Icons.open_in_new, size: 18),
+            onTap: () => _launchUrl(_privacyUrl),
+          ),
+          ListTile(
+            leading: const Icon(Icons.description_outlined),
+            title: const Text('이용약관'),
+            trailing: const Icon(Icons.open_in_new, size: 18),
+            onTap: () => _launchUrl(_termsUrl),
+          ),
+          const Divider(),
+          const SizedBox(height: 24),
+          Center(
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const FlutterLogo(size: 24),
+                const SizedBox(width: 8),
+                Text(
+                  'Made with Flutter',
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 32),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _launchUrl(String url) async {
+    final uri = Uri.parse(url);
+    if (await canLaunchUrl(uri)) {
+      await launchUrl(uri, mode: LaunchMode.externalApplication);
+    }
+  }
+}

--- a/frontend/lib/features/settings/presentation/pages/settings_page.dart
+++ b/frontend/lib/features/settings/presentation/pages/settings_page.dart
@@ -1,12 +1,45 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:budget_book/features/auth/presentation/bloc/auth_bloc.dart';
 import 'package:budget_book/features/auth/presentation/bloc/auth_event.dart';
 import 'package:budget_book/features/auth/presentation/bloc/auth_state.dart';
+import 'package:budget_book/features/payment_method/presentation/bloc/payment_method_bloc.dart';
+import 'package:budget_book/features/payment_method/presentation/bloc/payment_method_event.dart';
+import 'package:budget_book/features/payment_method/presentation/bloc/payment_method_state.dart';
+import 'package:budget_book/features/settings/presentation/cubit/theme_cubit.dart';
+import 'package:budget_book/features/settings/presentation/cubit/locale_cubit.dart';
+import 'package:budget_book/core/di/injection.dart';
 
-class SettingsPage extends StatelessWidget {
+class SettingsPage extends StatefulWidget {
   const SettingsPage({super.key});
+
+  @override
+  State<SettingsPage> createState() => _SettingsPageState();
+}
+
+class _SettingsPageState extends State<SettingsPage> {
+  String? _defaultPaymentMethodId;
+  String? _defaultPaymentMethodName;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadDefaultPaymentMethod();
+  }
+
+  Future<void> _loadDefaultPaymentMethod() async {
+    final prefs = await SharedPreferences.getInstance();
+    final id = prefs.getString('default_payment_method_id');
+    if (id != null && mounted) {
+      setState(() {
+        _defaultPaymentMethodId = id;
+      });
+      // Load payment methods to resolve the name
+      getIt<PaymentMethodBloc>().add(const LoadPaymentMethods());
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -103,6 +136,67 @@ class SettingsPage extends StatelessWidget {
               onTap: () => context.push('/weekly-budgets'),
             ),
             const Divider(),
+            // Theme setting
+            BlocBuilder<ThemeCubit, ThemeMode>(
+              builder: (context, themeMode) {
+                return ListTile(
+                  leading: const Icon(Icons.palette),
+                  title: const Text('테마'),
+                  subtitle: Text(_themeModeLabel(themeMode)),
+                  trailing: const Icon(Icons.chevron_right),
+                  onTap: () => _showThemeDialog(context, themeMode),
+                );
+              },
+            ),
+            // Language setting
+            BlocBuilder<LocaleCubit, Locale?>(
+              builder: (context, locale) {
+                return ListTile(
+                  leading: const Icon(Icons.language),
+                  title: const Text('언어'),
+                  subtitle: Text(_localeLabel(locale)),
+                  trailing: const Icon(Icons.chevron_right),
+                  onTap: () => _showLocaleDialog(context, locale),
+                );
+              },
+            ),
+            // Default payment method
+            BlocProvider<PaymentMethodBloc>.value(
+              value: getIt<PaymentMethodBloc>(),
+              child: BlocBuilder<PaymentMethodBloc, PaymentMethodState>(
+                builder: (context, pmState) {
+                  String subtitle = '설정 안 됨';
+                  if (_defaultPaymentMethodId != null &&
+                      pmState is PaymentMethodLoaded) {
+                    final match = pmState.paymentMethods.where(
+                      (pm) => pm.id == _defaultPaymentMethodId,
+                    );
+                    if (match.isNotEmpty) {
+                      subtitle = match.first.name;
+                      _defaultPaymentMethodName = match.first.name;
+                    }
+                  } else if (_defaultPaymentMethodName != null) {
+                    subtitle = _defaultPaymentMethodName!;
+                  }
+                  return ListTile(
+                    leading: const Icon(Icons.credit_card),
+                    title: const Text('기본 결제수단'),
+                    subtitle: Text(subtitle),
+                    trailing: const Icon(Icons.chevron_right),
+                    onTap: () => _showDefaultPaymentMethodDialog(
+                        context, pmState),
+                  );
+                },
+              ),
+            ),
+            const Divider(),
+            // App info
+            ListTile(
+              leading: const Icon(Icons.info_outline),
+              title: const Text('앱 정보'),
+              trailing: const Icon(Icons.chevron_right),
+              onTap: () => context.push('/settings/app-info'),
+            ),
             // Logout
             ListTile(
               leading: const Icon(Icons.logout, color: Colors.red),
@@ -137,6 +231,196 @@ class SettingsPage extends StatelessWidget {
             ),
           ],
         ),
+      ),
+    );
+  }
+
+  String _themeModeLabel(ThemeMode mode) {
+    switch (mode) {
+      case ThemeMode.light:
+        return '라이트 모드';
+      case ThemeMode.dark:
+        return '다크 모드';
+      case ThemeMode.system:
+        return '시스템 설정 따르기';
+    }
+  }
+
+  String _localeLabel(Locale? locale) {
+    if (locale == null) return '시스템 설정 따르기';
+    switch (locale.languageCode) {
+      case 'ko':
+        return '한국어';
+      case 'en':
+        return 'English';
+      default:
+        return locale.languageCode;
+    }
+  }
+
+  void _showThemeDialog(BuildContext context, ThemeMode current) {
+    showDialog(
+      context: context,
+      builder: (dialogContext) => SimpleDialog(
+        title: const Text('테마 선택'),
+        children: [
+          _themeOption(dialogContext, '라이트 모드', ThemeMode.light, current),
+          _themeOption(dialogContext, '다크 모드', ThemeMode.dark, current),
+          _themeOption(
+              dialogContext, '시스템 설정 따르기', ThemeMode.system, current),
+        ],
+      ),
+    );
+  }
+
+  Widget _themeOption(
+    BuildContext dialogContext,
+    String label,
+    ThemeMode mode,
+    ThemeMode current,
+  ) {
+    final isSelected = mode == current;
+    return SimpleDialogOption(
+      onPressed: () {
+        context.read<ThemeCubit>().setThemeMode(mode);
+        Navigator.of(dialogContext).pop();
+      },
+      child: Row(
+        children: [
+          Icon(
+            isSelected ? Icons.radio_button_checked : Icons.radio_button_off,
+            color: isSelected
+                ? Theme.of(context).colorScheme.primary
+                : Theme.of(context).colorScheme.onSurfaceVariant,
+          ),
+          const SizedBox(width: 12),
+          Text(label),
+        ],
+      ),
+    );
+  }
+
+  void _showLocaleDialog(BuildContext context, Locale? current) {
+    showDialog(
+      context: context,
+      builder: (dialogContext) => SimpleDialog(
+        title: const Text('언어 선택'),
+        children: [
+          _localeOption(dialogContext, '한국어', const Locale('ko'), current),
+          _localeOption(dialogContext, 'English', const Locale('en'), current),
+          _localeOption(dialogContext, '시스템 설정 따르기', null, current),
+        ],
+      ),
+    );
+  }
+
+  Widget _localeOption(
+    BuildContext dialogContext,
+    String label,
+    Locale? locale,
+    Locale? current,
+  ) {
+    final isSelected = (locale == null && current == null) ||
+        (locale != null &&
+            current != null &&
+            locale.languageCode == current.languageCode);
+    return SimpleDialogOption(
+      onPressed: () {
+        context.read<LocaleCubit>().setLocale(locale);
+        Navigator.of(dialogContext).pop();
+      },
+      child: Row(
+        children: [
+          Icon(
+            isSelected ? Icons.radio_button_checked : Icons.radio_button_off,
+            color: isSelected
+                ? Theme.of(context).colorScheme.primary
+                : Theme.of(context).colorScheme.onSurfaceVariant,
+          ),
+          const SizedBox(width: 12),
+          Text(label),
+        ],
+      ),
+    );
+  }
+
+  void _showDefaultPaymentMethodDialog(
+    BuildContext context,
+    PaymentMethodState pmState,
+  ) {
+    // Ensure payment methods are loaded
+    if (pmState is! PaymentMethodLoaded) {
+      getIt<PaymentMethodBloc>().add(const LoadPaymentMethods());
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('결제수단 목록을 불러오는 중입니다...')),
+      );
+      return;
+    }
+
+    final methods = pmState.activePaymentMethods;
+    showDialog(
+      context: context,
+      builder: (dialogContext) => SimpleDialog(
+        title: const Text('기본 결제수단 선택'),
+        children: [
+          SimpleDialogOption(
+            onPressed: () async {
+              final prefs = await SharedPreferences.getInstance();
+              await prefs.remove('default_payment_method_id');
+              if (mounted) {
+                setState(() {
+                  _defaultPaymentMethodId = null;
+                  _defaultPaymentMethodName = null;
+                });
+              }
+              if (dialogContext.mounted) Navigator.of(dialogContext).pop();
+            },
+            child: Row(
+              children: [
+                Icon(
+                  _defaultPaymentMethodId == null
+                      ? Icons.radio_button_checked
+                      : Icons.radio_button_off,
+                  color: _defaultPaymentMethodId == null
+                      ? Theme.of(context).colorScheme.primary
+                      : Theme.of(context).colorScheme.onSurfaceVariant,
+                ),
+                const SizedBox(width: 12),
+                const Text('설정 안 함'),
+              ],
+            ),
+          ),
+          ...methods.map((pm) {
+            final isSelected = pm.id == _defaultPaymentMethodId;
+            return SimpleDialogOption(
+              onPressed: () async {
+                final prefs = await SharedPreferences.getInstance();
+                await prefs.setString('default_payment_method_id', pm.id);
+                if (mounted) {
+                  setState(() {
+                    _defaultPaymentMethodId = pm.id;
+                    _defaultPaymentMethodName = pm.name;
+                  });
+                }
+                if (dialogContext.mounted) Navigator.of(dialogContext).pop();
+              },
+              child: Row(
+                children: [
+                  Icon(
+                    isSelected
+                        ? Icons.radio_button_checked
+                        : Icons.radio_button_off,
+                    color: isSelected
+                        ? Theme.of(context).colorScheme.primary
+                        : Theme.of(context).colorScheme.onSurfaceVariant,
+                  ),
+                  const SizedBox(width: 12),
+                  Text(pm.name),
+                ],
+              ),
+            );
+          }),
+        ],
       ),
     );
   }

--- a/frontend/lib/features/transaction/presentation/pages/transaction_form_page.dart
+++ b/frontend/lib/features/transaction/presentation/pages/transaction_form_page.dart
@@ -5,6 +5,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:budget_book/features/category/domain/entities/category.dart';
 import 'package:budget_book/features/category/presentation/bloc/category_bloc.dart';
 import 'package:budget_book/features/category/presentation/bloc/category_state.dart';
@@ -64,6 +65,19 @@ class _TransactionFormPageState extends State<TransactionFormPage> {
       _isLoadingTransaction = true;
       // Load the transaction by ID via the bloc
       _loadTransaction();
+    } else {
+      // Pre-select default payment method for new transactions
+      _loadDefaultPaymentMethod();
+    }
+  }
+
+  Future<void> _loadDefaultPaymentMethod() async {
+    final prefs = await SharedPreferences.getInstance();
+    final defaultId = prefs.getString('default_payment_method_id');
+    if (defaultId != null && mounted) {
+      setState(() {
+        _selectedPaymentMethodId = defaultId;
+      });
     }
   }
 

--- a/frontend/test/app_test.dart
+++ b/frontend/test/app_test.dart
@@ -2,10 +2,13 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:bloc_test/bloc_test.dart';
 import 'package:get_it/get_it.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:budget_book/app.dart';
 import 'package:budget_book/features/auth/presentation/bloc/auth_bloc.dart';
 import 'package:budget_book/features/auth/presentation/bloc/auth_event.dart';
 import 'package:budget_book/features/auth/presentation/bloc/auth_state.dart';
+import 'package:budget_book/features/settings/presentation/cubit/theme_cubit.dart';
+import 'package:budget_book/features/settings/presentation/cubit/locale_cubit.dart';
 
 class MockAuthBloc extends MockBloc<AuthEvent, AuthState>
     implements AuthBloc {}
@@ -13,11 +16,14 @@ class MockAuthBloc extends MockBloc<AuthEvent, AuthState>
 void main() {
   testWidgets('BudgetBookApp renders login page with all elements',
       (tester) async {
+    SharedPreferences.setMockInitialValues({});
     final mockAuthBloc = MockAuthBloc();
     when(() => mockAuthBloc.state).thenReturn(const AuthUnauthenticated());
 
     await GetIt.instance.reset();
     GetIt.instance.registerFactory<AuthBloc>(() => mockAuthBloc);
+    GetIt.instance.registerLazySingleton<ThemeCubit>(() => ThemeCubit());
+    GetIt.instance.registerLazySingleton<LocaleCubit>(() => LocaleCubit());
 
     await tester.pumpWidget(const BudgetBookApp());
     await tester.pump();

--- a/frontend/test/features/settings/presentation/cubit/locale_cubit_test.dart
+++ b/frontend/test/features/settings/presentation/cubit/locale_cubit_test.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:bloc_test/bloc_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:budget_book/features/settings/presentation/cubit/locale_cubit.dart';
+
+void main() {
+  group('LocaleCubit', () {
+    setUp(() {
+      SharedPreferences.setMockInitialValues({});
+    });
+
+    test('initial state is null (system default)', () {
+      final cubit = LocaleCubit();
+      expect(cubit.state, isNull);
+      cubit.close();
+    });
+
+    blocTest<LocaleCubit, Locale?>(
+      'emits Locale(ko) when setLocale(ko) is called',
+      setUp: () => SharedPreferences.setMockInitialValues({}),
+      build: () => LocaleCubit(),
+      act: (cubit) => cubit.setLocale(const Locale('ko')),
+      expect: () => [const Locale('ko')],
+    );
+
+    blocTest<LocaleCubit, Locale?>(
+      'emits Locale(en) when setLocale(en) is called',
+      setUp: () => SharedPreferences.setMockInitialValues({}),
+      build: () => LocaleCubit(),
+      act: (cubit) => cubit.setLocale(const Locale('en')),
+      expect: () => [const Locale('en')],
+    );
+
+    blocTest<LocaleCubit, Locale?>(
+      'emits null when setLocale(null) is called (system)',
+      setUp: () => SharedPreferences.setMockInitialValues({}),
+      build: () => LocaleCubit(),
+      act: (cubit) async {
+        await cubit.setLocale(const Locale('en'));
+        await cubit.setLocale(null);
+      },
+      expect: () => [const Locale('en'), null],
+    );
+
+    test('persists and loads locale from SharedPreferences', () async {
+      SharedPreferences.setMockInitialValues({'locale': 'en'});
+      final cubit = LocaleCubit();
+      await Future.delayed(const Duration(milliseconds: 100));
+      expect(cubit.state, const Locale('en'));
+      cubit.close();
+    });
+
+    test('loads null when saved value is system', () async {
+      SharedPreferences.setMockInitialValues({'locale': 'system'});
+      final cubit = LocaleCubit();
+      await Future.delayed(const Duration(milliseconds: 100));
+      expect(cubit.state, isNull);
+      cubit.close();
+    });
+
+    test('persists locale to SharedPreferences', () async {
+      SharedPreferences.setMockInitialValues({});
+      final cubit = LocaleCubit();
+      await cubit.setLocale(const Locale('ko'));
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getString('locale'), 'ko');
+      cubit.close();
+    });
+
+    test('persists system to SharedPreferences when null', () async {
+      SharedPreferences.setMockInitialValues({});
+      final cubit = LocaleCubit();
+      await cubit.setLocale(null);
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getString('locale'), 'system');
+      cubit.close();
+    });
+  });
+}

--- a/frontend/test/features/settings/presentation/cubit/theme_cubit_test.dart
+++ b/frontend/test/features/settings/presentation/cubit/theme_cubit_test.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:bloc_test/bloc_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:budget_book/features/settings/presentation/cubit/theme_cubit.dart';
+
+void main() {
+  group('ThemeCubit', () {
+    setUp(() {
+      SharedPreferences.setMockInitialValues({});
+    });
+
+    test('initial state is ThemeMode.system', () {
+      final cubit = ThemeCubit();
+      expect(cubit.state, ThemeMode.system);
+      cubit.close();
+    });
+
+    blocTest<ThemeCubit, ThemeMode>(
+      'emits dark when setThemeMode(dark) is called',
+      setUp: () => SharedPreferences.setMockInitialValues({}),
+      build: () => ThemeCubit(),
+      act: (cubit) => cubit.setThemeMode(ThemeMode.dark),
+      expect: () => [ThemeMode.dark],
+    );
+
+    blocTest<ThemeCubit, ThemeMode>(
+      'emits light when setThemeMode(light) is called',
+      setUp: () => SharedPreferences.setMockInitialValues({}),
+      build: () => ThemeCubit(),
+      act: (cubit) => cubit.setThemeMode(ThemeMode.light),
+      expect: () => [ThemeMode.light],
+    );
+
+    blocTest<ThemeCubit, ThemeMode>(
+      'emits system when setThemeMode(system) is called',
+      setUp: () => SharedPreferences.setMockInitialValues({}),
+      build: () => ThemeCubit(),
+      act: (cubit) => cubit.setThemeMode(ThemeMode.system),
+      expect: () => [ThemeMode.system],
+    );
+
+    test('persists and loads theme from SharedPreferences', () async {
+      SharedPreferences.setMockInitialValues({'theme_mode': 'dark'});
+      final cubit = ThemeCubit();
+      // Wait for async _load to complete
+      await Future.delayed(const Duration(milliseconds: 100));
+      expect(cubit.state, ThemeMode.dark);
+      cubit.close();
+    });
+
+    test('persists light theme to SharedPreferences', () async {
+      SharedPreferences.setMockInitialValues({});
+      final cubit = ThemeCubit();
+      await cubit.setThemeMode(ThemeMode.light);
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getString('theme_mode'), 'light');
+      cubit.close();
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Dark mode toggle (Light/Dark/System) with persistence
- Language selector (한국어/English/System)
- Default payment method setting
- App info page
- ThemeCubit + LocaleCubit with SharedPreferences
- 317 tests (13 new)

## Test plan
- [ ] FE tests pass in CI
- [ ] Dark mode toggle works
- [ ] Language switch works
- [ ] Default payment method pre-selects in transaction form

🤖 Generated with [Claude Code](https://claude.com/claude-code)