### PR TITLE
feat(filter): 공개 범위 BE 전달 + DTO 도입 (PR-B)

### DIFF
--- a/backend/src/main/kotlin/com/budgetbook/transaction/controller/TransactionController.kt
+++ b/backend/src/main/kotlin/com/budgetbook/transaction/controller/TransactionController.kt
@@ -49,7 +49,7 @@ class TransactionController(
         return ApiResponse.ok(transactionService.listTransactions(
             userId, filter.year, filter.month, filter.type, filter.categoryId,
             filter.keyword, filter.paymentMethodId, filter.pocketId, filter.amountMin, filter.amountMax,
-            filter.dateFrom, filter.dateTo, page, size
+            filter.dateFrom, filter.dateTo, filter.visibility, page, size
         ))
     }
 

--- a/backend/src/main/kotlin/com/budgetbook/transaction/repository/TransactionSpecifications.kt
+++ b/backend/src/main/kotlin/com/budgetbook/transaction/repository/TransactionSpecifications.kt
@@ -24,7 +24,10 @@ object TransactionSpecifications {
         pocketId: UUID?,
         amountMin: Long?,
         amountMax: Long?,
-        userId: UUID? = null
+        userId: UUID? = null,
+        // null/"ALL": 기본 동작(공유 + 본인 개인). "SHARED": 공유 거래만. "PRIVATE": 본인 개인만.
+        // 호출자(Service) 단계에서 이미 uppercase 정규화 + 유효성 검증된 값.
+        visibility: String? = null
     ): Specification<Transaction> {
         return Specification { root: Root<Transaction>, _: CriteriaQuery<*>, cb: CriteriaBuilder ->
             val predicates = mutableListOf<Predicate>()
@@ -60,14 +63,30 @@ object TransactionSpecifications {
                 predicates.add(cb.lessThanOrEqualTo(root.get("amount"), it))
             }
 
-            // Visibility filter: SHARED or owned by current user
-            userId?.let { uid ->
-                predicates.add(
-                    cb.or(
-                        cb.equal(root.get<Visibility>("visibility"), Visibility.SHARED),
-                        cb.equal(root.get<Any>("owner").get<UUID>("id"), uid)
-                    )
-                )
+            // Visibility 필터:
+            //   - "SHARED": 커플 공유 거래만
+            //   - "PRIVATE": 본인 소유 개인 거래만 (커플 모드에서 상대방 PRIVATE 은 자연스럽게 제외)
+            //   - null/"ALL": 기본 정책(공유 + 본인 개인)
+            when (visibility) {
+                "SHARED" -> {
+                    predicates.add(cb.equal(root.get<Visibility>("visibility"), Visibility.SHARED))
+                }
+                "PRIVATE" -> {
+                    predicates.add(cb.equal(root.get<Visibility>("visibility"), Visibility.PRIVATE))
+                    userId?.let { uid ->
+                        predicates.add(cb.equal(root.get<Any>("owner").get<UUID>("id"), uid))
+                    }
+                }
+                else -> {
+                    userId?.let { uid ->
+                        predicates.add(
+                            cb.or(
+                                cb.equal(root.get<Visibility>("visibility"), Visibility.SHARED),
+                                cb.equal(root.get<Any>("owner").get<UUID>("id"), uid)
+                            )
+                        )
+                    }
+                }
             }
 
             cb.and(*predicates.toTypedArray())

--- a/backend/src/main/kotlin/com/budgetbook/transaction/service/TransactionService.kt
+++ b/backend/src/main/kotlin/com/budgetbook/transaction/service/TransactionService.kt
@@ -65,6 +65,7 @@ class TransactionService(
         amountMax: Long? = null,
         dateFrom: LocalDate? = null,
         dateTo: LocalDate? = null,
+        visibility: String? = null,
         page: Int,
         size: Int
     ): PageResponse<TransactionResponse> {
@@ -91,12 +92,21 @@ class TransactionService(
             }
         }
 
+        // visibility 필터: 'ALL'/null 은 기본 동작(공유 + 본인 개인), 'SHARED'/'PRIVATE' 는 명시적 필터.
+        // 유효하지 않은 값은 VALIDATION_ERROR.
+        val visibilityFilter = visibility?.uppercase()?.takeIf { it != "ALL" }
+        if (visibilityFilter != null && visibilityFilter != "SHARED" && visibilityFilter != "PRIVATE") {
+            throw BusinessException("VALIDATION_ERROR", "Invalid visibility: $visibility")
+        }
+
         val pageSize = size.coerceIn(1, 100)
         val sort = Sort.by(Sort.Order.desc("transactionDate"), Sort.Order.desc("createdAt"))
         val pageable = PageRequest.of(page, pageSize, sort)
 
+        // SHARED/PRIVATE visibility 필터가 들어오면 legacy JPQL 경로는 지원하지 않으므로 Spec 경로로 강제.
         val hasExtendedFilters = keyword != null || paymentMethodId != null ||
-            pocketId != null || amountMin != null || amountMax != null
+            pocketId != null || amountMin != null || amountMax != null ||
+            visibilityFilter != null
 
         val result = if (hasExtendedFilters) {
             val spec = TransactionSpecifications.withFilters(
@@ -110,7 +120,8 @@ class TransactionService(
                 pocketId = pocketId,
                 amountMin = amountMin,
                 amountMax = amountMax,
-                userId = userId
+                userId = userId,
+                visibility = visibilityFilter
             )
             transactionRepository.findAll(spec, pageable)
         } else {

--- a/backend/src/test/kotlin/com/budgetbook/transaction/controller/TransactionControllerTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/transaction/controller/TransactionControllerTest.kt
@@ -55,7 +55,7 @@ class TransactionControllerTest : FunSpec({
             content = listOf(sampleTransactionResponse()),
             page = 0, size = 20, totalElements = 1, totalPages = 1, first = true, last = true
         )
-        every { transactionService.listTransactions(testUserId, 2024, 1, null, null, null, null, null, null, null, null, null, 0, 20) } returns pageResponse
+        every { transactionService.listTransactions(testUserId, 2024, 1, null, null, null, null, null, null, null, null, null, null, 0, 20) } returns pageResponse
 
         val filter = CommonFilterParams(year = 2024, month = 1)
         val result = controller.listTransactions(testUserId, filter, 0, 20)
@@ -70,7 +70,7 @@ class TransactionControllerTest : FunSpec({
             content = listOf(sampleTransactionResponse()),
             page = 0, size = 20, totalElements = 1, totalPages = 1, first = true, last = true
         )
-        every { transactionService.listTransactions(testUserId, 2024, 1, null, null, "점심", null, null, null, null, null, null, 0, 20) } returns pageResponse
+        every { transactionService.listTransactions(testUserId, 2024, 1, null, null, "점심", null, null, null, null, null, null, null, 0, 20) } returns pageResponse
 
         val filter = CommonFilterParams(year = 2024, month = 1, keyword = "점심")
         val result = controller.listTransactions(testUserId, filter, 0, 20)
@@ -85,7 +85,7 @@ class TransactionControllerTest : FunSpec({
             content = listOf(sampleTransactionResponse()),
             page = 0, size = 20, totalElements = 1, totalPages = 1, first = true, last = true
         )
-        every { transactionService.listTransactions(testUserId, 2024, 1, null, null, null, null, null, 10000, 50000, null, null, 0, 20) } returns pageResponse
+        every { transactionService.listTransactions(testUserId, 2024, 1, null, null, null, null, null, 10000, 50000, null, null, null, 0, 20) } returns pageResponse
 
         val filter = CommonFilterParams(year = 2024, month = 1, amountMin = 10000, amountMax = 50000)
         val result = controller.listTransactions(testUserId, filter, 0, 20)
@@ -102,7 +102,7 @@ class TransactionControllerTest : FunSpec({
         )
         val from = LocalDate.of(2024, 1, 1)
         val to = LocalDate.of(2024, 3, 31)
-        every { transactionService.listTransactions(testUserId, null, null, null, null, null, null, null, null, null, from, to, 0, 20) } returns pageResponse
+        every { transactionService.listTransactions(testUserId, null, null, null, null, null, null, null, null, null, from, to, null, 0, 20) } returns pageResponse
 
         val filter = CommonFilterParams(dateFrom = from, dateTo = to)
         val result = controller.listTransactions(testUserId, filter, 0, 20)
@@ -118,13 +118,46 @@ class TransactionControllerTest : FunSpec({
             page = 0, size = 20, totalElements = 1, totalPages = 1, first = true, last = true
         )
         val from = LocalDate.of(2024, 1, 1)
-        every { transactionService.listTransactions(testUserId, null, null, null, null, null, null, null, null, null, from, null, 0, 20) } returns pageResponse
+        every { transactionService.listTransactions(testUserId, null, null, null, null, null, null, null, null, null, from, null, null, 0, 20) } returns pageResponse
 
         val filter = CommonFilterParams(dateFrom = from)
         val result = controller.listTransactions(testUserId, filter, 0, 20)
 
         result.success shouldBe true
         result.data!!.totalElements shouldBe 1
+    }
+
+    test("listTransactions forwards visibility='SHARED' from filter to service (P6)") {
+
+        val pageResponse = PageResponse(
+            content = listOf(sampleTransactionResponse()),
+            page = 0, size = 20, totalElements = 1, totalPages = 1, first = true, last = true
+        )
+        every { transactionService.listTransactions(testUserId, 2024, 1, null, null, null, null, null, null, null, null, null, "SHARED", 0, 20) } returns pageResponse
+
+        val filter = CommonFilterParams(year = 2024, month = 1, visibility = "SHARED")
+        val result = controller.listTransactions(testUserId, filter, 0, 20)
+
+        result.success shouldBe true
+        verify(exactly = 1) {
+            transactionService.listTransactions(testUserId, 2024, 1, null, null, null, null, null, null, null, null, null, "SHARED", 0, 20)
+        }
+    }
+
+    test("listTransactions forwards visibility='PRIVATE' from filter to service (P6)") {
+
+        val pageResponse = PageResponse(
+            content = emptyList<TransactionResponse>(),
+            page = 0, size = 20, totalElements = 0, totalPages = 0, first = true, last = true
+        )
+        every { transactionService.listTransactions(testUserId, 2024, 1, null, null, null, null, null, null, null, null, null, "PRIVATE", 0, 20) } returns pageResponse
+
+        val filter = CommonFilterParams(year = 2024, month = 1, visibility = "PRIVATE")
+        controller.listTransactions(testUserId, filter, 0, 20)
+
+        verify(exactly = 1) {
+            transactionService.listTransactions(testUserId, 2024, 1, null, null, null, null, null, null, null, null, null, "PRIVATE", 0, 20)
+        }
     }
 
     test("createTransaction returns 201") {

--- a/backend/src/test/kotlin/com/budgetbook/transaction/service/TransactionServiceTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/transaction/service/TransactionServiceTest.kt
@@ -383,7 +383,7 @@ class TransactionServiceTest : BehaviorSpec({
         ) } returns page
 
         When("listTransactions is called for January 2024 without extended filters") {
-            val result = service.listTransactions(user1.id, 2024, 1, null, null, null, null, null, null, null, null, null, 0, 20)
+            val result = service.listTransactions(user1.id, 2024, 1, null, null, null, null, null, null, null, null, null, null, 0, 20)
 
             Then("returns paginated results using legacy query") {
                 result.content.size shouldBe 2
@@ -406,7 +406,7 @@ class TransactionServiceTest : BehaviorSpec({
         every { transactionRepository.findAll(any<org.springframework.data.jpa.domain.Specification<Transaction>>(), any<org.springframework.data.domain.Pageable>()) } returns page
 
         When("listTransactions is called with keyword filter") {
-            val result = service.listTransactions(user1.id, 2024, 1, null, null, "점심", null, null, null, null, null, null, 0, 20)
+            val result = service.listTransactions(user1.id, 2024, 1, null, null, "점심", null, null, null, null, null, null, null, 0, 20)
 
             Then("returns filtered results via specification") {
                 result.content.size shouldBe 1
@@ -426,7 +426,7 @@ class TransactionServiceTest : BehaviorSpec({
         every { transactionRepository.findAll(any<org.springframework.data.jpa.domain.Specification<Transaction>>(), any<org.springframework.data.domain.Pageable>()) } returns page
 
         When("listTransactions is called with amountMin and amountMax") {
-            val result = service.listTransactions(user1.id, 2024, 1, null, null, null, null, null, 10000, 50000, null, null, 0, 20)
+            val result = service.listTransactions(user1.id, 2024, 1, null, null, null, null, null, 10000, 50000, null, null, null, 0, 20)
 
             Then("returns filtered results via specification") {
                 result.content.size shouldBe 1
@@ -579,7 +579,7 @@ class TransactionServiceTest : BehaviorSpec({
         When("listTransactions is called with dateFrom and dateTo spanning multiple months") {
             val result = service.listTransactions(
                 user1.id, null, null, null, null, null, null, null, null, null,
-                LocalDate.of(2024, 1, 1), LocalDate.of(2024, 3, 31), 0, 20
+                LocalDate.of(2024, 1, 1), LocalDate.of(2024, 3, 31), null, 0, 20
             )
 
             Then("returns transactions in the date range, ignoring year/month") {
@@ -604,7 +604,7 @@ class TransactionServiceTest : BehaviorSpec({
         When("listTransactions is called with dateFrom only") {
             val result = service.listTransactions(
                 user1.id, null, null, null, null, null, null, null, null, null,
-                LocalDate.of(2024, 6, 1), null, 0, 20
+                LocalDate.of(2024, 6, 1), null, null, 0, 20
             )
 
             Then("returns transactions from dateFrom onwards") {
@@ -628,7 +628,7 @@ class TransactionServiceTest : BehaviorSpec({
         When("listTransactions is called with dateTo only") {
             val result = service.listTransactions(
                 user1.id, null, null, null, null, null, null, null, null, null,
-                null, LocalDate.of(2024, 3, 31), 0, 20
+                null, LocalDate.of(2024, 3, 31), null, 0, 20
             )
 
             Then("returns transactions up to dateTo") {
@@ -743,10 +743,102 @@ class TransactionServiceTest : BehaviorSpec({
         every { transactionRepository.findAll(any<org.springframework.data.jpa.domain.Specification<Transaction>>(), any<org.springframework.data.domain.Pageable>()) } returns page
 
         When("listTransactions is called with paymentMethodId") {
-            val result = service.listTransactions(user1.id, 2024, 1, null, null, null, pmId, null, null, null, null, null, 0, 20)
+            val result = service.listTransactions(user1.id, 2024, 1, null, null, null, pmId, null, null, null, null, null, null, 0, 20)
 
             Then("returns filtered results via specification") {
                 result.content.size shouldBe 1
+            }
+        }
+    }
+
+    // --- visibility 필터 (P6) ---
+
+    Given("transactions exist and visibility filter SHARED is used") {
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
+
+        val sharedTx = Transaction(
+            couple = couple, author = user1, type = TransactionType.EXPENSE,
+            amount = 15000, description = "공유 지출", transactionDate = LocalDate.of(2024, 1, 15),
+            visibility = Visibility.SHARED, owner = null
+        )
+        val page = PageImpl(listOf(sharedTx), PageRequest.of(0, 20), 1)
+        every { transactionRepository.findAll(any<org.springframework.data.jpa.domain.Specification<Transaction>>(), any<org.springframework.data.domain.Pageable>()) } returns page
+
+        When("listTransactions is called with visibility='SHARED'") {
+            val result = service.listTransactions(
+                user1.id, 2024, 1, null, null, null, null, null, null, null, null, null, "SHARED", 0, 20
+            )
+
+            Then("routes through Specification and returns shared-only transactions") {
+                result.content.size shouldBe 1
+                result.totalElements shouldBe 1
+                verify { transactionRepository.findAll(any<org.springframework.data.jpa.domain.Specification<Transaction>>(), any<org.springframework.data.domain.Pageable>()) }
+            }
+        }
+    }
+
+    Given("transactions exist and visibility filter PRIVATE is used") {
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
+
+        val privateTx = Transaction(
+            couple = couple, author = user1, type = TransactionType.EXPENSE,
+            amount = 5000, description = "개인 지출", transactionDate = LocalDate.of(2024, 1, 10),
+            visibility = Visibility.PRIVATE, owner = user1
+        )
+        val page = PageImpl(listOf(privateTx), PageRequest.of(0, 20), 1)
+        every { transactionRepository.findAll(any<org.springframework.data.jpa.domain.Specification<Transaction>>(), any<org.springframework.data.domain.Pageable>()) } returns page
+
+        When("listTransactions is called with visibility='PRIVATE'") {
+            val result = service.listTransactions(
+                user1.id, 2024, 1, null, null, null, null, null, null, null, null, null, "PRIVATE", 0, 20
+            )
+
+            Then("routes through Specification and returns owner's private transactions") {
+                result.content.size shouldBe 1
+                result.totalElements shouldBe 1
+                verify { transactionRepository.findAll(any<org.springframework.data.jpa.domain.Specification<Transaction>>(), any<org.springframework.data.domain.Pageable>()) }
+            }
+        }
+    }
+
+    Given("transactions exist and visibility filter ALL is used") {
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
+
+        val tx = Transaction(
+            couple = couple, author = user1, type = TransactionType.EXPENSE,
+            amount = 15000, description = "거래", transactionDate = LocalDate.of(2024, 1, 15),
+            visibility = Visibility.SHARED, owner = null
+        )
+        val page = PageImpl(listOf(tx), PageRequest.of(0, 20), 1)
+        every { transactionRepository.findByCoupleIdAndFilters(
+            couple.id, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 1, 31), null, null, user1.id, any()
+        ) } returns page
+
+        When("listTransactions is called with visibility='ALL'") {
+            val result = service.listTransactions(
+                user1.id, 2024, 1, null, null, null, null, null, null, null, null, null, "ALL", 0, 20
+            )
+
+            Then("falls back to legacy JPQL path (ALL == default behavior)") {
+                result.content.size shouldBe 1
+                verify { transactionRepository.findByCoupleIdAndFilters(
+                    couple.id, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 1, 31), null, null, user1.id, any()
+                ) }
+            }
+        }
+    }
+
+    Given("an invalid visibility value is provided") {
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
+
+        When("listTransactions is called with visibility='INVALID'") {
+            Then("throws BusinessException with VALIDATION_ERROR") {
+                val ex = shouldThrow<com.budgetbook.common.exception.BusinessException> {
+                    service.listTransactions(
+                        user1.id, 2024, 1, null, null, null, null, null, null, null, null, null, "INVALID", 0, 20
+                    )
+                }
+                ex.code shouldBe "VALIDATION_ERROR"
             }
         }
     }

--- a/frontend/lib/features/transaction/data/datasources/transaction_remote_datasource.dart
+++ b/frontend/lib/features/transaction/data/datasources/transaction_remote_datasource.dart
@@ -2,6 +2,7 @@ import 'package:budget_book/core/network/api_client.dart';
 import 'package:budget_book/core/constants/api_endpoints.dart';
 import 'package:budget_book/features/transaction/data/models/transaction_model.dart';
 import 'package:budget_book/features/transaction/domain/entities/page_response.dart';
+import 'package:budget_book/features/transaction/domain/entities/transaction_filter.dart';
 import 'package:budget_book/features/transaction/domain/repositories/transaction_repository.dart';
 
 abstract class TransactionRemoteDataSource {
@@ -17,6 +18,7 @@ abstract class TransactionRemoteDataSource {
     int? amountMax,
     String? dateFrom,
     String? dateTo,
+    String? visibility,
     int page = 0,
     int size = 20,
   });
@@ -46,24 +48,31 @@ class TransactionRemoteDataSourceImpl implements TransactionRemoteDataSource {
     int? amountMax,
     String? dateFrom,
     String? dateTo,
+    String? visibility,
     int page = 0,
     int size = 20,
   }) async {
+    // S2 구조적 수정: 개별 필드 인라인 조립 제거, TransactionFilter.toQueryParams() 로 중앙화.
+    // 신규 필터는 TransactionFilter VO + toQueryParams() 한 곳만 수정하면 FE→BE 전달 자동 반영.
+    final filter = TransactionFilter(
+      keyword: keyword,
+      categoryId: categoryId,
+      paymentMethodId: paymentMethodId,
+      pocketId: pocketId,
+      amountMin: amountMin,
+      amountMax: amountMax,
+      dateFrom: dateFrom,
+      dateTo: dateTo,
+      type: type,
+      visibility: visibility,
+    );
     final queryParams = <String, dynamic>{
       'page': page,
       'size': size,
+      ...filter.toQueryParams(),
     };
     if (year != null) queryParams['year'] = year;
     if (month != null) queryParams['month'] = month;
-    if (type != null) queryParams['type'] = type;
-    if (categoryId != null) queryParams['categoryId'] = categoryId;
-    if (keyword != null && keyword.isNotEmpty) queryParams['keyword'] = keyword;
-    if (paymentMethodId != null) queryParams['paymentMethodId'] = paymentMethodId;
-    if (pocketId != null) queryParams['pocketId'] = pocketId;
-    if (amountMin != null) queryParams['amountMin'] = amountMin;
-    if (amountMax != null) queryParams['amountMax'] = amountMax;
-    if (dateFrom != null) queryParams['dateFrom'] = dateFrom;
-    if (dateTo != null) queryParams['dateTo'] = dateTo;
 
     final response = await apiClient.dio.get(
       ApiEndpoints.transactions,

--- a/frontend/lib/features/transaction/data/repositories/transaction_repository_impl.dart
+++ b/frontend/lib/features/transaction/data/repositories/transaction_repository_impl.dart
@@ -25,6 +25,7 @@ class TransactionRepositoryImpl implements TransactionRepository {
     int? amountMax,
     String? dateFrom,
     String? dateTo,
+    String? visibility,
     int page = 0,
     int size = 20,
   }) async {
@@ -41,6 +42,7 @@ class TransactionRepositoryImpl implements TransactionRepository {
         amountMax: amountMax,
         dateFrom: dateFrom,
         dateTo: dateTo,
+        visibility: visibility,
         page: page,
         size: size,
       );

--- a/frontend/lib/features/transaction/domain/entities/transaction_filter.dart
+++ b/frontend/lib/features/transaction/domain/entities/transaction_filter.dart
@@ -88,3 +88,30 @@ class TransactionFilter extends Equatable {
         visibility,
       ];
 }
+
+/// 필터 VO → 네트워크 queryParams 변환의 단일 접근점.
+///
+/// DataSource 가 개별 필드를 인라인으로 조립하다가 한 필드를 빠뜨리는 사고
+/// (예: 2026-04-20 visibility 필터 BE 미전달, 4회째 재발) 재발 방지를 위한
+/// S2 구조적 수정. 신규 필터 추가 시 이 한 곳만 수정하면 FE→BE 전달이 보장된다.
+///
+/// 주의: 'ALL' visibility 는 BE 기본 동작(공유 + 본인 개인)과 동일하므로
+/// queryParams 에 포함하지 않는다 (불필요한 네트워크 바이트 + BE 와일드카드 방지).
+extension TransactionFilterQueryParams on TransactionFilter {
+  Map<String, dynamic> toQueryParams() {
+    final params = <String, dynamic>{};
+    if (type != null) params['type'] = type;
+    if (categoryId != null) params['categoryId'] = categoryId;
+    if (keyword != null && keyword!.isNotEmpty) params['keyword'] = keyword;
+    if (paymentMethodId != null) params['paymentMethodId'] = paymentMethodId;
+    if (pocketId != null) params['pocketId'] = pocketId;
+    if (amountMin != null) params['amountMin'] = amountMin;
+    if (amountMax != null) params['amountMax'] = amountMax;
+    if (dateFrom != null) params['dateFrom'] = dateFrom;
+    if (dateTo != null) params['dateTo'] = dateTo;
+    if (visibility != null && visibility != 'ALL') {
+      params['visibility'] = visibility;
+    }
+    return params;
+  }
+}

--- a/frontend/lib/features/transaction/domain/repositories/transaction_repository.dart
+++ b/frontend/lib/features/transaction/domain/repositories/transaction_repository.dart
@@ -16,6 +16,7 @@ abstract class TransactionRepository {
     int? amountMax,
     String? dateFrom,
     String? dateTo,
+    String? visibility,
     int page = 0,
     int size = 20,
   });

--- a/frontend/lib/features/transaction/presentation/bloc/transaction_bloc.dart
+++ b/frontend/lib/features/transaction/presentation/bloc/transaction_bloc.dart
@@ -112,6 +112,7 @@ class TransactionBloc extends Bloc<TransactionEvent, TransactionState> {
         dateFrom: event.dateFrom,
         dateTo: event.dateTo,
         type: event.type,
+        visibility: event.visibility,
         page: 0,
         size: _pageSize,
       );
@@ -255,6 +256,7 @@ class TransactionBloc extends Bloc<TransactionEvent, TransactionState> {
         dateFrom: _currentDateFrom,
         dateTo: _currentDateTo,
         type: _currentType,
+        visibility: _currentVisibility,
         page: nextPage,
         size: _pageSize,
       );
@@ -344,6 +346,7 @@ class TransactionBloc extends Bloc<TransactionEvent, TransactionState> {
               dateFrom: _currentDateFrom,
               dateTo: _currentDateTo,
               type: _currentType,
+              visibility: _currentVisibility,
             )),
       );
     } catch (e) {
@@ -395,6 +398,7 @@ class TransactionBloc extends Bloc<TransactionEvent, TransactionState> {
               dateFrom: _currentDateFrom,
               dateTo: _currentDateTo,
               type: _currentType,
+              visibility: _currentVisibility,
             )),
       );
     } catch (e) {

--- a/frontend/test/features/transaction/data/repositories/transaction_repository_impl_test.dart
+++ b/frontend/test/features/transaction/data/repositories/transaction_repository_impl_test.dart
@@ -27,6 +27,7 @@ class MockTransactionRemoteDataSource extends Mock
     int? amountMax,
     String? dateFrom,
     String? dateTo,
+    String? visibility,
     int page = 0,
     int size = 20,
   }) =>
@@ -43,6 +44,7 @@ class MockTransactionRemoteDataSource extends Mock
           #amountMax: amountMax,
           #dateFrom: dateFrom,
           #dateTo: dateTo,
+          #visibility: visibility,
           #page: page,
           #size: size,
         }),

--- a/frontend/test/features/transaction/presentation/bloc/transaction_bloc_test.dart
+++ b/frontend/test/features/transaction/presentation/bloc/transaction_bloc_test.dart
@@ -27,6 +27,7 @@ class MockTransactionRepository extends Mock
     int? amountMax,
     String? dateFrom,
     String? dateTo,
+    String? visibility,
     int page = 0,
     int size = 20,
   }) =>
@@ -43,6 +44,7 @@ class MockTransactionRepository extends Mock
           #amountMax: amountMax,
           #dateFrom: dateFrom,
           #dateTo: dateTo,
+          #visibility: visibility,
           #page: page,
           #size: size,
         }),


### PR DESCRIPTION
## Summary
- P6: visibility 필드 FE→BE 전달 체인 완성 — Repo/DataSource + Controller/Service
- S2 구조적 수정: `TransactionFilter.toQueryParams()` 확장 함수 중앙화 (인라인 직렬화 제거)
- couple 모드 SHARED / PRIVATE / ALL 3가지 동작
- 기존 `CommonFilterParams` DTO 재활용 (visibility 필드 이미 있었음 — 누락은 Controller→Service 전달뿐)

## Test plan
- [x] BE `./gradlew test` — PASS
- [x] BE `./gradlew build` — PASS
- [x] FE `flutter analyze` — No issues found
- [x] FE `flutter test` — 669 tests pass
- [x] FE `flutter build web --release` — PASS
- [ ] 라이브: "공유" 공개 범위 선택 + 적용 → BE 쿼리에 visibility=SHARED 전달 확인

Refs: docs/sessions/2026-04-20_6_plan.md PR-B

🤖 Generated with [Claude Code](https://claude.com/claude-code)