### PR TITLE
feat: Sprint 6e - CSV import, budget alerts, payment stats

### DIFF
--- a/backend/src/main/kotlin/com/budgetbook/budget/controller/BudgetController.kt
+++ b/backend/src/main/kotlin/com/budgetbook/budget/controller/BudgetController.kt
@@ -1,5 +1,6 @@
 package com.budgetbook.budget.controller
 
+import com.budgetbook.budget.dto.BudgetAlertResponse
 import com.budgetbook.budget.dto.BudgetRequest
 import com.budgetbook.budget.dto.BudgetResponse
 import com.budgetbook.budget.dto.BudgetSummaryResponse
@@ -7,6 +8,7 @@ import com.budgetbook.budget.dto.BudgetUpdateRequest
 import com.budgetbook.budget.dto.CopyBudgetRequest
 import com.budgetbook.budget.dto.CurrentWeekSummaryResponse
 import com.budgetbook.budget.dto.WeeklyOverviewResponse
+import com.budgetbook.budget.service.BudgetAlertService
 import com.budgetbook.budget.service.BudgetService
 import com.budgetbook.budget.service.WeeklyBudgetService
 import com.budgetbook.common.dto.ApiResponse
@@ -29,7 +31,8 @@ import java.util.UUID
 @RequestMapping("/api/v1/budgets")
 class BudgetController(
     private val budgetService: BudgetService,
-    private val weeklyBudgetService: WeeklyBudgetService
+    private val weeklyBudgetService: WeeklyBudgetService,
+    private val budgetAlertService: BudgetAlertService
 ) {
 
     @PostMapping
@@ -80,6 +83,15 @@ class BudgetController(
         val userId = authentication.principal as UUID
         val result = budgetService.copyFromPreviousMonth(userId, request)
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.ok(result))
+    }
+
+    @GetMapping("/alerts")
+    fun getBudgetAlerts(
+        authentication: Authentication,
+        @RequestParam yearMonth: String
+    ): ApiResponse<List<BudgetAlertResponse>> {
+        val userId = authentication.principal as UUID
+        return ApiResponse.ok(budgetAlertService.getBudgetAlerts(userId, yearMonth))
     }
 
     @GetMapping("/summary")

--- a/backend/src/main/kotlin/com/budgetbook/budget/dto/BudgetDtos.kt
+++ b/backend/src/main/kotlin/com/budgetbook/budget/dto/BudgetDtos.kt
@@ -85,6 +85,15 @@ data class BudgetSummaryItemResponse(
     val usageRate: Double
 )
 
