### PR TITLE
feat: Sprint 6c - onboarding, empty states, skeleton loader

### DIFF
--- a/frontend/lib/core/router/app_router.dart
+++ b/frontend/lib/core/router/app_router.dart
@@ -55,6 +55,8 @@ import 'package:budget_book/features/pocket/presentation/bloc/pocket_transfer_ev
 import 'package:budget_book/features/pocket/presentation/pages/pocket_page.dart';
 import 'package:budget_book/features/pocket/presentation/pages/distribute_wizard_page.dart';
 import 'package:budget_book/features/pocket/presentation/pages/pocket_transfer_page.dart';
+import 'package:budget_book/features/onboarding/presentation/pages/onboarding_page.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 /// Adapts a BLoC stream into a [Listenable] for GoRouter.refreshListenable.
 class _BlocListenable extends ChangeNotifier {
@@ -73,6 +75,23 @@ class _BlocListenable extends ChangeNotifier {
 
 final _rootNavigatorKey = GlobalKey<NavigatorState>();
 
+/// Cached onboarding completion flag.
+/// Set by [initOnboardingFlag] at app startup.
+bool _onboardingCompleted = false;
+
+/// Must be called before [createAppRouter] to load the cached flag.
+Future<void> initOnboardingFlag() async {
+  final prefs = await SharedPreferences.getInstance();
+  _onboardingCompleted = prefs.getBool(kOnboardingCompleted) ?? false;
+}
+
+/// Marks onboarding as completed and updates the cached flag.
+Future<void> markOnboardingCompleted() async {
+  final prefs = await SharedPreferences.getInstance();
+  await prefs.setBool(kOnboardingCompleted, true);
+  _onboardingCompleted = true;
+}
+
 GoRouter createAppRouter(AuthBloc authBloc) => GoRouter(
   navigatorKey: _rootNavigatorKey,
   initialLocation: '/login',
@@ -83,15 +102,27 @@ GoRouter createAppRouter(AuthBloc authBloc) => GoRouter(
     final isOnLoginPage = state.matchedLocation == '/login';
     final isOnCallbackPage = state.matchedLocation == '/auth/callback';
     final isOnCouplePage = state.matchedLocation == '/couple';
+    final isOnOnboardingPage = state.matchedLocation == '/onboarding';
 
     // Allow callback page to proceed regardless of auth state
     if (isOnCallbackPage) return null;
 
     if (authState is AuthAuthenticated && isOnLoginPage) {
+      // Check onboarding first
+      if (!_onboardingCompleted) return '/onboarding';
       return authState.user.coupleId != null ? '/home' : '/couple';
     }
 
     if (authState is AuthAuthenticated) {
+      // Allow onboarding page to pass through
+      if (isOnOnboardingPage) return null;
+
+      // If onboarding not completed, redirect to onboarding
+      // (except couple page which can be accessed from onboarding)
+      if (!_onboardingCompleted && !isOnCouplePage) {
+        return '/onboarding';
+      }
+
       // If no couple and trying to access couple-required pages, redirect to /couple
       // But allow /couple itself and /settings to pass through
       if (authState.user.coupleId == null &&
@@ -121,6 +152,10 @@ GoRouter createAppRouter(AuthBloc authBloc) => GoRouter(
         accessToken: state.uri.queryParameters['accessToken'],
         refreshToken: state.uri.queryParameters['refreshToken'],
       ),
+    ),
+    GoRoute(
+      path: '/onboarding',
+      builder: (context, state) => const OnboardingPage(),
     ),
     GoRoute(
       path: '/couple',

--- a/frontend/lib/core/widgets/empty_state_widget.dart
+++ b/frontend/lib/core/widgets/empty_state_widget.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+
+/// A reusable widget that displays an empty state with an icon, title,
+/// optional subtitle, and optional action button.
+class EmptyStateWidget extends StatelessWidget {
+  final IconData icon;
+  final String title;
+  final String? subtitle;
+  final String? actionLabel;
+  final VoidCallback? onAction;
+
+  const EmptyStateWidget({
+    super.key,
+    required this.icon,
+    required this.title,
+    this.subtitle,
+    this.actionLabel,
+    this.onAction,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final mutedColor =
+        theme.colorScheme.onSurface.withValues(alpha: 0.4);
+
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(
+              icon,
+              size: 48,
+              color: mutedColor,
+            ),
+            const SizedBox(height: 16),
+            Text(
+              title,
+              style: theme.textTheme.titleSmall?.copyWith(
+                fontWeight: FontWeight.w600,
+              ),
+              textAlign: TextAlign.center,
+            ),
+            if (subtitle != null) ...[
+              const SizedBox(height: 8),
+              Text(
+                subtitle!,
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: mutedColor,
+                ),
+                textAlign: TextAlign.center,
+              ),
+            ],
+            if (actionLabel != null && onAction != null) ...[
+              const SizedBox(height: 20),
+              FilledButton.tonal(
+                onPressed: onAction,
+                child: Text(actionLabel!),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/lib/core/widgets/skeleton_loader.dart
+++ b/frontend/lib/core/widgets/skeleton_loader.dart
@@ -1,0 +1,140 @@
+import 'package:flutter/material.dart';
+
+/// A shimmer-effect loading placeholder that mimics list items.
+class SkeletonLoader extends StatefulWidget {
+  final int itemCount;
+  final double height;
+
+  const SkeletonLoader({
+    super.key,
+    this.itemCount = 5,
+    this.height = 72,
+  });
+
+  @override
+  State<SkeletonLoader> createState() => _SkeletonLoaderState();
+}
+
+class _SkeletonLoaderState extends State<SkeletonLoader>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+  late final Animation<double> _animation;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 1500),
+    )..repeat();
+    _animation = Tween<double>(begin: -1.0, end: 2.0).animate(
+      CurvedAnimation(parent: _controller, curve: Curves.easeInOutSine),
+    );
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: _animation,
+      builder: (context, child) {
+        return ListView.builder(
+          physics: const NeverScrollableScrollPhysics(),
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+          itemCount: widget.itemCount,
+          itemBuilder: (context, index) {
+            return _SkeletonItem(
+              height: widget.height,
+              shimmerValue: _animation.value,
+            );
+          },
+        );
+      },
+    );
+  }
+}
+
+class _SkeletonItem extends StatelessWidget {
+  final double height;
+  final double shimmerValue;
+
+  const _SkeletonItem({
+    required this.height,
+    required this.shimmerValue,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final baseColor = Theme.of(context).colorScheme.surfaceContainerHighest;
+    final highlightColor = Theme.of(context).colorScheme.surface;
+
+    final gradient = LinearGradient(
+      begin: Alignment(shimmerValue - 1, 0),
+      end: Alignment(shimmerValue, 0),
+      colors: [
+        baseColor,
+        highlightColor,
+        baseColor,
+      ],
+      stops: const [0.0, 0.5, 1.0],
+    );
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: Row(
+        children: [
+          // Circle avatar placeholder
+          Container(
+            width: 40,
+            height: 40,
+            decoration: BoxDecoration(
+              shape: BoxShape.circle,
+              gradient: gradient,
+            ),
+          ),
+          const SizedBox(width: 12),
+          // Text lines placeholder
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Container(
+                  height: 14,
+                  width: double.infinity,
+                  decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(4),
+                    gradient: gradient,
+                  ),
+                ),
+                const SizedBox(height: 8),
+                Container(
+                  height: 12,
+                  width: 150,
+                  decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(4),
+                    gradient: gradient,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(width: 12),
+          // Trailing placeholder
+          Container(
+            height: 14,
+            width: 60,
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(4),
+              gradient: gradient,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/frontend/lib/features/budget/presentation/pages/budget_list_page.dart
+++ b/frontend/lib/features/budget/presentation/pages/budget_list_page.dart
@@ -10,6 +10,8 @@ import 'package:budget_book/features/budget/presentation/widgets/budget_summary_
 import 'package:budget_book/core/widgets/icon_picker.dart';
 import 'package:budget_book/core/widgets/color_picker.dart';
 import 'package:budget_book/core/widgets/error_widget.dart';
+import 'package:budget_book/core/widgets/empty_state_widget.dart';
+import 'package:budget_book/core/widgets/skeleton_loader.dart';
 
 class BudgetListPage extends StatelessWidget {
   const BudgetListPage({super.key});
@@ -93,9 +95,8 @@ class BudgetListPage extends StatelessWidget {
         },
         builder: (context, state) {
           return switch (state) {
-            BudgetInitial() || BudgetLoading() => const Center(
-                child: CircularProgressIndicator(),
-              ),
+            BudgetInitial() || BudgetLoading() =>
+              const SkeletonLoader(itemCount: 5),
             BudgetLoaded() => _buildLoaded(context, state),
             BudgetError() => _buildError(context),
           };
@@ -238,40 +239,15 @@ class BudgetListPage extends StatelessWidget {
   }
 
   Widget _buildEmpty(BuildContext context) {
-    return Center(
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          Icon(
-            Icons.account_balance_wallet_outlined,
-            size: 64,
-            color: Theme.of(context)
-                .colorScheme
-                .onSurface
-                .withValues(alpha: 0.3),
-          ),
-          const SizedBox(height: 16),
-          Text(
-            '이 달에 설정된 예산이 없습니다',
-            style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                  color: Theme.of(context)
-                      .colorScheme
-                      .onSurface
-                      .withValues(alpha: 0.5),
-                ),
-          ),
-          const SizedBox(height: 8),
-          Text(
-            '+ 버튼을 눌러 예산을 설정하세요',
-            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                  color: Theme.of(context)
-                      .colorScheme
-                      .onSurface
-                      .withValues(alpha: 0.4),
-                ),
-          ),
-        ],
-      ),
+    final state = context.read<BudgetBloc>().state;
+    final year = state is BudgetLoaded ? state.year : DateTime.now().year;
+    final month = state is BudgetLoaded ? state.month : DateTime.now().month;
+    return EmptyStateWidget(
+      icon: Icons.account_balance_wallet,
+      title: '예산이 없습니다',
+      subtitle: '이 달에 설정된 예산이 없습니다',
+      actionLabel: '예산 추가',
+      onAction: () => context.push('/budgets/create?year=$year&month=$month'),
     );
   }
 

--- a/frontend/lib/features/category/presentation/pages/category_page.dart
+++ b/frontend/lib/features/category/presentation/pages/category_page.dart
@@ -7,6 +7,7 @@ import 'package:budget_book/features/category/presentation/bloc/category_state.d
 import 'package:budget_book/features/category/presentation/widgets/category_form_sheet.dart';
 import 'package:budget_book/features/category/presentation/widgets/category_list_tile.dart';
 import 'package:budget_book/core/widgets/error_widget.dart';
+import 'package:budget_book/core/widgets/empty_state_widget.dart';
 
 class CategoryPage extends StatelessWidget {
   const CategoryPage({super.key});
@@ -86,30 +87,12 @@ class CategoryPage extends StatelessWidget {
     String type,
   ) {
     if (categories.isEmpty) {
-      return Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Icon(
-              Icons.category_outlined,
-              size: 64,
-              color: Theme.of(context)
-                  .colorScheme
-                  .onSurface
-                  .withValues(alpha: 0.3),
-            ),
-            const SizedBox(height: 16),
-            Text(
-              type == 'EXPENSE' ? '지출 카테고리가 없습니다' : '수입 카테고리가 없습니다',
-              style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                    color: Theme.of(context)
-                        .colorScheme
-                        .onSurface
-                        .withValues(alpha: 0.5),
-                  ),
-            ),
-          ],
-        ),
+      return EmptyStateWidget(
+        icon: Icons.category,
+        title: '카테고리가 없습니다',
+        subtitle: type == 'EXPENSE' ? '지출 카테고리가 없습니다' : '수입 카테고리가 없습니다',
+        actionLabel: '카테고리 추가',
+        onAction: () => _showAddCategory(context),
       );
     }
 

--- a/frontend/lib/features/category_group/presentation/pages/category_group_page.dart
+++ b/frontend/lib/features/category_group/presentation/pages/category_group_page.dart
@@ -7,6 +7,7 @@ import 'package:budget_book/features/category_group/presentation/bloc/category_g
 import 'package:budget_book/features/category_group/presentation/bloc/category_group_state.dart';
 import 'package:budget_book/features/category_group/presentation/widgets/category_group_form_sheet.dart';
 import 'package:budget_book/core/widgets/error_widget.dart';
+import 'package:budget_book/core/widgets/empty_state_widget.dart';
 
 class CategoryGroupPage extends StatelessWidget {
   const CategoryGroupPage({super.key});
@@ -57,40 +58,12 @@ class CategoryGroupPage extends StatelessWidget {
 
   Widget _buildGroupList(BuildContext context, List<CategoryGroup> groups) {
     if (groups.isEmpty) {
-      return Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Icon(
-              Icons.folder_outlined,
-              size: 64,
-              color: Theme.of(context)
-                  .colorScheme
-                  .onSurface
-                  .withValues(alpha: 0.3),
-            ),
-            const SizedBox(height: 16),
-            Text(
-              '카테고리 그룹이 없습니다',
-              style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                    color: Theme.of(context)
-                        .colorScheme
-                        .onSurface
-                        .withValues(alpha: 0.5),
-                  ),
-            ),
-            const SizedBox(height: 8),
-            Text(
-              '그룹을 추가하여 카테고리를 정리하세요',
-              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                    color: Theme.of(context)
-                        .colorScheme
-                        .onSurface
-                        .withValues(alpha: 0.4),
-                  ),
-            ),
-          ],
-        ),
+      return EmptyStateWidget(
+        icon: Icons.folder,
+        title: '카테고리 그룹이 없습니다',
+        subtitle: '그룹을 추가하여 카테고리를 정리하세요',
+        actionLabel: '그룹 추가',
+        onAction: () => _showAddGroup(context),
       );
     }
 

--- a/frontend/lib/features/home/presentation/pages/dashboard_page.dart
+++ b/frontend/lib/features/home/presentation/pages/dashboard_page.dart
@@ -8,6 +8,7 @@ import 'package:budget_book/features/home/presentation/bloc/dashboard_event.dart
 import 'package:budget_book/features/transaction/domain/entities/transaction.dart';
 import 'package:budget_book/features/budget/domain/entities/budget.dart';
 import 'package:budget_book/core/widgets/error_widget.dart';
+import 'package:budget_book/core/widgets/skeleton_loader.dart';
 
 class DashboardPage extends StatelessWidget {
   const DashboardPage({super.key});
@@ -28,7 +29,7 @@ class DashboardPage extends StatelessWidget {
       body: BlocBuilder<DashboardBloc, DashboardState>(
         builder: (context, state) {
           if (state is DashboardLoading || state is DashboardInitial) {
-            return const Center(child: CircularProgressIndicator());
+            return const SkeletonLoader(itemCount: 5);
           }
 
           if (state is DashboardError) {

--- a/frontend/lib/features/onboarding/presentation/pages/onboarding_page.dart
+++ b/frontend/lib/features/onboarding/presentation/pages/onboarding_page.dart
@@ -1,0 +1,234 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Key used to store onboarding completion flag in SharedPreferences.
+const String kOnboardingCompleted = 'onboarding_completed';
+
+/// A 3-step onboarding flow shown once after first login.
+class OnboardingPage extends StatefulWidget {
+  const OnboardingPage({super.key});
+
+  @override
+  State<OnboardingPage> createState() => _OnboardingPageState();
+}
+
+class _OnboardingPageState extends State<OnboardingPage> {
+  final PageController _pageController = PageController();
+  int _currentPage = 0;
+
+  @override
+  void dispose() {
+    _pageController.dispose();
+    super.dispose();
+  }
+
+  void _goToNextPage() {
+    if (_currentPage < 2) {
+      _pageController.animateToPage(
+        _currentPage + 1,
+        duration: const Duration(milliseconds: 300),
+        curve: Curves.easeInOut,
+      );
+    }
+  }
+
+  Future<void> _completeOnboarding() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(kOnboardingCompleted, true);
+    if (mounted) {
+      context.go('/home');
+    }
+  }
+
+  void _goToCouplePage() {
+    context.push('/couple');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: SafeArea(
+        child: Column(
+          children: [
+            Expanded(
+              child: PageView(
+                controller: _pageController,
+                onPageChanged: (page) {
+                  setState(() => _currentPage = page);
+                },
+                children: [
+                  _WelcomeStep(),
+                  _CoupleStep(
+                    onConnect: _goToCouplePage,
+                    onSkip: _goToNextPage,
+                  ),
+                  _StartStep(
+                    onStart: _completeOnboarding,
+                  ),
+                ],
+              ),
+            ),
+            // Dot indicators
+            Padding(
+              padding: const EdgeInsets.only(bottom: 32),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: List.generate(3, (index) {
+                  final isActive = index == _currentPage;
+                  return AnimatedContainer(
+                    duration: const Duration(milliseconds: 200),
+                    margin: const EdgeInsets.symmetric(horizontal: 4),
+                    width: isActive ? 24 : 8,
+                    height: 8,
+                    decoration: BoxDecoration(
+                      borderRadius: BorderRadius.circular(4),
+                      color: isActive
+                          ? Theme.of(context).colorScheme.primary
+                          : Theme.of(context)
+                              .colorScheme
+                              .onSurface
+                              .withValues(alpha: 0.2),
+                    ),
+                  );
+                }),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _WelcomeStep extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 32),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(
+            Icons.account_balance_wallet,
+            size: 80,
+            color: theme.colorScheme.primary,
+          ),
+          const SizedBox(height: 32),
+          Text(
+            '환영합니다',
+            style: theme.textTheme.headlineMedium?.copyWith(
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          const SizedBox(height: 16),
+          Text(
+            '부부 공유 가계부에 오신 것을 환영합니다',
+            style: theme.textTheme.bodyLarge?.copyWith(
+              color: theme.colorScheme.onSurface.withValues(alpha: 0.7),
+            ),
+            textAlign: TextAlign.center,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _CoupleStep extends StatelessWidget {
+  final VoidCallback onConnect;
+  final VoidCallback onSkip;
+
+  const _CoupleStep({
+    required this.onConnect,
+    required this.onSkip,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 32),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(
+            Icons.favorite,
+            size: 80,
+            color: theme.colorScheme.error,
+          ),
+          const SizedBox(height: 32),
+          Text(
+            '커플 연결',
+            style: theme.textTheme.headlineMedium?.copyWith(
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          const SizedBox(height: 16),
+          Text(
+            '파트너와 연결하여 함께 가계부를 관리하세요',
+            style: theme.textTheme.bodyLarge?.copyWith(
+              color: theme.colorScheme.onSurface.withValues(alpha: 0.7),
+            ),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 32),
+          FilledButton(
+            onPressed: onConnect,
+            child: const Text('커플 연결하기'),
+          ),
+          const SizedBox(height: 12),
+          TextButton(
+            onPressed: onSkip,
+            child: const Text('나중에'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _StartStep extends StatelessWidget {
+  final VoidCallback onStart;
+
+  const _StartStep({required this.onStart});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 32),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          const Icon(
+            Icons.check_circle,
+            size: 80,
+            color: Colors.green,
+          ),
+          const SizedBox(height: 32),
+          Text(
+            '준비 완료!',
+            style: theme.textTheme.headlineMedium?.copyWith(
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          const SizedBox(height: 16),
+          Text(
+            '첫 거래를 기록해보세요',
+            style: theme.textTheme.bodyLarge?.copyWith(
+              color: theme.colorScheme.onSurface.withValues(alpha: 0.7),
+            ),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 32),
+          FilledButton(
+            onPressed: onStart,
+            child: const Text('시작하기'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/frontend/lib/features/payment_method/presentation/pages/payment_method_page.dart
+++ b/frontend/lib/features/payment_method/presentation/pages/payment_method_page.dart
@@ -7,6 +7,7 @@ import 'package:budget_book/features/payment_method/presentation/bloc/payment_me
 import 'package:budget_book/features/payment_method/presentation/widgets/payment_method_form_sheet.dart';
 import 'package:budget_book/features/payment_method/presentation/widgets/card_pending_summary.dart';
 import 'package:budget_book/core/widgets/error_widget.dart';
+import 'package:budget_book/core/widgets/empty_state_widget.dart';
 
 class PaymentMethodPage extends StatelessWidget {
   const PaymentMethodPage({super.key});
@@ -64,30 +65,12 @@ class PaymentMethodPage extends StatelessWidget {
     bool hasCardPendings,
   ) {
     if (methods.isEmpty) {
-      return Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Icon(
-              Icons.account_balance_wallet_outlined,
-              size: 64,
-              color: Theme.of(context)
-                  .colorScheme
-                  .onSurface
-                  .withValues(alpha: 0.3),
-            ),
-            const SizedBox(height: 16),
-            Text(
-              '등록된 결제수단이 없습니다',
-              style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                    color: Theme.of(context)
-                        .colorScheme
-                        .onSurface
-                        .withValues(alpha: 0.5),
-                  ),
-            ),
-          ],
-        ),
+      return EmptyStateWidget(
+        icon: Icons.payment,
+        title: '결제수단이 없습니다',
+        subtitle: '등록된 결제수단이 없습니다',
+        actionLabel: '결제수단 추가',
+        onAction: () => _showAddPaymentMethod(context),
       );
     }
 

--- a/frontend/lib/features/pocket/presentation/pages/pocket_page.dart
+++ b/frontend/lib/features/pocket/presentation/pages/pocket_page.dart
@@ -8,6 +8,7 @@ import 'package:budget_book/features/pocket/presentation/bloc/pocket_event.dart'
 import 'package:budget_book/features/pocket/presentation/bloc/pocket_state.dart';
 import 'package:budget_book/features/pocket/presentation/widgets/pocket_form_sheet.dart';
 import 'package:budget_book/core/widgets/error_widget.dart';
+import 'package:budget_book/core/widgets/empty_state_widget.dart';
 
 class PocketPage extends StatelessWidget {
   const PocketPage({super.key});
@@ -72,40 +73,12 @@ class PocketPage extends StatelessWidget {
     PocketLoaded state,
   ) {
     if (pockets.isEmpty) {
-      return Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Icon(
-              Icons.account_balance_wallet_outlined,
-              size: 64,
-              color: Theme.of(context)
-                  .colorScheme
-                  .onSurface
-                  .withValues(alpha: 0.3),
-            ),
-            const SizedBox(height: 16),
-            Text(
-              '등록된 포켓이 없습니다',
-              style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                    color: Theme.of(context)
-                        .colorScheme
-                        .onSurface
-                        .withValues(alpha: 0.5),
-                  ),
-            ),
-            const SizedBox(height: 8),
-            Text(
-              '+ 버튼을 눌러 첫 포켓을 만드세요',
-              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                    color: Theme.of(context)
-                        .colorScheme
-                        .onSurface
-                        .withValues(alpha: 0.4),
-                  ),
-            ),
-          ],
-        ),
+      return EmptyStateWidget(
+        icon: Icons.savings,
+        title: '포켓이 없습니다',
+        subtitle: '+ 버튼을 눌러 첫 포켓을 만드세요',
+        actionLabel: '포켓 추가',
+        onAction: () => _showAddPocket(context),
       );
     }
 

--- a/frontend/lib/features/recurring/presentation/pages/recurring_list_page.dart
+++ b/frontend/lib/features/recurring/presentation/pages/recurring_list_page.dart
@@ -6,6 +6,7 @@ import 'package:budget_book/features/recurring/presentation/bloc/recurring_event
 import 'package:budget_book/features/recurring/presentation/bloc/recurring_state.dart';
 import 'package:budget_book/features/recurring/presentation/widgets/recurring_list_tile.dart';
 import 'package:budget_book/core/widgets/error_widget.dart';
+import 'package:budget_book/core/widgets/empty_state_widget.dart';
 
 class RecurringListPage extends StatelessWidget {
   const RecurringListPage({super.key});
@@ -58,24 +59,12 @@ class RecurringListPage extends StatelessWidget {
     final theme = Theme.of(context);
 
     if (state.transactions.isEmpty) {
-      return Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Icon(
-              Icons.repeat_outlined,
-              size: 64,
-              color: theme.colorScheme.onSurface.withValues(alpha: 0.3),
-            ),
-            const SizedBox(height: 16),
-            Text(
-              '등록된 반복 거래가 없습니다',
-              style: theme.textTheme.bodyLarge?.copyWith(
-                color: theme.colorScheme.onSurface.withValues(alpha: 0.5),
-              ),
-            ),
-          ],
-        ),
+      return EmptyStateWidget(
+        icon: Icons.repeat,
+        title: '반복 거래가 없습니다',
+        subtitle: '등록된 반복 거래가 없습니다',
+        actionLabel: '반복 거래 추가',
+        onAction: () => context.push('/recurring/create'),
       );
     }
 

--- a/frontend/lib/features/transaction/presentation/bloc/transaction_bloc.dart
+++ b/frontend/lib/features/transaction/presentation/bloc/transaction_bloc.dart
@@ -17,10 +17,13 @@ class TransactionBloc extends Bloc<TransactionEvent, TransactionState> {
   TransactionBloc({required this.transactionRepository})
       : super(const TransactionInitial()) {
     on<LoadTransactions>(_onLoadTransactions);
+    on<LoadMoreTransactions>(_onLoadMoreTransactions);
     on<CreateTransaction>(_onCreateTransaction);
     on<UpdateTransaction>(_onUpdateTransaction);
     on<DeleteTransaction>(_onDeleteTransaction);
   }
+
+  static const int _pageSize = 30;
 
   Future<void> _onLoadTransactions(
     LoadTransactions event,
@@ -43,7 +46,8 @@ class TransactionBloc extends Bloc<TransactionEvent, TransactionState> {
       pocketId: event.pocketId,
       amountMin: event.amountMin,
       amountMax: event.amountMax,
-      size: 100,
+      page: 0,
+      size: _pageSize,
     );
     result.fold(
       (failure) => emit(TransactionError(failure.message)),
@@ -53,7 +57,75 @@ class TransactionBloc extends Bloc<TransactionEvent, TransactionState> {
         month: event.month,
         totalElements: page.totalElements,
         hasMore: !page.last,
+        currentPage: 0,
       )),
+    );
+  }
+
+  Future<void> _onLoadMoreTransactions(
+    LoadMoreTransactions event,
+    Emitter<TransactionState> emit,
+  ) async {
+    final currentState = state;
+    if (currentState is! TransactionLoaded ||
+        !currentState.hasMore ||
+        currentState.isLoadingMore) {
+      return;
+    }
+
+    final nextPage = currentState.currentPage + 1;
+
+    // Emit loading-more state
+    emit(TransactionLoaded(
+      transactions: currentState.transactions,
+      year: currentState.year,
+      month: currentState.month,
+      totalElements: currentState.totalElements,
+      hasMore: currentState.hasMore,
+      currentPage: currentState.currentPage,
+      isLoadingMore: true,
+    ));
+
+    final result = await transactionRepository.getTransactions(
+      year: _currentYear,
+      month: _currentMonth,
+      keyword: _currentKeyword,
+      paymentMethodId: _currentPaymentMethodId,
+      pocketId: _currentPocketId,
+      amountMin: _currentAmountMin,
+      amountMax: _currentAmountMax,
+      page: nextPage,
+      size: _pageSize,
+    );
+
+    result.fold(
+      (failure) {
+        // Revert to non-loading state on error
+        emit(TransactionLoaded(
+          transactions: currentState.transactions,
+          year: currentState.year,
+          month: currentState.month,
+          totalElements: currentState.totalElements,
+          hasMore: currentState.hasMore,
+          currentPage: currentState.currentPage,
+          isLoadingMore: false,
+          operationError: failure.message,
+        ));
+      },
+      (page) {
+        final allTransactions = [
+          ...currentState.transactions,
+          ...page.content,
+        ];
+        emit(TransactionLoaded(
+          transactions: allTransactions,
+          year: currentState.year,
+          month: currentState.month,
+          totalElements: page.totalElements,
+          hasMore: !page.last,
+          currentPage: nextPage,
+        ));
+      },
     );
   }
 

--- a/frontend/lib/features/transaction/presentation/bloc/transaction_event.dart
+++ b/frontend/lib/features/transaction/presentation/bloc/transaction_event.dart
@@ -85,6 +85,10 @@ class UpdateTransaction extends TransactionEvent {
       [id, amount, description, categoryId, transactionDate, memo, clearMemo, paymentMethodId, pocketId];
 }
 
+class LoadMoreTransactions extends TransactionEvent {
+  const LoadMoreTransactions();
+}
+
 class DeleteTransaction extends TransactionEvent {
   final String id;
 

--- a/frontend/lib/features/transaction/presentation/bloc/transaction_state.dart
+++ b/frontend/lib/features/transaction/presentation/bloc/transaction_state.dart
@@ -22,6 +22,8 @@ class TransactionLoaded extends TransactionState {
   final int month;
   final int totalElements;
   final bool hasMore;
+  final int currentPage;
+  final bool isLoadingMore;
   final String? operationError;
   final String? operationSuccess;
 
@@ -31,6 +33,8 @@ class TransactionLoaded extends TransactionState {
     required this.month,
     required this.totalElements,
     required this.hasMore,
+    this.currentPage = 0,
+    this.isLoadingMore = false,
     this.operationError,
     this.operationSuccess,
   });
@@ -55,7 +59,7 @@ class TransactionLoaded extends TransactionState {
 
   @override
   List<Object?> get props =>
-      [transactions, year, month, totalElements, hasMore, operationError, operationSuccess];
+      [transactions, year, month, totalElements, hasMore, currentPage, isLoadingMore, operationError, operationSuccess];
 }
 
 class TransactionError extends TransactionState {

--- a/frontend/lib/features/transaction/presentation/pages/transaction_list_page.dart
+++ b/frontend/lib/features/transaction/presentation/pages/transaction_list_page.dart
@@ -11,6 +11,8 @@ import 'package:budget_book/features/transaction/presentation/bloc/transaction_s
 import 'package:budget_book/features/transaction/presentation/widgets/month_summary_bar.dart';
 import 'package:budget_book/features/transaction/presentation/widgets/transaction_list_tile.dart';
 import 'package:budget_book/core/widgets/error_widget.dart';
+import 'package:budget_book/core/widgets/empty_state_widget.dart';
+import 'package:budget_book/core/widgets/skeleton_loader.dart';
 
 class TransactionListPage extends StatefulWidget {
   const TransactionListPage({super.key});
@@ -317,9 +319,8 @@ class _TransactionListPageState extends State<TransactionListPage> {
         },
         builder: (context, state) {
           return switch (state) {
-            TransactionInitial() || TransactionLoading() => const Center(
-                child: CircularProgressIndicator(),
-              ),
+            TransactionInitial() || TransactionLoading() =>
+              const SkeletonLoader(itemCount: 5),
             TransactionLoaded() => _buildLoaded(context, state),
             TransactionError() => _buildError(context),
           };
@@ -410,93 +411,95 @@ class _TransactionListPageState extends State<TransactionListPage> {
     final grouped = state.groupedByDate;
     final sortedDates = grouped.keys.toList()..sort((a, b) => b.compareTo(a));
 
-    return ListView.builder(
-      itemCount: sortedDates.length,
-      itemBuilder: (context, index) {
-        final date = sortedDates[index];
-        final transactions = grouped[date]!;
-        return Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            _DateHeader(dateStr: date),
-            ...transactions.map((t) => TransactionListTile(
-                  transaction: t,
-                  onTap: () => context.push('/transactions/edit/${t.id}'),
-                  onDelete: () {
-                    showDialog(
-                      context: context,
-                      builder: (ctx) => AlertDialog(
-                        title: const Text('거래 삭제'),
-                        content: const Text('정말 삭제하시겠습니까?'),
-                        actions: [
-                          TextButton(
-                            onPressed: () => Navigator.of(ctx).pop(),
-                            child: const Text('취소'),
-                          ),
-                          FilledButton(
-                            onPressed: () {
-                              Navigator.of(ctx).pop();
-                              context
-                                  .read<TransactionBloc>()
-                                  .add(DeleteTransaction(t.id));
-                              ScaffoldMessenger.of(context).showSnackBar(
-                                const SnackBar(
-                                  content: Text('거래가 삭제되었습니다'),
-                                ),
-                              );
-                            },
-                            style: FilledButton.styleFrom(
-                              backgroundColor:
-                                  Theme.of(context).colorScheme.error,
-                            ),
-                            child: const Text('삭제'),
-                          ),
-                        ],
-                      ),
-                    );
-                  },
-                )),
-          ],
-        );
+    // Add 1 extra item for the loading indicator when loading more
+    final itemCount =
+        sortedDates.length + (state.isLoadingMore || state.hasMore ? 1 : 0);
+
+    return NotificationListener<ScrollNotification>(
+      onNotification: (notification) {
+        if (notification is ScrollUpdateNotification) {
+          final maxScroll = notification.metrics.maxScrollExtent;
+          final currentScroll = notification.metrics.pixels;
+          // Trigger load more at 80% scroll
+          if (currentScroll >= maxScroll * 0.8) {
+            final bloc = context.read<TransactionBloc>();
+            final currentState = bloc.state;
+            if (currentState is TransactionLoaded &&
+                currentState.hasMore &&
+                !currentState.isLoadingMore) {
+              bloc.add(const LoadMoreTransactions());
+            }
+          }
+        }
+        return false;
       },
+      child: ListView.builder(
+        itemCount: itemCount,
+        itemBuilder: (context, index) {
+          // Last item is loading indicator
+          if (index >= sortedDates.length) {
+            return const Padding(
+              padding: EdgeInsets.symmetric(vertical: 16),
+              child: Center(child: CircularProgressIndicator()),
+            );
+          }
+          final date = sortedDates[index];
+          final transactions = grouped[date]!;
+          return Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              _DateHeader(dateStr: date),
+              ...transactions.map((t) => TransactionListTile(
+                    transaction: t,
+                    onTap: () => context.push('/transactions/edit/${t.id}'),
+                    onDelete: () {
+                      showDialog(
+                        context: context,
+                        builder: (ctx) => AlertDialog(
+                          title: const Text('거래 삭제'),
+                          content: const Text('정말 삭제하시겠습니까?'),
+                          actions: [
+                            TextButton(
+                              onPressed: () => Navigator.of(ctx).pop(),
+                              child: const Text('취소'),
+                            ),
+                            FilledButton(
+                              onPressed: () {
+                                Navigator.of(ctx).pop();
+                                context
+                                    .read<TransactionBloc>()
+                                    .add(DeleteTransaction(t.id));
+                                ScaffoldMessenger.of(context).showSnackBar(
+                                  const SnackBar(
+                                    content: Text('거래가 삭제되었습니다'),
+                                  ),
+                                );
+                              },
+                              style: FilledButton.styleFrom(
+                                backgroundColor:
+                                    Theme.of(context).colorScheme.error,
+                              ),
+                              child: const Text('삭제'),
+                            ),
+                          ],
+                        ),
+                      );
+                    },
+                  )),
+            ],
+          );
+        },
+      ),
     );
   }
 
   Widget _buildEmpty(BuildContext context) {
-    return Center(
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          Icon(
-            Icons.receipt_long_outlined,
-            size: 64,
-            color: Theme.of(context)
-                .colorScheme
-                .onSurface
-                .withValues(alpha: 0.3),
-          ),
-          const SizedBox(height: 16),
-          Text(
-            '이 달에 기록된 거래가 없습니다',
-            style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                  color: Theme.of(context)
-                      .colorScheme
-                      .onSurface
-                      .withValues(alpha: 0.5),
-                ),
-          ),
-          const SizedBox(height: 8),
-          Text(
-            '+ 버튼을 눌러 첫 거래를 추가하세요',
-            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                  color: Theme.of(context)
-                      .colorScheme
-                      .onSurface
-                      .withValues(alpha: 0.4),
-                ),
-          ),
-        ],
-      ),
+    return EmptyStateWidget(
+      icon: Icons.receipt_long,
+      title: '거래 내역이 없습니다',
+      subtitle: '이 달에 기록된 거래가 없습니다',
+      actionLabel: '거래 추가',
+      onAction: () => context.push('/transactions/create'),
     );
   }
 

--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -4,6 +4,7 @@ import 'package:flutter_web_plugins/url_strategy.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:budget_book/app.dart';
 import 'package:budget_book/core/di/injection.dart';
+import 'package:budget_book/core/router/app_router.dart';
 
 // Task #18: SENTRY_DSN is injected at build time via --dart-define=SENTRY_DSN=<dsn>
 // or via CI/CD environment (never hardcoded). Leave empty to disable Sentry.
@@ -13,6 +14,7 @@ void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   usePathUrlStrategy();
   await configureDependencies();
+  await initOnboardingFlag();
   Bloc.observer = AppBlocObserver();
 
   if (_sentryDsn.isNotEmpty) {

--- a/frontend/test/core/widgets/empty_state_widget_test.dart
+++ b/frontend/test/core/widgets/empty_state_widget_test.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:budget_book/core/widgets/empty_state_widget.dart';
+
+void main() {
+  group('EmptyStateWidget', () {
+    testWidgets('renders icon and title', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: EmptyStateWidget(
+              icon: Icons.receipt_long,
+              title: '거래 내역이 없습니다',
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byIcon(Icons.receipt_long), findsOneWidget);
+      expect(find.text('거래 내역이 없습니다'), findsOneWidget);
+    });
+
+    testWidgets('renders subtitle when provided', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: EmptyStateWidget(
+              icon: Icons.receipt_long,
+              title: '거래 내역이 없습니다',
+              subtitle: '이 달에 기록된 거래가 없습니다',
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('이 달에 기록된 거래가 없습니다'), findsOneWidget);
+    });
+
+    testWidgets('does not render subtitle when null', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: EmptyStateWidget(
+              icon: Icons.receipt_long,
+              title: '거래 내역이 없습니다',
+            ),
+          ),
+        ),
+      );
+
+      // Only title and icon, no subtitle
+      expect(find.byType(Text), findsOneWidget);
+    });
+
+    testWidgets('renders action button when label and callback provided',
+        (tester) async {
+      bool pressed = false;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: EmptyStateWidget(
+              icon: Icons.receipt_long,
+              title: '거래 내역이 없습니다',
+              actionLabel: '거래 추가',
+              onAction: () => pressed = true,
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('거래 추가'), findsOneWidget);
+      expect(find.byType(FilledButton), findsOneWidget);
+
+      await tester.tap(find.text('거래 추가'));
+      expect(pressed, isTrue);
+    });
+
+    testWidgets('does not render action button when no callback',
+        (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: EmptyStateWidget(
+              icon: Icons.receipt_long,
+              title: '거래 내역이 없습니다',
+              actionLabel: '거래 추가',
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byType(FilledButton), findsNothing);
+    });
+  });
+}

--- a/frontend/test/core/widgets/skeleton_loader_test.dart
+++ b/frontend/test/core/widgets/skeleton_loader_test.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:budget_book/core/widgets/skeleton_loader.dart';
+
+void main() {
+  group('SkeletonLoader', () {
+    testWidgets('renders with default parameters', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: SkeletonLoader(),
+          ),
+        ),
+      );
+
+      expect(find.byType(SkeletonLoader), findsOneWidget);
+      expect(find.byType(ListView), findsOneWidget);
+    });
+
+    testWidgets('renders specified number of items', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: SkeletonLoader(itemCount: 3),
+          ),
+        ),
+      );
+
+      expect(find.byType(SkeletonLoader), findsOneWidget);
+    });
+
+    testWidgets('animates shimmer effect', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: SkeletonLoader(itemCount: 2),
+          ),
+        ),
+      );
+
+      // Pump to advance animation
+      await tester.pump(const Duration(milliseconds: 500));
+      await tester.pump(const Duration(milliseconds: 500));
+      // No errors means animation is running correctly
+      expect(find.byType(SkeletonLoader), findsOneWidget);
+    });
+  });
+}

--- a/frontend/test/features/budget/presentation/pages/budget_list_page_test.dart
+++ b/frontend/test/features/budget/presentation/pages/budget_list_page_test.dart
@@ -9,6 +9,7 @@ import 'package:budget_book/features/budget/presentation/bloc/budget_state.dart'
 import 'package:budget_book/features/budget/presentation/pages/budget_list_page.dart';
 import 'package:budget_book/features/budget/domain/entities/budget.dart';
 import 'package:budget_book/features/transaction/domain/entities/transaction_category.dart';
+import 'package:budget_book/core/widgets/skeleton_loader.dart';
 
 class MockBudgetBloc extends MockBloc<BudgetEvent, BudgetState>
     implements BudgetBloc {}
@@ -87,7 +88,7 @@ void main() {
         (tester) async {
       when(() => mockBudgetBloc.state).thenReturn(const BudgetLoading());
       await tester.pumpWidget(buildTestWidget());
-      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      expect(find.byType(SkeletonLoader), findsOneWidget);
     });
 
     testWidgets('shows empty state when no budgets', (tester) async {

--- a/frontend/test/features/onboarding/presentation/pages/onboarding_page_test.dart
+++ b/frontend/test/features/onboarding/presentation/pages/onboarding_page_test.dart
@@ -1,0 +1,133 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:budget_book/features/onboarding/presentation/pages/onboarding_page.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  group('OnboardingPage', () {
+    testWidgets('renders step 1 - welcome', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: OnboardingPage(),
+        ),
+      );
+
+      expect(find.text('환영합니다'), findsOneWidget);
+      expect(
+        find.text('부부 공유 가계부에 오신 것을 환영합니다'),
+        findsOneWidget,
+      );
+      expect(find.byIcon(Icons.account_balance_wallet), findsOneWidget);
+    });
+
+    testWidgets('shows 3 dot indicators', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: OnboardingPage(),
+        ),
+      );
+
+      // 3 dot indicators rendered as AnimatedContainer
+      expect(find.byType(AnimatedContainer), findsNWidgets(3));
+    });
+
+    testWidgets('can swipe to step 2 - couple', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: OnboardingPage(),
+        ),
+      );
+
+      // Swipe left to go to step 2
+      await tester.drag(find.byType(PageView), const Offset(-400, 0));
+      await tester.pumpAndSettle();
+
+      expect(find.text('커플 연결'), findsOneWidget);
+      expect(
+        find.text('파트너와 연결하여 함께 가계부를 관리하세요'),
+        findsOneWidget,
+      );
+      expect(find.text('커플 연결하기'), findsOneWidget);
+      expect(find.text('나중에'), findsOneWidget);
+    });
+
+    testWidgets('나중에 button advances to next page', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: OnboardingPage(),
+        ),
+      );
+
+      // Go to step 2
+      await tester.drag(find.byType(PageView), const Offset(-400, 0));
+      await tester.pumpAndSettle();
+
+      // Tap 나중에
+      await tester.tap(find.text('나중에'));
+      await tester.pumpAndSettle();
+
+      // Should be on step 3
+      expect(find.text('준비 완료!'), findsOneWidget);
+      expect(find.text('시작하기'), findsOneWidget);
+    });
+
+    testWidgets('can swipe to step 3 - start', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: OnboardingPage(),
+        ),
+      );
+
+      // Swipe through to step 3
+      await tester.drag(find.byType(PageView), const Offset(-400, 0));
+      await tester.pumpAndSettle();
+      await tester.drag(find.byType(PageView), const Offset(-400, 0));
+      await tester.pumpAndSettle();
+
+      expect(find.text('준비 완료!'), findsOneWidget);
+      expect(find.text('첫 거래를 기록해보세요'), findsOneWidget);
+      expect(find.text('시작하기'), findsOneWidget);
+    });
+
+    testWidgets('시작하기 saves completion flag', (tester) async {
+      SharedPreferences.setMockInitialValues({});
+
+      final router = GoRouter(
+        initialLocation: '/onboarding',
+        routes: [
+          GoRoute(
+            path: '/onboarding',
+            builder: (_, __) => const OnboardingPage(),
+          ),
+          GoRoute(
+            path: '/home',
+            builder: (_, __) => const Scaffold(body: Text('Home')),
+          ),
+        ],
+      );
+
+      await tester.pumpWidget(
+        MaterialApp.router(routerConfig: router),
+      );
+
+      // Navigate to step 3
+      await tester.drag(find.byType(PageView), const Offset(-400, 0));
+      await tester.pumpAndSettle();
+      await tester.drag(find.byType(PageView), const Offset(-400, 0));
+      await tester.pumpAndSettle();
+
+      // Tap 시작하기
+      await tester.tap(find.text('시작하기'));
+      await tester.pumpAndSettle();
+
+      // Verify the flag was saved
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getBool(kOnboardingCompleted), isTrue);
+    });
+  });
+}

