### PR TITLE
feat: Sprint 6b - performance optimization & error handling

### DIFF
--- a/backend/src/main/kotlin/com/budgetbook/budget/service/BudgetService.kt
+++ b/backend/src/main/kotlin/com/budgetbook/budget/service/BudgetService.kt
@@ -15,8 +15,7 @@ import com.budgetbook.common.exception.ConflictException
 import com.budgetbook.common.exception.ForbiddenException
 import com.budgetbook.common.exception.NotFoundException
 import com.budgetbook.couple.domain.Couple
-import com.budgetbook.couple.domain.CoupleStatus
-import com.budgetbook.couple.repository.CoupleRepository
+import com.budgetbook.couple.service.CoupleResolver
 import com.budgetbook.sync.SyncEvent
 import com.budgetbook.sync.SyncEventPublisher
 import com.budgetbook.transaction.domain.TransactionType
@@ -31,7 +30,7 @@ import java.util.UUID
 @Service
 class BudgetService(
     private val budgetRepository: MonthlyBudgetRepository,
-    private val coupleRepository: CoupleRepository,
+    private val coupleResolver: CoupleResolver,
     private val categoryRepository: CategoryRepository,
     private val transactionRepository: TransactionRepository,
     private val syncEventPublisher: SyncEventPublisher
@@ -296,8 +295,7 @@ class BudgetService(
     }
 
     private fun getActiveCouple(userId: UUID): Couple {
-        return coupleRepository.findByUserIdAndStatus(userId, CoupleStatus.ACTIVE)
-            ?: throw NotFoundException("COUPLE_NOT_FOUND", "User is not in an active couple.")
+        return coupleResolver.getActiveCouple(userId)
     }
 
     private fun formatYearMonth(year: Int, month: Int): String =

--- a/backend/src/main/kotlin/com/budgetbook/budget/service/WeeklyBudgetService.kt
+++ b/backend/src/main/kotlin/com/budgetbook/budget/service/WeeklyBudgetService.kt
@@ -13,8 +13,7 @@ import com.budgetbook.category.repository.CategoryGroupRepository
 import com.budgetbook.category.repository.CategoryRepository
 import com.budgetbook.common.exception.NotFoundException
 import com.budgetbook.couple.domain.Couple
-import com.budgetbook.couple.domain.CoupleStatus
-import com.budgetbook.couple.repository.CoupleRepository
+import com.budgetbook.couple.service.CoupleResolver
 import com.budgetbook.transaction.domain.TransactionType
 import com.budgetbook.transaction.repository.TransactionRepository
 import org.springframework.stereotype.Service
@@ -27,7 +26,7 @@ import java.util.UUID
 class WeeklyBudgetService(
     private val snapshotRepository: WeeklyBudgetSnapshotRepository,
     private val budgetRepository: MonthlyBudgetRepository,
-    private val coupleRepository: CoupleRepository,
+    private val coupleResolver: CoupleResolver,
     private val categoryGroupRepository: CategoryGroupRepository,
     private val categoryRepository: CategoryRepository,
     private val transactionRepository: TransactionRepository
@@ -97,22 +96,26 @@ class WeeklyBudgetService(
         val weekNumber = currentWeekIndex + 1
         val (weekStart, weekEnd) = weekRanges[currentWeekIndex]
 
-        // Get all WEEKLY-type category groups for this couple
-        val weeklyGroups = categoryGroupRepository.findByCoupleId(couple.id)
-            .filter { it.budgetType == BudgetType.WEEKLY }
+        // Batch-fetch all data upfront (eliminates N+1 queries)
+        val allGroups = categoryGroupRepository.findByCoupleId(couple.id)
+        val weeklyGroups = allGroups.filter { it.budgetType == BudgetType.WEEKLY }
+
+        val allCategories = categoryRepository.findByCoupleId(couple.id)
+        val categoriesByGroupId = allCategories.groupBy { it.group?.id }
+
+        val allBudgets = budgetRepository.findByCoupleIdAndYearMonth(couple.id, yearMonth)
+        val budgetByCategoryId = allBudgets.associateBy { it.category?.id }
 
         val groups = weeklyGroups.map { group ->
-            // Find categories in this group
-            val categoriesInGroup = categoryRepository.findByCoupleIdAndGroupId(couple.id, group.id)
+            val categoriesInGroup = categoriesByGroupId[group.id] ?: emptyList()
             val categoryIds = categoriesInGroup.map { it.id }.toSet()
 
-            // Get monthly budget for this group's categories and calculate weekly amount
-            val budgets = budgetRepository.findByCoupleIdAndYearMonth(couple.id, yearMonth)
-            val groupBudgetAmount = budgets
-                .filter { it.category != null && categoryIds.contains(it.category!!.id) }
-                .sumOf { it.weeklyAmount ?: (it.amount / weekRanges.size) }
+            val groupBudgetAmount = categoryIds.sumOf { catId ->
+                val budget = budgetByCategoryId[catId]
+                budget?.weeklyAmount ?: (budget?.amount?.div(weekRanges.size) ?: 0L)
+            }
 
-            // Use optimized SUM query filtered by categories
+            // Single SUM query per group (unavoidable without DB-level grouping)
             val spent = if (categoryIds.isNotEmpty()) {
                 calculateSpentForPeriodByCategories(couple.id, weekStart, weekEnd, categoryIds)
             } else {
@@ -236,8 +239,7 @@ class WeeklyBudgetService(
     }
 
     private fun getActiveCouple(userId: UUID): Couple {
-        return coupleRepository.findByUserIdAndStatus(userId, CoupleStatus.ACTIVE)
-            ?: throw NotFoundException("COUPLE_NOT_FOUND", "User is not in an active couple.")
+        return coupleResolver.getActiveCouple(userId)
     }
 
     private fun formatYearMonth(year: Int, month: Int): String =

--- a/backend/src/main/kotlin/com/budgetbook/category/service/CategoryGroupService.kt
+++ b/backend/src/main/kotlin/com/budgetbook/category/service/CategoryGroupService.kt
@@ -12,8 +12,7 @@ import com.budgetbook.common.exception.BusinessException
 import com.budgetbook.common.exception.ForbiddenException
 import com.budgetbook.common.exception.NotFoundException
 import com.budgetbook.couple.domain.Couple
-import com.budgetbook.couple.domain.CoupleStatus
-import com.budgetbook.couple.repository.CoupleRepository
+import com.budgetbook.couple.service.CoupleResolver
 import com.budgetbook.sync.SyncEvent
 import com.budgetbook.sync.SyncEventPublisher
 import org.springframework.stereotype.Service
@@ -25,7 +24,7 @@ class CategoryGroupService(
     private val categoryGroupRepository: CategoryGroupRepository,
     private val categoryRepository: CategoryRepository,
     private val categoryService: CategoryService,
-    private val coupleRepository: CoupleRepository,
+    private val coupleResolver: CoupleResolver,
     private val syncEventPublisher: SyncEventPublisher
 ) {
 
@@ -195,8 +194,7 @@ class CategoryGroupService(
     }
 
     private fun getActiveCouple(userId: UUID): Couple {
-        return coupleRepository.findByUserIdAndStatus(userId, CoupleStatus.ACTIVE)
-            ?: throw NotFoundException("COUPLE_NOT_FOUND", "User is not in an active couple.")
+        return coupleResolver.getActiveCouple(userId)
     }
 
     private fun CategoryGroup.toResponse(categories: List<CategoryResponse>) = CategoryGroupResponse(

--- a/backend/src/main/kotlin/com/budgetbook/category/service/CategoryService.kt
+++ b/backend/src/main/kotlin/com/budgetbook/category/service/CategoryService.kt
@@ -12,8 +12,7 @@ import com.budgetbook.common.exception.ForbiddenException
 import com.budgetbook.common.exception.NotFoundException
 import com.budgetbook.common.cache.RedisCacheService
 import com.budgetbook.couple.domain.Couple
-import com.budgetbook.couple.domain.CoupleStatus
-import com.budgetbook.couple.repository.CoupleRepository
+import com.budgetbook.couple.service.CoupleResolver
 import com.budgetbook.sync.SyncEvent
 import com.budgetbook.sync.SyncEventPublisher
 import org.slf4j.LoggerFactory
@@ -25,7 +24,7 @@ import java.util.UUID
 class CategoryService(
     private val categoryRepository: CategoryRepository,
     private val categoryGroupRepository: CategoryGroupRepository,
-    private val coupleRepository: CoupleRepository,
+    private val coupleResolver: CoupleResolver,
     private val syncEventPublisher: SyncEventPublisher,
     private val redisCacheService: RedisCacheService
 ) {
@@ -171,8 +170,7 @@ class CategoryService(
     }
 
     private fun getActiveCouple(userId: UUID): Couple {
-        return coupleRepository.findByUserIdAndStatus(userId, CoupleStatus.ACTIVE)
-            ?: throw NotFoundException("COUPLE_NOT_FOUND", "User is not in an active couple.")
+        return coupleResolver.getActiveCouple(userId)
     }
 
     fun Category.toResponse() = CategoryResponse(

--- a/backend/src/main/kotlin/com/budgetbook/couple/service/CoupleResolver.kt
+++ b/backend/src/main/kotlin/com/budgetbook/couple/service/CoupleResolver.kt
@@ -1,0 +1,48 @@
+package com.budgetbook.couple.service
+
+import com.budgetbook.common.exception.NotFoundException
+import com.budgetbook.couple.domain.Couple
+import com.budgetbook.couple.domain.CoupleStatus
+import com.budgetbook.couple.repository.CoupleRepository
+import org.springframework.stereotype.Component
+import org.springframework.web.context.annotation.RequestScope
+import java.util.UUID
+
+/**
+ * Request-scoped component that caches the active couple lookup for a given user,
+ * avoiding redundant DB queries when multiple services need the same couple within
+ * a single HTTP request.
+ */
+@Component
+@RequestScope
+class CoupleResolver(
+    private val coupleRepository: CoupleRepository
+) {
+    private val cache = mutableMapOf<UUID, Couple>()
+
+    /**
+     * Returns the active couple for the given user, caching the result for the
+     * lifetime of the current HTTP request.
+     *
+     * @throws NotFoundException if the user is not part of an active couple
+     */
+    fun getActiveCouple(userId: UUID): Couple {
+        return cache.getOrPut(userId) {
+            coupleRepository.findByUserIdAndStatus(userId, CoupleStatus.ACTIVE)
+                ?: throw NotFoundException("COUPLE_NOT_FOUND", "User is not in an active couple.")
+        }
+    }
+
+    /**
+     * Returns the active couple for the given user, or null if not found.
+     * Also caches the result when found.
+     */
+    fun getActiveCoupleOrNull(userId: UUID): Couple? {
+        cache[userId]?.let { return it }
+        val couple = coupleRepository.findByUserIdAndStatus(userId, CoupleStatus.ACTIVE)
+        if (couple != null) {
+            cache[userId] = couple
+        }
+        return couple
+    }
+}

--- a/backend/src/main/kotlin/com/budgetbook/paymentmethod/service/PaymentMethodService.kt
+++ b/backend/src/main/kotlin/com/budgetbook/paymentmethod/service/PaymentMethodService.kt
@@ -4,8 +4,7 @@ import com.budgetbook.common.exception.BusinessException
 import com.budgetbook.common.exception.ForbiddenException
 import com.budgetbook.common.exception.NotFoundException
 import com.budgetbook.couple.domain.Couple
-import com.budgetbook.couple.domain.CoupleStatus
-import com.budgetbook.couple.repository.CoupleRepository
+import com.budgetbook.couple.service.CoupleResolver
 import com.budgetbook.paymentmethod.domain.PaymentMethod
 import com.budgetbook.paymentmethod.domain.PaymentMethodType
 import com.budgetbook.paymentmethod.dto.CardPendingResponse
@@ -25,7 +24,7 @@ import java.util.UUID
 @Service
 class PaymentMethodService(
     private val paymentMethodRepository: PaymentMethodRepository,
-    private val coupleRepository: CoupleRepository,
+    private val coupleResolver: CoupleResolver,
     private val transactionRepository: TransactionRepository,
     private val syncEventPublisher: SyncEventPublisher
 ) {
@@ -166,8 +165,7 @@ class PaymentMethodService(
     }
 
     private fun getActiveCouple(userId: UUID): Couple {
-        return coupleRepository.findByUserIdAndStatus(userId, CoupleStatus.ACTIVE)
-            ?: throw NotFoundException("COUPLE_NOT_FOUND", "User is not in an active couple.")
+        return coupleResolver.getActiveCouple(userId)
     }
 
     private fun PaymentMethod.toResponse() = PaymentMethodResponse(

--- a/backend/src/main/kotlin/com/budgetbook/pocket/service/DistributionRatioService.kt
+++ b/backend/src/main/kotlin/com/budgetbook/pocket/service/DistributionRatioService.kt
@@ -3,8 +3,7 @@ package com.budgetbook.pocket.service
 import com.budgetbook.common.exception.BusinessException
 import com.budgetbook.common.exception.NotFoundException
 import com.budgetbook.couple.domain.Couple
-import com.budgetbook.couple.domain.CoupleStatus
-import com.budgetbook.couple.repository.CoupleRepository
+import com.budgetbook.couple.service.CoupleResolver
 import com.budgetbook.pocket.domain.DistributionRatio
 import com.budgetbook.pocket.dto.DistributionRatioResponse
 import com.budgetbook.pocket.dto.SaveDistributionRatiosRequest
@@ -19,7 +18,7 @@ import java.util.UUID
 class DistributionRatioService(
     private val distributionRatioRepository: DistributionRatioRepository,
     private val moneyPocketRepository: MoneyPocketRepository,
-    private val coupleRepository: CoupleRepository
+    private val coupleResolver: CoupleResolver
 ) {
 
     @Transactional(readOnly = true)
@@ -95,7 +94,6 @@ class DistributionRatioService(
     }
 
     private fun getActiveCouple(userId: UUID): Couple {
-        return coupleRepository.findByUserIdAndStatus(userId, CoupleStatus.ACTIVE)
-            ?: throw NotFoundException("COUPLE_NOT_FOUND", "User is not in an active couple.")
+        return coupleResolver.getActiveCouple(userId)
     }
 }

--- a/backend/src/main/kotlin/com/budgetbook/pocket/service/MoneyPocketService.kt
+++ b/backend/src/main/kotlin/com/budgetbook/pocket/service/MoneyPocketService.kt
@@ -4,8 +4,7 @@ import com.budgetbook.common.exception.BusinessException
 import com.budgetbook.common.exception.ForbiddenException
 import com.budgetbook.common.exception.NotFoundException
 import com.budgetbook.couple.domain.Couple
-import com.budgetbook.couple.domain.CoupleStatus
-import com.budgetbook.couple.repository.CoupleRepository
+import com.budgetbook.couple.service.CoupleResolver
 import com.budgetbook.pocket.domain.MoneyPocket
 import com.budgetbook.pocket.domain.PocketType
 import com.budgetbook.pocket.dto.CreatePocketRequest
@@ -24,7 +23,7 @@ import java.util.UUID
 @Service
 class MoneyPocketService(
     private val moneyPocketRepository: MoneyPocketRepository,
-    private val coupleRepository: CoupleRepository,
+    private val coupleResolver: CoupleResolver,
     private val syncEventPublisher: SyncEventPublisher,
     private val pocketTransferRepository: PocketTransferRepository,
     private val transactionRepository: TransactionRepository
@@ -156,8 +155,7 @@ class MoneyPocketService(
     }
 
     internal fun getActiveCouple(userId: UUID): Couple {
-        return coupleRepository.findByUserIdAndStatus(userId, CoupleStatus.ACTIVE)
-            ?: throw NotFoundException("COUPLE_NOT_FOUND", "User is not in an active couple.")
+        return coupleResolver.getActiveCouple(userId)
     }
 
     private fun MoneyPocket.toResponse(balance: Long) = PocketResponse(

--- a/backend/src/main/kotlin/com/budgetbook/pocket/service/PocketTransferService.kt
+++ b/backend/src/main/kotlin/com/budgetbook/pocket/service/PocketTransferService.kt
@@ -4,8 +4,7 @@ import com.budgetbook.auth.repository.UserRepository
 import com.budgetbook.common.exception.BusinessException
 import com.budgetbook.common.exception.NotFoundException
 import com.budgetbook.couple.domain.Couple
-import com.budgetbook.couple.domain.CoupleStatus
-import com.budgetbook.couple.repository.CoupleRepository
+import com.budgetbook.couple.service.CoupleResolver
 import com.budgetbook.pocket.domain.PocketTransfer
 import com.budgetbook.pocket.dto.CreateTransferRequest
 import com.budgetbook.pocket.dto.DistributeRequest
@@ -25,7 +24,7 @@ import java.util.UUID
 class PocketTransferService(
     private val pocketTransferRepository: PocketTransferRepository,
     private val moneyPocketRepository: MoneyPocketRepository,
-    private val coupleRepository: CoupleRepository,
+    private val coupleResolver: CoupleResolver,
     private val userRepository: UserRepository,
     private val syncEventPublisher: SyncEventPublisher
 ) {
@@ -122,8 +121,7 @@ class PocketTransferService(
     }
 
     private fun getActiveCouple(userId: UUID): Couple {
-        return coupleRepository.findByUserIdAndStatus(userId, CoupleStatus.ACTIVE)
-            ?: throw NotFoundException("COUPLE_NOT_FOUND", "User is not in an active couple.")
+        return coupleResolver.getActiveCouple(userId)
     }
 
     private fun PocketTransfer.toResponse() = PocketTransferResponse(

--- a/backend/src/main/kotlin/com/budgetbook/recurring/service/RecurringTransactionService.kt
+++ b/backend/src/main/kotlin/com/budgetbook/recurring/service/RecurringTransactionService.kt
@@ -6,8 +6,7 @@ import com.budgetbook.common.exception.BusinessException
 import com.budgetbook.common.exception.ForbiddenException
 import com.budgetbook.common.exception.NotFoundException
 import com.budgetbook.couple.domain.Couple
-import com.budgetbook.couple.domain.CoupleStatus
-import com.budgetbook.couple.repository.CoupleRepository
+import com.budgetbook.couple.service.CoupleResolver
 import com.budgetbook.paymentmethod.repository.PaymentMethodRepository
 import com.budgetbook.recurring.domain.Frequency
 import com.budgetbook.recurring.domain.RecurringTransaction
@@ -30,7 +29,7 @@ import java.util.UUID
 class RecurringTransactionService(
     private val recurringRepository: RecurringTransactionRepository,
     private val transactionRepository: TransactionRepository,
-    private val coupleRepository: CoupleRepository,
+    private val coupleResolver: CoupleResolver,
     private val userRepository: UserRepository,
     private val categoryRepository: CategoryRepository,
     private val paymentMethodRepository: PaymentMethodRepository
@@ -296,7 +295,6 @@ class RecurringTransactionService(
     }
 
     private fun getActiveCouple(userId: UUID): Couple {
-        return coupleRepository.findByUserIdAndStatus(userId, CoupleStatus.ACTIVE)
-            ?: throw NotFoundException("COUPLE_NOT_FOUND", "User is not in an active couple.")
+        return coupleResolver.getActiveCouple(userId)
     }
 }

--- a/backend/src/main/kotlin/com/budgetbook/report/service/ReportService.kt
+++ b/backend/src/main/kotlin/com/budgetbook/report/service/ReportService.kt
@@ -6,8 +6,7 @@ import com.budgetbook.category.repository.CategoryGroupRepository
 import com.budgetbook.category.repository.CategoryRepository
 import com.budgetbook.common.exception.NotFoundException
 import com.budgetbook.couple.domain.Couple
-import com.budgetbook.couple.domain.CoupleStatus
-import com.budgetbook.couple.repository.CoupleRepository
+import com.budgetbook.couple.service.CoupleResolver
 import com.budgetbook.report.dto.CardPendingReportSummary
 import com.budgetbook.report.dto.CategorySpendingItem
 import com.budgetbook.report.dto.DailySpendingItem
@@ -32,7 +31,7 @@ import java.util.UUID
 @Service
 class ReportService(
     private val transactionRepository: TransactionRepository,
-    private val coupleRepository: CoupleRepository,
+    private val coupleResolver: CoupleResolver,
     private val categoryGroupRepository: CategoryGroupRepository,
     private val categoryRepository: CategoryRepository,
     private val budgetRepository: MonthlyBudgetRepository
@@ -500,7 +499,6 @@ class ReportService(
     }
 
     private fun getActiveCouple(userId: UUID): Couple {
-        return coupleRepository.findByUserIdAndStatus(userId, CoupleStatus.ACTIVE)
-            ?: throw NotFoundException("COUPLE_NOT_FOUND", "User is not in an active couple.")
+        return coupleResolver.getActiveCouple(userId)
     }
 }

--- a/backend/src/main/kotlin/com/budgetbook/statistics/service/StatisticsService.kt
+++ b/backend/src/main/kotlin/com/budgetbook/statistics/service/StatisticsService.kt
@@ -3,8 +3,7 @@ package com.budgetbook.statistics.service
 import com.budgetbook.common.exception.BusinessException
 import com.budgetbook.common.exception.NotFoundException
 import com.budgetbook.couple.domain.Couple
-import com.budgetbook.couple.domain.CoupleStatus
-import com.budgetbook.couple.repository.CoupleRepository
+import com.budgetbook.couple.service.CoupleResolver
 import com.budgetbook.statistics.dto.CategoryStatisticsResponse
 import com.budgetbook.statistics.dto.MonthlyTrendResponse
 import com.budgetbook.statistics.dto.StatisticsSummaryResponse
@@ -20,7 +19,7 @@ import java.util.UUID
 @Service
 class StatisticsService(
     private val transactionRepository: TransactionRepository,
-    private val coupleRepository: CoupleRepository
+    private val coupleResolver: CoupleResolver
 ) {
 
     @Transactional(readOnly = true)
@@ -145,7 +144,6 @@ class StatisticsService(
     }
 
     private fun getActiveCouple(userId: UUID): Couple {
-        return coupleRepository.findByUserIdAndStatus(userId, CoupleStatus.ACTIVE)
-            ?: throw NotFoundException("COUPLE_NOT_FOUND", "User is not in an active couple.")
+        return coupleResolver.getActiveCouple(userId)
     }
 }

--- a/backend/src/main/kotlin/com/budgetbook/transaction/service/TransactionExportService.kt
+++ b/backend/src/main/kotlin/com/budgetbook/transaction/service/TransactionExportService.kt
@@ -3,8 +3,7 @@ package com.budgetbook.transaction.service
 import com.budgetbook.common.exception.BusinessException
 import com.budgetbook.common.exception.NotFoundException
 import com.budgetbook.couple.domain.Couple
-import com.budgetbook.couple.domain.CoupleStatus
-import com.budgetbook.couple.repository.CoupleRepository
+import com.budgetbook.couple.service.CoupleResolver
 import com.budgetbook.transaction.domain.Transaction
 import com.budgetbook.transaction.domain.TransactionType
 import com.budgetbook.transaction.repository.TransactionRepository
@@ -19,7 +18,7 @@ import java.util.UUID
 @Service
 class TransactionExportService(
     private val transactionRepository: TransactionRepository,
-    private val coupleRepository: CoupleRepository
+    private val coupleResolver: CoupleResolver
 ) {
 
     @Transactional(readOnly = true)
@@ -100,7 +99,6 @@ class TransactionExportService(
     }
 
     private fun getActiveCouple(userId: UUID): Couple {
-        return coupleRepository.findByUserIdAndStatus(userId, CoupleStatus.ACTIVE)
-            ?: throw NotFoundException("COUPLE_NOT_FOUND", "User is not in an active couple.")
+        return coupleResolver.getActiveCouple(userId)
     }
 }

--- a/backend/src/main/kotlin/com/budgetbook/transaction/service/TransactionService.kt
+++ b/backend/src/main/kotlin/com/budgetbook/transaction/service/TransactionService.kt
@@ -6,9 +6,8 @@ import com.budgetbook.common.exception.BusinessException
 import com.budgetbook.common.exception.ForbiddenException
 import com.budgetbook.common.exception.NotFoundException
 import com.budgetbook.couple.domain.Couple
-import com.budgetbook.couple.domain.CoupleStatus
 import com.budgetbook.couple.dto.UserSummary
-import com.budgetbook.couple.repository.CoupleRepository
+import com.budgetbook.couple.service.CoupleResolver
 import com.budgetbook.paymentmethod.domain.PaymentMethodType
 import com.budgetbook.paymentmethod.repository.PaymentMethodRepository
 import com.budgetbook.pocket.repository.MoneyPocketRepository
@@ -34,7 +33,7 @@ import java.util.UUID
 @Service
 class TransactionService(
     private val transactionRepository: TransactionRepository,
-    private val coupleRepository: CoupleRepository,
+    private val coupleResolver: CoupleResolver,
     private val userRepository: UserRepository,
     private val categoryRepository: CategoryRepository,
     private val paymentMethodRepository: PaymentMethodRepository,
@@ -306,8 +305,7 @@ class TransactionService(
     }
 
     private fun getActiveCouple(userId: UUID): Couple {
-        return coupleRepository.findByUserIdAndStatus(userId, CoupleStatus.ACTIVE)
-            ?: throw NotFoundException("COUPLE_NOT_FOUND", "User is not in an active couple.")
+        return coupleResolver.getActiveCouple(userId)
     }
 
     private fun calculateSettlementDate(

--- a/backend/src/main/resources/db/migration/V20__add_performance_indexes.sql
+++ b/backend/src/main/resources/db/migration/V20__add_performance_indexes.sql
@@ -1,0 +1,28 @@
+-- V20: Performance indexes for frequently queried patterns
+
+-- 1. Couples: findByUserIdAndStatus is called on every authenticated API request.
+--    Existing idx_couples_user1_id and idx_couples_user2_id only index user IDs alone.
+--    Adding composite indexes with status eliminates filter-after-scan overhead.
+CREATE INDEX IF NOT EXISTS idx_couples_user1_status ON couples (user1_id, status);
+CREATE INDEX IF NOT EXISTS idx_couples_user2_status ON couples (user2_id, status);
+
+-- 2. Transactions: SUM queries filter by (couple_id, type, transaction_date) range.
+--    Existing idx_transactions_couple_date covers (couple_id, transaction_date DESC)
+--    but doesn't include type, forcing a filter step on each aggregate query.
+CREATE INDEX IF NOT EXISTS idx_transactions_couple_type_date
+    ON transactions (couple_id, type, transaction_date);
+
+-- 3. Categories: findByCoupleIdAndGroupId is used in weekly budget summary.
+--    Existing idx_categories_couple_id and idx_categories_group_id are single-column.
+CREATE INDEX IF NOT EXISTS idx_categories_couple_group
+    ON categories (couple_id, group_id);
+
+-- 4. Recurring transactions: findByCoupleIdAndIsActiveTrue filters on both columns.
+--    Existing idx_recurring_couple only indexes couple_id.
+CREATE INDEX IF NOT EXISTS idx_recurring_couple_active
+    ON recurring_transactions (couple_id, is_active);
+
+-- 5. Money pockets: findByCoupleIdAndIsActiveTrue with ORDER BY display_order.
+--    No composite index exists for this common query.
+CREATE INDEX IF NOT EXISTS idx_pockets_couple_active_order
+    ON money_pockets (couple_id, is_active, display_order);

--- a/backend/src/test/kotlin/com/budgetbook/budget/service/BudgetServiceTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/budget/service/BudgetServiceTest.kt
@@ -16,7 +16,7 @@ import com.budgetbook.common.exception.ForbiddenException
 import com.budgetbook.common.exception.NotFoundException
 import com.budgetbook.couple.domain.Couple
 import com.budgetbook.couple.domain.CoupleStatus
-import com.budgetbook.couple.repository.CoupleRepository
+import com.budgetbook.couple.service.CoupleResolver
 import com.budgetbook.sync.SyncEventPublisher
 import com.budgetbook.transaction.domain.TransactionType
 import com.budgetbook.transaction.repository.TransactionRepository
@@ -37,11 +37,11 @@ class BudgetServiceTest : BehaviorSpec({
     isolationMode = IsolationMode.InstancePerLeaf
 
     val budgetRepository = mockk<MonthlyBudgetRepository>()
-    val coupleRepository = mockk<CoupleRepository>()
+    val coupleResolver = mockk<CoupleResolver>()
     val categoryRepository = mockk<CategoryRepository>()
     val transactionRepository = mockk<TransactionRepository>()
     val syncEventPublisher = mockk<SyncEventPublisher>(relaxed = true)
-    val service = BudgetService(budgetRepository, coupleRepository, categoryRepository, transactionRepository, syncEventPublisher)
+    val service = BudgetService(budgetRepository, coupleResolver, categoryRepository, transactionRepository, syncEventPublisher)
 
     val user1 = User(email = "u1@test.com", nickname = "U1", provider = AuthProvider.GOOGLE, providerId = "g1")
     val user2 = User(email = "u2@test.com", nickname = "U2", provider = AuthProvider.KAKAO, providerId = "k2")
@@ -51,7 +51,7 @@ class BudgetServiceTest : BehaviorSpec({
     // --- createBudget ---
 
     Given("a user in an active couple") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
 
         When("creating a budget with a category") {
             every { categoryRepository.findById(category.id) } returns Optional.of(category)
@@ -132,7 +132,7 @@ class BudgetServiceTest : BehaviorSpec({
     // --- getBudgetsByMonth ---
 
     Given("budgets exist for the user's couple") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
 
         val budget1 = MonthlyBudget(couple = couple, category = category, yearMonth = "2026-03", amount = 150000)
         val budget2 = MonthlyBudget(couple = couple, category = null, yearMonth = "2026-03", amount = 3000000)
@@ -154,7 +154,7 @@ class BudgetServiceTest : BehaviorSpec({
     // --- updateBudget ---
 
     Given("an existing budget to update") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
         val budget = MonthlyBudget(couple = couple, category = category, yearMonth = "2026-03", amount = 150000)
         every { budgetRepository.findById(budget.id) } returns Optional.of(budget)
         every { budgetRepository.save(budget) } returns budget
@@ -170,7 +170,7 @@ class BudgetServiceTest : BehaviorSpec({
     }
 
     Given("a budget from a different couple") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
         val otherCouple = Couple(user1 = user2, status = CoupleStatus.ACTIVE)
         val budget = MonthlyBudget(couple = otherCouple, yearMonth = "2026-03", amount = 100000)
         every { budgetRepository.findById(budget.id) } returns Optional.of(budget)
@@ -185,7 +185,7 @@ class BudgetServiceTest : BehaviorSpec({
     }
 
     Given("an existing MONTHLY budget switching to WEEKLY") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
         val budget = MonthlyBudget(
             couple = couple, category = category, yearMonth = "2026-03", amount = 150000,
             budgetPeriod = BudgetPeriod.MONTHLY, weeklyAmount = null
@@ -207,7 +207,7 @@ class BudgetServiceTest : BehaviorSpec({
     }
 
     Given("an existing WEEKLY budget updating amount only") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
         val budget = MonthlyBudget(
             couple = couple, category = category, yearMonth = "2026-03", amount = 150000,
             budgetPeriod = BudgetPeriod.WEEKLY, weeklyAmount = 30000
@@ -229,7 +229,7 @@ class BudgetServiceTest : BehaviorSpec({
     }
 
     Given("an existing WEEKLY budget with explicit weeklyAmount") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
         val budget = MonthlyBudget(
             couple = couple, category = category, yearMonth = "2026-03", amount = 200000,
             budgetPeriod = BudgetPeriod.WEEKLY, weeklyAmount = 40000
@@ -249,7 +249,7 @@ class BudgetServiceTest : BehaviorSpec({
     }
 
     Given("an existing WEEKLY budget switching to MONTHLY") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
         val budget = MonthlyBudget(
             couple = couple, category = category, yearMonth = "2026-03", amount = 200000,
             budgetPeriod = BudgetPeriod.WEEKLY, weeklyAmount = 40000
@@ -270,7 +270,7 @@ class BudgetServiceTest : BehaviorSpec({
     }
 
     Given("an existing budget with invalid budgetPeriod in update") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
         val budget = MonthlyBudget(
             couple = couple, category = category, yearMonth = "2026-03", amount = 150000
         )
@@ -287,7 +287,7 @@ class BudgetServiceTest : BehaviorSpec({
     }
 
     Given("a non-existent budget to update") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
         val fakeId = UUID.randomUUID()
         every { budgetRepository.findById(fakeId) } returns Optional.empty()
 
@@ -304,7 +304,7 @@ class BudgetServiceTest : BehaviorSpec({
     // --- deleteBudget ---
 
     Given("a budget to delete") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
         val budget = MonthlyBudget(couple = couple, category = category, yearMonth = "2026-03", amount = 150000)
         every { budgetRepository.findById(budget.id) } returns Optional.of(budget)
         every { budgetRepository.delete(budget) } returns Unit
@@ -319,7 +319,7 @@ class BudgetServiceTest : BehaviorSpec({
     }
 
     Given("a budget from a different couple to delete") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
         val otherCouple = Couple(user1 = user2, status = CoupleStatus.ACTIVE)
         val budget = MonthlyBudget(couple = otherCouple, yearMonth = "2026-03", amount = 100000)
         every { budgetRepository.findById(budget.id) } returns Optional.of(budget)
@@ -336,7 +336,7 @@ class BudgetServiceTest : BehaviorSpec({
     // --- getBudgetSummary ---
 
     Given("budgets and transactions exist for summary") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
 
         val budget1 = MonthlyBudget(couple = couple, category = category, yearMonth = "2026-03", amount = 150000)
         val budget2 = MonthlyBudget(couple = couple, category = null, yearMonth = "2026-03", amount = 3000000)
@@ -393,7 +393,7 @@ class BudgetServiceTest : BehaviorSpec({
     // --- copyFromPreviousMonth ---
 
     Given("a user in an active couple for copy") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
 
         When("copying budgets from a month with budgets to an empty month") {
             val sourceBudget1 = MonthlyBudget(couple = couple, category = category, yearMonth = "2026-02", amount = 150000)
@@ -477,7 +477,7 @@ class BudgetServiceTest : BehaviorSpec({
     // --- user not in couple ---
 
     Given("a user not in any couple") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns null
+        every { coupleResolver.getActiveCouple(user1.id) } throws NotFoundException("COUPLE_NOT_FOUND", "User is not in an active couple.")
 
         When("any budget operation is called") {
             Then("throws NotFoundException for createBudget") {

--- a/backend/src/test/kotlin/com/budgetbook/budget/service/WeeklyBudgetServiceTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/budget/service/WeeklyBudgetServiceTest.kt
@@ -17,7 +17,7 @@ import com.budgetbook.category.repository.CategoryRepository
 import com.budgetbook.common.exception.NotFoundException
 import com.budgetbook.couple.domain.Couple
 import com.budgetbook.couple.domain.CoupleStatus
-import com.budgetbook.couple.repository.CoupleRepository
+import com.budgetbook.couple.service.CoupleResolver
 import com.budgetbook.transaction.domain.TransactionType
 import com.budgetbook.transaction.repository.TransactionRepository
 import io.kotest.assertions.throwables.shouldThrow
@@ -36,12 +36,12 @@ class WeeklyBudgetServiceTest : BehaviorSpec({
 
     val snapshotRepository = mockk<WeeklyBudgetSnapshotRepository>()
     val budgetRepository = mockk<MonthlyBudgetRepository>()
-    val coupleRepository = mockk<CoupleRepository>()
+    val coupleResolver = mockk<CoupleResolver>()
     val categoryGroupRepository = mockk<CategoryGroupRepository>()
     val categoryRepository = mockk<CategoryRepository>()
     val transactionRepository = mockk<TransactionRepository>()
     val service = WeeklyBudgetService(
-        snapshotRepository, budgetRepository, coupleRepository,
+        snapshotRepository, budgetRepository, coupleResolver,
         categoryGroupRepository, categoryRepository, transactionRepository
     )
 
@@ -81,7 +81,7 @@ class WeeklyBudgetServiceTest : BehaviorSpec({
     // --- getWeeklyOverview ---
 
     Given("budgets exist for a user's couple") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
 
         val budget = MonthlyBudget(
             couple = couple, yearMonth = "2026-03", amount = 500000,
@@ -114,7 +114,7 @@ class WeeklyBudgetServiceTest : BehaviorSpec({
     }
 
     Given("snapshots already exist") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
 
         val snapshot = WeeklyBudgetSnapshot(
             couple = couple, yearMonth = "2026-03", weekNumber = 1,
@@ -147,7 +147,7 @@ class WeeklyBudgetServiceTest : BehaviorSpec({
     // --- getCurrentWeekSummary ---
 
     Given("weekly groups exist for the couple") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
 
         val weeklyGroup = CategoryGroup(
             couple = couple, name = "생활비", budgetType = BudgetType.WEEKLY
@@ -161,7 +161,7 @@ class WeeklyBudgetServiceTest : BehaviorSpec({
             couple = couple, name = "식비", type = CategoryType.EXPENSE,
             group = weeklyGroup
         )
-        every { categoryRepository.findByCoupleIdAndGroupId(couple.id, weeklyGroup.id) } returns listOf(category1)
+        every { categoryRepository.findByCoupleId(couple.id) } returns listOf(category1)
 
         val today = LocalDate.now()
         val yearMonth = "%04d-%02d".format(today.year, today.monthValue)
@@ -204,7 +204,7 @@ class WeeklyBudgetServiceTest : BehaviorSpec({
     // --- user not in couple ---
 
     Given("a user not in any couple") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns null
+        every { coupleResolver.getActiveCouple(user1.id) } throws NotFoundException("COUPLE_NOT_FOUND", "User is not in an active couple.")
 
         When("getWeeklyOverview is called") {
             Then("throws NotFoundException") {

--- a/backend/src/test/kotlin/com/budgetbook/category/service/CategoryGroupServiceTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/category/service/CategoryGroupServiceTest.kt
@@ -15,7 +15,7 @@ import com.budgetbook.common.exception.NotFoundException
 import com.budgetbook.couple.domain.Couple
 import com.budgetbook.common.cache.RedisCacheService
 import com.budgetbook.couple.domain.CoupleStatus
-import com.budgetbook.couple.repository.CoupleRepository
+import com.budgetbook.couple.service.CoupleResolver
 import com.budgetbook.sync.SyncEventPublisher
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.IsolationMode
@@ -34,12 +34,12 @@ class CategoryGroupServiceTest : BehaviorSpec({
 
     val categoryGroupRepository = mockk<CategoryGroupRepository>()
     val categoryRepository = mockk<CategoryRepository>()
-    val coupleRepository = mockk<CoupleRepository>()
+    val coupleResolver = mockk<CoupleResolver>()
     val syncEventPublisher = mockk<SyncEventPublisher>(relaxed = true)
     val redisCacheService = mockk<RedisCacheService>(relaxed = true)
-    val categoryService = CategoryService(categoryRepository, categoryGroupRepository, coupleRepository, syncEventPublisher, redisCacheService)
+    val categoryService = CategoryService(categoryRepository, categoryGroupRepository, coupleResolver, syncEventPublisher, redisCacheService)
     val categoryGroupService = CategoryGroupService(
-        categoryGroupRepository, categoryRepository, categoryService, coupleRepository, syncEventPublisher
+        categoryGroupRepository, categoryRepository, categoryService, coupleResolver, syncEventPublisher
     )
 
     val user1 = User(
@@ -59,7 +59,7 @@ class CategoryGroupServiceTest : BehaviorSpec({
     // --- listCategoryGroups ---
 
     Given("a user in an active couple with category groups") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
 
         val group1 = CategoryGroup(
             couple = couple, name = "생활비", icon = "wallet", color = "#4CAF50",
@@ -95,7 +95,7 @@ class CategoryGroupServiceTest : BehaviorSpec({
     }
 
     Given("a user with no uncategorized categories") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
 
         val group = CategoryGroup(couple = couple, name = "생활비", displayOrder = 1, isDefault = true)
         every { categoryGroupRepository.findByCoupleIdOrderByDisplayOrder(couple.id) } returns listOf(group)
@@ -113,7 +113,7 @@ class CategoryGroupServiceTest : BehaviorSpec({
     }
 
     Given("a user not in a couple") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns null
+        every { coupleResolver.getActiveCouple(user1.id) } throws NotFoundException("COUPLE_NOT_FOUND", "User is not in an active couple.")
 
         When("listCategoryGroups is called") {
             Then("throws NotFoundException") {
@@ -128,7 +128,7 @@ class CategoryGroupServiceTest : BehaviorSpec({
     // --- createCategoryGroup ---
 
     Given("a user in a couple creating a category group") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
 
         val groupSlot = slot<CategoryGroup>()
         every { categoryGroupRepository.save(capture(groupSlot)) } answers { groupSlot.captured }
@@ -163,7 +163,7 @@ class CategoryGroupServiceTest : BehaviorSpec({
     // --- updateCategoryGroup ---
 
     Given("a category group owned by the user's couple") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
 
         val group = CategoryGroup(
             couple = couple, name = "생활비", icon = "wallet", color = "#4CAF50",
@@ -187,7 +187,7 @@ class CategoryGroupServiceTest : BehaviorSpec({
     }
 
     Given("a non-existent category group") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
         val fakeId = UUID.randomUUID()
         every { categoryGroupRepository.findByIdAndCoupleId(fakeId, couple.id) } returns null
 
@@ -204,7 +204,7 @@ class CategoryGroupServiceTest : BehaviorSpec({
     // --- deleteCategoryGroup ---
 
     Given("a custom (non-default) category group") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
 
         val group = CategoryGroup(couple = couple, name = "Custom Group", isDefault = false)
         every { categoryGroupRepository.findByIdAndCoupleId(group.id, couple.id) } returns group
@@ -222,7 +222,7 @@ class CategoryGroupServiceTest : BehaviorSpec({
     }
 
     Given("a custom group with categories assigned") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
 
         val group = CategoryGroup(couple = couple, name = "Custom Group", isDefault = false)
         val category = Category(couple = couple, name = "Test Cat", type = CategoryType.EXPENSE, group = group)
@@ -243,7 +243,7 @@ class CategoryGroupServiceTest : BehaviorSpec({
     }
 
     Given("a default category group") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
 
         val group = CategoryGroup(couple = couple, name = "생활비", isDefault = true)
         every { categoryGroupRepository.findByIdAndCoupleId(group.id, couple.id) } returns group

--- a/backend/src/test/kotlin/com/budgetbook/category/service/CategoryServiceTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/category/service/CategoryServiceTest.kt
@@ -14,7 +14,7 @@ import com.budgetbook.common.exception.NotFoundException
 import com.budgetbook.couple.domain.Couple
 import com.budgetbook.common.cache.RedisCacheService
 import com.budgetbook.couple.domain.CoupleStatus
-import com.budgetbook.couple.repository.CoupleRepository
+import com.budgetbook.couple.service.CoupleResolver
 import com.budgetbook.sync.SyncEventPublisher
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.IsolationMode
@@ -34,10 +34,10 @@ class CategoryServiceTest : BehaviorSpec({
 
     val categoryRepository = mockk<CategoryRepository>()
     val categoryGroupRepository = mockk<CategoryGroupRepository>()
-    val coupleRepository = mockk<CoupleRepository>()
+    val coupleResolver = mockk<CoupleResolver>()
     val syncEventPublisher = mockk<SyncEventPublisher>(relaxed = true)
     val redisCacheService = mockk<RedisCacheService>(relaxed = true)
-    val categoryService = CategoryService(categoryRepository, categoryGroupRepository, coupleRepository, syncEventPublisher, redisCacheService)
+    val categoryService = CategoryService(categoryRepository, categoryGroupRepository, coupleResolver, syncEventPublisher, redisCacheService)
 
     val user1 = User(
         email = "user1@example.com",
@@ -56,7 +56,7 @@ class CategoryServiceTest : BehaviorSpec({
     // --- listCategories ---
 
     Given("a user in an active couple with categories") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
 
         val category1 = Category(couple = couple, name = "식비", type = CategoryType.EXPENSE, isDefault = true)
         val category2 = Category(couple = couple, name = "급여", type = CategoryType.INCOME, isDefault = true)
@@ -83,7 +83,7 @@ class CategoryServiceTest : BehaviorSpec({
     }
 
     Given("a user not in a couple") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns null
+        every { coupleResolver.getActiveCouple(user1.id) } throws NotFoundException("COUPLE_NOT_FOUND", "User is not in an active couple.")
 
         When("listCategories is called") {
             Then("throws NotFoundException") {
@@ -98,7 +98,7 @@ class CategoryServiceTest : BehaviorSpec({
     // --- createCategory ---
 
     Given("a user in a couple creating a category") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
 
         val categorySlot = slot<Category>()
         every { categoryRepository.save(capture(categorySlot)) } answers { categorySlot.captured }
@@ -129,7 +129,7 @@ class CategoryServiceTest : BehaviorSpec({
     // --- updateCategory ---
 
     Given("a category owned by the user's couple") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
 
         val category = Category(couple = couple, name = "식비", type = CategoryType.EXPENSE, icon = "restaurant", color = "#FF5733")
         every { categoryRepository.findById(category.id) } returns Optional.of(category)
@@ -149,7 +149,7 @@ class CategoryServiceTest : BehaviorSpec({
     }
 
     Given("a category owned by a different couple") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
 
         val otherCouple = Couple(user1 = user2, status = CoupleStatus.ACTIVE)
         val category = Category(couple = otherCouple, name = "Other", type = CategoryType.EXPENSE)
@@ -166,7 +166,7 @@ class CategoryServiceTest : BehaviorSpec({
     }
 
     Given("a non-existent category") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
         val fakeId = UUID.randomUUID()
         every { categoryRepository.findById(fakeId) } returns Optional.empty()
 
@@ -183,7 +183,7 @@ class CategoryServiceTest : BehaviorSpec({
     // --- deleteCategory ---
 
     Given("a custom (non-default) category") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
 
         val category = Category(couple = couple, name = "Custom", type = CategoryType.EXPENSE, isDefault = false)
         every { categoryRepository.findById(category.id) } returns Optional.of(category)
@@ -199,7 +199,7 @@ class CategoryServiceTest : BehaviorSpec({
     }
 
     Given("a default category") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
 
         val category = Category(couple = couple, name = "식비", type = CategoryType.EXPENSE, isDefault = true)
         every { categoryRepository.findById(category.id) } returns Optional.of(category)

--- a/backend/src/test/kotlin/com/budgetbook/couple/service/CoupleResolverTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/couple/service/CoupleResolverTest.kt
@@ -1,0 +1,90 @@
+package com.budgetbook.couple.service
+
+import com.budgetbook.auth.domain.AuthProvider
+import com.budgetbook.auth.domain.User
+import com.budgetbook.common.exception.NotFoundException
+import com.budgetbook.couple.domain.Couple
+import com.budgetbook.couple.domain.CoupleStatus
+import com.budgetbook.couple.repository.CoupleRepository
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+
+class CoupleResolverTest : BehaviorSpec({
+
+    isolationMode = IsolationMode.InstancePerLeaf
+
+    val coupleRepository = mockk<CoupleRepository>()
+    val resolver = CoupleResolver(coupleRepository)
+
+    val user1 = User(email = "u1@test.com", nickname = "U1", provider = AuthProvider.GOOGLE, providerId = "g1")
+    val user2 = User(email = "u2@test.com", nickname = "U2", provider = AuthProvider.KAKAO, providerId = "k2")
+    val couple = Couple(user1 = user1, user2 = user2, status = CoupleStatus.ACTIVE)
+
+    Given("a user in an active couple") {
+        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+
+        When("getActiveCouple is called") {
+            val result = resolver.getActiveCouple(user1.id)
+
+            Then("returns the couple") {
+                result shouldBe couple
+            }
+        }
+
+        When("getActiveCouple is called twice for the same user") {
+            resolver.getActiveCouple(user1.id)
+            resolver.getActiveCouple(user1.id)
+
+            Then("queries the repository only once (request-scoped cache)") {
+                verify(exactly = 1) { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) }
+            }
+        }
+    }
+
+    Given("a user not in any active couple") {
+        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns null
+
+        When("getActiveCouple is called") {
+            Then("throws NotFoundException") {
+                val ex = shouldThrow<NotFoundException> {
+                    resolver.getActiveCouple(user1.id)
+                }
+                ex.code shouldBe "COUPLE_NOT_FOUND"
+            }
+        }
+
+        When("getActiveCoupleOrNull is called") {
+            val result = resolver.getActiveCoupleOrNull(user1.id)
+
+            Then("returns null") {
+                result shouldBe null
+            }
+        }
+    }
+
+    Given("a user in an active couple using getActiveCoupleOrNull") {
+        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+
+        When("getActiveCoupleOrNull is called") {
+            val result = resolver.getActiveCoupleOrNull(user1.id)
+
+            Then("returns the couple") {
+                result shouldBe couple
+            }
+        }
+
+        When("getActiveCoupleOrNull then getActiveCouple is called") {
+            resolver.getActiveCoupleOrNull(user1.id)
+            resolver.getActiveCouple(user1.id)
+
+            Then("queries the repository only once (cached from first call)") {
+                verify(exactly = 1) { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) }
+            }
+        }
+    }
+})

--- a/backend/src/test/kotlin/com/budgetbook/paymentmethod/service/PaymentMethodServiceTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/paymentmethod/service/PaymentMethodServiceTest.kt
@@ -6,7 +6,7 @@ import com.budgetbook.common.exception.BusinessException
 import com.budgetbook.common.exception.NotFoundException
 import com.budgetbook.couple.domain.Couple
 import com.budgetbook.couple.domain.CoupleStatus
-import com.budgetbook.couple.repository.CoupleRepository
+import com.budgetbook.couple.service.CoupleResolver
 import com.budgetbook.paymentmethod.domain.PaymentMethod
 import com.budgetbook.paymentmethod.domain.PaymentMethodType
 import com.budgetbook.paymentmethod.dto.CreatePaymentMethodRequest
@@ -31,10 +31,10 @@ class PaymentMethodServiceTest : BehaviorSpec({
     isolationMode = IsolationMode.InstancePerLeaf
 
     val paymentMethodRepository = mockk<PaymentMethodRepository>()
-    val coupleRepository = mockk<CoupleRepository>()
+    val coupleResolver = mockk<CoupleResolver>()
     val transactionRepository = mockk<TransactionRepository>()
     val syncEventPublisher = mockk<SyncEventPublisher>(relaxed = true)
-    val service = PaymentMethodService(paymentMethodRepository, coupleRepository, transactionRepository, syncEventPublisher)
+    val service = PaymentMethodService(paymentMethodRepository, coupleResolver, transactionRepository, syncEventPublisher)
 
     val user1 = User(email = "u1@test.com", nickname = "U1", provider = AuthProvider.GOOGLE, providerId = "g1")
     val user2 = User(email = "u2@test.com", nickname = "U2", provider = AuthProvider.KAKAO, providerId = "k2")
@@ -43,7 +43,7 @@ class PaymentMethodServiceTest : BehaviorSpec({
     // --- listPaymentMethods ---
 
     Given("a user in an active couple with payment methods") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
 
         val cash = PaymentMethod(couple = couple, name = "현금", type = PaymentMethodType.CASH, isDefault = true, displayOrder = 0)
         val debit = PaymentMethod(couple = couple, name = "체크카드", type = PaymentMethodType.DEBIT, isDefault = true, displayOrder = 1)
@@ -63,7 +63,7 @@ class PaymentMethodServiceTest : BehaviorSpec({
     // --- createPaymentMethod ---
 
     Given("a user in an active couple") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
 
         When("creating a CASH payment method") {
             val request = CreatePaymentMethodRequest(name = "현금", type = "CASH")
@@ -123,7 +123,7 @@ class PaymentMethodServiceTest : BehaviorSpec({
     // --- updatePaymentMethod ---
 
     Given("an existing payment method to update") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
         val method = PaymentMethod(couple = couple, name = "현금", type = PaymentMethodType.CASH, displayOrder = 0)
         every { paymentMethodRepository.findByIdAndCoupleId(method.id, couple.id) } returns method
         every { paymentMethodRepository.save(method) } returns method
@@ -157,7 +157,7 @@ class PaymentMethodServiceTest : BehaviorSpec({
     }
 
     Given("a non-existent payment method") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
         val fakeId = UUID.randomUUID()
         every { paymentMethodRepository.findByIdAndCoupleId(fakeId, couple.id) } returns null
 
@@ -174,7 +174,7 @@ class PaymentMethodServiceTest : BehaviorSpec({
     // --- deletePaymentMethod ---
 
     Given("a non-default payment method to delete") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
         val method = PaymentMethod(couple = couple, name = "삭제할 카드", type = PaymentMethodType.CREDIT)
         every { paymentMethodRepository.findByIdAndCoupleId(method.id, couple.id) } returns method
         every { paymentMethodRepository.delete(method) } returns Unit
@@ -189,7 +189,7 @@ class PaymentMethodServiceTest : BehaviorSpec({
     }
 
     Given("a default payment method") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
         val method = PaymentMethod(couple = couple, name = "현금", type = PaymentMethodType.CASH, isDefault = true)
         every { paymentMethodRepository.findByIdAndCoupleId(method.id, couple.id) } returns method
 
@@ -228,7 +228,7 @@ class PaymentMethodServiceTest : BehaviorSpec({
     // --- getCardPendingSummary ---
 
     Given("a couple with credit cards and transactions") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
 
         val creditCard = PaymentMethod(
             couple = couple, name = "신한카드", type = PaymentMethodType.CREDIT,
@@ -274,7 +274,7 @@ class PaymentMethodServiceTest : BehaviorSpec({
     // --- user not in couple ---
 
     Given("a user not in any couple") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns null
+        every { coupleResolver.getActiveCouple(user1.id) } throws NotFoundException("COUPLE_NOT_FOUND", "User is not in an active couple.")
 
         When("listPaymentMethods is called") {
             Then("throws NotFoundException") {

--- a/backend/src/test/kotlin/com/budgetbook/pocket/service/DistributionRatioServiceTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/pocket/service/DistributionRatioServiceTest.kt
@@ -6,7 +6,7 @@ import com.budgetbook.common.exception.BusinessException
 import com.budgetbook.common.exception.NotFoundException
 import com.budgetbook.couple.domain.Couple
 import com.budgetbook.couple.domain.CoupleStatus
-import com.budgetbook.couple.repository.CoupleRepository
+import com.budgetbook.couple.service.CoupleResolver
 import com.budgetbook.pocket.domain.DistributionRatio
 import com.budgetbook.pocket.domain.MoneyPocket
 import com.budgetbook.pocket.domain.PocketType
@@ -32,8 +32,8 @@ class DistributionRatioServiceTest : BehaviorSpec({
 
     val distributionRatioRepository = mockk<DistributionRatioRepository>()
     val moneyPocketRepository = mockk<MoneyPocketRepository>()
-    val coupleRepository = mockk<CoupleRepository>()
-    val service = DistributionRatioService(distributionRatioRepository, moneyPocketRepository, coupleRepository)
+    val coupleResolver = mockk<CoupleResolver>()
+    val service = DistributionRatioService(distributionRatioRepository, moneyPocketRepository, coupleResolver)
 
     val user1 = User(email = "u1@test.com", nickname = "U1", provider = AuthProvider.GOOGLE, providerId = "g1")
     val user2 = User(email = "u2@test.com", nickname = "U2", provider = AuthProvider.KAKAO, providerId = "k2")
@@ -45,7 +45,7 @@ class DistributionRatioServiceTest : BehaviorSpec({
     // --- getRatios ---
 
     Given("a couple with saved distribution ratios") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
         val ratio1 = DistributionRatio(couple = couple, pocket = pocket1, ratio = BigDecimal("70.00"))
         val ratio2 = DistributionRatio(couple = couple, pocket = pocket2, ratio = BigDecimal("30.00"))
         every { distributionRatioRepository.findByCoupleId(couple.id) } returns listOf(ratio1, ratio2)
@@ -66,7 +66,7 @@ class DistributionRatioServiceTest : BehaviorSpec({
     // --- saveRatios ---
 
     Given("a couple with active pockets") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
         every { moneyPocketRepository.findByCoupleIdAndIsActiveTrue(couple.id) } returns listOf(pocket1, pocket2)
         justRun { distributionRatioRepository.deleteByCoupleId(couple.id) }
         val ratioSlot = slot<DistributionRatio>()
@@ -91,7 +91,7 @@ class DistributionRatioServiceTest : BehaviorSpec({
     }
 
     Given("ratios that sum to 99.99 (within tolerance)") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
         every { moneyPocketRepository.findByCoupleIdAndIsActiveTrue(couple.id) } returns listOf(pocket1, pocket2)
         justRun { distributionRatioRepository.deleteByCoupleId(couple.id) }
         val ratioSlot = slot<DistributionRatio>()
@@ -115,7 +115,7 @@ class DistributionRatioServiceTest : BehaviorSpec({
     }
 
     Given("ratios that sum to 100.01 (within tolerance)") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
         every { moneyPocketRepository.findByCoupleIdAndIsActiveTrue(couple.id) } returns listOf(pocket1, pocket2)
         justRun { distributionRatioRepository.deleteByCoupleId(couple.id) }
         val ratioSlot = slot<DistributionRatio>()
@@ -139,7 +139,7 @@ class DistributionRatioServiceTest : BehaviorSpec({
     }
 
     Given("ratios that do not sum to 100") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
 
         When("saving ratios summing to 90") {
             val request = SaveDistributionRatiosRequest(
@@ -159,7 +159,7 @@ class DistributionRatioServiceTest : BehaviorSpec({
     }
 
     Given("ratios that sum to 99.98 (outside tolerance)") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
 
         When("saving ratios summing to 99.98") {
             val request = SaveDistributionRatiosRequest(
@@ -179,7 +179,7 @@ class DistributionRatioServiceTest : BehaviorSpec({
     }
 
     Given("ratios with an invalid pocket ID") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
         every { moneyPocketRepository.findByCoupleIdAndIsActiveTrue(couple.id) } returns listOf(pocket1)
 
         When("saving ratios referencing a non-existent pocket") {
@@ -201,7 +201,7 @@ class DistributionRatioServiceTest : BehaviorSpec({
     }
 
     Given("ratios with duplicate pocket IDs") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
         every { moneyPocketRepository.findByCoupleIdAndIsActiveTrue(couple.id) } returns listOf(pocket1, pocket2)
 
         When("saving ratios with duplicated pocket") {
@@ -224,7 +224,7 @@ class DistributionRatioServiceTest : BehaviorSpec({
     // --- getActiveCouple error ---
 
     Given("a user not in an active couple") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns null
+        every { coupleResolver.getActiveCouple(user1.id) } throws NotFoundException("COUPLE_NOT_FOUND", "User is not in an active couple.")
 
         When("getRatios is called") {
             Then("throws NotFoundException") {

--- a/backend/src/test/kotlin/com/budgetbook/pocket/service/MoneyPocketServiceTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/pocket/service/MoneyPocketServiceTest.kt
@@ -6,7 +6,7 @@ import com.budgetbook.common.exception.BusinessException
 import com.budgetbook.common.exception.NotFoundException
 import com.budgetbook.couple.domain.Couple
 import com.budgetbook.couple.domain.CoupleStatus
-import com.budgetbook.couple.repository.CoupleRepository
+import com.budgetbook.couple.service.CoupleResolver
 import com.budgetbook.pocket.domain.MoneyPocket
 import com.budgetbook.pocket.domain.PocketType
 import com.budgetbook.pocket.dto.CreatePocketRequest
@@ -31,7 +31,7 @@ class MoneyPocketServiceTest : BehaviorSpec({
     isolationMode = IsolationMode.InstancePerLeaf
 
     val moneyPocketRepository = mockk<MoneyPocketRepository>()
-    val coupleRepository = mockk<CoupleRepository>()
+    val coupleResolver = mockk<CoupleResolver>()
     val syncEventPublisher = mockk<SyncEventPublisher>(relaxed = true)
     val pocketTransferRepository = mockk<PocketTransferRepository> {
         every { sumAmountByToPocketId(any()) } returns 0L
@@ -40,7 +40,7 @@ class MoneyPocketServiceTest : BehaviorSpec({
     val transactionRepository = mockk<TransactionRepository> {
         every { sumExpenseByPocketId(any()) } returns 0L
     }
-    val service = MoneyPocketService(moneyPocketRepository, coupleRepository, syncEventPublisher, pocketTransferRepository, transactionRepository)
+    val service = MoneyPocketService(moneyPocketRepository, coupleResolver, syncEventPublisher, pocketTransferRepository, transactionRepository)
 
     val user1 = User(email = "u1@test.com", nickname = "U1", provider = AuthProvider.GOOGLE, providerId = "g1")
     val user2 = User(email = "u2@test.com", nickname = "U2", provider = AuthProvider.KAKAO, providerId = "k2")
@@ -49,7 +49,7 @@ class MoneyPocketServiceTest : BehaviorSpec({
     // --- getPockets ---
 
     Given("a user in an active couple with pockets") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
 
         val pocket1 = MoneyPocket(couple = couple, name = "생활비", type = PocketType.LIVING, allocatedAmount = 500000, displayOrder = 1)
         val pocket2 = MoneyPocket(couple = couple, name = "저축", type = PocketType.SAVINGS, allocatedAmount = 1000000, displayOrder = 2)
@@ -72,7 +72,7 @@ class MoneyPocketServiceTest : BehaviorSpec({
     // --- createPocket ---
 
     Given("a user in an active couple") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
         every { moneyPocketRepository.maxDisplayOrderByCoupleId(couple.id) } returns 2
 
         When("creating a pocket with valid data") {
@@ -122,7 +122,7 @@ class MoneyPocketServiceTest : BehaviorSpec({
     // --- updatePocket ---
 
     Given("an existing active pocket") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
         val pocket = MoneyPocket(couple = couple, name = "생활비", type = PocketType.LIVING, allocatedAmount = 500000, displayOrder = 1)
         every { moneyPocketRepository.findByIdAndCoupleId(pocket.id, couple.id) } returns pocket
         every { moneyPocketRepository.save(pocket) } returns pocket
@@ -143,7 +143,7 @@ class MoneyPocketServiceTest : BehaviorSpec({
     }
 
     Given("a non-existent pocket") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
         val fakeId = java.util.UUID.randomUUID()
         every { moneyPocketRepository.findByIdAndCoupleId(fakeId, couple.id) } returns null
 
@@ -158,7 +158,7 @@ class MoneyPocketServiceTest : BehaviorSpec({
     }
 
     Given("an inactive pocket") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
         val pocket = MoneyPocket(couple = couple, name = "삭제됨", type = PocketType.CUSTOM, allocatedAmount = 0, isActive = false)
         every { moneyPocketRepository.findByIdAndCoupleId(pocket.id, couple.id) } returns pocket
 
@@ -174,7 +174,7 @@ class MoneyPocketServiceTest : BehaviorSpec({
     // --- deletePocket ---
 
     Given("an active pocket to delete") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
         val pocket = MoneyPocket(couple = couple, name = "삭제할거", type = PocketType.CUSTOM, allocatedAmount = 100000, displayOrder = 1)
         every { moneyPocketRepository.findByIdAndCoupleId(pocket.id, couple.id) } returns pocket
         every { moneyPocketRepository.save(pocket) } returns pocket
@@ -219,7 +219,7 @@ class MoneyPocketServiceTest : BehaviorSpec({
     // --- goal amount in create ---
 
     Given("a user creating a pocket with goal fields") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
         every { moneyPocketRepository.maxDisplayOrderByCoupleId(couple.id) } returns 0
 
         When("creating a pocket with goalAmount and targetDate") {
@@ -245,7 +245,7 @@ class MoneyPocketServiceTest : BehaviorSpec({
     // --- goal amount in update ---
 
     Given("an existing pocket to update with goal fields") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
         val pocket = MoneyPocket(couple = couple, name = "저축", type = PocketType.SAVINGS, allocatedAmount = 100000, displayOrder = 1)
         every { moneyPocketRepository.findByIdAndCoupleId(pocket.id, couple.id) } returns pocket
         every { moneyPocketRepository.save(pocket) } returns pocket
@@ -264,7 +264,7 @@ class MoneyPocketServiceTest : BehaviorSpec({
     // --- getActiveCouple error ---
 
     Given("a user not in any active couple") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns null
+        every { coupleResolver.getActiveCouple(user1.id) } throws NotFoundException("COUPLE_NOT_FOUND", "User is not in an active couple.")
 
         When("getPockets is called") {
             Then("throws NotFoundException") {

--- a/backend/src/test/kotlin/com/budgetbook/pocket/service/PocketTransferServiceTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/pocket/service/PocketTransferServiceTest.kt
@@ -7,7 +7,7 @@ import com.budgetbook.common.exception.BusinessException
 import com.budgetbook.common.exception.NotFoundException
 import com.budgetbook.couple.domain.Couple
 import com.budgetbook.couple.domain.CoupleStatus
-import com.budgetbook.couple.repository.CoupleRepository
+import com.budgetbook.couple.service.CoupleResolver
 import com.budgetbook.pocket.domain.MoneyPocket
 import com.budgetbook.pocket.domain.PocketTransfer
 import com.budgetbook.pocket.domain.PocketType
@@ -35,10 +35,10 @@ class PocketTransferServiceTest : BehaviorSpec({
 
     val pocketTransferRepository = mockk<PocketTransferRepository>()
     val moneyPocketRepository = mockk<MoneyPocketRepository>()
-    val coupleRepository = mockk<CoupleRepository>()
+    val coupleResolver = mockk<CoupleResolver>()
     val userRepository = mockk<UserRepository>()
     val syncEventPublisher = mockk<SyncEventPublisher>(relaxed = true)
-    val service = PocketTransferService(pocketTransferRepository, moneyPocketRepository, coupleRepository, userRepository, syncEventPublisher)
+    val service = PocketTransferService(pocketTransferRepository, moneyPocketRepository, coupleResolver, userRepository, syncEventPublisher)
 
     val user1 = User(email = "u1@test.com", nickname = "U1", provider = AuthProvider.GOOGLE, providerId = "g1")
     val user2 = User(email = "u2@test.com", nickname = "U2", provider = AuthProvider.KAKAO, providerId = "k2")
@@ -49,7 +49,7 @@ class PocketTransferServiceTest : BehaviorSpec({
     // --- getTransfers ---
 
     Given("a user with transfers") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
         val transfer = PocketTransfer(
             couple = couple, fromPocket = pocket1, toPocket = pocket2,
             amount = 100000, description = "저축 이동", transferDate = LocalDate.of(2024, 3, 1), author = user1
@@ -72,7 +72,7 @@ class PocketTransferServiceTest : BehaviorSpec({
     // --- createTransfer ---
 
     Given("a user creating a transfer") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
         every { userRepository.findById(user1.id) } returns Optional.of(user1)
         every { moneyPocketRepository.findByIdAndCoupleId(pocket1.id, couple.id) } returns pocket1
         every { moneyPocketRepository.findByIdAndCoupleId(pocket2.id, couple.id) } returns pocket2
@@ -120,7 +120,7 @@ class PocketTransferServiceTest : BehaviorSpec({
     }
 
     Given("a user creating a transfer with non-existent source pocket") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
         every { userRepository.findById(user1.id) } returns Optional.of(user1)
         val fakeId = java.util.UUID.randomUUID()
         every { moneyPocketRepository.findByIdAndCoupleId(fakeId, couple.id) } returns null
@@ -144,7 +144,7 @@ class PocketTransferServiceTest : BehaviorSpec({
     // --- distribute ---
 
     Given("a user distributing income") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
         every { moneyPocketRepository.findByIdAndCoupleId(pocket1.id, couple.id) } returns pocket1
         every { moneyPocketRepository.findByIdAndCoupleId(pocket2.id, couple.id) } returns pocket2
         every { moneyPocketRepository.save(any()) } answers { firstArg() }
@@ -177,7 +177,7 @@ class PocketTransferServiceTest : BehaviorSpec({
     }
 
     Given("a user distributing with mismatched total") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
 
         When("distribute is called with wrong total") {
             val request = DistributeRequest(
@@ -200,7 +200,7 @@ class PocketTransferServiceTest : BehaviorSpec({
     // --- getActiveCouple error ---
 
     Given("a user not in any active couple") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns null
+        every { coupleResolver.getActiveCouple(user1.id) } throws NotFoundException("COUPLE_NOT_FOUND", "User is not in an active couple.")
 
         When("getTransfers is called") {
             Then("throws NotFoundException") {

--- a/backend/src/test/kotlin/com/budgetbook/recurring/service/RecurringTransactionServiceTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/recurring/service/RecurringTransactionServiceTest.kt
@@ -11,7 +11,7 @@ import com.budgetbook.common.exception.ForbiddenException
 import com.budgetbook.common.exception.NotFoundException
 import com.budgetbook.couple.domain.Couple
 import com.budgetbook.couple.domain.CoupleStatus
-import com.budgetbook.couple.repository.CoupleRepository
+import com.budgetbook.couple.service.CoupleResolver
 import com.budgetbook.paymentmethod.repository.PaymentMethodRepository
 import com.budgetbook.recurring.domain.Frequency
 import com.budgetbook.recurring.domain.RecurringTransaction
@@ -41,12 +41,12 @@ class RecurringTransactionServiceTest : BehaviorSpec({
 
     val recurringRepository = mockk<RecurringTransactionRepository>()
     val transactionRepository = mockk<TransactionRepository>()
-    val coupleRepository = mockk<CoupleRepository>()
+    val coupleResolver = mockk<CoupleResolver>()
     val userRepository = mockk<UserRepository>()
     val categoryRepository = mockk<CategoryRepository>()
     val paymentMethodRepository = mockk<PaymentMethodRepository>()
     val service = RecurringTransactionService(
-        recurringRepository, transactionRepository, coupleRepository,
+        recurringRepository, transactionRepository, coupleResolver,
         userRepository, categoryRepository, paymentMethodRepository
     )
 
@@ -58,7 +58,7 @@ class RecurringTransactionServiceTest : BehaviorSpec({
     // --- createRecurringTransaction ---
 
     Given("a user in an active couple") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
         every { userRepository.findById(user1.id) } returns Optional.of(user1)
 
         When("creating a MONTHLY recurring transaction") {
@@ -196,7 +196,7 @@ class RecurringTransactionServiceTest : BehaviorSpec({
     // --- listRecurringTransactions ---
 
     Given("recurring transactions exist for couple") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
 
         val recurring1 = RecurringTransaction(
             couple = couple, author = user1, type = TransactionType.EXPENSE,
@@ -224,7 +224,7 @@ class RecurringTransactionServiceTest : BehaviorSpec({
     // --- updateRecurringTransaction ---
 
     Given("an existing recurring transaction to update") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
         val recurring = RecurringTransaction(
             couple = couple, author = user1, type = TransactionType.EXPENSE,
             amount = 50000, description = "월세", frequency = Frequency.MONTHLY,
@@ -254,7 +254,7 @@ class RecurringTransactionServiceTest : BehaviorSpec({
     }
 
     Given("a recurring transaction from a different couple") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
         val otherCouple = Couple(user1 = user2, status = CoupleStatus.ACTIVE)
         val recurring = RecurringTransaction(
             couple = otherCouple, author = user2, type = TransactionType.EXPENSE,
@@ -275,7 +275,7 @@ class RecurringTransactionServiceTest : BehaviorSpec({
     // --- deleteRecurringTransaction ---
 
     Given("a recurring transaction to delete") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
         val recurring = RecurringTransaction(
             couple = couple, author = user1, type = TransactionType.EXPENSE,
             amount = 50000, description = "월세", frequency = Frequency.MONTHLY,
@@ -387,7 +387,7 @@ class RecurringTransactionServiceTest : BehaviorSpec({
     // --- user not in couple ---
 
     Given("a user not in any couple") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns null
+        every { coupleResolver.getActiveCouple(user1.id) } throws NotFoundException("COUPLE_NOT_FOUND", "User is not in an active couple.")
 
         When("listRecurringTransactions is called") {
             Then("throws NotFoundException") {

--- a/backend/src/test/kotlin/com/budgetbook/report/service/ReportServiceTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/report/service/ReportServiceTest.kt
@@ -13,7 +13,7 @@ import com.budgetbook.category.repository.CategoryRepository
 import com.budgetbook.common.exception.NotFoundException
 import com.budgetbook.couple.domain.Couple
 import com.budgetbook.couple.domain.CoupleStatus
-import com.budgetbook.couple.repository.CoupleRepository
+import com.budgetbook.couple.service.CoupleResolver
 import com.budgetbook.transaction.domain.Transaction
 import com.budgetbook.transaction.domain.TransactionType
 import com.budgetbook.transaction.repository.TransactionRepository
@@ -36,14 +36,14 @@ class ReportServiceTest : BehaviorSpec({
     isolationMode = IsolationMode.InstancePerLeaf
 
     val transactionRepository = mockk<TransactionRepository>()
-    val coupleRepository = mockk<CoupleRepository>()
+    val coupleResolver = mockk<CoupleResolver>()
     val categoryGroupRepository = mockk<CategoryGroupRepository>()
     val categoryRepository = mockk<CategoryRepository>()
     val budgetRepository = mockk<MonthlyBudgetRepository>()
 
     val service = ReportService(
         transactionRepository,
-        coupleRepository,
+        coupleResolver,
         categoryGroupRepository,
         categoryRepository,
         budgetRepository
@@ -68,7 +68,7 @@ class ReportServiceTest : BehaviorSpec({
     // --- getWeeklyReport ---
 
     Given("a user in an active couple for weekly report") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
 
         When("requesting week 1 of March 2026 with transactions") {
             // Week 1: March 1-7
@@ -259,7 +259,7 @@ class ReportServiceTest : BehaviorSpec({
     }
 
     Given("a user NOT in a couple for weekly report") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns null
+        every { coupleResolver.getActiveCouple(user1.id) } throws NotFoundException("COUPLE_NOT_FOUND", "User is not in an active couple.")
 
         When("requesting weekly report") {
             Then("throws NotFoundException") {
@@ -273,7 +273,7 @@ class ReportServiceTest : BehaviorSpec({
     // --- getMonthlyReport ---
 
     Given("a user in an active couple for monthly report") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
 
         When("requesting March 2026 monthly report") {
             // Income/expense totals
@@ -490,7 +490,7 @@ class ReportServiceTest : BehaviorSpec({
     }
 
     Given("a user NOT in a couple for monthly report") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns null
+        every { coupleResolver.getActiveCouple(user1.id) } throws NotFoundException("COUPLE_NOT_FOUND", "User is not in an active couple.")
 
         When("requesting monthly report") {
             Then("throws NotFoundException") {

--- a/backend/src/test/kotlin/com/budgetbook/statistics/service/StatisticsServiceTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/statistics/service/StatisticsServiceTest.kt
@@ -6,7 +6,7 @@ import com.budgetbook.common.exception.BusinessException
 import com.budgetbook.common.exception.NotFoundException
 import com.budgetbook.couple.domain.Couple
 import com.budgetbook.couple.domain.CoupleStatus
-import com.budgetbook.couple.repository.CoupleRepository
+import com.budgetbook.couple.service.CoupleResolver
 import com.budgetbook.transaction.domain.TransactionType
 import com.budgetbook.transaction.repository.TransactionRepository
 import io.kotest.assertions.throwables.shouldThrow
@@ -25,8 +25,8 @@ class StatisticsServiceTest : BehaviorSpec({
     isolationMode = IsolationMode.InstancePerLeaf
 
     val transactionRepository = mockk<TransactionRepository>()
-    val coupleRepository = mockk<CoupleRepository>()
-    val service = StatisticsService(transactionRepository, coupleRepository)
+    val coupleResolver = mockk<CoupleResolver>()
+    val service = StatisticsService(transactionRepository, coupleResolver)
 
     val user1 = User(email = "u1@test.com", nickname = "U1", provider = AuthProvider.GOOGLE, providerId = "g1")
     val user2 = User(email = "u2@test.com", nickname = "U2", provider = AuthProvider.KAKAO, providerId = "k2")
@@ -35,7 +35,7 @@ class StatisticsServiceTest : BehaviorSpec({
     // --- getMonthlySummary ---
 
     Given("a user in an active couple for monthly summary") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
 
         When("there are income and expense transactions") {
             every {
@@ -82,7 +82,7 @@ class StatisticsServiceTest : BehaviorSpec({
     }
 
     Given("a user NOT in a couple for monthly summary") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns null
+        every { coupleResolver.getActiveCouple(user1.id) } throws NotFoundException("COUPLE_NOT_FOUND", "User is not in an active couple.")
 
         When("requesting summary") {
             Then("throws NotFoundException") {
@@ -96,7 +96,7 @@ class StatisticsServiceTest : BehaviorSpec({
     // --- getCategoryBreakdown ---
 
     Given("a user in an active couple for category breakdown") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
 
         val catId1 = UUID.randomUUID()
         val catId2 = UUID.randomUUID()
@@ -157,7 +157,7 @@ class StatisticsServiceTest : BehaviorSpec({
     // --- getMonthlyTrend ---
 
     Given("a user in an active couple for monthly trend") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
 
         When("requesting 3 months of trend data") {
             val now = YearMonth.now()

--- a/backend/src/test/kotlin/com/budgetbook/transaction/service/TransactionExportServiceTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/transaction/service/TransactionExportServiceTest.kt
@@ -8,7 +8,7 @@ import com.budgetbook.common.exception.BusinessException
 import com.budgetbook.common.exception.NotFoundException
 import com.budgetbook.couple.domain.Couple
 import com.budgetbook.couple.domain.CoupleStatus
-import com.budgetbook.couple.repository.CoupleRepository
+import com.budgetbook.couple.service.CoupleResolver
 import com.budgetbook.paymentmethod.domain.PaymentMethod
 import com.budgetbook.paymentmethod.domain.PaymentMethodType
 import com.budgetbook.transaction.domain.Transaction
@@ -31,8 +31,8 @@ class TransactionExportServiceTest : BehaviorSpec({
     isolationMode = IsolationMode.InstancePerLeaf
 
     val transactionRepository = mockk<TransactionRepository>()
-    val coupleRepository = mockk<CoupleRepository>()
-    val service = TransactionExportService(transactionRepository, coupleRepository)
+    val coupleResolver = mockk<CoupleResolver>()
+    val service = TransactionExportService(transactionRepository, coupleResolver)
 
     val user1 = User(email = "u1@test.com", nickname = "U1", provider = AuthProvider.GOOGLE, providerId = "g1")
     val user2 = User(email = "u2@test.com", nickname = "U2", provider = AuthProvider.KAKAO, providerId = "k2")
@@ -53,7 +53,7 @@ class TransactionExportServiceTest : BehaviorSpec({
     )
 
     Given("a couple with transactions") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
 
         val tx1 = Transaction(
             couple = couple,
@@ -99,7 +99,7 @@ class TransactionExportServiceTest : BehaviorSpec({
     }
 
     Given("a couple with no transactions") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
         every { transactionRepository.findAll(any<Specification<Transaction>>(), any<Sort>()) } returns emptyList()
 
         When("exportCsv is called") {
@@ -114,7 +114,7 @@ class TransactionExportServiceTest : BehaviorSpec({
     }
 
     Given("a transaction with CSV-special characters in description") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
 
         val tx = Transaction(
             couple = couple,
@@ -139,7 +139,7 @@ class TransactionExportServiceTest : BehaviorSpec({
     }
 
     Given("an invalid transaction type for export") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
 
         When("exportCsv is called with invalid type") {
             Then("throws BusinessException") {
@@ -152,7 +152,7 @@ class TransactionExportServiceTest : BehaviorSpec({
     }
 
     Given("a user not in an active couple") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns null
+        every { coupleResolver.getActiveCouple(user1.id) } throws NotFoundException("COUPLE_NOT_FOUND", "User is not in an active couple.")
 
         When("exportCsv is called") {
             Then("throws NotFoundException") {

--- a/backend/src/test/kotlin/com/budgetbook/transaction/service/TransactionServiceTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/transaction/service/TransactionServiceTest.kt
@@ -11,7 +11,7 @@ import com.budgetbook.common.exception.ForbiddenException
 import com.budgetbook.common.exception.NotFoundException
 import com.budgetbook.couple.domain.Couple
 import com.budgetbook.couple.domain.CoupleStatus
-import com.budgetbook.couple.repository.CoupleRepository
+import com.budgetbook.couple.service.CoupleResolver
 import com.budgetbook.paymentmethod.domain.PaymentMethod
 import com.budgetbook.paymentmethod.domain.PaymentMethodType
 import com.budgetbook.paymentmethod.repository.PaymentMethodRepository
@@ -41,13 +41,13 @@ class TransactionServiceTest : BehaviorSpec({
     isolationMode = IsolationMode.InstancePerLeaf
 
     val transactionRepository = mockk<TransactionRepository>()
-    val coupleRepository = mockk<CoupleRepository>()
+    val coupleResolver = mockk<CoupleResolver>()
     val userRepository = mockk<UserRepository>()
     val categoryRepository = mockk<CategoryRepository>()
     val paymentMethodRepository = mockk<PaymentMethodRepository>()
     val moneyPocketRepository = mockk<MoneyPocketRepository>()
     val syncEventPublisher = mockk<SyncEventPublisher>(relaxed = true)
-    val service = TransactionService(transactionRepository, coupleRepository, userRepository, categoryRepository, paymentMethodRepository, moneyPocketRepository, syncEventPublisher)
+    val service = TransactionService(transactionRepository, coupleResolver, userRepository, categoryRepository, paymentMethodRepository, moneyPocketRepository, syncEventPublisher)
 
     val user1 = User(email = "u1@test.com", nickname = "U1", provider = AuthProvider.GOOGLE, providerId = "g1")
     val user2 = User(email = "u2@test.com", nickname = "U2", provider = AuthProvider.KAKAO, providerId = "k2")
@@ -57,7 +57,7 @@ class TransactionServiceTest : BehaviorSpec({
     // --- createTransaction ---
 
     Given("a user in an active couple") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
         every { userRepository.findById(user1.id) } returns Optional.of(user1)
 
         When("creating a transaction without category") {
@@ -119,7 +119,7 @@ class TransactionServiceTest : BehaviorSpec({
     // --- getTransaction ---
 
     Given("an existing transaction in the user's couple") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
         val tx = Transaction(
             couple = couple, author = user1, type = TransactionType.EXPENSE,
             amount = 15000, description = "점심", transactionDate = LocalDate.of(2024, 1, 15)
@@ -137,7 +137,7 @@ class TransactionServiceTest : BehaviorSpec({
     }
 
     Given("a transaction from a different couple") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
         val otherCouple = Couple(user1 = user2, status = CoupleStatus.ACTIVE)
         val tx = Transaction(
             couple = otherCouple, author = user2, type = TransactionType.INCOME,
@@ -153,7 +153,7 @@ class TransactionServiceTest : BehaviorSpec({
     }
 
     Given("a non-existent transaction") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
         val fakeId = UUID.randomUUID()
         every { transactionRepository.findById(fakeId) } returns Optional.empty()
 
@@ -168,7 +168,7 @@ class TransactionServiceTest : BehaviorSpec({
     // --- updateTransaction ---
 
     Given("an existing transaction to update") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
         val tx = Transaction(
             couple = couple, author = user1, type = TransactionType.EXPENSE,
             amount = 15000, description = "점심", transactionDate = LocalDate.of(2024, 1, 15)
@@ -188,7 +188,7 @@ class TransactionServiceTest : BehaviorSpec({
     }
 
     Given("an existing transaction with memo to clear") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
         val tx = Transaction(
             couple = couple, author = user1, type = TransactionType.EXPENSE,
             amount = 15000, description = "점심", memo = "기존 메모",
@@ -217,7 +217,7 @@ class TransactionServiceTest : BehaviorSpec({
     }
 
     Given("an existing transaction with a category to clear") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
         val tx = Transaction(
             couple = couple, author = user1, type = TransactionType.EXPENSE,
             amount = 15000, description = "점심", category = category,
@@ -248,7 +248,7 @@ class TransactionServiceTest : BehaviorSpec({
     }
 
     Given("an existing transaction with a payment method to clear") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
         val pm = PaymentMethod(couple = couple, name = "신한카드", type = PaymentMethodType.CREDIT, settlementDay = 15, closingDay = 25)
         val tx = Transaction(
             couple = couple, author = user1, type = TransactionType.EXPENSE,
@@ -271,7 +271,7 @@ class TransactionServiceTest : BehaviorSpec({
     }
 
     Given("a transaction with a credit card where transactionDate changes") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
         val pm = PaymentMethod(couple = couple, name = "신한카드", type = PaymentMethodType.CREDIT, settlementDay = 15, closingDay = 25)
         val tx = Transaction(
             couple = couple, author = user1, type = TransactionType.EXPENSE,
@@ -295,7 +295,7 @@ class TransactionServiceTest : BehaviorSpec({
     }
 
     Given("a transaction with a DEBIT card where transactionDate changes") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
         val pm = PaymentMethod(couple = couple, name = "체크카드", type = PaymentMethodType.DEBIT)
         val tx = Transaction(
             couple = couple, author = user1, type = TransactionType.EXPENSE,
@@ -317,7 +317,7 @@ class TransactionServiceTest : BehaviorSpec({
     }
 
     Given("a transaction with CASH (no payment method) where transactionDate changes") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
         val tx = Transaction(
             couple = couple, author = user1, type = TransactionType.EXPENSE,
             amount = 5000, description = "편의점", paymentMethod = null,
@@ -340,7 +340,7 @@ class TransactionServiceTest : BehaviorSpec({
     // --- deleteTransaction ---
 
     Given("a transaction to delete") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
         val tx = Transaction(
             couple = couple, author = user1, type = TransactionType.EXPENSE,
             amount = 15000, description = "삭제", transactionDate = LocalDate.of(2024, 1, 15)
@@ -360,7 +360,7 @@ class TransactionServiceTest : BehaviorSpec({
     // --- listTransactions ---
 
     Given("transactions exist for the user's couple") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
 
         val tx1 = Transaction(
             couple = couple, author = user1, type = TransactionType.EXPENSE,
@@ -389,7 +389,7 @@ class TransactionServiceTest : BehaviorSpec({
     }
 
     Given("transactions exist and keyword filter is used") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
 
         val tx1 = Transaction(
             couple = couple, author = user1, type = TransactionType.EXPENSE,
@@ -409,7 +409,7 @@ class TransactionServiceTest : BehaviorSpec({
     }
 
     Given("transactions exist and amount range filter is used") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
 
         val tx1 = Transaction(
             couple = couple, author = user1, type = TransactionType.EXPENSE,
@@ -428,7 +428,7 @@ class TransactionServiceTest : BehaviorSpec({
     }
 
     Given("transactions exist and paymentMethodId filter is used") {
-        every { coupleRepository.findByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns couple
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
         val pmId = UUID.randomUUID()
 
         val tx1 = Transaction(

--- a/frontend/lib/core/network/api_client.dart
+++ b/frontend/lib/core/network/api_client.dart
@@ -1,6 +1,7 @@
 import 'package:dio/dio.dart';
 import 'package:budget_book/core/constants/api_endpoints.dart';
 import 'package:budget_book/core/network/api_interceptor.dart';
+import 'package:budget_book/core/network/retry_interceptor.dart';
 
 class ApiClient {
   late final Dio dio;
@@ -9,8 +10,8 @@ class ApiClient {
     dio = Dio(
       BaseOptions(
         baseUrl: ApiEndpoints.baseUrl,
-        connectTimeout: const Duration(seconds: 10),
-        receiveTimeout: const Duration(seconds: 10),
+        connectTimeout: const Duration(seconds: 15),
+        receiveTimeout: const Duration(seconds: 30),
         headers: {
           'Content-Type': 'application/json',
           'Accept': 'application/json',
@@ -18,6 +19,11 @@ class ApiClient {
       ),
     );
     dio.interceptors.add(AuthInterceptor());
+    dio.interceptors.add(RetryInterceptor(
+      dio: dio,
+      maxRetries: 2,
+      baseDelay: const Duration(seconds: 1),
+    ));
     dio.interceptors.add(LogInterceptor(
       requestBody: true,
       responseBody: true,

--- a/frontend/lib/core/network/retry_interceptor.dart
+++ b/frontend/lib/core/network/retry_interceptor.dart
@@ -1,0 +1,89 @@
+import 'dart:async';
+import 'dart:math';
+import 'package:dio/dio.dart';
+
+/// A Dio interceptor that retries failed requests with exponential backoff.
+///
+/// Retry policy:
+/// - Retries on network errors (connectionTimeout, sendTimeout, receiveTimeout,
+///   connectionError, unknown with no response).
+/// - Retries on 5xx server errors.
+/// - Does NOT retry on 4xx client errors.
+/// - Max [maxRetries] attempts with exponential backoff starting at
+///   [baseDelay] (1s, 2s, 4s, ...).
+class RetryInterceptor extends Interceptor {
+  final Dio dio;
+  final int maxRetries;
+  final Duration baseDelay;
+
+  RetryInterceptor({
+    required this.dio,
+    this.maxRetries = 2,
+    this.baseDelay = const Duration(seconds: 1),
+  });
+
+  @override
+  Future<void> onError(
+    DioException err,
+    ErrorInterceptorHandler handler,
+  ) async {
+    if (!_shouldRetry(err)) {
+      handler.next(err);
+      return;
+    }
+
+    final retryCount = _getRetryCount(err.requestOptions);
+    if (retryCount >= maxRetries) {
+      handler.next(err);
+      return;
+    }
+
+    // Exponential backoff: baseDelay * 2^retryCount
+    final delay = baseDelay * pow(2, retryCount).toInt();
+    await Future<void>.delayed(delay);
+
+    // Increment retry count
+    final options = err.requestOptions;
+    _setRetryCount(options, retryCount + 1);
+
+    try {
+      final response = await dio.fetch(options);
+      handler.resolve(response);
+    } on DioException catch (e) {
+      handler.next(e);
+    }
+  }
+
+  bool _shouldRetry(DioException err) {
+    // Retry on timeout and network errors
+    switch (err.type) {
+      case DioExceptionType.connectionTimeout:
+      case DioExceptionType.sendTimeout:
+      case DioExceptionType.receiveTimeout:
+      case DioExceptionType.connectionError:
+        return true;
+      case DioExceptionType.badResponse:
+        // Retry on 5xx server errors, not on 4xx client errors
+        final statusCode = err.response?.statusCode;
+        if (statusCode != null && statusCode >= 500) {
+          return true;
+        }
+        return false;
+      case DioExceptionType.unknown:
+        // Retry on unknown errors that have no response (likely network issues)
+        return err.response == null;
+      default:
+        return false;
+    }
+  }
+
+  static const _retryCountKey = 'retry_interceptor_count';
+
+  int _getRetryCount(RequestOptions options) {
+    return (options.extra[_retryCountKey] as int?) ?? 0;
+  }
+
+  void _setRetryCount(RequestOptions options, int count) {
+    options.extra[_retryCountKey] = count;
+  }
+}

--- a/frontend/lib/core/widgets/error_widget.dart
+++ b/frontend/lib/core/widgets/error_widget.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+/// A reusable error widget that displays an error icon, message,
+/// an optional retry button, and an optional "go home" button.
+///
+/// Use this across all list/data pages when handling error states
+/// to provide a consistent user experience.
+class AppErrorWidget extends StatelessWidget {
+  /// The error message to display.
+  final String message;
+
+  /// Callback invoked when the user taps the "다시 시도" (retry) button.
+  /// If null, the retry button is hidden.
+  final VoidCallback? onRetry;
+
+  /// Whether to show a "홈으로" (go home) button that navigates to '/home'.
+  final bool showHomeButton;
+
+  const AppErrorWidget({
+    super.key,
+    required this.message,
+    this.onRetry,
+    this.showHomeButton = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 32),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(
+              Icons.error_outline,
+              size: 48,
+              color: theme.colorScheme.error,
+            ),
+            const SizedBox(height: 16),
+            Text(
+              message,
+              textAlign: TextAlign.center,
+              style: theme.textTheme.bodyLarge?.copyWith(
+                color: theme.colorScheme.onSurface.withValues(alpha: 0.7),
+              ),
+            ),
+            if (onRetry != null) ...[
+              const SizedBox(height: 16),
+              FilledButton.icon(
+                onPressed: onRetry,
+                icon: const Icon(Icons.refresh, size: 18),
+                label: const Text('다시 시도'),
+              ),
+            ],
+            if (showHomeButton) ...[
+              const SizedBox(height: 8),
+              TextButton.icon(
+                onPressed: () => context.go('/home'),
+                icon: const Icon(Icons.home_outlined, size: 18),
+                label: const Text('홈으로'),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/lib/features/budget/presentation/pages/budget_list_page.dart
+++ b/frontend/lib/features/budget/presentation/pages/budget_list_page.dart
@@ -9,6 +9,7 @@ import 'package:budget_book/features/budget/presentation/bloc/budget_state.dart'
 import 'package:budget_book/features/budget/presentation/widgets/budget_summary_card.dart';
 import 'package:budget_book/core/widgets/icon_picker.dart';
 import 'package:budget_book/core/widgets/color_picker.dart';
+import 'package:budget_book/core/widgets/error_widget.dart';
 
 class BudgetListPage extends StatelessWidget {
   const BudgetListPage({super.key});
@@ -276,24 +277,14 @@ class BudgetListPage extends StatelessWidget {
 
   Widget _buildError(BuildContext context) {
     final now = DateTime.now();
-    return Center(
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          const Icon(Icons.error_outline, size: 48, color: Colors.red),
-          const SizedBox(height: 16),
-          const Text('예산을 불러오지 못했습니다'),
-          const SizedBox(height: 16),
-          FilledButton(
-            onPressed: () {
-              context.read<BudgetBloc>().add(
-                    LoadBudgets(year: now.year, month: now.month),
-                  );
-            },
-            child: const Text('다시 시도'),
-          ),
-        ],
-      ),
+    return AppErrorWidget(
+      message: '예산을 불러오지 못했습니다',
+      onRetry: () {
+        context.read<BudgetBloc>().add(
+              LoadBudgets(year: now.year, month: now.month),
+            );
+      },
+      showHomeButton: true,
     );
   }
 

--- a/frontend/lib/features/category/presentation/pages/category_page.dart
+++ b/frontend/lib/features/category/presentation/pages/category_page.dart
@@ -6,6 +6,7 @@ import 'package:budget_book/features/category/presentation/bloc/category_event.d
 import 'package:budget_book/features/category/presentation/bloc/category_state.dart';
 import 'package:budget_book/features/category/presentation/widgets/category_form_sheet.dart';
 import 'package:budget_book/features/category/presentation/widgets/category_list_tile.dart';
+import 'package:budget_book/core/widgets/error_widget.dart';
 
 class CategoryPage extends StatelessWidget {
   const CategoryPage({super.key});
@@ -129,22 +130,12 @@ class CategoryPage extends StatelessWidget {
   }
 
   Widget _buildError(BuildContext context) {
-    return Center(
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          const Icon(Icons.error_outline, size: 48, color: Colors.red),
-          const SizedBox(height: 16),
-          const Text('카테고리를 불러오지 못했습니다'),
-          const SizedBox(height: 16),
-          FilledButton(
-            onPressed: () {
-              context.read<CategoryBloc>().add(const LoadCategories());
-            },
-            child: const Text('다시 시도'),
-          ),
-        ],
-      ),
+    return AppErrorWidget(
+      message: '카테고리를 불러오지 못했습니다',
+      onRetry: () {
+        context.read<CategoryBloc>().add(const LoadCategories());
+      },
+      showHomeButton: true,
     );
   }
 

--- a/frontend/lib/features/category_group/presentation/pages/category_group_page.dart
+++ b/frontend/lib/features/category_group/presentation/pages/category_group_page.dart
@@ -6,6 +6,7 @@ import 'package:budget_book/features/category_group/presentation/bloc/category_g
 import 'package:budget_book/features/category_group/presentation/bloc/category_group_event.dart';
 import 'package:budget_book/features/category_group/presentation/bloc/category_group_state.dart';
 import 'package:budget_book/features/category_group/presentation/widgets/category_group_form_sheet.dart';
+import 'package:budget_book/core/widgets/error_widget.dart';
 
 class CategoryGroupPage extends StatelessWidget {
   const CategoryGroupPage({super.key});
@@ -244,24 +245,14 @@ class CategoryGroupPage extends StatelessWidget {
   }
 
   Widget _buildError(BuildContext context) {
-    return Center(
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          const Icon(Icons.error_outline, size: 48, color: Colors.red),
-          const SizedBox(height: 16),
-          const Text('카테고리 그룹을 불러오지 못했습니다'),
-          const SizedBox(height: 16),
-          FilledButton(
-            onPressed: () {
-              context
-                  .read<CategoryGroupBloc>()
-                  .add(const LoadCategoryGroups());
-            },
-            child: const Text('다시 시도'),
-          ),
-        ],
-      ),
+    return AppErrorWidget(
+      message: '카테고리 그룹을 불러오지 못했습니다',
+      onRetry: () {
+        context
+            .read<CategoryGroupBloc>()
+            .add(const LoadCategoryGroups());
+      },
+      showHomeButton: true,
     );
   }
 

--- a/frontend/lib/features/home/presentation/pages/dashboard_page.dart
+++ b/frontend/lib/features/home/presentation/pages/dashboard_page.dart
@@ -7,6 +7,7 @@ import 'package:budget_book/features/home/presentation/bloc/dashboard_state.dart
 import 'package:budget_book/features/home/presentation/bloc/dashboard_event.dart';
 import 'package:budget_book/features/transaction/domain/entities/transaction.dart';
 import 'package:budget_book/features/budget/domain/entities/budget.dart';
+import 'package:budget_book/core/widgets/error_widget.dart';
 
 class DashboardPage extends StatelessWidget {
   const DashboardPage({super.key});
@@ -31,26 +32,14 @@ class DashboardPage extends StatelessWidget {
           }
 
           if (state is DashboardError) {
-            return Center(
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  Text(
-                    state.message,
-                    style: Theme.of(context).textTheme.bodyLarge,
-                  ),
-                  const SizedBox(height: 16),
-                  FilledButton(
-                    onPressed: () {
-                      final now = DateTime.now();
-                      context.read<DashboardBloc>().add(
-                            LoadDashboard(year: now.year, month: now.month),
-                          );
-                    },
-                    child: const Text('다시 시도'),
-                  ),
-                ],
-              ),
+            return AppErrorWidget(
+              message: state.message,
+              onRetry: () {
+                final now = DateTime.now();
+                context.read<DashboardBloc>().add(
+                      LoadDashboard(year: now.year, month: now.month),
+                    );
+              },
             );
           }
 

--- a/frontend/lib/features/payment_method/presentation/pages/payment_method_page.dart
+++ b/frontend/lib/features/payment_method/presentation/pages/payment_method_page.dart
@@ -6,6 +6,7 @@ import 'package:budget_book/features/payment_method/presentation/bloc/payment_me
 import 'package:budget_book/features/payment_method/presentation/bloc/payment_method_state.dart';
 import 'package:budget_book/features/payment_method/presentation/widgets/payment_method_form_sheet.dart';
 import 'package:budget_book/features/payment_method/presentation/widgets/card_pending_summary.dart';
+import 'package:budget_book/core/widgets/error_widget.dart';
 
 class PaymentMethodPage extends StatelessWidget {
   const PaymentMethodPage({super.key});
@@ -258,24 +259,14 @@ class PaymentMethodPage extends StatelessWidget {
   }
 
   Widget _buildError(BuildContext context) {
-    return Center(
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          const Icon(Icons.error_outline, size: 48, color: Colors.red),
-          const SizedBox(height: 16),
-          const Text('결제수단을 불러오지 못했습니다'),
-          const SizedBox(height: 16),
-          FilledButton(
-            onPressed: () {
-              context
-                  .read<PaymentMethodBloc>()
-                  .add(const LoadPaymentMethods());
-            },
-            child: const Text('다시 시도'),
-          ),
-        ],
-      ),
+    return AppErrorWidget(
+      message: '결제수단을 불러오지 못했습니다',
+      onRetry: () {
+        context
+            .read<PaymentMethodBloc>()
+            .add(const LoadPaymentMethods());
+      },
+      showHomeButton: true,
     );
   }
 

--- a/frontend/lib/features/pocket/presentation/pages/pocket_page.dart
+++ b/frontend/lib/features/pocket/presentation/pages/pocket_page.dart
@@ -7,6 +7,7 @@ import 'package:budget_book/features/pocket/presentation/bloc/pocket_bloc.dart';
 import 'package:budget_book/features/pocket/presentation/bloc/pocket_event.dart';
 import 'package:budget_book/features/pocket/presentation/bloc/pocket_state.dart';
 import 'package:budget_book/features/pocket/presentation/widgets/pocket_form_sheet.dart';
+import 'package:budget_book/core/widgets/error_widget.dart';
 
 class PocketPage extends StatelessWidget {
   const PocketPage({super.key});
@@ -128,22 +129,12 @@ class PocketPage extends StatelessWidget {
   }
 
   Widget _buildError(BuildContext context) {
-    return Center(
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          const Icon(Icons.error_outline, size: 48, color: Colors.red),
-          const SizedBox(height: 16),
-          const Text('포켓을 불러오지 못했습니다'),
-          const SizedBox(height: 16),
-          FilledButton(
-            onPressed: () {
-              context.read<PocketBloc>().add(const LoadPockets());
-            },
-            child: const Text('다시 시도'),
-          ),
-        ],
-      ),
+    return AppErrorWidget(
+      message: '포켓을 불러오지 못했습니다',
+      onRetry: () {
+        context.read<PocketBloc>().add(const LoadPockets());
+      },
+      showHomeButton: true,
     );
   }
 

--- a/frontend/lib/features/recurring/presentation/pages/recurring_list_page.dart
+++ b/frontend/lib/features/recurring/presentation/pages/recurring_list_page.dart
@@ -5,6 +5,7 @@ import 'package:budget_book/features/recurring/presentation/bloc/recurring_bloc.
 import 'package:budget_book/features/recurring/presentation/bloc/recurring_event.dart';
 import 'package:budget_book/features/recurring/presentation/bloc/recurring_state.dart';
 import 'package:budget_book/features/recurring/presentation/widgets/recurring_list_tile.dart';
+import 'package:budget_book/core/widgets/error_widget.dart';
 
 class RecurringListPage extends StatelessWidget {
   const RecurringListPage({super.key});
@@ -155,24 +156,14 @@ class RecurringListPage extends StatelessWidget {
   }
 
   Widget _buildError(BuildContext context) {
-    return Center(
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          const Icon(Icons.error_outline, size: 48, color: Colors.red),
-          const SizedBox(height: 16),
-          const Text('반복 거래를 불러오지 못했습니다'),
-          const SizedBox(height: 16),
-          FilledButton(
-            onPressed: () {
-              context
-                  .read<RecurringBloc>()
-                  .add(const LoadRecurringTransactions());
-            },
-            child: const Text('다시 시도'),
-          ),
-        ],
-      ),
+    return AppErrorWidget(
+      message: '반복 거래를 불러오지 못했습니다',
+      onRetry: () {
+        context
+            .read<RecurringBloc>()
+            .add(const LoadRecurringTransactions());
+      },
+      showHomeButton: true,
     );
   }
 }

--- a/frontend/lib/features/report/presentation/pages/report_page.dart
+++ b/frontend/lib/features/report/presentation/pages/report_page.dart
@@ -9,6 +9,7 @@ import 'package:budget_book/features/report/presentation/bloc/report_state.dart'
 import 'package:budget_book/features/report/presentation/widgets/overspend_category_tile.dart';
 import 'package:budget_book/features/report/presentation/widgets/daily_spending_chart.dart';
 import 'package:budget_book/features/report/presentation/widgets/month_comparison_card.dart';
+import 'package:budget_book/core/widgets/error_widget.dart';
 
 class ReportPage extends StatefulWidget {
   const ReportPage({super.key});
@@ -582,26 +583,16 @@ class _ReportPageState extends State<ReportPage> {
   }
 
   Widget _buildError(BuildContext context, String message) {
-    return Center(
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          const Icon(Icons.error_outline, size: 48, color: Colors.red),
-          const SizedBox(height: 16),
-          Text(message),
-          const SizedBox(height: 16),
-          FilledButton(
-            onPressed: () {
-              final now = DateTime.now();
-              context.read<ReportBloc>()
-                ..add(LoadMonthlyReport(year: now.year, month: now.month))
-                ..add(LoadWeeklyReport(
-                    year: now.year, month: now.month, week: 1));
-            },
-            child: const Text('다시 시도'),
-          ),
-        ],
-      ),
+    return AppErrorWidget(
+      message: message,
+      onRetry: () {
+        final now = DateTime.now();
+        context.read<ReportBloc>()
+          ..add(LoadMonthlyReport(year: now.year, month: now.month))
+          ..add(LoadWeeklyReport(
+              year: now.year, month: now.month, week: 1));
+      },
+      showHomeButton: true,
     );
   }
 

--- a/frontend/lib/features/transaction/presentation/pages/transaction_list_page.dart
+++ b/frontend/lib/features/transaction/presentation/pages/transaction_list_page.dart
@@ -10,6 +10,7 @@ import 'package:budget_book/features/transaction/presentation/bloc/transaction_e
 import 'package:budget_book/features/transaction/presentation/bloc/transaction_state.dart';
 import 'package:budget_book/features/transaction/presentation/widgets/month_summary_bar.dart';
 import 'package:budget_book/features/transaction/presentation/widgets/transaction_list_tile.dart';
+import 'package:budget_book/core/widgets/error_widget.dart';
 
 class TransactionListPage extends StatefulWidget {
   const TransactionListPage({super.key});
@@ -501,24 +502,14 @@ class _TransactionListPageState extends State<TransactionListPage> {
 
   Widget _buildError(BuildContext context) {
     final now = DateTime.now();
-    return Center(
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          const Icon(Icons.error_outline, size: 48, color: Colors.red),
-          const SizedBox(height: 16),
-          const Text('거래를 불러오지 못했습니다'),
-          const SizedBox(height: 16),
-          FilledButton(
-            onPressed: () {
-              context.read<TransactionBloc>().add(
-                    LoadTransactions(year: now.year, month: now.month),
-                  );
-            },
-            child: const Text('다시 시도'),
-          ),
-        ],
-      ),
+    return AppErrorWidget(
+      message: '거래를 불러오지 못했습니다',
+      onRetry: () {
+        context.read<TransactionBloc>().add(
+              LoadTransactions(year: now.year, month: now.month),
+            );
+      },
+      showHomeButton: true,
     );
   }
 }

--- a/frontend/lib/features/weekly_budget/presentation/pages/weekly_budget_page.dart
+++ b/frontend/lib/features/weekly_budget/presentation/pages/weekly_budget_page.dart
@@ -6,6 +6,7 @@ import 'package:budget_book/features/weekly_budget/presentation/bloc/weekly_budg
 import 'package:budget_book/features/weekly_budget/presentation/bloc/weekly_budget_event.dart';
 import 'package:budget_book/features/weekly_budget/presentation/bloc/weekly_budget_state.dart';
 import 'package:budget_book/features/weekly_budget/presentation/widgets/week_summary_card.dart';
+import 'package:budget_book/core/widgets/error_widget.dart';
 
 class WeeklyBudgetPage extends StatelessWidget {
   const WeeklyBudgetPage({super.key});
@@ -190,25 +191,15 @@ class WeeklyBudgetPage extends StatelessWidget {
   }
 
   Widget _buildError(BuildContext context, String message) {
-    return Center(
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          const Icon(Icons.error_outline, size: 48, color: Colors.red),
-          const SizedBox(height: 16),
-          Text(message),
-          const SizedBox(height: 16),
-          FilledButton(
-            onPressed: () {
-              final now = DateTime.now();
-              context.read<WeeklyBudgetBloc>()
-                ..add(LoadWeeklyOverview(year: now.year, month: now.month))
-                ..add(const LoadCurrentWeek());
-            },
-            child: const Text('다시 시도'),
-          ),
-        ],
-      ),
+    return AppErrorWidget(
+      message: message,
+      onRetry: () {
+        final now = DateTime.now();
+        context.read<WeeklyBudgetBloc>()
+          ..add(LoadWeeklyOverview(year: now.year, month: now.month))
+          ..add(const LoadCurrentWeek());
+      },
+      showHomeButton: true,
     );
   }
 }

--- a/frontend/test/core/network/retry_interceptor_test.dart
+++ b/frontend/test/core/network/retry_interceptor_test.dart
@@ -1,0 +1,134 @@
+import 'dart:async';
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:budget_book/core/network/retry_interceptor.dart';
+
+/// A test-friendly error handler that captures whether next() or resolve() was called.
+class _TestErrorHandler extends ErrorInterceptorHandler {
+  bool nextCalled = false;
+  bool resolveCalled = false;
+  final Completer<void> _completer = Completer<void>();
+
+  Future<void> get done => _completer.future;
+
+  @override
+  void next(DioException err) {
+    nextCalled = true;
+    if (!_completer.isCompleted) _completer.complete();
+  }
+
+  @override
+  void resolve(Response response) {
+    resolveCalled = true;
+    if (!_completer.isCompleted) _completer.complete();
+  }
+}
+
+void main() {
+  group('RetryInterceptor', () {
+    late Dio dio;
+    late RetryInterceptor interceptor;
+
+    setUp(() {
+      dio = Dio(BaseOptions(baseUrl: 'https://example.com'));
+      interceptor = RetryInterceptor(
+        dio: dio,
+        maxRetries: 2,
+        baseDelay: const Duration(milliseconds: 10), // fast for tests
+      );
+    });
+
+    test('should be created with default values', () {
+      final defaultInterceptor = RetryInterceptor(dio: dio);
+      expect(defaultInterceptor.maxRetries, 2);
+      expect(defaultInterceptor.baseDelay, const Duration(seconds: 1));
+    });
+
+    test('constructor accepts custom parameters', () {
+      final customInterceptor = RetryInterceptor(
+        dio: dio,
+        maxRetries: 5,
+        baseDelay: const Duration(seconds: 3),
+      );
+
+      expect(customInterceptor.maxRetries, 5);
+      expect(customInterceptor.baseDelay, const Duration(seconds: 3));
+    });
+
+    group('does not retry on client errors', () {
+      for (final statusCode in [400, 401, 403, 404, 422]) {
+        test('does not retry on $statusCode', () async {
+          final requestOptions = RequestOptions(path: '/test');
+          final err = DioException(
+            type: DioExceptionType.badResponse,
+            requestOptions: requestOptions,
+            response: Response(
+              statusCode: statusCode,
+              requestOptions: requestOptions,
+            ),
+          );
+
+          final handler = _TestErrorHandler();
+          interceptor.onError(err, handler);
+          await handler.done;
+
+          expect(handler.nextCalled, isTrue,
+              reason: 'Should call next (no retry) for $statusCode');
+          expect(handler.resolveCalled, isFalse);
+          // retry count should not be set (no retry attempted)
+          expect(requestOptions.extra['retry_interceptor_count'], isNull);
+        });
+      }
+    });
+
+    test('does not retry on cancel', () async {
+      final requestOptions = RequestOptions(path: '/test');
+      final err = DioException(
+        type: DioExceptionType.cancel,
+        requestOptions: requestOptions,
+      );
+
+      final handler = _TestErrorHandler();
+      interceptor.onError(err, handler);
+      await handler.done;
+
+      expect(handler.nextCalled, isTrue);
+      expect(requestOptions.extra['retry_interceptor_count'], isNull);
+    });
+
+    test('does not retry when maxRetries is already reached', () async {
+      final requestOptions = RequestOptions(path: '/test');
+      // Simulate that we already retried 2 times
+      requestOptions.extra['retry_interceptor_count'] = 2;
+
+      final err = DioException(
+        type: DioExceptionType.connectionTimeout,
+        requestOptions: requestOptions,
+      );
+
+      final handler = _TestErrorHandler();
+      interceptor.onError(err, handler);
+      await handler.done;
+
+      expect(handler.nextCalled, isTrue,
+          reason: 'Should give up after maxRetries');
+      // retry count should remain at 2, not increment
+      expect(requestOptions.extra['retry_interceptor_count'], 2);
+    });
+
+    test('does not retry on badCertificate', () async {
+      final requestOptions = RequestOptions(path: '/test');
+      final err = DioException(
+        type: DioExceptionType.badCertificate,
+        requestOptions: requestOptions,
+      );
+
+      final handler = _TestErrorHandler();
+      interceptor.onError(err, handler);
+      await handler.done;
+
+      expect(handler.nextCalled, isTrue);
+      expect(requestOptions.extra['retry_interceptor_count'], isNull);
+    });
+  });
+}

--- a/frontend/test/core/widgets/error_widget_test.dart
+++ b/frontend/test/core/widgets/error_widget_test.dart
@@ -1,0 +1,100 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:budget_book/core/widgets/error_widget.dart';
+
+void main() {
+  group('AppErrorWidget', () {
+    testWidgets('displays error icon and message', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppErrorWidget(message: 'Something went wrong'),
+          ),
+        ),
+      );
+
+      expect(find.byIcon(Icons.error_outline), findsOneWidget);
+      expect(find.text('Something went wrong'), findsOneWidget);
+    });
+
+    testWidgets('shows retry button when onRetry is provided', (tester) async {
+      bool retried = false;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppErrorWidget(
+              message: 'Error',
+              onRetry: () => retried = true,
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('다시 시도'), findsOneWidget);
+      expect(find.byIcon(Icons.refresh), findsOneWidget);
+
+      await tester.tap(find.text('다시 시도'));
+      expect(retried, isTrue);
+    });
+
+    testWidgets('hides retry button when onRetry is null', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppErrorWidget(message: 'Error'),
+          ),
+        ),
+      );
+
+      expect(find.text('다시 시도'), findsNothing);
+    });
+
+    testWidgets('shows home button when showHomeButton is true',
+        (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppErrorWidget(
+              message: 'Error',
+              showHomeButton: true,
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('홈으로'), findsOneWidget);
+      expect(find.byIcon(Icons.home_outlined), findsOneWidget);
+    });
+
+    testWidgets('hides home button by default', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppErrorWidget(message: 'Error'),
+          ),
+        ),
+      );
+
+      expect(find.text('홈으로'), findsNothing);
+    });
+
+    testWidgets('shows both retry and home buttons together', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppErrorWidget(
+              message: 'Error message',
+              onRetry: () {},
+              showHomeButton: true,
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('다시 시도'), findsOneWidget);
+      expect(find.text('홈으로'), findsOneWidget);
+      expect(find.text('Error message'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- CoupleResolver: request-scoped cache reducing 9→1 DB calls per request
- WeeklyBudgetService N+1 query fix
- V20: 5 composite indexes for frequent queries
- AppErrorWidget standardized across 10 pages
- RetryInterceptor with exponential backoff (network/5xx errors)
- Dio timeout: connect 15s, receive 30s

## Test plan
- [x] BE tests: 373 PASS
- [x] FE tests: 334 PASS
- [x] FE analyze: no issues
- [x] FE build web: SUCCESS

🤖 Generated with [Claude Code](https://claude.com/claude-code)