+data class BudgetAlertResponse(
+    val categoryId: String,
+    val categoryName: String,
+    val budgetAmount: Long,
+    val spentAmount: Long,
+    val percentage: Int,
+    val alertLevel: String  // "SAFE", "WARNING" (>=80%), "EXCEEDED" (>=100%)
+)
+
 fun MonthlyBudget.toResponse() = BudgetResponse(
     id = id,
     coupleId = couple.id,

--- a/backend/src/main/kotlin/com/budgetbook/budget/service/BudgetAlertService.kt
+++ b/backend/src/main/kotlin/com/budgetbook/budget/service/BudgetAlertService.kt
@@ -1,0 +1,86 @@
+package com.budgetbook.budget.service
+
+import com.budgetbook.budget.dto.BudgetAlertResponse
+import com.budgetbook.budget.repository.MonthlyBudgetRepository
+import com.budgetbook.couple.service.CoupleResolver
+import com.budgetbook.transaction.domain.TransactionType
+import com.budgetbook.transaction.repository.TransactionRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.YearMonth
+import java.util.UUID
+
+@Service
+class BudgetAlertService(
+    private val budgetRepository: MonthlyBudgetRepository,
+    private val transactionRepository: TransactionRepository,
+    private val coupleResolver: CoupleResolver
+) {
+
+    @Transactional(readOnly = true)
+    fun getBudgetAlerts(userId: UUID, yearMonth: String): List<BudgetAlertResponse> {
+        val couple = coupleResolver.getActiveCouple(userId)
+
+        val parts = yearMonth.split("-")
+        val ym = YearMonth.of(parts[0].toInt(), parts[1].toInt())
+        val startDate = ym.atDay(1)
+        val endDate = ym.atEndOfMonth()
+
+        val budgets = budgetRepository.findByCoupleIdAndYearMonth(couple.id, yearMonth)
+        if (budgets.isEmpty()) return emptyList()
+
+        // Single aggregation query: GROUP BY category
+        val categoryExpenseResults = transactionRepository.sumByCategoryForCouple(
+            couple.id, startDate, endDate, TransactionType.EXPENSE
+        )
+        val spendingByCategory = categoryExpenseResults.associate { row ->
+            (row[2] as UUID) to (row[0] as Long)
+        }
+
+        // For total budget (no category), get total expenses
+        val totalExpense = transactionRepository.sumAmountByCoupleIdAndDateRange(
+            coupleId = couple.id,
+            startDate = startDate,
+            endDate = endDate,
+            type = TransactionType.EXPENSE
+        )
+
+        return budgets.mapNotNull { budget ->
+            val categoryId = budget.category?.id
+            val categoryName = budget.category?.name ?: "Total"
+            val budgetAmount = budget.amount
+
+            val spentAmount = if (categoryId != null) {
+                spendingByCategory[categoryId] ?: 0L
+            } else {
+                totalExpense
+            }
+
+            val percentage = if (budgetAmount > 0) {
+                ((spentAmount.toDouble() / budgetAmount) * 100).toInt()
+            } else {
+                0
+            }
+
+            val alertLevel = when {
+                percentage >= 100 -> "EXCEEDED"
+                percentage >= 80 -> "WARNING"
+                else -> "SAFE"
+            }
+
+            // Only return WARNING or EXCEEDED
+            if (alertLevel == "SAFE") {
+                null
+            } else {
+                BudgetAlertResponse(
+                    categoryId = categoryId?.toString() ?: "",
+                    categoryName = categoryName,
+                    budgetAmount = budgetAmount,
+                    spentAmount = spentAmount,
+                    percentage = percentage,
+                    alertLevel = alertLevel
+                )
+            }
+        }
+    }
+}

--- a/backend/src/main/kotlin/com/budgetbook/paymentmethod/repository/PaymentMethodRepository.kt
+++ b/backend/src/main/kotlin/com/budgetbook/paymentmethod/repository/PaymentMethodRepository.kt
@@ -10,4 +10,6 @@ interface PaymentMethodRepository : JpaRepository<PaymentMethod, UUID> {
     fun findByCoupleIdOrderByDisplayOrder(coupleId: UUID): List<PaymentMethod>
     fun findByIdAndCoupleId(id: UUID, coupleId: UUID): PaymentMethod?
     fun findByCoupleIdAndTypeAndIsActiveTrue(coupleId: UUID, type: PaymentMethodType): List<PaymentMethod>
+
+    fun findByCoupleIdAndNameIn(coupleId: UUID, names: List<String>): List<PaymentMethod>
 }

--- a/backend/src/main/kotlin/com/budgetbook/statistics/controller/StatisticsController.kt
+++ b/backend/src/main/kotlin/com/budgetbook/statistics/controller/StatisticsController.kt
@@ -3,7 +3,9 @@ package com.budgetbook.statistics.controller
 import com.budgetbook.common.dto.ApiResponse
 import com.budgetbook.statistics.dto.CategoryStatisticsResponse
 import com.budgetbook.statistics.dto.MonthlyTrendResponse
+import com.budgetbook.statistics.dto.PaymentMethodStatResponse
 import com.budgetbook.statistics.dto.StatisticsSummaryResponse
+import com.budgetbook.statistics.service.PaymentMethodStatisticsService
 import com.budgetbook.statistics.service.StatisticsService
 import org.springframework.security.core.Authentication
 import org.springframework.web.bind.annotation.GetMapping
@@ -15,7 +17,8 @@ import java.util.UUID
 @RestController
 @RequestMapping("/api/v1/statistics")
 class StatisticsController(
-    private val statisticsService: StatisticsService
+    private val statisticsService: StatisticsService,
+    private val paymentMethodStatisticsService: PaymentMethodStatisticsService
 ) {
 
     @GetMapping("/summary")
@@ -37,6 +40,16 @@ class StatisticsController(
     ): ApiResponse<List<CategoryStatisticsResponse>> {
         val userId = authentication.principal as UUID
         return ApiResponse.ok(statisticsService.getCategoryBreakdown(userId, year, month, type))
+    }
+
+    @GetMapping("/payment-methods")
+    fun getPaymentMethodStats(
+        authentication: Authentication,
+        @RequestParam year: Int,
+        @RequestParam month: Int
+    ): ApiResponse<List<PaymentMethodStatResponse>> {
+        val userId = authentication.principal as UUID
+        return ApiResponse.ok(paymentMethodStatisticsService.getPaymentMethodStats(userId, year, month))
     }
 
     @GetMapping("/monthly-trend")

--- a/backend/src/main/kotlin/com/budgetbook/statistics/dto/StatisticsDtos.kt
+++ b/backend/src/main/kotlin/com/budgetbook/statistics/dto/StatisticsDtos.kt
@@ -23,3 +23,11 @@ data class MonthlyTrendResponse(
     val totalExpense: Long,
     val balance: Long
 )
+
+data class PaymentMethodStatResponse(
+    val paymentMethodId: String,
+    val paymentMethodName: String,
+    val totalAmount: Long,
+    val transactionCount: Int,
+    val percentage: Double
+)

--- a/backend/src/main/kotlin/com/budgetbook/statistics/service/PaymentMethodStatisticsService.kt
+++ b/backend/src/main/kotlin/com/budgetbook/statistics/service/PaymentMethodStatisticsService.kt
@@ -1,0 +1,52 @@
+package com.budgetbook.statistics.service
+
+import com.budgetbook.couple.service.CoupleResolver
+import com.budgetbook.statistics.dto.PaymentMethodStatResponse
+import com.budgetbook.transaction.repository.TransactionRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.YearMonth
+import java.util.UUID
+
+@Service
+class PaymentMethodStatisticsService(
+    private val transactionRepository: TransactionRepository,
+    private val coupleResolver: CoupleResolver
+) {
+
+    @Transactional(readOnly = true)
+    fun getPaymentMethodStats(userId: UUID, year: Int, month: Int): List<PaymentMethodStatResponse> {
+        val couple = coupleResolver.getActiveCouple(userId)
+        val yearMonth = YearMonth.of(year, month)
+        val startDate = yearMonth.atDay(1)
+        val endDate = yearMonth.atEndOfMonth()
+
+        // Single aggregation query with GROUP BY payment_method_id
+        val results = transactionRepository.sumByPaymentMethodForCouple(
+            couple.id, startDate, endDate
+        )
+
+        if (results.isEmpty()) return emptyList()
+
+        val totalAmount = results.sumOf { (it[2] as Long) }
+
+        return results.map { row ->
+            val pmId = row[0] as UUID
+            val pmName = row[1] as String
+            val amount = row[2] as Long
+            val count = (row[3] as Long).toInt()
+
+            PaymentMethodStatResponse(
+                paymentMethodId = pmId.toString(),
+                paymentMethodName = pmName,
+                totalAmount = amount,
+                transactionCount = count,
+                percentage = if (totalAmount > 0) {
+                    Math.round(amount.toDouble() / totalAmount * 1000) / 10.0
+                } else {
+                    0.0
+                }
+            )
+        }
+    }
+}

--- a/backend/src/main/kotlin/com/budgetbook/transaction/controller/TransactionController.kt
+++ b/backend/src/main/kotlin/com/budgetbook/transaction/controller/TransactionController.kt
@@ -2,10 +2,12 @@ package com.budgetbook.transaction.controller
 
 import com.budgetbook.common.dto.ApiResponse
 import com.budgetbook.transaction.dto.CreateTransactionRequest
+import com.budgetbook.transaction.dto.CsvImportResponse
 import com.budgetbook.transaction.dto.PageResponse
 import com.budgetbook.transaction.dto.TransactionResponse
 import com.budgetbook.transaction.dto.UpdateTransactionRequest
 import com.budgetbook.transaction.service.TransactionExportService
+import com.budgetbook.transaction.service.TransactionImportService
 import com.budgetbook.transaction.service.TransactionService
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
@@ -22,13 +24,15 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.multipart.MultipartFile
 import java.util.UUID
 
 @RestController
 @RequestMapping("/api/v1/transactions")
 class TransactionController(
     private val transactionService: TransactionService,
-    private val transactionExportService: TransactionExportService
+    private val transactionExportService: TransactionExportService,
+    private val transactionImportService: TransactionImportService
 ) {
 
     @GetMapping
@@ -91,6 +95,15 @@ class TransactionController(
         val userId = authentication.principal as UUID
         transactionService.deleteTransaction(userId, id)
         return ResponseEntity.noContent().build()
+    }
+
+    @PostMapping("/import/csv")
+    fun importCsv(
+        authentication: Authentication,
+        @RequestParam("file") file: MultipartFile
+    ): ApiResponse<CsvImportResponse> {
+        val userId = authentication.principal as UUID
+        return ApiResponse.ok(transactionImportService.importCsv(userId, file))
     }
 
     @GetMapping("/export/csv")

--- a/backend/src/main/kotlin/com/budgetbook/transaction/dto/TransactionDtos.kt
+++ b/backend/src/main/kotlin/com/budgetbook/transaction/dto/TransactionDtos.kt
@@ -99,3 +99,14 @@ data class PageResponse<T>(
     val first: Boolean,
     val last: Boolean
 )
+
+data class CsvImportResponse(
+    val imported: Int,
+    val skipped: Int,
+    val errors: List<CsvImportError>
+)
+
+data class CsvImportError(
+    val row: Int,
+    val reason: String
+)

--- a/backend/src/main/kotlin/com/budgetbook/transaction/repository/TransactionRepository.kt
+++ b/backend/src/main/kotlin/com/budgetbook/transaction/repository/TransactionRepository.kt
@@ -142,6 +142,22 @@ interface TransactionRepository : JpaRepository<Transaction, UUID>, JpaSpecifica
     """)
     fun sumExpenseByPocketId(@Param("pocketId") pocketId: UUID): Long
 
+    @Query("""
+        SELECT t.paymentMethod.id, t.paymentMethod.name, SUM(t.amount), COUNT(t)
+        FROM Transaction t
+        WHERE t.couple.id = :coupleId
+        AND t.transactionDate BETWEEN :startDate AND :endDate
+        AND t.type = com.budgetbook.transaction.domain.TransactionType.EXPENSE
+        AND t.paymentMethod IS NOT NULL
+        GROUP BY t.paymentMethod.id, t.paymentMethod.name
+        ORDER BY SUM(t.amount) DESC
+    """)
+    fun sumByPaymentMethodForCouple(
+        @Param("coupleId") coupleId: UUID,
+        @Param("startDate") startDate: LocalDate,
+        @Param("endDate") endDate: LocalDate
+    ): List<Array<Any>>
+
     @Query("SELECT COUNT(DISTINCT t.author.id) FROM Transaction t WHERE t.createdAt >= :since")
     fun countDistinctAuthorsSince(@Param("since") since: java.time.Instant): Long
 

--- a/backend/src/main/kotlin/com/budgetbook/transaction/service/TransactionImportService.kt
+++ b/backend/src/main/kotlin/com/budgetbook/transaction/service/TransactionImportService.kt
@@ -1,0 +1,229 @@
+package com.budgetbook.transaction.service
+
+import com.budgetbook.auth.repository.UserRepository
+import com.budgetbook.category.repository.CategoryRepository
+import com.budgetbook.common.exception.BusinessException
+import com.budgetbook.common.exception.NotFoundException
+import com.budgetbook.couple.domain.Couple
+import com.budgetbook.couple.service.CoupleResolver
+import com.budgetbook.paymentmethod.repository.PaymentMethodRepository
+import com.budgetbook.transaction.domain.Transaction
+import com.budgetbook.transaction.domain.TransactionType
+import com.budgetbook.transaction.dto.CsvImportResponse
+import com.budgetbook.transaction.dto.CsvImportError
+import com.budgetbook.transaction.repository.TransactionRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.web.multipart.MultipartFile
+import java.io.BufferedReader
+import java.io.InputStreamReader
+import java.time.LocalDate
+import java.time.format.DateTimeParseException
+import java.util.UUID
+
+@Service
+class TransactionImportService(
+    private val transactionRepository: TransactionRepository,
+    private val coupleResolver: CoupleResolver,
+    private val userRepository: UserRepository,
+    private val categoryRepository: CategoryRepository,
+    private val paymentMethodRepository: PaymentMethodRepository
+) {
+
+    companion object {
+        private const val MAX_ROWS = 1000
+        private const val BATCH_SIZE = 50
+        private const val BOM = "\uFEFF"
+    }
+
+    @Transactional
+    fun importCsv(userId: UUID, file: MultipartFile): CsvImportResponse {
+        val couple = coupleResolver.getActiveCouple(userId)
+        val user = userRepository.findById(userId)
+            .orElseThrow { NotFoundException("USER_NOT_FOUND", "User not found.") }
+
+        val lines = readCsvLines(file)
+        if (lines.isEmpty()) {
+            return CsvImportResponse(imported = 0, skipped = 0, errors = emptyList())
+        }
+
+        if (lines.size > MAX_ROWS) {
+            throw BusinessException("VALIDATION_ERROR", "CSV file exceeds maximum of $MAX_ROWS rows.")
+        }
+
+        // Pre-fetch categories and payment methods for the couple (batch lookup)
+        val categories = categoryRepository.findByCoupleId(couple.id)
+        val categoryByNameLower = categories.associateBy { it.name.lowercase() }
+
+        val paymentMethods = paymentMethodRepository.findByCoupleIdOrderByDisplayOrder(couple.id)
+        val pmByNameLower = paymentMethods.associateBy { it.name.lowercase() }
+
+        val errors = mutableListOf<CsvImportError>()
+        val transactionsToSave = mutableListOf<Transaction>()
+
+        for ((index, line) in lines.withIndex()) {
+            val rowNumber = index + 2 // 1-based, skip header row
+            val result = parseCsvRow(line, rowNumber, couple, user, categoryByNameLower, pmByNameLower)
+            when (result) {
+                is RowParseResult.Success -> transactionsToSave.add(result.transaction)
+                is RowParseResult.Error -> errors.add(result.error)
+            }
+        }
+
+        // Batch insert in chunks of BATCH_SIZE
+        for (batch in transactionsToSave.chunked(BATCH_SIZE)) {
+            transactionRepository.saveAll(batch)
+        }
+
+        return CsvImportResponse(
+            imported = transactionsToSave.size,
+            skipped = errors.size,
+            errors = errors
+        )
+    }
+
+    private fun readCsvLines(file: MultipartFile): List<String> {
+        val reader = BufferedReader(InputStreamReader(file.inputStream, Charsets.UTF_8))
+        val allLines = reader.use { it.readLines() }
+
+        if (allLines.isEmpty()) return emptyList()
+
+        // Skip header (first line), strip BOM if present
+        val header = allLines[0].removePrefix(BOM).trim()
+        if (header.isBlank()) return emptyList()
+
+        // Return data lines only (skip empty lines)
+        return allLines.drop(1).filter { it.isNotBlank() }
+    }
+
+    private fun parseCsvRow(
+        line: String,
+        rowNumber: Int,
+        couple: Couple,
+        user: com.budgetbook.auth.domain.User,
+        categoryByNameLower: Map<String, com.budgetbook.category.domain.Category>,
+        pmByNameLower: Map<String, com.budgetbook.paymentmethod.domain.PaymentMethod>
+    ): RowParseResult {
+        val fields = parseCsvFields(line)
+
+        // Expected columns: date, type, amount, description, categoryName, paymentMethodName
+        if (fields.size < 4) {
+            return RowParseResult.Error(CsvImportError(rowNumber, "Not enough columns. Expected at least: date, type, amount, description."))
+        }
+
+        val dateStr = fields[0].trim()
+        val typeStr = fields[1].trim()
+        val amountStr = fields[2].trim()
+        val description = fields[3].trim()
+        val categoryName = fields.getOrNull(4)?.trim() ?: ""
+        val paymentMethodName = fields.getOrNull(5)?.trim() ?: ""
+
+        // Parse date
+        val date = try {
+            LocalDate.parse(dateStr)
+        } catch (e: DateTimeParseException) {
+            return RowParseResult.Error(CsvImportError(rowNumber, "Invalid date format: $dateStr"))
+        }
+
+        // Parse type (accept both Korean and enum names)
+        val transactionType = when (typeStr.lowercase()) {
+            "income", "\uc218\uc785" -> TransactionType.INCOME
+            "expense", "\uc9c0\ucd9c" -> TransactionType.EXPENSE
+            else -> return RowParseResult.Error(CsvImportError(rowNumber, "Invalid transaction type: $typeStr"))
+        }
+
+        // Parse amount
+        val amount = try {
+            amountStr.toLong()
+        } catch (e: NumberFormatException) {
+            return RowParseResult.Error(CsvImportError(rowNumber, "Invalid amount: $amountStr"))
+        }
+
+        if (amount <= 0) {
+            return RowParseResult.Error(CsvImportError(rowNumber, "Amount must be positive: $amount"))
+        }
+
+        if (description.isBlank()) {
+            return RowParseResult.Error(CsvImportError(rowNumber, "Description cannot be empty."))
+        }
+
+        // Match category by name (case-insensitive)
+        val category = if (categoryName.isNotBlank()) {
+            val matched = categoryByNameLower[categoryName.lowercase()]
+            if (matched == null) {
+                return RowParseResult.Error(CsvImportError(rowNumber, "Category not found: $categoryName"))
+            }
+            matched
+        } else {
+            null
+        }
+
+        // Match payment method by name (case-insensitive)
+        val paymentMethod = if (paymentMethodName.isNotBlank()) {
+            val matched = pmByNameLower[paymentMethodName.lowercase()]
+            if (matched == null) {
+                return RowParseResult.Error(CsvImportError(rowNumber, "Payment method not found: $paymentMethodName"))
+            }
+            matched
+        } else {
+            null
+        }
+
+        val transaction = Transaction(
+            couple = couple,
+            author = user,
+            category = category,
+            type = transactionType,
+            amount = amount,
+            description = description,
+            transactionDate = date,
+            paymentMethod = paymentMethod
+        )
+
+        return RowParseResult.Success(transaction)
+    }
+
+    /**
+     * Parse CSV fields handling quoted fields with embedded commas and quotes.
+     */
+    private fun parseCsvFields(line: String): List<String> {
+        val fields = mutableListOf<String>()
+        val current = StringBuilder()
+        var inQuotes = false
+        var i = 0
+
+        while (i < line.length) {
+            val c = line[i]
+            when {
+                c == '"' && !inQuotes -> {
+                    inQuotes = true
+                }
+                c == '"' && inQuotes -> {
+                    // Check for escaped quote ""
+                    if (i + 1 < line.length && line[i + 1] == '"') {
+                        current.append('"')
+                        i++ // skip next quote
+                    } else {
+                        inQuotes = false
+                    }
+                }
+                c == ',' && !inQuotes -> {
+                    fields.add(current.toString())
+                    current.clear()
+                }
+                else -> {
+                    current.append(c)
+                }
+            }
+            i++
+        }
+        fields.add(current.toString())
+
+        return fields
+    }
+
+    private sealed class RowParseResult {
+        data class Success(val transaction: Transaction) : RowParseResult()
+        data class Error(val error: CsvImportError) : RowParseResult()
+    }
+}

--- a/backend/src/test/kotlin/com/budgetbook/budget/controller/BudgetControllerTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/budget/controller/BudgetControllerTest.kt
@@ -10,6 +10,7 @@ import com.budgetbook.budget.dto.CurrentWeekSummaryResponse
 import com.budgetbook.budget.dto.WeeklyGroupSummary
 import com.budgetbook.budget.dto.WeeklyOverviewResponse
 import com.budgetbook.budget.dto.WeeklySnapshotResponse
+import com.budgetbook.budget.service.BudgetAlertService
 import com.budgetbook.budget.service.BudgetService
 import com.budgetbook.budget.service.WeeklyBudgetService
 import com.budgetbook.transaction.dto.CategorySummary
@@ -29,7 +30,8 @@ class BudgetControllerTest : FunSpec({
 
     val budgetService = mockk<BudgetService>()
     val weeklyBudgetService = mockk<WeeklyBudgetService>()
-    val controller = BudgetController(budgetService, weeklyBudgetService)
+    val budgetAlertService = mockk<BudgetAlertService>()
+    val controller = BudgetController(budgetService, weeklyBudgetService, budgetAlertService)
     val testUserId = UUID.randomUUID()
 
     fun createAuth(userId: UUID): Authentication =

--- a/backend/src/test/kotlin/com/budgetbook/budget/service/BudgetAlertServiceTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/budget/service/BudgetAlertServiceTest.kt
@@ -1,0 +1,346 @@
+package com.budgetbook.budget.service
+
+import com.budgetbook.auth.domain.AuthProvider
+import com.budgetbook.auth.domain.User
+import com.budgetbook.budget.domain.MonthlyBudget
+import com.budgetbook.budget.repository.MonthlyBudgetRepository
+import com.budgetbook.category.domain.Category
+import com.budgetbook.category.domain.CategoryType
+import com.budgetbook.common.exception.NotFoundException
+import com.budgetbook.couple.domain.Couple
+import com.budgetbook.couple.domain.CoupleStatus
+import com.budgetbook.couple.service.CoupleResolver
+import com.budgetbook.transaction.domain.TransactionType
+import com.budgetbook.transaction.repository.TransactionRepository
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import java.time.LocalDate
+import java.util.UUID
+
+class BudgetAlertServiceTest : BehaviorSpec({
+
+    isolationMode = IsolationMode.InstancePerLeaf
+
+    val budgetRepository = mockk<MonthlyBudgetRepository>()
+    val transactionRepository = mockk<TransactionRepository>()
+    val coupleResolver = mockk<CoupleResolver>()
+    val service = BudgetAlertService(budgetRepository, transactionRepository, coupleResolver)
+
+    val user1 = User(email = "u1@test.com", nickname = "U1", provider = AuthProvider.GOOGLE, providerId = "g1")
+    val user2 = User(email = "u2@test.com", nickname = "U2", provider = AuthProvider.KAKAO, providerId = "k2")
+    val couple = Couple(user1 = user1, user2 = user2, status = CoupleStatus.ACTIVE)
+
+    val foodCategory = Category(couple = couple, name = "Food", type = CategoryType.EXPENSE, icon = "restaurant", color = "#FF0000")
+    val transportCategory = Category(couple = couple, name = "Transport", type = CategoryType.EXPENSE, icon = "car", color = "#0000FF")
+    val entertainmentCategory = Category(couple = couple, name = "Entertainment", type = CategoryType.EXPENSE, icon = "movie", color = "#00FF00")
+
+    Given("budgets with varying spending levels") {
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
+
+        val foodBudget = MonthlyBudget(couple = couple, category = foodCategory, yearMonth = "2026-03", amount = 500000)
+        val transportBudget = MonthlyBudget(couple = couple, category = transportCategory, yearMonth = "2026-03", amount = 200000)
+        val entertainmentBudget = MonthlyBudget(couple = couple, category = entertainmentCategory, yearMonth = "2026-03", amount = 100000)
+
+        every { budgetRepository.findByCoupleIdAndYearMonth(couple.id, "2026-03") } returns
+            listOf(foodBudget, transportBudget, entertainmentBudget)
+
+        // Food: 450000/500000 = 90% -> WARNING
+        // Transport: 210000/200000 = 105% -> EXCEEDED
+        // Entertainment: 50000/100000 = 50% -> SAFE (excluded)
+        every {
+            transactionRepository.sumByCategoryForCouple(
+                couple.id,
+                LocalDate.of(2026, 3, 1),
+                LocalDate.of(2026, 3, 31),
+                TransactionType.EXPENSE
+            )
+        } returns listOf(
+            arrayOf(450000L, 15L, foodCategory.id, "Food", CategoryType.EXPENSE, "restaurant", "#FF0000"),
+            arrayOf(210000L, 8L, transportCategory.id, "Transport", CategoryType.EXPENSE, "car", "#0000FF"),
+            arrayOf(50000L, 3L, entertainmentCategory.id, "Entertainment", CategoryType.EXPENSE, "movie", "#00FF00")
+        )
+
+        every {
+            transactionRepository.sumAmountByCoupleIdAndDateRange(
+                couple.id,
+                LocalDate.of(2026, 3, 1),
+                LocalDate.of(2026, 3, 31),
+                TransactionType.EXPENSE
+            )
+        } returns 710000L
+
+        When("getBudgetAlerts is called") {
+            val result = service.getBudgetAlerts(user1.id, "2026-03")
+
+            Then("returns only WARNING and EXCEEDED alerts") {
+                result shouldHaveSize 2
+            }
+
+            Then("food budget shows WARNING") {
+                val foodAlert = result.find { it.categoryName == "Food" }!!
+                foodAlert.budgetAmount shouldBe 500000
+                foodAlert.spentAmount shouldBe 450000
+                foodAlert.percentage shouldBe 90
+                foodAlert.alertLevel shouldBe "WARNING"
+            }
+
+            Then("transport budget shows EXCEEDED") {
+                val transportAlert = result.find { it.categoryName == "Transport" }!!
+                transportAlert.budgetAmount shouldBe 200000
+                transportAlert.spentAmount shouldBe 210000
+                transportAlert.percentage shouldBe 105
+                transportAlert.alertLevel shouldBe "EXCEEDED"
+            }
+        }
+    }
+
+    Given("all budgets are under 80%") {
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
+
+        val budget = MonthlyBudget(couple = couple, category = foodCategory, yearMonth = "2026-03", amount = 500000)
+
+        every { budgetRepository.findByCoupleIdAndYearMonth(couple.id, "2026-03") } returns listOf(budget)
+
+        every {
+            transactionRepository.sumByCategoryForCouple(
+                couple.id,
+                LocalDate.of(2026, 3, 1),
+                LocalDate.of(2026, 3, 31),
+                TransactionType.EXPENSE
+            )
+        } returns listOf(
+            arrayOf(200000L, 5L, foodCategory.id, "Food", CategoryType.EXPENSE, "restaurant", "#FF0000")
+        )
+
+        every {
+            transactionRepository.sumAmountByCoupleIdAndDateRange(
+                couple.id,
+                LocalDate.of(2026, 3, 1),
+                LocalDate.of(2026, 3, 31),
+                TransactionType.EXPENSE
+            )
+        } returns 200000L
+
+        When("getBudgetAlerts is called") {
+            val result = service.getBudgetAlerts(user1.id, "2026-03")
+
+            Then("returns empty list") {
+                result shouldHaveSize 0
+            }
+        }
+    }
+
+    Given("no budgets for the month") {
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
+        every { budgetRepository.findByCoupleIdAndYearMonth(couple.id, "2026-03") } returns emptyList()
+
+        When("getBudgetAlerts is called") {
+            val result = service.getBudgetAlerts(user1.id, "2026-03")
+
+            Then("returns empty list") {
+                result shouldHaveSize 0
+            }
+        }
+    }
+
+    Given("a total budget (no category) that is exceeded") {
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
+
+        val totalBudget = MonthlyBudget(couple = couple, category = null, yearMonth = "2026-03", amount = 1000000)
+
+        every { budgetRepository.findByCoupleIdAndYearMonth(couple.id, "2026-03") } returns listOf(totalBudget)
+
+        every {
+            transactionRepository.sumByCategoryForCouple(
+                couple.id,
+                LocalDate.of(2026, 3, 1),
+                LocalDate.of(2026, 3, 31),
+                TransactionType.EXPENSE
+            )
+        } returns emptyList()
+
+        every {
+            transactionRepository.sumAmountByCoupleIdAndDateRange(
+                couple.id,
+                LocalDate.of(2026, 3, 1),
+                LocalDate.of(2026, 3, 31),
+                TransactionType.EXPENSE
+            )
+        } returns 1100000L
+
+        When("getBudgetAlerts is called") {
+            val result = service.getBudgetAlerts(user1.id, "2026-03")
+
+            Then("returns EXCEEDED alert for total budget") {
+                result shouldHaveSize 1
+                result[0].categoryName shouldBe "Total"
+                result[0].categoryId shouldBe ""
+                result[0].percentage shouldBe 110
+                result[0].alertLevel shouldBe "EXCEEDED"
+            }
+        }
+    }
+
+    Given("a budget at exactly 80%") {
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
+
+        val budget = MonthlyBudget(couple = couple, category = foodCategory, yearMonth = "2026-03", amount = 100000)
+
+        every { budgetRepository.findByCoupleIdAndYearMonth(couple.id, "2026-03") } returns listOf(budget)
+
+        every {
+            transactionRepository.sumByCategoryForCouple(
+                couple.id,
+                LocalDate.of(2026, 3, 1),
+                LocalDate.of(2026, 3, 31),
+                TransactionType.EXPENSE
+            )
+        } returns listOf(
+            arrayOf(80000L, 5L, foodCategory.id, "Food", CategoryType.EXPENSE, "restaurant", "#FF0000")
+        )
+
+        every {
+            transactionRepository.sumAmountByCoupleIdAndDateRange(
+                couple.id,
+                LocalDate.of(2026, 3, 1),
+                LocalDate.of(2026, 3, 31),
+                TransactionType.EXPENSE
+            )
+        } returns 80000L
+
+        When("getBudgetAlerts is called") {
+            val result = service.getBudgetAlerts(user1.id, "2026-03")
+
+            Then("returns WARNING (80% is the threshold)") {
+                result shouldHaveSize 1
+                result[0].percentage shouldBe 80
+                result[0].alertLevel shouldBe "WARNING"
+            }
+        }
+    }
+
+    Given("a budget at exactly 100%") {
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
+
+        val budget = MonthlyBudget(couple = couple, category = foodCategory, yearMonth = "2026-03", amount = 100000)
+
+        every { budgetRepository.findByCoupleIdAndYearMonth(couple.id, "2026-03") } returns listOf(budget)
+
+        every {
+            transactionRepository.sumByCategoryForCouple(
+                couple.id,
+                LocalDate.of(2026, 3, 1),
+                LocalDate.of(2026, 3, 31),
+                TransactionType.EXPENSE
+            )
+        } returns listOf(
+            arrayOf(100000L, 10L, foodCategory.id, "Food", CategoryType.EXPENSE, "restaurant", "#FF0000")
+        )
+
+        every {
+            transactionRepository.sumAmountByCoupleIdAndDateRange(
+                couple.id,
+                LocalDate.of(2026, 3, 1),
+                LocalDate.of(2026, 3, 31),
+                TransactionType.EXPENSE
+            )
+        } returns 100000L
+
+        When("getBudgetAlerts is called") {
+            val result = service.getBudgetAlerts(user1.id, "2026-03")
+
+            Then("returns EXCEEDED (100% threshold)") {
+                result shouldHaveSize 1
+                result[0].percentage shouldBe 100
+                result[0].alertLevel shouldBe "EXCEEDED"
+            }
+        }
+    }
+
+    Given("a budget with zero amount") {
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
+
+        val budget = MonthlyBudget(couple = couple, category = foodCategory, yearMonth = "2026-03", amount = 0)
+
+        every { budgetRepository.findByCoupleIdAndYearMonth(couple.id, "2026-03") } returns listOf(budget)
+
+        every {
+            transactionRepository.sumByCategoryForCouple(
+                couple.id,
+                LocalDate.of(2026, 3, 1),
+                LocalDate.of(2026, 3, 31),
+                TransactionType.EXPENSE
+            )
+        } returns emptyList()
+
+        every {
+            transactionRepository.sumAmountByCoupleIdAndDateRange(
+                couple.id,
+                LocalDate.of(2026, 3, 1),
+                LocalDate.of(2026, 3, 31),
+                TransactionType.EXPENSE
+            )
+        } returns 0L
+
+        When("getBudgetAlerts is called") {
+            val result = service.getBudgetAlerts(user1.id, "2026-03")
+
+            Then("returns empty (0% is SAFE)") {
+                result shouldHaveSize 0
+            }
+        }
+    }
+
+    Given("a user not in an active couple") {
+        every { coupleResolver.getActiveCouple(user1.id) } throws NotFoundException("COUPLE_NOT_FOUND", "User is not in an active couple.")
+
+        When("getBudgetAlerts is called") {
+            Then("throws NotFoundException") {
+                val ex = shouldThrow<NotFoundException> {
+                    service.getBudgetAlerts(user1.id, "2026-03")
+                }
+                ex.code shouldBe "COUPLE_NOT_FOUND"
+            }
+        }
+    }
+
+    Given("a category budget with no spending") {
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
+
+        val budget = MonthlyBudget(couple = couple, category = foodCategory, yearMonth = "2026-03", amount = 500000)
+
+        every { budgetRepository.findByCoupleIdAndYearMonth(couple.id, "2026-03") } returns listOf(budget)
+
+        // No spending for food category
+        every {
+            transactionRepository.sumByCategoryForCouple(
+                couple.id,
+                LocalDate.of(2026, 3, 1),
+                LocalDate.of(2026, 3, 31),
+                TransactionType.EXPENSE
+            )
+        } returns emptyList()
+
+        every {
+            transactionRepository.sumAmountByCoupleIdAndDateRange(
+                couple.id,
+                LocalDate.of(2026, 3, 1),
+                LocalDate.of(2026, 3, 31),
+                TransactionType.EXPENSE
+            )
+        } returns 0L
+
+        When("getBudgetAlerts is called") {
+            val result = service.getBudgetAlerts(user1.id, "2026-03")
+
+            Then("returns empty since 0% is SAFE") {
+                result shouldHaveSize 0
+            }
+        }
+    }
+})

--- a/backend/src/test/kotlin/com/budgetbook/statistics/controller/StatisticsControllerTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/statistics/controller/StatisticsControllerTest.kt
@@ -3,6 +3,7 @@ package com.budgetbook.statistics.controller
 import com.budgetbook.statistics.dto.CategoryStatisticsResponse
 import com.budgetbook.statistics.dto.MonthlyTrendResponse
 import com.budgetbook.statistics.dto.StatisticsSummaryResponse
+import com.budgetbook.statistics.service.PaymentMethodStatisticsService
 import com.budgetbook.statistics.service.StatisticsService
 import com.budgetbook.transaction.dto.CategorySummary
 import io.kotest.core.spec.style.FunSpec
@@ -16,7 +17,8 @@ import java.util.UUID
 class StatisticsControllerTest : FunSpec({
 
     val statisticsService = mockk<StatisticsService>()
-    val controller = StatisticsController(statisticsService)
+    val paymentMethodStatisticsService = mockk<PaymentMethodStatisticsService>()
+    val controller = StatisticsController(statisticsService, paymentMethodStatisticsService)
     val testUserId = UUID.randomUUID()
 
     fun createAuth(userId: UUID): Authentication =

--- a/backend/src/test/kotlin/com/budgetbook/statistics/service/PaymentMethodStatisticsServiceTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/statistics/service/PaymentMethodStatisticsServiceTest.kt
@@ -1,0 +1,160 @@
+package com.budgetbook.statistics.service
+
+import com.budgetbook.auth.domain.AuthProvider
+import com.budgetbook.auth.domain.User
+import com.budgetbook.common.exception.NotFoundException
+import com.budgetbook.couple.domain.Couple
+import com.budgetbook.couple.domain.CoupleStatus
+import com.budgetbook.couple.service.CoupleResolver
+import com.budgetbook.transaction.repository.TransactionRepository
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import java.time.LocalDate
+import java.util.UUID
+
+class PaymentMethodStatisticsServiceTest : BehaviorSpec({
+
+    isolationMode = IsolationMode.InstancePerLeaf
+
+    val transactionRepository = mockk<TransactionRepository>()
+    val coupleResolver = mockk<CoupleResolver>()
+    val service = PaymentMethodStatisticsService(transactionRepository, coupleResolver)
+
+    val user1 = User(email = "u1@test.com", nickname = "U1", provider = AuthProvider.GOOGLE, providerId = "g1")
+    val user2 = User(email = "u2@test.com", nickname = "U2", provider = AuthProvider.KAKAO, providerId = "k2")
+    val couple = Couple(user1 = user1, user2 = user2, status = CoupleStatus.ACTIVE)
+
+    val pmId1 = UUID.randomUUID()
+    val pmId2 = UUID.randomUUID()
+
+    Given("a user in an active couple with payment method spending") {
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
+
+        every {
+            transactionRepository.sumByPaymentMethodForCouple(
+                couple.id,
+                LocalDate.of(2026, 3, 1),
+                LocalDate.of(2026, 3, 31)
+            )
+        } returns listOf(
+            arrayOf(pmId1, "Shinhan Card", 800000L, 20L),
+            arrayOf(pmId2, "Cash", 200000L, 15L)
+        )
+
+        When("getPaymentMethodStats is called") {
+            val result = service.getPaymentMethodStats(user1.id, 2026, 3)
+
+            Then("returns statistics for each payment method") {
+                result shouldHaveSize 2
+            }
+
+            Then("first payment method has correct values") {
+                result[0].paymentMethodId shouldBe pmId1.toString()
+                result[0].paymentMethodName shouldBe "Shinhan Card"
+                result[0].totalAmount shouldBe 800000L
+                result[0].transactionCount shouldBe 20
+                result[0].percentage shouldBe 80.0
+            }
+
+            Then("second payment method has correct values") {
+                result[1].paymentMethodId shouldBe pmId2.toString()
+                result[1].paymentMethodName shouldBe "Cash"
+                result[1].totalAmount shouldBe 200000L
+                result[1].transactionCount shouldBe 15
+                result[1].percentage shouldBe 20.0
+            }
+        }
+    }
+
+    Given("a user with no expense transactions") {
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
+
+        every {
+            transactionRepository.sumByPaymentMethodForCouple(
+                couple.id,
+                LocalDate.of(2026, 3, 1),
+                LocalDate.of(2026, 3, 31)
+            )
+        } returns emptyList()
+
+        When("getPaymentMethodStats is called") {
+            val result = service.getPaymentMethodStats(user1.id, 2026, 3)
+
+            Then("returns empty list") {
+                result shouldHaveSize 0
+            }
+        }
+    }
+
+    Given("a single payment method used for all expenses") {
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
+
+        every {
+            transactionRepository.sumByPaymentMethodForCouple(
+                couple.id,
+                LocalDate.of(2026, 3, 1),
+                LocalDate.of(2026, 3, 31)
+            )
+        } returns listOf(
+            arrayOf(pmId1, "KB Card", 500000L, 30L)
+        )
+
+        When("getPaymentMethodStats is called") {
+            val result = service.getPaymentMethodStats(user1.id, 2026, 3)
+
+            Then("single payment method has 100% share") {
+                result shouldHaveSize 1
+                result[0].percentage shouldBe 100.0
+                result[0].totalAmount shouldBe 500000L
+                result[0].transactionCount shouldBe 30
+            }
+        }
+    }
+
+    Given("a user not in an active couple") {
+        every { coupleResolver.getActiveCouple(user1.id) } throws NotFoundException("COUPLE_NOT_FOUND", "User is not in an active couple.")
+
+        When("getPaymentMethodStats is called") {
+            Then("throws NotFoundException") {
+                val ex = shouldThrow<NotFoundException> {
+                    service.getPaymentMethodStats(user1.id, 2026, 3)
+                }
+                ex.code shouldBe "COUPLE_NOT_FOUND"
+            }
+        }
+    }
+
+    Given("three payment methods with varying amounts") {
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
+
+        val pmId3 = UUID.randomUUID()
+
+        every {
+            transactionRepository.sumByPaymentMethodForCouple(
+                couple.id,
+                LocalDate.of(2026, 3, 1),
+                LocalDate.of(2026, 3, 31)
+            )
+        } returns listOf(
+            arrayOf(pmId1, "Card A", 700000L, 10L),
+            arrayOf(pmId2, "Card B", 200000L, 5L),
+            arrayOf(pmId3, "Cash", 100000L, 20L)
+        )
+
+        When("getPaymentMethodStats is called") {
+            val result = service.getPaymentMethodStats(user1.id, 2026, 3)
+
+            Then("percentages add up correctly") {
+                result shouldHaveSize 3
+                result[0].percentage shouldBe 70.0
+                result[1].percentage shouldBe 20.0
+                result[2].percentage shouldBe 10.0
+            }
+        }
+    }
+})

--- a/backend/src/test/kotlin/com/budgetbook/transaction/controller/TransactionControllerTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/transaction/controller/TransactionControllerTest.kt
@@ -6,6 +6,7 @@ import com.budgetbook.transaction.dto.PageResponse
 import com.budgetbook.transaction.dto.TransactionResponse
 import com.budgetbook.transaction.dto.UpdateTransactionRequest
 import com.budgetbook.transaction.service.TransactionExportService
+import com.budgetbook.transaction.service.TransactionImportService
 import com.budgetbook.transaction.service.TransactionService
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
@@ -24,7 +25,8 @@ class TransactionControllerTest : FunSpec({
 
     val transactionService = mockk<TransactionService>()
     val transactionExportService = mockk<TransactionExportService>()
-    val controller = TransactionController(transactionService, transactionExportService)
+    val transactionImportService = mockk<TransactionImportService>()
+    val controller = TransactionController(transactionService, transactionExportService, transactionImportService)
     val testUserId = UUID.randomUUID()
 
     fun createAuth(userId: UUID): Authentication =

--- a/backend/src/test/kotlin/com/budgetbook/transaction/service/TransactionImportServiceTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/transaction/service/TransactionImportServiceTest.kt
@@ -1,0 +1,398 @@
+package com.budgetbook.transaction.service
+
+import com.budgetbook.auth.domain.AuthProvider
+import com.budgetbook.auth.domain.User
+import com.budgetbook.auth.repository.UserRepository
+import com.budgetbook.category.domain.Category
+import com.budgetbook.category.domain.CategoryType
+import com.budgetbook.category.repository.CategoryRepository
+import com.budgetbook.common.exception.BusinessException
+import com.budgetbook.common.exception.NotFoundException
+import com.budgetbook.couple.domain.Couple
+import com.budgetbook.couple.domain.CoupleStatus
+import com.budgetbook.couple.service.CoupleResolver
+import com.budgetbook.paymentmethod.domain.PaymentMethod
+import com.budgetbook.paymentmethod.domain.PaymentMethodType
+import com.budgetbook.paymentmethod.repository.PaymentMethodRepository
+import com.budgetbook.transaction.domain.Transaction
+import com.budgetbook.transaction.repository.TransactionRepository
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.springframework.web.multipart.MultipartFile
+import java.io.ByteArrayInputStream
+import java.util.Optional
+import java.util.UUID
+
+class TransactionImportServiceTest : BehaviorSpec({
+
+    isolationMode = IsolationMode.InstancePerLeaf
+
+    val transactionRepository = mockk<TransactionRepository>()
+    val coupleResolver = mockk<CoupleResolver>()
+    val userRepository = mockk<UserRepository>()
+    val categoryRepository = mockk<CategoryRepository>()
+    val paymentMethodRepository = mockk<PaymentMethodRepository>()
+    val service = TransactionImportService(
+        transactionRepository, coupleResolver, userRepository, categoryRepository, paymentMethodRepository
+    )
+
+    val user1 = User(email = "u1@test.com", nickname = "U1", provider = AuthProvider.GOOGLE, providerId = "g1")
+    val user2 = User(email = "u2@test.com", nickname = "U2", provider = AuthProvider.KAKAO, providerId = "k2")
+    val couple = Couple(user1 = user1, user2 = user2, status = CoupleStatus.ACTIVE)
+
+    val foodCategory = Category(couple = couple, name = "Food", type = CategoryType.EXPENSE, icon = "restaurant", color = "#FF0000")
+    val salaryCategory = Category(couple = couple, name = "Salary", type = CategoryType.INCOME, icon = "work", color = "#00FF00")
+
+    val creditCard = PaymentMethod(couple = couple, name = "Shinhan Card", type = PaymentMethodType.CREDIT)
+    val cashMethod = PaymentMethod(couple = couple, name = "Cash", type = PaymentMethodType.CASH)
+
+    fun mockFile(content: String): MultipartFile {
+        val file = mockk<MultipartFile>()
+        every { file.inputStream } returns ByteArrayInputStream(content.toByteArray(Charsets.UTF_8))
+        return file
+    }
+
+    fun setupCommonMocks() {
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
+        every { userRepository.findById(user1.id) } returns Optional.of(user1)
+        every { categoryRepository.findByCoupleId(couple.id) } returns listOf(foodCategory, salaryCategory)
+        every { paymentMethodRepository.findByCoupleIdOrderByDisplayOrder(couple.id) } returns listOf(creditCard, cashMethod)
+    }
+
+    Given("a valid CSV file with matching categories and payment methods") {
+        setupCommonMocks()
+        every { transactionRepository.saveAll(any<List<Transaction>>()) } answers { firstArg() }
+
+        val csv = """date,type,amount,description,categoryName,paymentMethodName
+2026-03-01,INCOME,3000000,Monthly salary,Salary,
+2026-03-05,EXPENSE,15000,Lunch,Food,Shinhan Card
+2026-03-10,EXPENSE,5000,Coffee,Food,Cash"""
+
+        When("importCsv is called") {
+            val result = service.importCsv(user1.id, mockFile(csv))
+
+            Then("all rows are imported successfully") {
+                result.imported shouldBe 3
+                result.skipped shouldBe 0
+                result.errors.size shouldBe 0
+            }
+
+            Then("transactions are saved in batches") {
+                verify(exactly = 1) { transactionRepository.saveAll(any<List<Transaction>>()) }
+            }
+        }
+    }
+
+    Given("a CSV file with BOM prefix") {
+        setupCommonMocks()
+        every { transactionRepository.saveAll(any<List<Transaction>>()) } answers { firstArg() }
+
+        val csv = "\uFEFFdate,type,amount,description,categoryName,paymentMethodName\n2026-03-01,EXPENSE,10000,Test,Food,"
+
+        When("importCsv is called") {
+            val result = service.importCsv(user1.id, mockFile(csv))
+
+            Then("BOM is handled correctly") {
+                result.imported shouldBe 1
+                result.skipped shouldBe 0
+            }
+        }
+    }
+
+    Given("a CSV file with Korean type names") {
+        setupCommonMocks()
+        every { transactionRepository.saveAll(any<List<Transaction>>()) } answers { firstArg() }
+
+        val csv = "date,type,amount,description,categoryName,paymentMethodName\n2026-03-01,\uc218\uc785,3000000,\uc6d4\uae09,Salary,\n2026-03-05,\uc9c0\ucd9c,15000,\uc810\uc2ec,Food,"
+
+        When("importCsv is called") {
+            val result = service.importCsv(user1.id, mockFile(csv))
+
+            Then("Korean type names are parsed correctly") {
+                result.imported shouldBe 2
+                result.skipped shouldBe 0
+            }
+        }
+    }
+
+    Given("a CSV file with unmatched category") {
+        setupCommonMocks()
+        every { transactionRepository.saveAll(any<List<Transaction>>()) } answers { firstArg() }
+
+        val csv = "date,type,amount,description,categoryName,paymentMethodName\n2026-03-01,EXPENSE,10000,Test,NonExistentCategory,"
+
+        When("importCsv is called") {
+            val result = service.importCsv(user1.id, mockFile(csv))
+
+            Then("the row is skipped with error") {
+                result.imported shouldBe 0
+                result.skipped shouldBe 1
+                result.errors[0].row shouldBe 2
+                result.errors[0].reason shouldBe "Category not found: NonExistentCategory"
+            }
+        }
+    }
+
+    Given("a CSV file with unmatched payment method") {
+        setupCommonMocks()
+        every { transactionRepository.saveAll(any<List<Transaction>>()) } answers { firstArg() }
+
+        val csv = "date,type,amount,description,categoryName,paymentMethodName\n2026-03-01,EXPENSE,10000,Test,Food,Unknown Card"
+
+        When("importCsv is called") {
+            val result = service.importCsv(user1.id, mockFile(csv))
+
+            Then("the row is skipped with error") {
+                result.imported shouldBe 0
+                result.skipped shouldBe 1
+                result.errors[0].row shouldBe 2
+                result.errors[0].reason shouldBe "Payment method not found: Unknown Card"
+            }
+        }
+    }
+
+    Given("a CSV file with invalid date") {
+        setupCommonMocks()
+        every { transactionRepository.saveAll(any<List<Transaction>>()) } answers { firstArg() }
+
+        val csv = "date,type,amount,description,categoryName,paymentMethodName\nnot-a-date,EXPENSE,10000,Test,Food,"
+
+        When("importCsv is called") {
+            val result = service.importCsv(user1.id, mockFile(csv))
+
+            Then("the row is skipped with date error") {
+                result.imported shouldBe 0
+                result.skipped shouldBe 1
+                result.errors[0].row shouldBe 2
+                result.errors[0].reason shouldBe "Invalid date format: not-a-date"
+            }
+        }
+    }
+
+    Given("a CSV file with invalid amount") {
+        setupCommonMocks()
+        every { transactionRepository.saveAll(any<List<Transaction>>()) } answers { firstArg() }
+
+        val csv = "date,type,amount,description,categoryName,paymentMethodName\n2026-03-01,EXPENSE,abc,Test,Food,"
+
+        When("importCsv is called") {
+            val result = service.importCsv(user1.id, mockFile(csv))
+
+            Then("the row is skipped with amount error") {
+                result.imported shouldBe 0
+                result.skipped shouldBe 1
+                result.errors[0].row shouldBe 2
+                result.errors[0].reason shouldBe "Invalid amount: abc"
+            }
+        }
+    }
+
+    Given("a CSV file with zero amount") {
+        setupCommonMocks()
+        every { transactionRepository.saveAll(any<List<Transaction>>()) } answers { firstArg() }
+
+        val csv = "date,type,amount,description,categoryName,paymentMethodName\n2026-03-01,EXPENSE,0,Test,Food,"
+
+        When("importCsv is called") {
+            val result = service.importCsv(user1.id, mockFile(csv))
+
+            Then("the row is skipped with positive amount error") {
+                result.imported shouldBe 0
+                result.skipped shouldBe 1
+                result.errors[0].reason shouldBe "Amount must be positive: 0"
+            }
+        }
+    }
+
+    Given("a CSV file with invalid transaction type") {
+        setupCommonMocks()
+        every { transactionRepository.saveAll(any<List<Transaction>>()) } answers { firstArg() }
+
+        val csv = "date,type,amount,description,categoryName,paymentMethodName\n2026-03-01,INVALID_TYPE,10000,Test,Food,"
+
+        When("importCsv is called") {
+            val result = service.importCsv(user1.id, mockFile(csv))
+
+            Then("the row is skipped with type error") {
+                result.imported shouldBe 0
+                result.skipped shouldBe 1
+                result.errors[0].reason shouldBe "Invalid transaction type: INVALID_TYPE"
+            }
+        }
+    }
+
+    Given("a CSV file with mixed valid and invalid rows") {
+        setupCommonMocks()
+        every { transactionRepository.saveAll(any<List<Transaction>>()) } answers { firstArg() }
+
+        val csv = """date,type,amount,description,categoryName,paymentMethodName
+2026-03-01,EXPENSE,15000,Valid row,Food,
+bad-date,EXPENSE,10000,Bad date row,,
+2026-03-03,EXPENSE,5000,Another valid,Food,Cash"""
+
+        When("importCsv is called") {
+            val result = service.importCsv(user1.id, mockFile(csv))
+
+            Then("valid rows are imported, invalid rows are skipped") {
+                result.imported shouldBe 2
+                result.skipped shouldBe 1
+                result.errors[0].row shouldBe 3
+            }
+        }
+    }
+
+    Given("an empty CSV file") {
+        setupCommonMocks()
+
+        val csv = ""
+
+        When("importCsv is called") {
+            val result = service.importCsv(user1.id, mockFile(csv))
+
+            Then("returns zero imported") {
+                result.imported shouldBe 0
+                result.skipped shouldBe 0
+            }
+        }
+    }
+
+    Given("a CSV file with only header") {
+        setupCommonMocks()
+
+        val csv = "date,type,amount,description,categoryName,paymentMethodName"
+
+        When("importCsv is called") {
+            val result = service.importCsv(user1.id, mockFile(csv))
+
+            Then("returns zero imported") {
+                result.imported shouldBe 0
+                result.skipped shouldBe 0
+            }
+        }
+    }
+
+    Given("a CSV file with case-insensitive category matching") {
+        setupCommonMocks()
+        every { transactionRepository.saveAll(any<List<Transaction>>()) } answers { firstArg() }
+
+        val csv = "date,type,amount,description,categoryName,paymentMethodName\n2026-03-01,EXPENSE,10000,Test,food,shinhan card"
+
+        When("importCsv is called") {
+            val result = service.importCsv(user1.id, mockFile(csv))
+
+            Then("category and payment method are matched case-insensitively") {
+                result.imported shouldBe 1
+                result.skipped shouldBe 0
+            }
+        }
+    }
+
+    Given("a CSV file with quoted fields containing commas") {
+        setupCommonMocks()
+        every { transactionRepository.saveAll(any<List<Transaction>>()) } answers { firstArg() }
+
+        val csv = "date,type,amount,description,categoryName,paymentMethodName\n2026-03-01,EXPENSE,10000,\"Coffee, cake\",Food,"
+
+        When("importCsv is called") {
+            val result = service.importCsv(user1.id, mockFile(csv))
+
+            Then("quoted fields are parsed correctly") {
+                result.imported shouldBe 1
+                result.skipped shouldBe 0
+            }
+        }
+    }
+
+    Given("a CSV file with too few columns") {
+        setupCommonMocks()
+        every { transactionRepository.saveAll(any<List<Transaction>>()) } answers { firstArg() }
+
+        val csv = "date,type,amount,description\n2026-03-01,EXPENSE,10000"
+
+        When("importCsv is called") {
+            val result = service.importCsv(user1.id, mockFile(csv))
+
+            Then("the row is skipped with not enough columns error") {
+                result.imported shouldBe 0
+                result.skipped shouldBe 1
+                result.errors[0].reason shouldBe "Not enough columns. Expected at least: date, type, amount, description."
+            }
+        }
+    }
+
+    Given("a user not in an active couple") {
+        every { coupleResolver.getActiveCouple(user1.id) } throws NotFoundException("COUPLE_NOT_FOUND", "User is not in an active couple.")
+
+        When("importCsv is called") {
+            Then("throws NotFoundException") {
+                val ex = shouldThrow<NotFoundException> {
+                    service.importCsv(user1.id, mockFile("header\ndata"))
+                }
+                ex.code shouldBe "COUPLE_NOT_FOUND"
+            }
+        }
+    }
+
+    Given("a CSV with more than 1000 rows") {
+        setupCommonMocks()
+
+        val header = "date,type,amount,description,categoryName,paymentMethodName"
+        val rows = (1..1001).joinToString("\n") { "2026-03-01,EXPENSE,1000,Item $it,Food," }
+        val csv = "$header\n$rows"
+
+        When("importCsv is called") {
+            Then("throws BusinessException for exceeding max rows") {
+                val ex = shouldThrow<BusinessException> {
+                    service.importCsv(user1.id, mockFile(csv))
+                }
+                ex.code shouldBe "VALIDATION_ERROR"
+            }
+        }
+    }
+
+    Given("a CSV with rows that need batching") {
+        setupCommonMocks()
+        every { transactionRepository.saveAll(any<List<Transaction>>()) } answers { firstArg() }
+
+        // 60 rows should result in 2 batch saves (50 + 10)
+        val header = "date,type,amount,description,categoryName,paymentMethodName"
+        val rows = (1..60).joinToString("\n") { "2026-03-01,EXPENSE,1000,Item $it,Food," }
+        val csv = "$header\n$rows"
+
+        When("importCsv is called") {
+            val result = service.importCsv(user1.id, mockFile(csv))
+
+            Then("all rows are imported in batches") {
+                result.imported shouldBe 60
+                result.skipped shouldBe 0
+            }
+
+            Then("saveAll is called twice (batch size 50)") {
+                verify(exactly = 2) { transactionRepository.saveAll(any<List<Transaction>>()) }
+            }
+        }
+    }
+
+    Given("a CSV file with empty description") {
+        setupCommonMocks()
+        every { transactionRepository.saveAll(any<List<Transaction>>()) } answers { firstArg() }
+
+        val csv = "date,type,amount,description,categoryName,paymentMethodName\n2026-03-01,EXPENSE,10000,,Food,"
+
+        When("importCsv is called") {
+            val result = service.importCsv(user1.id, mockFile(csv))
+
+            Then("the row is skipped with empty description error") {
+                result.imported shouldBe 0
+                result.skipped shouldBe 1
+                result.errors[0].reason shouldBe "Description cannot be empty."
+            }
+        }
+    }
+})

--- a/frontend/lib/core/constants/api_endpoints.dart
+++ b/frontend/lib/core/constants/api_endpoints.dart
@@ -60,9 +60,18 @@ class ApiEndpoints {
   // Pocket Transfers
   static const String pocketTransfers = '/api/v1/pocket-transfers';
 
-  // Export
+  // Export / Import
   static const String transactionsExportCsv =
       '/api/v1/transactions/export/csv';
+  static const String transactionsImportCsv =
+      '/api/v1/transactions/import/csv';
+
+  // Budget Alerts
+  static const String budgetAlerts = '/api/v1/budgets/alerts';
+
+  // Statistics - Payment Methods
+  static const String statisticsPaymentMethods =
+      '/api/v1/statistics/payment-methods';
 
   // Admin
   static const String adminStats = '/api/v1/admin/stats';

--- a/frontend/lib/core/router/app_router.dart
+++ b/frontend/lib/core/router/app_router.dart
@@ -19,6 +19,8 @@ import 'package:budget_book/features/transaction/presentation/bloc/transaction_b
 import 'package:budget_book/features/transaction/presentation/bloc/transaction_event.dart';
 import 'package:budget_book/features/transaction/presentation/pages/transaction_list_page.dart';
 import 'package:budget_book/features/transaction/presentation/pages/transaction_form_page.dart';
+import 'package:budget_book/features/transaction/presentation/pages/transaction_import_page.dart';
+import 'package:budget_book/features/transaction/presentation/pages/transaction_detail_page.dart';
 import 'package:budget_book/features/budget/presentation/bloc/budget_bloc.dart';
 import 'package:budget_book/features/budget/presentation/bloc/budget_event.dart';
 import 'package:budget_book/features/budget/presentation/pages/budget_list_page.dart';
@@ -244,7 +246,8 @@ GoRouter createAppRouter(AuthBloc authBloc) => GoRouter(
                 final now = DateTime.now();
                 return BlocProvider<StatisticsBloc>(
                   create: (_) => getIt<StatisticsBloc>()
-                    ..add(LoadAllStatistics(year: now.year, month: now.month)),
+                    ..add(LoadAllStatistics(year: now.year, month: now.month))
+                    ..add(LoadPaymentMethodStats(year: now.year, month: now.month)),
                   child: const StatisticsPage(),
                 );
               },
@@ -329,6 +332,22 @@ GoRouter createAppRouter(AuthBloc authBloc) => GoRouter(
           child: TransactionFormPage(
             transactionId: transactionId,
           ),
+        );
+      },
+    ),
+    GoRoute(
+      path: '/transactions/import',
+      parentNavigatorKey: _rootNavigatorKey,
+      builder: (context, state) => const TransactionImportPage(),
+    ),
+    GoRoute(
+      path: '/transactions/detail/:id',
+      parentNavigatorKey: _rootNavigatorKey,
+      builder: (context, state) {
+        final transactionId = state.pathParameters['id']!;
+        return BlocProvider<TransactionBloc>.value(
+          value: getIt<TransactionBloc>(),
+          child: TransactionDetailPage(transactionId: transactionId),
         );
       },
     ),

--- a/frontend/lib/core/utils/web_download_stub.dart
+++ b/frontend/lib/core/utils/web_download_stub.dart
@@ -1,0 +1,4 @@
+// Stub implementation for non-web platforms
+void triggerBrowserDownload(List<int> bytes, String filename, String mimeType) {
+  throw UnsupportedError('triggerBrowserDownload is only available on web');
+}

--- a/frontend/lib/core/utils/web_download_web.dart
+++ b/frontend/lib/core/utils/web_download_web.dart
@@ -1,0 +1,11 @@
+import 'dart:convert';
+import 'package:web/web.dart' as web;
+
+void triggerBrowserDownload(List<int> bytes, String filename, String mimeType) {
+  final base64Data = base64Encode(bytes);
+  final dataUrl = 'data:$mimeType;base64,$base64Data';
+  final anchor = web.document.createElement('a') as web.HTMLAnchorElement;
+  anchor.href = dataUrl;
+  anchor.download = filename;
+  anchor.click();
+}

--- a/frontend/lib/features/budget/presentation/widgets/budget_alert_widget.dart
+++ b/frontend/lib/features/budget/presentation/widgets/budget_alert_widget.dart
@@ -1,0 +1,148 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:intl/intl.dart';
+import 'package:budget_book/features/home/presentation/bloc/dashboard_bloc.dart';
+import 'package:budget_book/features/home/presentation/bloc/dashboard_state.dart';
+import 'package:budget_book/features/budget/domain/entities/budget.dart';
+
+/// Shows budget alerts on the dashboard for categories that are
+/// at WARNING (>=80%) or EXCEEDED (>=100%) usage levels.
+class BudgetAlertWidget extends StatelessWidget {
+  const BudgetAlertWidget({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<DashboardBloc, DashboardState>(
+      builder: (context, state) {
+        if (state is! DashboardLoaded) return const SizedBox.shrink();
+        if (state.budgetSummary == null) return const SizedBox.shrink();
+
+        final alertItems = state.budgetSummary!.items
+            .where((item) => item.usageRate >= 80)
+            .toList()
+          ..sort((a, b) => b.usageRate.compareTo(a.usageRate));
+
+        if (alertItems.isEmpty) return const SizedBox.shrink();
+
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Padding(
+              padding: const EdgeInsets.only(bottom: 8),
+              child: Row(
+                children: [
+                  Icon(
+                    Icons.warning_amber_rounded,
+                    size: 20,
+                    color: Theme.of(context).colorScheme.error,
+                  ),
+                  const SizedBox(width: 6),
+                  Text(
+                    '예산 알림',
+                    style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                          fontWeight: FontWeight.bold,
+                        ),
+                  ),
+                ],
+              ),
+            ),
+            ...alertItems.map(
+              (item) => _BudgetAlertCard(item: item),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}
+
+class _BudgetAlertCard extends StatelessWidget {
+  final BudgetSummaryItem item;
+
+  const _BudgetAlertCard({required this.item});
+
+  static final _formatter = NumberFormat('#,###');
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isExceeded = item.usageRate >= 100;
+    final alertColor = isExceeded ? theme.colorScheme.error : Colors.orange;
+    final bgColor = isExceeded
+        ? theme.colorScheme.errorContainer.withValues(alpha: 0.5)
+        : Colors.orange.withValues(alpha: 0.1);
+
+    return Card(
+      color: bgColor,
+      elevation: 0,
+      margin: const EdgeInsets.only(bottom: 8),
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Expanded(
+                  child: Text(
+                    item.category?.name ?? '전체',
+                    style: theme.textTheme.titleSmall?.copyWith(
+                      fontWeight: FontWeight.w600,
+                    ),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+                Container(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+                  decoration: BoxDecoration(
+                    color: alertColor.withValues(alpha: 0.2),
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                  child: Text(
+                    isExceeded ? '초과' : '주의',
+                    style: theme.textTheme.labelSmall?.copyWith(
+                      color: alertColor,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            ClipRRect(
+              borderRadius: BorderRadius.circular(4),
+              child: LinearProgressIndicator(
+                value: (item.usageRate / 100).clamp(0.0, 1.0),
+                minHeight: 6,
+                backgroundColor: theme.colorScheme.surfaceContainerHighest,
+                color: alertColor,
+              ),
+            ),
+            const SizedBox(height: 6),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text(
+                  '${_formatter.format(item.spentAmount)}원 / ${_formatter.format(item.budgetAmount)}원',
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: theme.colorScheme.onSurface
+                        .withValues(alpha: 0.7),
+                  ),
+                ),
+                Text(
+                  '${item.usageRate.toStringAsFixed(0)}%',
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: alertColor,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/lib/features/home/presentation/pages/dashboard_page.dart
+++ b/frontend/lib/features/home/presentation/pages/dashboard_page.dart
@@ -10,6 +10,7 @@ import 'package:budget_book/features/budget/domain/entities/budget.dart';
 import 'package:budget_book/core/widgets/error_widget.dart';
 import 'package:budget_book/core/widgets/skeleton_loader.dart';
 import 'package:budget_book/core/widgets/announcement_banner.dart';
+import 'package:budget_book/features/budget/presentation/widgets/budget_alert_widget.dart';
 
 class DashboardPage extends StatelessWidget {
   const DashboardPage({super.key});
@@ -57,6 +58,8 @@ class DashboardPage extends StatelessWidget {
                 children: [
                   // Announcement banner
                   const AnnouncementBanner(),
+                  // Budget alerts
+                  const BudgetAlertWidget(),
                   // Month/Year header with navigation
                   _MonthHeader(year: state.year, month: state.month),
                   const SizedBox(height: 16),

--- a/frontend/lib/features/statistics/data/datasources/statistics_remote_datasource.dart
+++ b/frontend/lib/features/statistics/data/datasources/statistics_remote_datasource.dart
@@ -3,6 +3,7 @@ import 'package:budget_book/core/constants/api_endpoints.dart';
 import 'package:budget_book/features/statistics/data/models/statistics_summary_model.dart';
 import 'package:budget_book/features/statistics/data/models/category_statistics_model.dart';
 import 'package:budget_book/features/statistics/data/models/monthly_trend_model.dart';
+import 'package:budget_book/features/statistics/data/models/payment_method_statistics_model.dart';
 
 abstract class StatisticsRemoteDataSource {
   Future<StatisticsSummaryModel> getSummary({
@@ -18,6 +19,11 @@ abstract class StatisticsRemoteDataSource {
 
   Future<List<MonthlyTrendModel>> getMonthlyTrend({
     int months = 6,
+  });
+
+  Future<List<PaymentMethodStatisticsModel>> getPaymentMethodStats({
+    required int year,
+    required int month,
   });
 }
 
@@ -68,6 +74,22 @@ class StatisticsRemoteDataSourceImpl implements StatisticsRemoteDataSource {
     final data = response.data['data'] as List<dynamic>;
     return data
         .map((e) => MonthlyTrendModel.fromJson(e as Map<String, dynamic>))
+        .toList();
+  }
+
+  @override
+  Future<List<PaymentMethodStatisticsModel>> getPaymentMethodStats({
+    required int year,
+    required int month,
+  }) async {
+    final response = await apiClient.dio.get(
+      ApiEndpoints.statisticsPaymentMethods,
+      queryParameters: {'yearMonth': '$year-${month.toString().padLeft(2, '0')}'},
+    );
+    final data = response.data['data'] as List<dynamic>;
+    return data
+        .map((e) => PaymentMethodStatisticsModel.fromJson(
+            e as Map<String, dynamic>))
         .toList();
   }
 }

--- a/frontend/lib/features/statistics/data/models/payment_method_statistics_model.dart
+++ b/frontend/lib/features/statistics/data/models/payment_method_statistics_model.dart
@@ -1,0 +1,23 @@
+import 'package:budget_book/features/statistics/domain/entities/payment_method_statistics.dart';
+
+class PaymentMethodStatisticsModel extends PaymentMethodStatistics {
+  const PaymentMethodStatisticsModel({
+    required super.paymentMethodId,
+    required super.paymentMethodName,
+    super.paymentMethodType,
+    required super.totalAmount,
+    required super.transactionCount,
+    required super.percentage,
+  });
+
+  factory PaymentMethodStatisticsModel.fromJson(Map<String, dynamic> json) {
+    return PaymentMethodStatisticsModel(
+      paymentMethodId: json['paymentMethodId'] as String? ?? '',
+      paymentMethodName: json['paymentMethodName'] as String? ?? '미분류',
+      paymentMethodType: json['paymentMethodType'] as String?,
+      totalAmount: json['totalAmount'] as int? ?? 0,
+      transactionCount: json['transactionCount'] as int? ?? 0,
+      percentage: (json['percentage'] as num?)?.toDouble() ?? 0.0,
+    );
+  }
+}

--- a/frontend/lib/features/statistics/data/repositories/statistics_repository_impl.dart
+++ b/frontend/lib/features/statistics/data/repositories/statistics_repository_impl.dart
@@ -5,6 +5,7 @@ import 'package:budget_book/features/statistics/data/datasources/statistics_remo
 import 'package:budget_book/features/statistics/domain/entities/statistics_summary.dart';
 import 'package:budget_book/features/statistics/domain/entities/category_statistics.dart';
 import 'package:budget_book/features/statistics/domain/entities/monthly_trend.dart';
+import 'package:budget_book/features/statistics/domain/entities/payment_method_statistics.dart';
 import 'package:budget_book/features/statistics/domain/repositories/statistics_repository.dart';
 
 class StatisticsRepositoryImpl implements StatisticsRepository {
@@ -55,6 +56,23 @@ class StatisticsRepositoryImpl implements StatisticsRepository {
       return Right(result);
     } on DioException catch (e) {
       return Left(_mapDioError(e, '월별 추이를 불러오지 못했습니다'));
+    }
+  }
+
+  @override
+  Future<Either<Failure, List<PaymentMethodStatistics>>>
+      getPaymentMethodStats({
+    required int year,
+    required int month,
+  }) async {
+    try {
+      final result = await remoteDataSource.getPaymentMethodStats(
+        year: year,
+        month: month,
+      );
+      return Right(result);
+    } on DioException catch (e) {
+      return Left(_mapDioError(e, '결제수단별 통계를 불러오지 못했습니다'));
     }
   }
 

--- a/frontend/lib/features/statistics/domain/entities/payment_method_statistics.dart
+++ b/frontend/lib/features/statistics/domain/entities/payment_method_statistics.dart
@@ -1,0 +1,29 @@
+import 'package:equatable/equatable.dart';
+
+class PaymentMethodStatistics extends Equatable {
+  final String paymentMethodId;
+  final String paymentMethodName;
+  final String? paymentMethodType;
+  final int totalAmount;
+  final int transactionCount;
+  final double percentage;
+
+  const PaymentMethodStatistics({
+    required this.paymentMethodId,
+    required this.paymentMethodName,
+    this.paymentMethodType,
+    required this.totalAmount,
+    required this.transactionCount,
+    required this.percentage,
+  });
+
+  @override
+  List<Object?> get props => [
+        paymentMethodId,
+        paymentMethodName,
+        paymentMethodType,
+        totalAmount,
+        transactionCount,
+        percentage,
+      ];
+}

--- a/frontend/lib/features/statistics/domain/repositories/statistics_repository.dart
+++ b/frontend/lib/features/statistics/domain/repositories/statistics_repository.dart
@@ -3,6 +3,7 @@ import 'package:budget_book/core/error/failure.dart';
 import 'package:budget_book/features/statistics/domain/entities/statistics_summary.dart';
 import 'package:budget_book/features/statistics/domain/entities/category_statistics.dart';
 import 'package:budget_book/features/statistics/domain/entities/monthly_trend.dart';
+import 'package:budget_book/features/statistics/domain/entities/payment_method_statistics.dart';
 
 abstract class StatisticsRepository {
   Future<Either<Failure, StatisticsSummary>> getSummary({
@@ -18,5 +19,11 @@ abstract class StatisticsRepository {
 
   Future<Either<Failure, List<MonthlyTrend>>> getMonthlyTrend({
     int months = 6,
+  });
+
+  Future<Either<Failure, List<PaymentMethodStatistics>>>
+      getPaymentMethodStats({
+    required int year,
+    required int month,
   });
 }

--- a/frontend/lib/features/statistics/presentation/bloc/statistics_bloc.dart
+++ b/frontend/lib/features/statistics/presentation/bloc/statistics_bloc.dart
@@ -19,6 +19,7 @@ class StatisticsBloc extends Bloc<StatisticsEvent, StatisticsState> {
     on<LoadCategoryBreakdown>(_onLoadCategoryBreakdown);
     on<LoadMonthlyTrend>(_onLoadMonthlyTrend);
     on<LoadYearComparison>(_onLoadYearComparison);
+    on<LoadPaymentMethodStats>(_onLoadPaymentMethodStats);
   }
 
   Future<void> _onLoadAll(
@@ -209,5 +210,30 @@ class StatisticsBloc extends Bloc<StatisticsEvent, StatisticsState> {
         previousYearSummary: previousSummary,
       ));
     }
+  }
+
+  Future<void> _onLoadPaymentMethodStats(
+    LoadPaymentMethodStats event,
+    Emitter<StatisticsState> emit,
+  ) async {
+    emit(state.copyWith(
+      paymentMethodLoading: true,
+      clearPaymentMethodError: true,
+    ));
+
+    final result = await statisticsRepository.getPaymentMethodStats(
+      year: event.year,
+      month: event.month,
+    );
+    result.fold(
+      (failure) => emit(state.copyWith(
+        paymentMethodLoading: false,
+        paymentMethodError: failure.message,
+      )),
+      (stats) => emit(state.copyWith(
+        paymentMethodLoading: false,
+        paymentMethodStats: stats,
+      )),
+    );
   }
 }

--- a/frontend/lib/features/statistics/presentation/bloc/statistics_event.dart
+++ b/frontend/lib/features/statistics/presentation/bloc/statistics_event.dart
@@ -60,3 +60,13 @@ class LoadYearComparison extends StatisticsEvent {
   @override
   List<Object?> get props => [year, month];
 }
+
+class LoadPaymentMethodStats extends StatisticsEvent {
+  final int year;
+  final int month;
+
+  const LoadPaymentMethodStats({required this.year, required this.month});
+
+  @override
+  List<Object?> get props => [year, month];
+}

--- a/frontend/lib/features/statistics/presentation/bloc/statistics_state.dart
+++ b/frontend/lib/features/statistics/presentation/bloc/statistics_state.dart
@@ -2,6 +2,7 @@ import 'package:equatable/equatable.dart';
 import 'package:budget_book/features/statistics/domain/entities/statistics_summary.dart';
 import 'package:budget_book/features/statistics/domain/entities/category_statistics.dart';
 import 'package:budget_book/features/statistics/domain/entities/monthly_trend.dart';
+import 'package:budget_book/features/statistics/domain/entities/payment_method_statistics.dart';
 
 class StatisticsState extends Equatable {
   final int year;
@@ -29,6 +30,11 @@ class StatisticsState extends Equatable {
   final StatisticsSummary? previousYearSummary;
   final String? comparisonError;
 
+  // Payment method stats
+  final bool paymentMethodLoading;
+  final List<PaymentMethodStatistics> paymentMethodStats;
+  final String? paymentMethodError;
+
   const StatisticsState({
     required this.year,
     required this.month,
@@ -46,6 +52,9 @@ class StatisticsState extends Equatable {
     this.currentYearSummary,
     this.previousYearSummary,
     this.comparisonError,
+    this.paymentMethodLoading = false,
+    this.paymentMethodStats = const [],
+    this.paymentMethodError,
   });
 
   bool get isAllLoading => summaryLoading && categoryLoading && trendLoading;
@@ -71,6 +80,10 @@ class StatisticsState extends Equatable {
     StatisticsSummary? previousYearSummary,
     String? comparisonError,
     bool clearComparisonError = false,
+    bool? paymentMethodLoading,
+    List<PaymentMethodStatistics>? paymentMethodStats,
+    String? paymentMethodError,
+    bool clearPaymentMethodError = false,
   }) {
     return StatisticsState(
       year: year ?? this.year,
@@ -93,6 +106,11 @@ class StatisticsState extends Equatable {
       comparisonError: clearComparisonError
           ? null
           : (comparisonError ?? this.comparisonError),
+      paymentMethodLoading: paymentMethodLoading ?? this.paymentMethodLoading,
+      paymentMethodStats: paymentMethodStats ?? this.paymentMethodStats,
+      paymentMethodError: clearPaymentMethodError
+          ? null
+          : (paymentMethodError ?? this.paymentMethodError),
     );
   }
 
@@ -114,5 +132,8 @@ class StatisticsState extends Equatable {
         currentYearSummary,
         previousYearSummary,
         comparisonError,
+        paymentMethodLoading,
+        paymentMethodStats,
+        paymentMethodError,
       ];
 }

--- a/frontend/lib/features/statistics/presentation/pages/statistics_page.dart
+++ b/frontend/lib/features/statistics/presentation/pages/statistics_page.dart
@@ -8,6 +8,7 @@ import 'package:budget_book/features/statistics/presentation/widgets/summary_tab
 import 'package:budget_book/features/statistics/presentation/widgets/category_breakdown_tab.dart';
 import 'package:budget_book/features/statistics/presentation/widgets/monthly_trend_tab.dart';
 import 'package:budget_book/features/statistics/presentation/widgets/year_comparison_tab.dart';
+import 'package:budget_book/features/statistics/presentation/widgets/payment_method_stats_tab.dart';
 
 class StatisticsPage extends StatelessWidget {
   const StatisticsPage({super.key});
@@ -15,7 +16,7 @@ class StatisticsPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return DefaultTabController(
-      length: 4,
+      length: 5,
       child: Scaffold(
         appBar: AppBar(
           title: const Text('통계'),
@@ -26,6 +27,7 @@ class StatisticsPage extends StatelessWidget {
               Tab(text: '카테고리별'),
               Tab(text: '추이'),
               Tab(text: '전년 비교'),
+              Tab(text: '결제수단별'),
             ],
           ),
         ),
@@ -71,6 +73,11 @@ class StatisticsPage extends StatelessWidget {
                         error: state.comparisonError,
                         year: state.year,
                         month: state.month,
+                      ),
+                      PaymentMethodStatsTab(
+                        stats: state.paymentMethodStats,
+                        isLoading: state.paymentMethodLoading,
+                        error: state.paymentMethodError,
                       ),
                     ],
                   ),
@@ -147,5 +154,6 @@ class _MonthNavigator extends StatelessWidget {
     final bloc = context.read<StatisticsBloc>();
     bloc.add(LoadAllStatistics(year: year, month: month));
     bloc.add(LoadYearComparison(year: year, month: month));
+    bloc.add(LoadPaymentMethodStats(year: year, month: month));
   }
 }

--- a/frontend/lib/features/statistics/presentation/widgets/payment_method_stats_tab.dart
+++ b/frontend/lib/features/statistics/presentation/widgets/payment_method_stats_tab.dart
@@ -1,0 +1,191 @@
+import 'package:flutter/material.dart';
+import 'package:fl_chart/fl_chart.dart';
+import 'package:intl/intl.dart';
+import 'package:budget_book/features/statistics/domain/entities/payment_method_statistics.dart';
+
+class PaymentMethodStatsTab extends StatelessWidget {
+  final List<PaymentMethodStatistics> stats;
+  final bool isLoading;
+  final String? error;
+
+  const PaymentMethodStatsTab({
+    super.key,
+    required this.stats,
+    required this.isLoading,
+    this.error,
+  });
+
+  static final _formatter = NumberFormat('#,###');
+
+  static const _colors = [
+    Color(0xFF2196F3),
+    Color(0xFFF44336),
+    Color(0xFF4CAF50),
+    Color(0xFFFF9800),
+    Color(0xFF9C27B0),
+    Color(0xFF00BCD4),
+    Color(0xFFE91E63),
+    Color(0xFF795548),
+    Color(0xFF607D8B),
+    Color(0xFFCDDC39),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    if (isLoading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    if (error != null) {
+      return Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(Icons.error_outline,
+                size: 48,
+                color: Theme.of(context).colorScheme.error),
+            const SizedBox(height: 12),
+            Text(error!, style: Theme.of(context).textTheme.bodyMedium),
+          ],
+        ),
+      );
+    }
+
+    if (stats.isEmpty) {
+      return Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(
+              Icons.credit_card_off,
+              size: 48,
+              color: Theme.of(context)
+                  .colorScheme
+                  .onSurface
+                  .withValues(alpha: 0.3),
+            ),
+            const SizedBox(height: 12),
+            Text(
+              '결제수단별 통계가 없습니다',
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: Theme.of(context)
+                        .colorScheme
+                        .onSurface
+                        .withValues(alpha: 0.5),
+                  ),
+            ),
+          ],
+        ),
+      );
+    }
+
+    return ListView(
+      padding: const EdgeInsets.all(16),
+      children: [
+        // Pie chart
+        SizedBox(
+          height: 220,
+          child: PieChart(
+            PieChartData(
+              sections: stats.asMap().entries.map((entry) {
+                final index = entry.key;
+                final stat = entry.value;
+                final color = _colors[index % _colors.length];
+                return PieChartSectionData(
+                  value: stat.totalAmount.toDouble(),
+                  color: color,
+                  title: stat.percentage >= 5
+                      ? '${stat.percentage.toStringAsFixed(0)}%'
+                      : '',
+                  titleStyle: const TextStyle(
+                    fontSize: 12,
+                    fontWeight: FontWeight.bold,
+                    color: Colors.white,
+                  ),
+                  radius: 80,
+                );
+              }).toList(),
+              sectionsSpace: 2,
+              centerSpaceRadius: 30,
+            ),
+          ),
+        ),
+        const SizedBox(height: 24),
+        // List of payment methods
+        ...stats.asMap().entries.map((entry) {
+          final index = entry.key;
+          final stat = entry.value;
+          final color = _colors[index % _colors.length];
+
+          return Card(
+            margin: const EdgeInsets.only(bottom: 8),
+            child: Padding(
+              padding: const EdgeInsets.all(12),
+              child: Row(
+                children: [
+                  // Color indicator
+                  Container(
+                    width: 12,
+                    height: 12,
+                    decoration: BoxDecoration(
+                      color: color,
+                      shape: BoxShape.circle,
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  // Payment method info
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          stat.paymentMethodName,
+                          style:
+                              Theme.of(context).textTheme.titleSmall?.copyWith(
+                                    fontWeight: FontWeight.w600,
+                                  ),
+                        ),
+                        const SizedBox(height: 2),
+                        Text(
+                          '${stat.transactionCount}건',
+                          style:
+                              Theme.of(context).textTheme.bodySmall?.copyWith(
+                                    color: Theme.of(context)
+                                        .colorScheme
+                                        .onSurface
+                                        .withValues(alpha: 0.5),
+                                  ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  // Amount and percentage
+                  Column(
+                    crossAxisAlignment: CrossAxisAlignment.end,
+                    children: [
+                      Text(
+                        '${_formatter.format(stat.totalAmount)}원',
+                        style:
+                            Theme.of(context).textTheme.titleSmall?.copyWith(
+                                  fontWeight: FontWeight.bold,
+                                ),
+                      ),
+                      Text(
+                        '${stat.percentage.toStringAsFixed(1)}%',
+                        style:
+                            Theme.of(context).textTheme.bodySmall?.copyWith(
+                                  color: color,
+                                  fontWeight: FontWeight.w600,
+                                ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          );
+        }),
+      ],
+    );
+  }
+}

--- a/frontend/lib/features/transaction/presentation/pages/transaction_detail_page.dart
+++ b/frontend/lib/features/transaction/presentation/pages/transaction_detail_page.dart
@@ -1,0 +1,319 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
+import 'package:intl/intl.dart';
+import 'package:budget_book/features/transaction/presentation/bloc/transaction_bloc.dart';
+import 'package:budget_book/features/transaction/presentation/bloc/transaction_event.dart';
+import 'package:budget_book/features/transaction/presentation/bloc/transaction_state.dart';
+import 'package:budget_book/features/transaction/domain/entities/transaction.dart';
+
+class TransactionDetailPage extends StatelessWidget {
+  final String transactionId;
+
+  const TransactionDetailPage({super.key, required this.transactionId});
+
+  static final _amountFormatter = NumberFormat('#,###');
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('거래 상세'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.edit),
+            tooltip: '수정',
+            onPressed: () =>
+                context.push('/transactions/edit/$transactionId'),
+          ),
+          IconButton(
+            icon: const Icon(Icons.delete),
+            tooltip: '삭제',
+            onPressed: () => _showDeleteConfirm(context),
+          ),
+        ],
+      ),
+      body: BlocBuilder<TransactionBloc, TransactionState>(
+        builder: (context, state) {
+          if (state is! TransactionLoaded) {
+            return const Center(child: CircularProgressIndicator());
+          }
+
+          final txn = _findTransaction(state);
+          if (txn == null) {
+            return Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Icon(
+                    Icons.search_off,
+                    size: 48,
+                    color: Theme.of(context)
+                        .colorScheme
+                        .onSurface
+                        .withValues(alpha: 0.3),
+                  ),
+                  const SizedBox(height: 12),
+                  const Text('거래를 찾을 수 없습니다'),
+                ],
+              ),
+            );
+          }
+
+          return _buildContent(context, txn);
+        },
+      ),
+    );
+  }
+
+  Transaction? _findTransaction(TransactionLoaded state) {
+    try {
+      return state.transactions.firstWhere((t) => t.id == transactionId);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  Widget _buildContent(BuildContext context, Transaction txn) {
+    final theme = Theme.of(context);
+    final isExpense = txn.isExpense;
+    final amountColor = isExpense ? Colors.red : Colors.blue;
+    final category = txn.category;
+
+    String formattedDate;
+    try {
+      final date = DateTime.parse(txn.transactionDate);
+      formattedDate = DateFormat('yyyy년 M월 d일 (E)', 'ko').format(date);
+    } catch (_) {
+      formattedDate = txn.transactionDate;
+    }
+
+    String formattedCreatedAt;
+    try {
+      formattedCreatedAt =
+          DateFormat('yyyy-MM-dd HH:mm').format(txn.createdAt);
+    } catch (_) {
+      formattedCreatedAt = txn.createdAt.toString();
+    }
+
+    return ListView(
+      padding: const EdgeInsets.all(20),
+      children: [
+        // Amount card
+        Card(
+          child: Padding(
+            padding: const EdgeInsets.all(24),
+            child: Column(
+              children: [
+                Icon(
+                  isExpense ? Icons.arrow_downward : Icons.arrow_upward,
+                  size: 36,
+                  color: amountColor,
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  isExpense ? '지출' : '수입',
+                  style: theme.textTheme.titleSmall?.copyWith(
+                    color: amountColor,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  '${isExpense ? "-" : "+"}${_amountFormatter.format(txn.amount)}원',
+                  style: theme.textTheme.headlineMedium?.copyWith(
+                    color: amountColor,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+        const SizedBox(height: 16),
+
+        // Details
+        Card(
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              children: [
+                _DetailRow(
+                  icon: Icons.description,
+                  label: '내용',
+                  value: txn.description,
+                ),
+                const Divider(height: 24),
+                _DetailRow(
+                  icon: Icons.calendar_today,
+                  label: '날짜',
+                  value: formattedDate,
+                ),
+                const Divider(height: 24),
+                // Category with icon and color
+                _DetailRow(
+                  icon: _resolveIcon(category?.icon),
+                  iconColor: _parseColor(category?.color),
+                  label: '카테고리',
+                  value: category?.name ?? '미분류',
+                ),
+                if (txn.paymentMethodName != null) ...[
+                  const Divider(height: 24),
+                  _DetailRow(
+                    icon: Icons.payment,
+                    label: '결제수단',
+                    value: txn.paymentMethodName!,
+                  ),
+                ],
+                if (txn.pocketName != null) ...[
+                  const Divider(height: 24),
+                  _DetailRow(
+                    icon: Icons.account_balance_wallet,
+                    label: '포켓',
+                    value: txn.pocketName!,
+                  ),
+                ],
+                if (txn.memo != null && txn.memo!.isNotEmpty) ...[
+                  const Divider(height: 24),
+                  _DetailRow(
+                    icon: Icons.note,
+                    label: '메모',
+                    value: txn.memo!,
+                  ),
+                ],
+                const Divider(height: 24),
+                _DetailRow(
+                  icon: Icons.person,
+                  label: '작성자',
+                  value: txn.author.nickname,
+                ),
+                const Divider(height: 24),
+                _DetailRow(
+                  icon: Icons.access_time,
+                  label: '등록일시',
+                  value: formattedCreatedAt,
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  void _showDeleteConfirm(BuildContext context) {
+    showDialog(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('거래 삭제'),
+        content: const Text('정말 이 거래를 삭제하시겠습니까?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(),
+            child: const Text('취소'),
+          ),
+          FilledButton(
+            onPressed: () {
+              Navigator.of(ctx).pop();
+              context
+                  .read<TransactionBloc>()
+                  .add(DeleteTransaction(transactionId));
+              context.pop();
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(content: Text('거래가 삭제되었습니다')),
+              );
+            },
+            style: FilledButton.styleFrom(
+              backgroundColor: Theme.of(context).colorScheme.error,
+            ),
+            child: const Text('삭제'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Color _parseColor(String? hex) {
+    if (hex == null || hex.isEmpty) return Colors.grey;
+    try {
+      final colorStr = hex.replaceFirst('#', '');
+      return Color(int.parse('FF$colorStr', radix: 16));
+    } catch (_) {
+      return Colors.grey;
+    }
+  }
+
+  IconData _resolveIcon(String? iconName) {
+    if (iconName == null) return Icons.receipt_long;
+    const iconMap = <String, IconData>{
+      'restaurant': Icons.restaurant,
+      'restaurant_menu': Icons.restaurant_menu,
+      'shopping_cart': Icons.shopping_cart,
+      'directions_bus': Icons.directions_bus,
+      'home': Icons.home,
+      'local_hospital': Icons.local_hospital,
+      'school': Icons.school,
+      'pets': Icons.pets,
+      'payments': Icons.payments,
+      'work': Icons.work,
+      'savings': Icons.savings,
+      'card_giftcard': Icons.card_giftcard,
+      'trending_up': Icons.trending_up,
+      'local_cafe': Icons.local_cafe,
+      'movie': Icons.movie,
+      'fitness_center': Icons.fitness_center,
+      'child_care': Icons.child_care,
+      'phone': Icons.phone,
+      'electric_bolt': Icons.electric_bolt,
+      'account_balance': Icons.account_balance,
+    };
+    return iconMap[iconName] ?? Icons.receipt_long;
+  }
+}
+
+class _DetailRow extends StatelessWidget {
+  final IconData icon;
+  final Color? iconColor;
+  final String label;
+  final String value;
+
+  const _DetailRow({
+    required this.icon,
+    this.iconColor,
+    required this.label,
+    required this.value,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Icon(
+          icon,
+          size: 20,
+          color: iconColor ??
+              theme.colorScheme.onSurface.withValues(alpha: 0.5),
+        ),
+        const SizedBox(width: 12),
+        SizedBox(
+          width: 72,
+          child: Text(
+            label,
+            style: theme.textTheme.bodyMedium?.copyWith(
+              color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
+            ),
+          ),
+        ),
+        Expanded(
+          child: Text(
+            value,
+            style: theme.textTheme.bodyMedium?.copyWith(
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/frontend/lib/features/transaction/presentation/pages/transaction_import_page.dart
+++ b/frontend/lib/features/transaction/presentation/pages/transaction_import_page.dart
@@ -1,0 +1,360 @@
+import 'package:dio/dio.dart';
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:budget_book/core/constants/api_endpoints.dart';
+import 'package:budget_book/core/di/injection.dart';
+import 'package:budget_book/core/network/api_client.dart';
+
+class TransactionImportPage extends StatefulWidget {
+  const TransactionImportPage({super.key});
+
+  @override
+  State<TransactionImportPage> createState() => _TransactionImportPageState();
+}
+
+class _TransactionImportPageState extends State<TransactionImportPage> {
+  PlatformFile? _selectedFile;
+  bool _isUploading = false;
+  _ImportResult? _result;
+  String? _errorMessage;
+
+  Future<void> _pickFile() async {
+    final result = await FilePicker.platform.pickFiles(
+      type: FileType.custom,
+      allowedExtensions: ['csv'],
+      withData: true,
+    );
+
+    if (result != null && result.files.isNotEmpty) {
+      setState(() {
+        _selectedFile = result.files.first;
+        _result = null;
+        _errorMessage = null;
+      });
+    }
+  }
+
+  Future<void> _uploadFile() async {
+    if (_selectedFile == null || _selectedFile!.bytes == null) return;
+
+    setState(() {
+      _isUploading = true;
+      _result = null;
+      _errorMessage = null;
+    });
+
+    try {
+      final formData = FormData.fromMap({
+        'file': MultipartFile.fromBytes(
+          _selectedFile!.bytes!,
+          filename: _selectedFile!.name,
+        ),
+      });
+
+      final response = await getIt<ApiClient>().dio.post(
+        ApiEndpoints.transactionsImportCsv,
+        data: formData,
+        options: Options(contentType: 'multipart/form-data'),
+      );
+
+      final data = response.data['data'] as Map<String, dynamic>?;
+      if (data != null) {
+        setState(() {
+          _result = _ImportResult(
+            successCount: data['successCount'] as int? ?? 0,
+            failCount: data['failCount'] as int? ?? 0,
+            errors: (data['errors'] as List<dynamic>?)
+                    ?.map((e) => e.toString())
+                    .toList() ??
+                [],
+          );
+        });
+      } else {
+        setState(() {
+          _result = const _ImportResult(
+            successCount: 0,
+            failCount: 0,
+            errors: [],
+          );
+        });
+      }
+    } on DioException catch (e) {
+      final errorData = e.response?.data;
+      String message = '가져오기에 실패했습니다';
+      if (errorData is Map<String, dynamic>) {
+        final error = errorData['error'] as Map<String, dynamic>?;
+        if (error != null) {
+          message = error['message'] as String? ?? message;
+        }
+      }
+      setState(() {
+        _errorMessage = message;
+      });
+    } catch (e) {
+      setState(() {
+        _errorMessage = '가져오기 실패: $e';
+      });
+    } finally {
+      setState(() {
+        _isUploading = false;
+      });
+    }
+  }
+
+  String _formatFileSize(int bytes) {
+    if (bytes < 1024) return '$bytes B';
+    if (bytes < 1024 * 1024) {
+      return '${(bytes / 1024).toStringAsFixed(1)} KB';
+    }
+    return '${(bytes / (1024 * 1024)).toStringAsFixed(1)} MB';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('거래 가져오기'),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            // Instructions
+            Card(
+              child: Padding(
+                padding: const EdgeInsets.all(16),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        Icon(Icons.info_outline,
+                            color: theme.colorScheme.primary),
+                        const SizedBox(width: 8),
+                        Text(
+                          'CSV 파일 가져오기',
+                          style: theme.textTheme.titleMedium?.copyWith(
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 8),
+                    Text(
+                      'CSV 파일을 선택하여 거래 내역을 일괄 등록할 수 있습니다.\n'
+                      '내보내기에서 다운로드한 CSV 형식과 동일한 형식을 사용해 주세요.',
+                      style: theme.textTheme.bodyMedium?.copyWith(
+                        color: theme.colorScheme.onSurface
+                            .withValues(alpha: 0.7),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            const SizedBox(height: 24),
+
+            // File picker area
+            InkWell(
+              onTap: _isUploading ? null : _pickFile,
+              borderRadius: BorderRadius.circular(12),
+              child: Container(
+                padding: const EdgeInsets.all(32),
+                decoration: BoxDecoration(
+                  border: Border.all(
+                    color: theme.colorScheme.outline.withValues(alpha: 0.5),
+                    width: 2,
+                    strokeAlign: BorderSide.strokeAlignInside,
+                  ),
+                  borderRadius: BorderRadius.circular(12),
+                  color: theme.colorScheme.surfaceContainerLow,
+                ),
+                child: Column(
+                  children: [
+                    Icon(
+                      _selectedFile != null
+                          ? Icons.description
+                          : Icons.upload_file,
+                      size: 48,
+                      color: _selectedFile != null
+                          ? theme.colorScheme.primary
+                          : theme.colorScheme.onSurface
+                              .withValues(alpha: 0.4),
+                    ),
+                    const SizedBox(height: 12),
+                    if (_selectedFile != null) ...[
+                      Text(
+                        _selectedFile!.name,
+                        style: theme.textTheme.titleSmall?.copyWith(
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                      const SizedBox(height: 4),
+                      Text(
+                        _formatFileSize(_selectedFile!.size),
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: theme.colorScheme.onSurface
+                              .withValues(alpha: 0.5),
+                        ),
+                      ),
+                    ] else ...[
+                      Text(
+                        '파일을 선택하세요',
+                        style: theme.textTheme.titleSmall?.copyWith(
+                          color: theme.colorScheme.onSurface
+                              .withValues(alpha: 0.6),
+                        ),
+                      ),
+                      const SizedBox(height: 4),
+                      Text(
+                        'CSV 파일만 지원됩니다',
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: theme.colorScheme.onSurface
+                              .withValues(alpha: 0.4),
+                        ),
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+            ),
+            const SizedBox(height: 24),
+
+            // Upload button
+            FilledButton.icon(
+              onPressed: _selectedFile != null && !_isUploading
+                  ? _uploadFile
+                  : null,
+              icon: _isUploading
+                  ? const SizedBox(
+                      width: 20,
+                      height: 20,
+                      child: CircularProgressIndicator(
+                        strokeWidth: 2,
+                        color: Colors.white,
+                      ),
+                    )
+                  : const Icon(Icons.upload),
+              label: Text(_isUploading ? '가져오는 중...' : '가져오기'),
+            ),
+
+            const SizedBox(height: 24),
+
+            // Results
+            if (_result != null) ...[
+              Card(
+                color: _result!.failCount > 0
+                    ? theme.colorScheme.errorContainer
+                    : theme.colorScheme.primaryContainer,
+                child: Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Row(
+                        children: [
+                          Icon(
+                            _result!.failCount > 0
+                                ? Icons.warning_amber
+                                : Icons.check_circle,
+                            color: _result!.failCount > 0
+                                ? theme.colorScheme.error
+                                : theme.colorScheme.primary,
+                          ),
+                          const SizedBox(width: 8),
+                          Text(
+                            '가져오기 결과',
+                            style: theme.textTheme.titleSmall?.copyWith(
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                        ],
+                      ),
+                      const SizedBox(height: 12),
+                      Text(
+                        '${NumberFormat('#,###').format(_result!.successCount)}건 가져오기 완료'
+                        '${_result!.failCount > 0 ? ', ${NumberFormat('#,###').format(_result!.failCount)}건 실패' : ''}',
+                        style: theme.textTheme.bodyLarge?.copyWith(
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                      if (_result!.errors.isNotEmpty) ...[
+                        const SizedBox(height: 12),
+                        const Divider(),
+                        const SizedBox(height: 8),
+                        Text(
+                          '오류 목록',
+                          style: theme.textTheme.titleSmall,
+                        ),
+                        const SizedBox(height: 8),
+                        ConstrainedBox(
+                          constraints: const BoxConstraints(maxHeight: 200),
+                          child: ListView.builder(
+                            shrinkWrap: true,
+                            itemCount: _result!.errors.length,
+                            itemBuilder: (context, index) {
+                              return Padding(
+                                padding:
+                                    const EdgeInsets.symmetric(vertical: 2),
+                                child: Text(
+                                  _result!.errors[index],
+                                  style:
+                                      theme.textTheme.bodySmall?.copyWith(
+                                    color: theme.colorScheme.error,
+                                  ),
+                                ),
+                              );
+                            },
+                          ),
+                        ),
+                      ],
+                    ],
+                  ),
+                ),
+              ),
+            ],
+
+            // Error message
+            if (_errorMessage != null)
+              Card(
+                color: theme.colorScheme.errorContainer,
+                child: Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: Row(
+                    children: [
+                      Icon(Icons.error, color: theme.colorScheme.error),
+                      const SizedBox(width: 8),
+                      Expanded(
+                        child: Text(
+                          _errorMessage!,
+                          style: theme.textTheme.bodyMedium?.copyWith(
+                            color: theme.colorScheme.onErrorContainer,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ImportResult {
+  final int successCount;
+  final int failCount;
+  final List<String> errors;
+
+  const _ImportResult({
+    required this.successCount,
+    required this.failCount,
+    required this.errors,
+  });
+}

--- a/frontend/lib/features/transaction/presentation/pages/transaction_list_page.dart
+++ b/frontend/lib/features/transaction/presentation/pages/transaction_list_page.dart
@@ -1,10 +1,16 @@
 import 'dart:async';
+import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
-import 'package:url_launcher/url_launcher.dart';
 import 'package:budget_book/core/constants/api_endpoints.dart';
+import 'package:budget_book/core/di/injection.dart';
+import 'package:budget_book/core/network/api_client.dart';
+import 'package:budget_book/core/utils/web_download_stub.dart'
+    if (dart.library.html) 'package:budget_book/core/utils/web_download_web.dart'
+    as web_download;
 import 'package:budget_book/features/transaction/presentation/bloc/transaction_bloc.dart';
 import 'package:budget_book/features/transaction/presentation/bloc/transaction_event.dart';
 import 'package:budget_book/features/transaction/presentation/bloc/transaction_state.dart';
@@ -72,19 +78,24 @@ class _TransactionListPageState extends State<TransactionListPage> {
     final month =
         state is TransactionLoaded ? state.month : DateTime.now().month;
 
-    final csvUrl = Uri.parse(
-      '${ApiEndpoints.baseUrl}${ApiEndpoints.transactionsExportCsv}?year=$year&month=$month',
-    );
-
     try {
-      if (await canLaunchUrl(csvUrl)) {
-        await launchUrl(csvUrl, mode: LaunchMode.externalApplication);
-      } else {
-        if (context.mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(content: Text('내보내기 URL을 열 수 없습니다')),
-          );
-        }
+      final response = await getIt<ApiClient>().dio.get(
+        ApiEndpoints.transactionsExportCsv,
+        queryParameters: {'year': year, 'month': month},
+        options: Options(responseType: ResponseType.bytes),
+      );
+
+      final bytes = response.data as List<int>;
+      final filename = 'transactions_${year}_$month.csv';
+
+      if (kIsWeb) {
+        web_download.triggerBrowserDownload(bytes, filename, 'text/csv');
+      }
+
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('CSV 내보내기 완료')),
+        );
       }
     } catch (e) {
       if (context.mounted) {
@@ -285,6 +296,11 @@ class _TransactionListPageState extends State<TransactionListPage> {
         title: const Text('거래'),
         actions: [
           IconButton(
+            icon: const Icon(Icons.file_upload),
+            tooltip: '가져오기',
+            onPressed: () => context.push('/transactions/import'),
+          ),
+          IconButton(
             icon: const Icon(Icons.file_download),
             tooltip: '내보내기',
             onPressed: () => _exportCsv(context),
@@ -451,7 +467,7 @@ class _TransactionListPageState extends State<TransactionListPage> {
               _DateHeader(dateStr: date),
               ...transactions.map((t) => TransactionListTile(
                     transaction: t,
-                    onTap: () => context.push('/transactions/edit/${t.id}'),
+                    onTap: () => context.push('/transactions/detail/${t.id}'),
                     onDelete: () {
                       showDialog(
                         context: context,

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -61,6 +61,7 @@ dependencies:
   uuid: ^4.5.1
   logger: ^2.4.0
   url_launcher: ^6.3.0
+  file_picker: ^8.0.0
 
   # Task #18: Sentry error monitoring (disabled when SENTRY_DSN dart-define is not set)
   sentry_flutter: ^8.10.1

--- a/frontend/test/features/budget/presentation/widgets/budget_alert_widget_test.dart
+++ b/frontend/test/features/budget/presentation/widgets/budget_alert_widget_test.dart
@@ -1,0 +1,168 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:bloc_test/bloc_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:budget_book/features/home/presentation/bloc/dashboard_bloc.dart';
+import 'package:budget_book/features/home/presentation/bloc/dashboard_event.dart';
+import 'package:budget_book/features/home/presentation/bloc/dashboard_state.dart';
+import 'package:budget_book/features/budget/domain/entities/budget.dart';
+import 'package:budget_book/features/budget/presentation/widgets/budget_alert_widget.dart';
+import 'package:budget_book/features/transaction/domain/entities/transaction.dart';
+import 'package:budget_book/features/transaction/domain/entities/transaction_category.dart';
+import 'package:budget_book/features/statistics/domain/entities/statistics_summary.dart';
+
+class MockDashboardBloc extends MockBloc<DashboardEvent, DashboardState>
+    implements DashboardBloc {}
+
+void main() {
+  late MockDashboardBloc mockDashboardBloc;
+
+  setUp(() {
+    mockDashboardBloc = MockDashboardBloc();
+  });
+
+  Widget createTestWidget() {
+    return MaterialApp(
+      home: Scaffold(
+        body: BlocProvider<DashboardBloc>.value(
+          value: mockDashboardBloc,
+          child: const BudgetAlertWidget(),
+        ),
+      ),
+    );
+  }
+
+  group('BudgetAlertWidget', () {
+    testWidgets('shows nothing when state is not DashboardLoaded',
+        (tester) async {
+      when(() => mockDashboardBloc.state).thenReturn(const DashboardLoading());
+      await tester.pumpWidget(createTestWidget());
+      expect(find.byType(BudgetAlertWidget), findsOneWidget);
+      // Should render empty SizedBox
+      expect(find.text('예산 알림'), findsNothing);
+    });
+
+    testWidgets('shows nothing when no budget summary', (tester) async {
+      when(() => mockDashboardBloc.state).thenReturn(const DashboardLoaded(
+        year: 2026,
+        month: 3,
+        summary: StatisticsSummary(
+          yearMonth: '2026-03',
+          totalIncome: 5000000,
+          totalExpense: 3000000,
+          balance: 2000000,
+          transactionCount: 10,
+        ),
+        budgetSummary: null,
+        recentTransactions: <Transaction>[],
+      ));
+      await tester.pumpWidget(createTestWidget());
+      expect(find.text('예산 알림'), findsNothing);
+    });
+
+    testWidgets('shows alert cards for items >= 80% usage', (tester) async {
+      when(() => mockDashboardBloc.state).thenReturn(const DashboardLoaded(
+        year: 2026,
+        month: 3,
+        summary: StatisticsSummary(
+          yearMonth: '2026-03',
+          totalIncome: 5000000,
+          totalExpense: 3000000,
+          balance: 2000000,
+          transactionCount: 10,
+        ),
+        budgetSummary: BudgetSummary(
+          yearMonth: '2026-03',
+          totalBudget: 1000000,
+          totalSpent: 850000,
+          items: [
+            BudgetSummaryItem(
+              category: TransactionCategory(
+                id: '1',
+                name: '식비',
+                type: 'EXPENSE',
+              ),
+              budgetAmount: 500000,
+              spentAmount: 450000,
+              remainingAmount: 50000,
+              usageRate: 90.0,
+            ),
+            BudgetSummaryItem(
+              category: TransactionCategory(
+                id: '2',
+                name: '교통비',
+                type: 'EXPENSE',
+              ),
+              budgetAmount: 200000,
+              spentAmount: 250000,
+              remainingAmount: -50000,
+              usageRate: 125.0,
+            ),
+            BudgetSummaryItem(
+              category: TransactionCategory(
+                id: '3',
+                name: '문화',
+                type: 'EXPENSE',
+              ),
+              budgetAmount: 300000,
+              spentAmount: 150000,
+              remainingAmount: 150000,
+              usageRate: 50.0,
+            ),
+          ],
+        ),
+        recentTransactions: <Transaction>[],
+      ));
+      await tester.pumpWidget(createTestWidget());
+
+      // Should show alert title
+      expect(find.text('예산 알림'), findsOneWidget);
+
+      // Should show cards for 식비 (90%) and 교통비 (125%), not 문화 (50%)
+      expect(find.text('식비'), findsOneWidget);
+      expect(find.text('교통비'), findsOneWidget);
+      expect(find.text('문화'), findsNothing);
+
+      // Should show status labels
+      expect(find.text('주의'), findsOneWidget); // 90%
+      expect(find.text('초과'), findsOneWidget); // 125%
+    });
+
+    testWidgets('shows nothing when all items are below 80%',
+        (tester) async {
+      when(() => mockDashboardBloc.state).thenReturn(const DashboardLoaded(
+        year: 2026,
+        month: 3,
+        summary: StatisticsSummary(
+          yearMonth: '2026-03',
+          totalIncome: 5000000,
+          totalExpense: 1000000,
+          balance: 4000000,
+          transactionCount: 5,
+        ),
+        budgetSummary: BudgetSummary(
+          yearMonth: '2026-03',
+          totalBudget: 1000000,
+          totalSpent: 300000,
+          items: [
+            BudgetSummaryItem(
+              category: TransactionCategory(
+                id: '1',
+                name: '식비',
+                type: 'EXPENSE',
+              ),
+              budgetAmount: 500000,
+              spentAmount: 200000,
+              remainingAmount: 300000,
+              usageRate: 40.0,
+            ),
+          ],
+        ),
+        recentTransactions: <Transaction>[],
+      ));
+      await tester.pumpWidget(createTestWidget());
+      expect(find.text('예산 알림'), findsNothing);
+    });
+  });
+}

--- a/frontend/test/features/statistics/payment_method_stats_tab_test.dart
+++ b/frontend/test/features/statistics/payment_method_stats_tab_test.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:budget_book/features/statistics/domain/entities/payment_method_statistics.dart';
+import 'package:budget_book/features/statistics/presentation/widgets/payment_method_stats_tab.dart';
+
+void main() {
+  Widget createTestWidget({
+    List<PaymentMethodStatistics> stats = const [],
+    bool isLoading = false,
+    String? error,
+  }) {
+    return MaterialApp(
+      home: Scaffold(
+        body: PaymentMethodStatsTab(
+          stats: stats,
+          isLoading: isLoading,
+          error: error,
+        ),
+      ),
+    );
+  }
+
+  group('PaymentMethodStatsTab', () {
+    testWidgets('shows loading indicator when loading', (tester) async {
+      await tester.pumpWidget(createTestWidget(isLoading: true));
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    });
+
+    testWidgets('shows error message when error occurs', (tester) async {
+      await tester.pumpWidget(
+        createTestWidget(error: '결제수단별 통계를 불러오지 못했습니다'),
+      );
+      expect(find.text('결제수단별 통계를 불러오지 못했습니다'), findsOneWidget);
+      expect(find.byIcon(Icons.error_outline), findsOneWidget);
+    });
+
+    testWidgets('shows empty state when no stats', (tester) async {
+      await tester.pumpWidget(createTestWidget(stats: const []));
+      expect(find.text('결제수단별 통계가 없습니다'), findsOneWidget);
+    });
+
+    testWidgets('shows payment method list with amounts', (tester) async {
+      const stats = [
+        PaymentMethodStatistics(
+          paymentMethodId: 'pm-1',
+          paymentMethodName: '신한카드',
+          paymentMethodType: 'CREDIT_CARD',
+          totalAmount: 1500000,
+          transactionCount: 20,
+          percentage: 65.2,
+        ),
+        PaymentMethodStatistics(
+          paymentMethodId: 'pm-2',
+          paymentMethodName: '현금',
+          paymentMethodType: 'CASH',
+          totalAmount: 800000,
+          transactionCount: 15,
+          percentage: 34.8,
+        ),
+      ];
+
+      await tester.pumpWidget(createTestWidget(stats: stats));
+
+      expect(find.text('신한카드'), findsOneWidget);
+      expect(find.text('현금'), findsOneWidget);
+      expect(find.text('20건'), findsOneWidget);
+      expect(find.text('15건'), findsOneWidget);
+      expect(find.text('1,500,000원'), findsOneWidget);
+      expect(find.text('800,000원'), findsOneWidget);
+      expect(find.text('65.2%'), findsOneWidget);
+      expect(find.text('34.8%'), findsOneWidget);
+    });
+  });
+}

--- a/frontend/test/features/statistics/statistics_bloc_test.dart
+++ b/frontend/test/features/statistics/statistics_bloc_test.dart
@@ -6,6 +6,7 @@ import 'package:budget_book/core/error/failure.dart';
 import 'package:budget_book/features/statistics/domain/entities/statistics_summary.dart';
 import 'package:budget_book/features/statistics/domain/entities/category_statistics.dart';
 import 'package:budget_book/features/statistics/domain/entities/monthly_trend.dart';
+import 'package:budget_book/features/statistics/domain/entities/payment_method_statistics.dart';
 import 'package:budget_book/features/statistics/domain/repositories/statistics_repository.dart';
 import 'package:budget_book/features/statistics/presentation/bloc/statistics_bloc.dart';
 import 'package:budget_book/features/statistics/presentation/bloc/statistics_event.dart';
@@ -250,6 +251,64 @@ void main() {
         verify: (bloc) {
           expect(bloc.state.comparisonLoading, false);
           expect(bloc.state.comparisonError, '통계 요약을 불러오지 못했습니다');
+        },
+      );
+    });
+
+    group('LoadPaymentMethodStats', () {
+      const testPaymentMethodStats = [
+        PaymentMethodStatistics(
+          paymentMethodId: 'pm-1',
+          paymentMethodName: '신한카드',
+          paymentMethodType: 'CREDIT_CARD',
+          totalAmount: 1500000,
+          transactionCount: 20,
+          percentage: 46.9,
+        ),
+        PaymentMethodStatistics(
+          paymentMethodId: 'pm-2',
+          paymentMethodName: '현금',
+          paymentMethodType: 'CASH',
+          totalAmount: 800000,
+          transactionCount: 15,
+          percentage: 25.0,
+        ),
+      ];
+
+      blocTest<StatisticsBloc, StatisticsState>(
+        'emits loaded payment method stats on success',
+        build: () {
+          when(() => mockRepository.getPaymentMethodStats(
+                year: 2026,
+                month: 3,
+              )).thenAnswer((_) async => const Right(testPaymentMethodStats));
+          return StatisticsBloc(statisticsRepository: mockRepository);
+        },
+        act: (bloc) =>
+            bloc.add(const LoadPaymentMethodStats(year: 2026, month: 3)),
+        verify: (bloc) {
+          expect(bloc.state.paymentMethodStats, testPaymentMethodStats);
+          expect(bloc.state.paymentMethodLoading, false);
+          expect(bloc.state.paymentMethodError, null);
+        },
+      );
+
+      blocTest<StatisticsBloc, StatisticsState>(
+        'emits error when LoadPaymentMethodStats fails',
+        build: () {
+          when(() => mockRepository.getPaymentMethodStats(
+                year: 2026,
+                month: 3,
+              )).thenAnswer((_) async =>
+              const Left(ServerFailure('결제수단별 통계를 불러오지 못했습니다')));
+          return StatisticsBloc(statisticsRepository: mockRepository);
+        },
+        act: (bloc) =>
+            bloc.add(const LoadPaymentMethodStats(year: 2026, month: 3)),
+        verify: (bloc) {
+          expect(
+              bloc.state.paymentMethodError, '결제수단별 통계를 불러오지 못했습니다');
+          expect(bloc.state.paymentMethodLoading, false);
         },
       );
     });

--- a/frontend/test/features/transaction/presentation/pages/transaction_detail_page_test.dart
+++ b/frontend/test/features/transaction/presentation/pages/transaction_detail_page_test.dart
@@ -1,0 +1,128 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:bloc_test/bloc_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:budget_book/features/transaction/presentation/bloc/transaction_bloc.dart';
+import 'package:budget_book/features/transaction/presentation/bloc/transaction_event.dart';
+import 'package:budget_book/features/transaction/presentation/bloc/transaction_state.dart';
+import 'package:budget_book/features/transaction/domain/entities/transaction.dart';
+import 'package:budget_book/features/transaction/domain/entities/transaction_author.dart';
+import 'package:budget_book/features/transaction/domain/entities/transaction_category.dart';
+import 'package:budget_book/features/transaction/presentation/pages/transaction_detail_page.dart';
+
+class MockTransactionBloc
+    extends MockBloc<TransactionEvent, TransactionState>
+    implements TransactionBloc {}
+
+void main() {
+  late MockTransactionBloc mockBloc;
+
+  setUp(() {
+    mockBloc = MockTransactionBloc();
+  });
+
+  final testTransaction = Transaction(
+    id: 'txn-1',
+    coupleId: 'couple-1',
+    author: const TransactionAuthor(
+      id: 'user-1',
+      nickname: '홍길동',
+    ),
+    category: const TransactionCategory(
+      id: 'cat-1',
+      name: '식비',
+      type: 'EXPENSE',
+      icon: 'restaurant',
+      color: '#FF5733',
+    ),
+    type: 'EXPENSE',
+    amount: 35000,
+    description: '점심 식사',
+    memo: '회사 근처 맛집',
+    transactionDate: '2026-03-15',
+    paymentMethodName: '신한카드',
+    pocketName: '생활비',
+    createdAt: DateTime(2026, 3, 15, 12, 30),
+    updatedAt: DateTime(2026, 3, 15, 12, 30),
+  );
+
+  Widget createTestWidget({String transactionId = 'txn-1'}) {
+    return MaterialApp(
+      home: BlocProvider<TransactionBloc>.value(
+        value: mockBloc,
+        child: TransactionDetailPage(transactionId: transactionId),
+      ),
+    );
+  }
+
+  group('TransactionDetailPage', () {
+    testWidgets('shows app bar with title and actions', (tester) async {
+      when(() => mockBloc.state).thenReturn(TransactionLoaded(
+        transactions: [testTransaction],
+        year: 2026,
+        month: 3,
+        totalElements: 1,
+        hasMore: false,
+      ));
+      await tester.pumpWidget(createTestWidget());
+
+      expect(find.text('거래 상세'), findsOneWidget);
+      expect(find.byIcon(Icons.edit), findsOneWidget);
+      expect(find.byIcon(Icons.delete), findsOneWidget);
+    });
+
+    testWidgets('shows transaction details correctly', (tester) async {
+      when(() => mockBloc.state).thenReturn(TransactionLoaded(
+        transactions: [testTransaction],
+        year: 2026,
+        month: 3,
+        totalElements: 1,
+        hasMore: false,
+      ));
+      await tester.pumpWidget(createTestWidget());
+
+      expect(find.text('점심 식사'), findsOneWidget);
+      expect(find.text('식비'), findsOneWidget);
+      expect(find.text('신한카드'), findsOneWidget);
+      expect(find.text('생활비'), findsOneWidget);
+      expect(find.text('회사 근처 맛집'), findsOneWidget);
+      expect(find.text('홍길동'), findsOneWidget);
+      expect(find.text('지출'), findsOneWidget);
+    });
+
+    testWidgets('shows not found message when transaction is missing',
+        (tester) async {
+      when(() => mockBloc.state).thenReturn(const TransactionLoaded(
+        transactions: [],
+        year: 2026,
+        month: 3,
+        totalElements: 0,
+        hasMore: false,
+      ));
+      await tester.pumpWidget(
+          createTestWidget(transactionId: 'non-existent'));
+
+      expect(find.text('거래를 찾을 수 없습니다'), findsOneWidget);
+    });
+
+    testWidgets('shows delete confirmation dialog', (tester) async {
+      when(() => mockBloc.state).thenReturn(TransactionLoaded(
+        transactions: [testTransaction],
+        year: 2026,
+        month: 3,
+        totalElements: 1,
+        hasMore: false,
+      ));
+      await tester.pumpWidget(createTestWidget());
+
+      await tester.tap(find.byIcon(Icons.delete));
+      await tester.pumpAndSettle();
+
+      expect(find.text('거래 삭제'), findsOneWidget);
+      expect(find.text('정말 이 거래를 삭제하시겠습니까?'), findsOneWidget);
+      expect(find.text('취소'), findsOneWidget);
+      expect(find.text('삭제'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- CSV import: bulk transaction upload (max 1000 rows)
- CSV export: auth fix (Dio instead of url_launcher)
- Budget alerts on dashboard (WARNING/EXCEEDED with progress bars)
- Payment method statistics (5th tab in statistics)
- Transaction detail page with edit/delete
- 445 BE tests, 376 FE tests

## Test plan
- [x] BE tests: PASS
- [x] FE tests: 376 PASS
- [x] FE analyze + build: SUCCESS

🤖 Generated with [Claude Code](https://claude.com/claude-code)