--- a/frontend/test/features/transaction/presentation/bloc/transaction_bloc_test.dart
+++ b/frontend/test/features/transaction/presentation/bloc/transaction_bloc_test.dart
@@ -191,7 +191,7 @@ void main() {
   final tPageResponse = PageResponse<Transaction>(
     content: tTransactions,
     page: 0,
-    size: 100,
+    size: 30,
     totalElements: 2,
     totalPages: 1,
     first: true,
@@ -220,7 +220,7 @@ void main() {
           when(mockRepository.getTransactions(
             year: 2024,
             month: 1,
-            size: 100,
+            size: 30,
           )).thenAnswer((_) async => Right(tPageResponse));
           return transactionBloc;
         },
@@ -247,7 +247,7 @@ void main() {
             keyword: 'lunch',
             amountMin: 5000,
             amountMax: 20000,
-            size: 100,
+            size: 30,
           )).thenAnswer((_) async => Right(tPageResponse));
           return transactionBloc;
         },
@@ -276,7 +276,7 @@ void main() {
           when(mockRepository.getTransactions(
             year: 2024,
             month: 1,
-            size: 100,
+            size: 30,
           )).thenAnswer((_) async =>
               const Left(ServerFailure('Failed to load transactions')));
           return transactionBloc;
@@ -331,7 +331,7 @@ void main() {
           when(mockRepository.getTransactions(
             year: 2024,
             month: 1,
-            size: 100,
+            size: 30,
           )).thenAnswer((_) async => Right(tPageResponse));
           return transactionBloc;
         },
@@ -352,7 +352,7 @@ void main() {
           verify(mockRepository.getTransactions(
             year: 2024,
             month: 1,
-            size: 100,
+            size: 30,
           )).called(1);
         },
       );
@@ -412,6 +412,105 @@ void main() {
             operationError: 'Failed to delete transaction',
           ),
         ],
+      );
+    });
+
+    group('LoadMoreTransactions', () {
+      final tPage1Response = PageResponse<Transaction>(
+        content: [tTransaction1],
+        page: 0,
+        size: 30,
+        totalElements: 2,
+        totalPages: 2,
+        first: true,
+        last: false,
+      );
+
+      final tPage2Response = PageResponse<Transaction>(
+        content: [tTransaction2],
+        page: 1,
+        size: 30,
+        totalElements: 2,
+        totalPages: 2,
+        first: false,
+        last: true,
+      );
+
+      blocTest<TransactionBloc, TransactionState>(
+        'appends more transactions when LoadMoreTransactions is dispatched',
+        build: () {
+          when(mockRepository.getTransactions(
+            year: 2024,
+            month: 1,
+            page: 0,
+            size: 30,
+          )).thenAnswer((_) async => Right(tPage1Response));
+          when(mockRepository.getTransactions(
+            year: 2024,
+            month: 1,
+            page: 1,
+            size: 30,
+          )).thenAnswer((_) async => Right(tPage2Response));
+          return transactionBloc;
+        },
+        act: (bloc) async {
+          bloc.add(const LoadTransactions(year: 2024, month: 1));
+          await Future.delayed(const Duration(milliseconds: 100));
+          bloc.add(const LoadMoreTransactions());
+        },
+        skip: 2, // skip TransactionLoading and first TransactionLoaded
+        expect: () => [
+          // isLoadingMore = true
+          TransactionLoaded(
+            transactions: [tTransaction1],
+            year: 2024,
+            month: 1,
+            totalElements: 2,
+            hasMore: true,
+            currentPage: 0,
+            isLoadingMore: true,
+          ),
+          // Loaded page 2, appended
+          TransactionLoaded(
+            transactions: [tTransaction1, tTransaction2],
+            year: 2024,
+            month: 1,
+            totalElements: 2,
+            hasMore: false,
+            currentPage: 1,
+          ),
+        ],
+      );
+
+      blocTest<TransactionBloc, TransactionState>(
+        'does nothing when hasMore is false',
+        build: () => transactionBloc,
+        seed: () => TransactionLoaded(
+          transactions: tTransactions,
+          year: 2024,
+          month: 1,
+          totalElements: 2,
+          hasMore: false,
+          currentPage: 0,
+        ),
+        act: (bloc) => bloc.add(const LoadMoreTransactions()),
+        expect: () => [], // no state change
+      );
+
+      blocTest<TransactionBloc, TransactionState>(
+        'does nothing when already loading more',
+        build: () => transactionBloc,
+        seed: () => TransactionLoaded(
+          transactions: [tTransaction1],
+          year: 2024,
+          month: 1,
+          totalElements: 2,
+          hasMore: true,
+          currentPage: 0,
+          isLoadingMore: true,
+        ),
+        act: (bloc) => bloc.add(const LoadMoreTransactions()),
+        expect: () => [], // no state change
       );
     });
 


### PR DESCRIPTION
## Summary
- 3-step onboarding flow (welcome → couple connect → start)
- EmptyStateWidget standardized across 7 list pages
- SkeletonLoader shimmer effect replacing CircularProgressIndicator
- Infinite scroll for transaction list (page size 30, load at 80%)

## Test plan
- [x] FE analyze: no issues
- [x] FE tests: 351 PASS (+17 new)
- [x] FE build web: SUCCESS

🤖 Generated with [Claude Code](https://claude.com/claude-code)