### PR TITLE
feat(widgets): 선택 sheet multi 모드 도입 (PR-C 1/N)

### DIFF
--- a/frontend/lib/core/widgets/category_group_selector_sheet.dart
+++ b/frontend/lib/core/widgets/category_group_selector_sheet.dart
@@ -17,25 +17,63 @@ import 'package:budget_book/features/preference/presentation/bloc/favorites_bloc
 import 'package:budget_book/features/preference/presentation/bloc/favorites_event.dart';
 import 'package:budget_book/features/preference/presentation/bloc/favorites_state.dart';
 
+/// Selection mode for [CategoryGroupSelectorSheet].
+///
+/// - [singleCategory]: Legacy behavior — tapping a category fires
+///   [CategoryGroupSelectorSheet.onSelected] and pops the sheet.
+/// - [multiCategoryWithGroup]: Checkboxes on every category and group header.
+///   Selecting a group checkbox cascades to its categories (both the group id
+///   is kept in `_tempGroupIds` and all child category ids are added to
+///   `_tempCategoryIds`). On apply, [CategoryGroupSelectorSheet.onApplyMulti]
+///   is invoked with `(categoryIds, groupIds)`.
+enum CategorySelectionMode { singleCategory, multiCategoryWithGroup }
+
 /// Hierarchical category selector: groups -> sub-categories.
 /// Groups are expandable headers, only sub-categories are selectable.
 /// Groups are separated into SHARED and PRIVATE sections.
 class CategoryGroupSelectorSheet extends StatefulWidget {
   final String? selectedCategoryId;
   final String categoryType; // 'INCOME' or 'EXPENSE'
-  final ValueChanged<Category?> onSelected;
+
+  /// Selection mode. Defaults to [CategorySelectionMode.singleCategory].
+  final CategorySelectionMode mode;
+
+  /// Single-mode selection callback.
+  final ValueChanged<Category?>? onSelected;
   final ValueChanged<String>? onDelete;
   /// Called with (category, groupName) for display purposes.
   final void Function(Category? category, String? groupName)? onSelectedWithGroupName;
+
+  /// Multi-mode: initially checked category ids.
+  final Set<String> initialCategoryIds;
+
+  /// Multi-mode: initially checked group ids.
+  final Set<String> initialGroupIds;
+
+  /// Multi-mode apply callback with `(categoryIds, groupIds)`.
+  final void Function(Set<String> categoryIds, Set<String> groupIds)? onApplyMulti;
 
   const CategoryGroupSelectorSheet({
     super.key,
     this.selectedCategoryId,
     required this.categoryType,
-    required this.onSelected,
+    this.mode = CategorySelectionMode.singleCategory,
+    this.onSelected,
     this.onDelete,
     this.onSelectedWithGroupName,
-  });
+    this.initialCategoryIds = const {},
+    this.initialGroupIds = const {},
+    this.onApplyMulti,
+  })  : assert(
+          mode == CategorySelectionMode.singleCategory ? onSelected != null : true,
+          'CategorySelectionMode.singleCategory requires onSelected',
+        ),
+        assert(
+          mode == CategorySelectionMode.multiCategoryWithGroup
+              ? onApplyMulti != null
+              : true,
+          'CategorySelectionMode.multiCategoryWithGroup requires onApplyMulti',
+        );
 
   @override
   State<CategoryGroupSelectorSheet> createState() =>
@@ -49,13 +87,54 @@ class _CategoryGroupSelectorSheetState
   final _categoryNameController = TextEditingController();
   bool _autoExpandedOnce = false;
 
+  late Set<String> _tempCategoryIds;
+  late Set<String> _tempGroupIds;
+
+  bool get _isMulti =>
+      widget.mode == CategorySelectionMode.multiCategoryWithGroup;
+
   @override
   void initState() {
     super.initState();
+    _tempCategoryIds = {...widget.initialCategoryIds};
+    _tempGroupIds = {...widget.initialGroupIds};
     final bloc = getIt<CategoryGroupBloc>();
     if (bloc.state is! CategoryGroupLoaded) {
       bloc.add(const LoadCategoryGroups());
     }
+  }
+
+  void _toggleCategory(String id) {
+    setState(() {
+      if (_tempCategoryIds.contains(id)) {
+        _tempCategoryIds.remove(id);
+      } else {
+        _tempCategoryIds.add(id);
+      }
+    });
+  }
+
+  void _setGroupCheckedCascade(CategoryGroup group, bool checked) {
+    final childIds = group.categories
+        .where((c) => c.type == widget.categoryType)
+        .map((c) => c.id)
+        .toList();
+    setState(() {
+      if (checked) {
+        _tempGroupIds.add(group.id);
+        _tempCategoryIds.addAll(childIds);
+      } else {
+        _tempGroupIds.remove(group.id);
+        _tempCategoryIds.removeAll(childIds);
+      }
+    });
+  }
+
+  void _clearAllMulti() {
+    setState(() {
+      _tempCategoryIds.clear();
+      _tempGroupIds.clear();
+    });
   }
 
   @override
@@ -137,19 +216,50 @@ class _CategoryGroupSelectorSheetState
                   ),
                 ),
                 const Divider(height: 1),
-                Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-                  child: Align(
-                    alignment: Alignment.centerRight,
-                    child: TextButton(
-                      onPressed: () {
-                        Navigator.of(context).pop();
-                        context.push('/asset-management');
-                      },
-                      child: const Text('순서 관리 >'),
+                if (_isMulti)
+                  Padding(
+                    padding: const EdgeInsets.fromLTRB(16, 8, 16, 12),
+                    child: Row(
+                      children: [
+                        Expanded(
+                          child: OutlinedButton(
+                            onPressed: _clearAllMulti,
+                            child: const Text('전체 해제'),
+                          ),
+                        ),
+                        const SizedBox(width: 8),
+                        Expanded(
+                          flex: 2,
+                          child: FilledButton(
+                            onPressed: () {
+                              widget.onApplyMulti!(
+                                {..._tempCategoryIds},
+                                {..._tempGroupIds},
+                              );
+                              Navigator.of(context).pop();
+                            },
+                            child: Text(
+                              '적용 (${_tempCategoryIds.length + _tempGroupIds.length})',
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  )
+                else
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                    child: Align(
+                      alignment: Alignment.centerRight,
+                      child: TextButton(
+                        onPressed: () {
+                          Navigator.of(context).pop();
+                          context.push('/asset-management');
+                        },
+                        child: const Text('순서 관리 >'),
+                      ),
                     ),
                   ),
-                ),
               ],
             ),
           ),
@@ -236,11 +346,20 @@ class _CategoryGroupSelectorSheetState
                       break;
                     }
                   }
+                  if (_isMulti) {
+                    final selected = _tempCategoryIds.contains(cat.id);
+                    return FilterChip(
+                      label: Text(cat.name),
+                      avatar: const Icon(Icons.star, size: 14, color: Colors.amber),
+                      selected: selected,
+                      onSelected: (_) => _toggleCategory(cat.id),
+                    );
+                  }
                   return ActionChip(
                     label: Text(cat.name),
                     avatar: const Icon(Icons.star, size: 14, color: Colors.amber),
                     onPressed: () {
-                      widget.onSelected(cat);
+                      widget.onSelected!(cat);
                       widget.onSelectedWithGroupName?.call(cat, groupName);
                       Navigator.of(context).pop();
                     },
@@ -272,25 +391,27 @@ class _CategoryGroupSelectorSheetState
           ));
         }
 
-        // Add shared group button
-        children.add(
-          ListTile(
-            dense: true,
-            leading: Icon(
-              Icons.add,
-              size: 18,
-              color: Theme.of(context).colorScheme.primary,
-            ),
-            title: Text(
-              '공유 그룹 추가',
-              style: TextStyle(
-                fontSize: 13,
+        // Add shared group button — hidden in multi mode (filter context)
+        if (!_isMulti) {
+          children.add(
+            ListTile(
+              dense: true,
+              leading: Icon(
+                Icons.add,
+                size: 18,
                 color: Theme.of(context).colorScheme.primary,
               ),
+              title: Text(
+                '공유 그룹 추가',
+                style: TextStyle(
+                  fontSize: 13,
+                  color: Theme.of(context).colorScheme.primary,
+                ),
+              ),
+              onTap: () => _showAddGroupDialog(context),
             ),
-            onTap: () => _showAddGroupDialog(context),
-          ),
-        );
+          );
+        }
 
         // Private section (couple mode only)
         if (coupled && (privateGroups.isNotEmpty || true)) {
@@ -353,8 +474,8 @@ class _CategoryGroupSelectorSheetState
           ));
         }
 
-        // Add private group button (couple mode only)
-        if (coupled) {
+        // Add private group button (couple mode only, hidden in multi)
+        if (coupled && !_isMulti) {
           children.add(
             ListTile(
               dense: true,
@@ -392,6 +513,8 @@ class _CategoryGroupSelectorSheetState
   ) {
     final color = UIHelpers.parseColor(group.color);
 
+    final groupChecked = _isMulti && _tempGroupIds.contains(group.id);
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -415,6 +538,15 @@ class _CategoryGroupSelectorSheetState
                 const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
             child: Row(
               children: [
+                if (_isMulti)
+                  Padding(
+                    padding: const EdgeInsets.only(right: 4),
+                    child: Checkbox(
+                      value: groupChecked,
+                      onChanged: (value) =>
+                          _setGroupCheckedCascade(group, value ?? false),
+                    ),
+                  ),
                 CircleAvatar(
                   radius: 16,
                   backgroundColor: color.withValues(alpha: 0.15),
@@ -477,26 +609,27 @@ class _CategoryGroupSelectorSheetState
         // Expanded sub-categories
         if (isExpanded) ...[
           ...categories.map((c) => _buildCategoryTile(context, c, group.name, favCategoryIds)),
-          // Add sub-category button
-          Padding(
-            padding: const EdgeInsets.only(left: 24),
-            child: ListTile(
-              dense: true,
-              leading: Icon(
-                Icons.add,
-                size: 18,
-                color: Theme.of(context).colorScheme.primary,
-              ),
-              title: Text(
-                '하위 카테고리 추가',
-                style: TextStyle(
-                  fontSize: 13,
+          // Add sub-category button — hidden in multi mode (filter context)
+          if (!_isMulti)
+            Padding(
+              padding: const EdgeInsets.only(left: 24),
+              child: ListTile(
+                dense: true,
+                leading: Icon(
+                  Icons.add,
+                  size: 18,
                   color: Theme.of(context).colorScheme.primary,
                 ),
+                title: Text(
+                  '하위 카테고리 추가',
+                  style: TextStyle(
+                    fontSize: 13,
+                    color: Theme.of(context).colorScheme.primary,
+                  ),
+                ),
+                onTap: () => _showAddCategoryDialog(context, group),
               ),
-              onTap: () => _showAddCategoryDialog(context, group),
             ),
-          ),
         ],
         const Divider(height: 1),
       ],
@@ -509,7 +642,9 @@ class _CategoryGroupSelectorSheetState
     String groupName,
     List<String> favCategoryIds,
   ) {
-    final isSelected = category.id == widget.selectedCategoryId;
+    final isSingleSelected =
+        !_isMulti && category.id == widget.selectedCategoryId;
+    final isMultiSelected = _isMulti && _tempCategoryIds.contains(category.id);
     final color = UIHelpers.parseColor(category.color);
     final isFavorite = favCategoryIds.contains(category.id);
 
@@ -517,22 +652,42 @@ class _CategoryGroupSelectorSheetState
       padding: const EdgeInsets.only(left: 24),
       child: ListTile(
         dense: true,
-        leading: CircleAvatar(
-          radius: 14,
-          backgroundColor: color.withValues(alpha: 0.15),
-          child: Icon(
-            Icons.label,
-            color: color,
-            size: 16,
-          ),
-        ),
+        leading: _isMulti
+            ? Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Checkbox(
+                    value: isMultiSelected,
+                    onChanged: (_) => _toggleCategory(category.id),
+                  ),
+                  CircleAvatar(
+                    radius: 14,
+                    backgroundColor: color.withValues(alpha: 0.15),
+                    child: Icon(
+                      Icons.label,
+                      color: color,
+                      size: 16,
+                    ),
+                  ),
+                ],
+              )
+            : CircleAvatar(
+                radius: 14,
+                backgroundColor: color.withValues(alpha: 0.15),
+                child: Icon(
+                  Icons.label,
+                  color: color,
+                  size: 16,
+                ),
+              ),
         title: Text(
           category.name,
           style: TextStyle(
-            fontWeight: isSelected ? FontWeight.bold : FontWeight.normal,
+            fontWeight:
+                (isSingleSelected || isMultiSelected) ? FontWeight.bold : FontWeight.normal,
           ),
         ),
-        selected: isSelected,
+        selected: isSingleSelected || isMultiSelected,
         selectedTileColor: Theme.of(context)
             .colorScheme
             .primaryContainer
@@ -557,25 +712,27 @@ class _CategoryGroupSelectorSheetState
                 ),
               ),
             ),
-            // Edit button
-            GestureDetector(
-              onTap: () => _showEditCategoryDialog(context, category),
-              child: Padding(
-                padding: const EdgeInsets.all(4),
-                child: Icon(
-                  Icons.edit_outlined,
-                  size: 16,
-                  color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.4),
+            // Edit button — hidden in multi mode (filter context)
+            if (!_isMulti)
+              GestureDetector(
+                onTap: () => _showEditCategoryDialog(context, category),
+                child: Padding(
+                  padding: const EdgeInsets.all(4),
+                  child: Icon(
+                    Icons.edit_outlined,
+                    size: 16,
+                    color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.4),
+                  ),
                 ),
               ),
-            ),
-            if (isSelected)
+            if (isSingleSelected)
               Icon(
                 Icons.check,
                 size: 18,
                 color: Theme.of(context).colorScheme.primary,
               ),
-            if (widget.onDelete != null)
+            // Delete button — hidden in multi mode (filter context)
+            if (widget.onDelete != null && !_isMulti)
               IconButton(
                 icon: Icon(
                   Icons.delete_outline,
@@ -588,9 +745,13 @@ class _CategoryGroupSelectorSheetState
           ],
         ),
         onTap: () {
-          widget.onSelected(category);
-          widget.onSelectedWithGroupName?.call(category, groupName);
-          Navigator.of(context).pop();
+          if (_isMulti) {
+            _toggleCategory(category.id);
+          } else {
+            widget.onSelected!(category);
+            widget.onSelectedWithGroupName?.call(category, groupName);
+            Navigator.of(context).pop();
+          }
         },
       ),
     );

--- a/frontend/lib/core/widgets/item_selector_sheet.dart
+++ b/frontend/lib/core/widgets/item_selector_sheet.dart
@@ -30,11 +30,38 @@ class SelectorItem {
   });
 }
 
-class ItemSelectorSheet extends StatelessWidget {
+/// Selection mode for [ItemSelectorSheet].
+///
+/// - [single]: Legacy behavior — tapping an item fires [ItemSelectorSheet.onSelected]
+///   and immediately pops the sheet.
+/// - [multi]: Each tile renders a checkbox; tapping toggles membership in an
+///   internal [Set]; a bottom apply bar invokes [ItemSelectorSheet.onApplyMulti]
+///   with the final selection and then pops.
+enum SelectionMode { single, multi }
+
+class ItemSelectorSheet extends StatefulWidget {
   final String title;
   final List<SelectorItem> items;
+
+  /// Selection mode. Defaults to [SelectionMode.single] for backward compatibility.
+  final SelectionMode mode;
+
+  /// Single-select: currently selected id (highlighted).
   final String? selectedId;
-  final ValueChanged<SelectorItem?> onSelected;
+
+  /// Single-select callback. Required when [mode] == [SelectionMode.single].
+  final ValueChanged<SelectorItem?>? onSelected;
+
+  /// Multi-select: initially selected ids.
+  final Set<String> initialSelectedIds;
+
+  /// Multi-select callback. Required when [mode] == [SelectionMode.multi].
+  /// Called once with the final set when the user presses the apply button.
+  final void Function(Set<String> ids)? onApplyMulti;
+
+  /// Multi-select upper bound. Beyond this, further checks are refused with a SnackBar.
+  final int maxSelection;
+
   final ValueChanged<String>? onDelete;
   final ValueChanged<SelectorItem>? onEdit;
   final VoidCallback? onCreate;
@@ -59,8 +86,12 @@ class ItemSelectorSheet extends StatelessWidget {
     super.key,
     required this.title,
     required this.items,
+    this.mode = SelectionMode.single,
     this.selectedId,
-    required this.onSelected,
+    this.onSelected,
+    this.initialSelectedIds = const {},
+    this.onApplyMulti,
+    this.maxSelection = 50,
     this.onDelete,
     this.onEdit,
     this.onCreate,
@@ -71,12 +102,99 @@ class ItemSelectorSheet extends StatelessWidget {
     this.favoriteType,
     this.reorderRoute,
     this.groupLabels,
-  });
+  })  : assert(
+          mode == SelectionMode.single ? onSelected != null : true,
+          'SelectionMode.single requires onSelected',
+        ),
+        assert(
+          mode == SelectionMode.multi ? onApplyMulti != null : true,
+          'SelectionMode.multi requires onApplyMulti',
+        );
+
+  @override
+  State<ItemSelectorSheet> createState() => _ItemSelectorSheetState();
+}
+
+class _ItemSelectorSheetState extends State<ItemSelectorSheet> {
+  late Set<String> _tempSelectedIds;
+
+  bool get _isMulti => widget.mode == SelectionMode.multi;
+
+  @override
+  void initState() {
+    super.initState();
+    _tempSelectedIds = {...widget.initialSelectedIds};
+  }
+
+  void _toggleItem(String id) {
+    setState(() {
+      if (_tempSelectedIds.contains(id)) {
+        _tempSelectedIds.remove(id);
+      } else {
+        if (_tempSelectedIds.length >= widget.maxSelection) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text('최대 ${widget.maxSelection}개까지 선택할 수 있습니다.'),
+              duration: const Duration(seconds: 2),
+            ),
+          );
+          return;
+        }
+        _tempSelectedIds.add(id);
+      }
+    });
+  }
+
+  void _setGroupSelection(Iterable<String> groupItemIds, bool select) {
+    setState(() {
+      if (select) {
+        for (final id in groupItemIds) {
+          if (_tempSelectedIds.contains(id)) continue;
+          if (_tempSelectedIds.length >= widget.maxSelection) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(
+                content: Text('최대 ${widget.maxSelection}개까지 선택할 수 있습니다.'),
+                duration: const Duration(seconds: 2),
+              ),
+            );
+            break;
+          }
+          _tempSelectedIds.add(id);
+        }
+      } else {
+        _tempSelectedIds.removeAll(groupItemIds);
+      }
+    });
+  }
+
+  void _selectAll(List<SelectorItem> sortedItems) {
+    setState(() {
+      final toAdd = sortedItems
+          .map((e) => e.id)
+          .where((id) => !_tempSelectedIds.contains(id))
+          .take(widget.maxSelection - _tempSelectedIds.length);
+      _tempSelectedIds.addAll(toAdd);
+      if (sortedItems.length > widget.maxSelection) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('최대 ${widget.maxSelection}개까지 선택되었습니다.'),
+            duration: const Duration(seconds: 2),
+          ),
+        );
+      }
+    });
+  }
+
+  void _clearAll() {
+    setState(() {
+      _tempSelectedIds.clear();
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
     // Sort items by displayOrder
-    final sortedItems = List<SelectorItem>.from(items)
+    final sortedItems = List<SelectorItem>.from(widget.items)
       ..sort((a, b) => a.displayOrder.compareTo(b.displayOrder));
 
     return BlocProvider<FavoritesBloc>.value(
@@ -102,7 +220,7 @@ class ItemSelectorSheet extends StatelessWidget {
                   mainAxisAlignment: MainAxisAlignment.spaceBetween,
                   children: [
                     Text(
-                      title,
+                      widget.title,
                       style: Theme.of(context).textTheme.titleMedium?.copyWith(
                             fontWeight: FontWeight.bold,
                           ),
@@ -122,7 +240,7 @@ class ItemSelectorSheet extends StatelessWidget {
                 child: BlocBuilder<FavoritesBloc, FavoritesState>(
                   builder: (context, favState) {
                     final favIds = _getFavoriteIds(favState);
-                    final favoriteItems = favoriteType != null
+                    final favoriteItems = widget.favoriteType != null
                         ? sortedItems.where((item) => favIds.contains(item.id)).toList()
                         : <SelectorItem>[];
 
@@ -152,20 +270,31 @@ class ItemSelectorSheet extends StatelessWidget {
                             child: Wrap(
                               spacing: 8,
                               runSpacing: 4,
-                              children: favoriteItems.map((item) => ActionChip(
-                                label: Text(item.label),
-                                avatar: const Icon(Icons.star, size: 14, color: Colors.amber),
-                                onPressed: () {
-                                  onSelected(item);
-                                  Navigator.of(context).pop();
-                                },
-                              )).toList(),
+                              children: favoriteItems.map((item) {
+                                if (_isMulti) {
+                                  final selected = _tempSelectedIds.contains(item.id);
+                                  return FilterChip(
+                                    label: Text(item.label),
+                                    avatar: const Icon(Icons.star, size: 14, color: Colors.amber),
+                                    selected: selected,
+                                    onSelected: (_) => _toggleItem(item.id),
+                                  );
+                                }
+                                return ActionChip(
+                                  label: Text(item.label),
+                                  avatar: const Icon(Icons.star, size: 14, color: Colors.amber),
+                                  onPressed: () {
+                                    widget.onSelected!(item);
+                                    Navigator.of(context).pop();
+                                  },
+                                );
+                              }).toList(),
                             ),
                           ),
                           const Divider(),
                         ],
-                        // Null option
-                        if (allowNull)
+                        // Null option — hidden in multi mode
+                        if (widget.allowNull && !_isMulti)
                           ListTile(
                             leading: CircleAvatar(
                               backgroundColor: Theme.of(context)
@@ -173,24 +302,24 @@ class ItemSelectorSheet extends StatelessWidget {
                                   .surfaceContainerHighest,
                               child: const Icon(Icons.block, size: 20),
                             ),
-                            title: Text(nullLabel),
-                            selected: selectedId == null,
+                            title: Text(widget.nullLabel),
+                            selected: widget.selectedId == null,
                             selectedTileColor: Theme.of(context)
                                 .colorScheme
                                 .primaryContainer
                                 .withValues(alpha: 0.3),
                             onTap: () {
-                              onSelected(null);
+                              widget.onSelected!(null);
                               Navigator.of(context).pop();
                             },
                           ),
                         // Items
-                        if (sortedItems.isEmpty && emptyLabel != null)
+                        if (sortedItems.isEmpty && widget.emptyLabel != null)
                           Padding(
                             padding: const EdgeInsets.all(24),
                             child: Center(
                               child: Text(
-                                emptyLabel!,
+                                widget.emptyLabel!,
                                 style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                                       color: Theme.of(context)
                                           .colorScheme
@@ -201,8 +330,8 @@ class ItemSelectorSheet extends StatelessWidget {
                             ),
                           ),
                         ..._buildGroupedItems(context, sortedItems, favIds),
-                        // Create option
-                        if (onCreate != null) ...[
+                        // Create option — hidden in multi mode (filter context)
+                        if (widget.onCreate != null && !_isMulti) ...[
                           const Divider(height: 1),
                           ListTile(
                             leading: CircleAvatar(
@@ -217,7 +346,7 @@ class ItemSelectorSheet extends StatelessWidget {
                               ),
                             ),
                             title: Text(
-                              createLabel,
+                              widget.createLabel,
                               style: TextStyle(
                                 color: Theme.of(context).colorScheme.primary,
                                 fontWeight: FontWeight.w500,
@@ -225,7 +354,7 @@ class ItemSelectorSheet extends StatelessWidget {
                             ),
                             onTap: () {
                               Navigator.of(context).pop();
-                              onCreate!();
+                              widget.onCreate!();
                             },
                           ),
                         ],
@@ -234,8 +363,42 @@ class ItemSelectorSheet extends StatelessWidget {
                   },
                 ),
               ),
-              // Reorder management link
-              if (reorderRoute != null) ...[
+              // Multi-mode apply bar
+              if (_isMulti) ...[
+                const Divider(height: 1),
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(16, 8, 16, 12),
+                  child: Row(
+                    children: [
+                      Expanded(
+                        child: OutlinedButton(
+                          onPressed: () => _selectAll(sortedItems),
+                          child: const Text('전체 선택'),
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      Expanded(
+                        child: OutlinedButton(
+                          onPressed: _clearAll,
+                          child: const Text('전체 해제'),
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      Expanded(
+                        child: FilledButton(
+                          onPressed: () {
+                            widget.onApplyMulti!({..._tempSelectedIds});
+                            Navigator.of(context).pop();
+                          },
+                          child: Text('적용 (${_tempSelectedIds.length})'),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+              // Reorder management link — hidden in multi mode (filter context)
+              if (widget.reorderRoute != null && !_isMulti) ...[
                 const Divider(height: 1),
                 Padding(
                   padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
@@ -244,7 +407,7 @@ class ItemSelectorSheet extends StatelessWidget {
                     child: TextButton(
                       onPressed: () {
                         Navigator.of(context).pop();
-                        context.push(reorderRoute!);
+                        context.push(widget.reorderRoute!);
                       },
                       child: const Text('순서 관리 >'),
                     ),
@@ -265,27 +428,24 @@ class ItemSelectorSheet extends StatelessWidget {
     List<SelectorItem> sortedItems,
     List<String> favIds,
   ) {
-    if (groupLabels == null || groupLabels!.isEmpty) {
+    if (widget.groupLabels == null || widget.groupLabels!.isEmpty) {
       return sortedItems.map((item) => _buildItemTile(context, item, favIds)).toList();
+    }
+
+    // Pre-group items by their group key so we can offer "group-all" checkbox in multi mode.
+    final itemsByGroup = <String, List<SelectorItem>>{};
+    for (final item in sortedItems) {
+      final key = item.group ?? '';
+      itemsByGroup.putIfAbsent(key, () => []).add(item);
     }
 
     final widgets = <Widget>[];
     String? lastGroup;
     for (final item in sortedItems) {
       if (item.group != null && item.group != lastGroup) {
-        final label = groupLabels![item.group] ?? item.group!;
-        widgets.add(
-          Padding(
-            padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
-            child: Text(
-              label,
-              style: Theme.of(context).textTheme.labelMedium?.copyWith(
-                    fontWeight: FontWeight.bold,
-                    color: Theme.of(context).colorScheme.primary,
-                  ),
-            ),
-          ),
-        );
+        final label = widget.groupLabels![item.group] ?? item.group!;
+        final groupItems = itemsByGroup[item.group!] ?? const <SelectorItem>[];
+        widgets.add(_buildGroupHeader(context, item.group!, label, groupItems));
         lastGroup = item.group;
       }
       widgets.add(_buildItemTile(context, item, favIds));
@@ -293,33 +453,104 @@ class ItemSelectorSheet extends StatelessWidget {
     return widgets;
   }
 
+  Widget _buildGroupHeader(
+    BuildContext context,
+    String groupKey,
+    String label,
+    List<SelectorItem> groupItems,
+  ) {
+    if (!_isMulti) {
+      return Padding(
+        padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
+        child: Text(
+          label,
+          style: Theme.of(context).textTheme.labelMedium?.copyWith(
+                fontWeight: FontWeight.bold,
+                color: Theme.of(context).colorScheme.primary,
+              ),
+        ),
+      );
+    }
+
+    final groupIds = groupItems.map((e) => e.id).toList();
+    final selectedInGroup =
+        groupIds.where((id) => _tempSelectedIds.contains(id)).length;
+    final allSelected =
+        groupIds.isNotEmpty && selectedInGroup == groupIds.length;
+    final someSelected = selectedInGroup > 0 && !allSelected;
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(8, 8, 16, 4),
+      child: Row(
+        children: [
+          Checkbox(
+            value: allSelected ? true : (someSelected ? null : false),
+            tristate: true,
+            onChanged: (_) =>
+                _setGroupSelection(groupIds, !allSelected),
+          ),
+          const SizedBox(width: 4),
+          Expanded(
+            child: Text(
+              '$label (그룹 전체)',
+              style: Theme.of(context).textTheme.labelMedium?.copyWith(
+                    fontWeight: FontWeight.bold,
+                    color: Theme.of(context).colorScheme.primary,
+                  ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
   List<String> _getFavoriteIds(FavoritesState state) {
-    if (state is! FavoritesLoaded || favoriteType == null) return [];
-    if (favoriteType == 'PAYMENT_METHOD') {
+    if (state is! FavoritesLoaded || widget.favoriteType == null) return [];
+    if (widget.favoriteType == 'PAYMENT_METHOD') {
       return state.favorites.paymentMethodIds;
-    } else if (favoriteType == 'CATEGORY') {
+    } else if (widget.favoriteType == 'CATEGORY') {
       return state.favorites.categoryIds;
     }
     return [];
   }
 
   Widget _buildItemTile(BuildContext context, SelectorItem item, List<String> favIds) {
-    final isSelected = item.id == selectedId;
+    final isSingleSelected = !_isMulti && item.id == widget.selectedId;
+    final isMultiSelected = _isMulti && _tempSelectedIds.contains(item.id);
     final isFavorite = favIds.contains(item.id);
 
     return ListTile(
-      leading: CircleAvatar(
-        backgroundColor:
-            (item.leadingColor ?? Colors.grey).withValues(alpha: 0.15),
-        child: Icon(
-          item.leadingIcon ?? Icons.label,
-          color: item.leadingColor ?? Colors.grey,
-          size: 20,
-        ),
-      ),
+      leading: _isMulti
+          ? Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Checkbox(
+                  value: isMultiSelected,
+                  onChanged: (_) => _toggleItem(item.id),
+                ),
+                CircleAvatar(
+                  backgroundColor:
+                      (item.leadingColor ?? Colors.grey).withValues(alpha: 0.15),
+                  child: Icon(
+                    item.leadingIcon ?? Icons.label,
+                    color: item.leadingColor ?? Colors.grey,
+                    size: 20,
+                  ),
+                ),
+              ],
+            )
+          : CircleAvatar(
+              backgroundColor:
+                  (item.leadingColor ?? Colors.grey).withValues(alpha: 0.15),
+              child: Icon(
+                item.leadingIcon ?? Icons.label,
+                color: item.leadingColor ?? Colors.grey,
+                size: 20,
+              ),
+            ),
       title: Text(item.label),
       subtitle: item.subtitle != null ? Text(item.subtitle!) : null,
-      selected: isSelected,
+      selected: isSingleSelected || isMultiSelected,
       selectedTileColor: Theme.of(context)
           .colorScheme
           .primaryContainer
@@ -328,11 +559,11 @@ class ItemSelectorSheet extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
         children: [
           // Favorite star toggle
-          if (favoriteType != null)
+          if (widget.favoriteType != null)
             GestureDetector(
               onTap: () {
                 getIt<FavoritesBloc>().add(ToggleFavorite(
-                  type: favoriteType!,
+                  type: widget.favoriteType!,
                   itemId: item.id,
                 ));
               },
@@ -347,12 +578,12 @@ class ItemSelectorSheet extends StatelessWidget {
                 ),
               ),
             ),
-          // Edit button
-          if (onEdit != null)
+          // Edit button — hidden in multi mode (filter context)
+          if (widget.onEdit != null && !_isMulti)
             GestureDetector(
               onTap: () {
                 Navigator.of(context).pop();
-                onEdit!(item);
+                widget.onEdit!(item);
               },
               child: Padding(
                 padding: const EdgeInsets.all(4),
@@ -363,13 +594,14 @@ class ItemSelectorSheet extends StatelessWidget {
                 ),
               ),
             ),
-          if (isSelected)
+          if (isSingleSelected)
             Icon(
               Icons.check,
               color: Theme.of(context).colorScheme.primary,
               size: 20,
             ),
-          if (item.isDeletable && onDelete != null)
+          // Delete button — hidden in multi mode (filter context)
+          if (item.isDeletable && widget.onDelete != null && !_isMulti)
             IconButton(
               icon: Icon(
                 Icons.delete_outline,
@@ -382,8 +614,12 @@ class ItemSelectorSheet extends StatelessWidget {
         ],
       ),
       onTap: () {
-        onSelected(item);
-        Navigator.of(context).pop();
+        if (_isMulti) {
+          _toggleItem(item.id);
+        } else {
+          widget.onSelected!(item);
+          Navigator.of(context).pop();
+        }
       },
     );
   }
@@ -408,7 +644,7 @@ class ItemSelectorSheet extends StatelessWidget {
       ),
     );
     if (confirmed == true) {
-      onDelete!(item.id);
+      widget.onDelete!(item.id);
     }
   }
 }

--- a/frontend/test/core/widgets/category_group_selector_sheet_multi_test.dart
+++ b/frontend/test/core/widgets/category_group_selector_sheet_multi_test.dart
@@ -1,0 +1,319 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:bloc_test/bloc_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:budget_book/core/di/injection.dart';
+import 'package:budget_book/core/widgets/category_group_selector_sheet.dart';
+import 'package:budget_book/features/category/domain/entities/category.dart';
+import 'package:budget_book/features/category/presentation/bloc/category_bloc.dart';
+import 'package:budget_book/features/category/presentation/bloc/category_event.dart';
+import 'package:budget_book/features/category/presentation/bloc/category_state.dart';
+import 'package:budget_book/features/category_group/domain/entities/category_group.dart';
+import 'package:budget_book/features/category_group/presentation/bloc/category_group_bloc.dart';
+import 'package:budget_book/features/category_group/presentation/bloc/category_group_event.dart';
+import 'package:budget_book/features/category_group/presentation/bloc/category_group_state.dart';
+import 'package:budget_book/features/couple/presentation/bloc/couple_bloc.dart';
+import 'package:budget_book/features/couple/presentation/bloc/couple_event.dart';
+import 'package:budget_book/features/couple/presentation/bloc/couple_state.dart';
+import 'package:budget_book/features/preference/domain/entities/favorites.dart';
+import 'package:budget_book/features/preference/presentation/bloc/favorites_bloc.dart';
+import 'package:budget_book/features/preference/presentation/bloc/favorites_event.dart';
+import 'package:budget_book/features/preference/presentation/bloc/favorites_state.dart';
+
+class _MockCategoryGroupBloc
+    extends MockBloc<CategoryGroupEvent, CategoryGroupState>
+    implements CategoryGroupBloc {}
+
+class _MockCategoryBloc extends MockBloc<CategoryEvent, CategoryState>
+    implements CategoryBloc {}
+
+class _MockFavoritesBloc extends MockBloc<FavoritesEvent, FavoritesState>
+    implements FavoritesBloc {}
+
+class _MockCoupleBloc extends MockBloc<CoupleEvent, CoupleState>
+    implements CoupleBloc {}
+
+void main() {
+  late _MockCategoryGroupBloc groupBloc;
+  late _MockCategoryBloc categoryBloc;
+  late _MockFavoritesBloc favoritesBloc;
+  late _MockCoupleBloc coupleBloc;
+
+  final now = DateTime(2026, 4, 20);
+
+  final foodCat1 = Category(
+    id: 'c-food-1',
+    name: '카페',
+    type: 'EXPENSE',
+    isDefault: false,
+    displayOrder: 0,
+    groupId: 'g-food',
+    createdAt: now,
+  );
+  final foodCat2 = Category(
+    id: 'c-food-2',
+    name: '식당',
+    type: 'EXPENSE',
+    isDefault: false,
+    displayOrder: 1,
+    groupId: 'g-food',
+    createdAt: now,
+  );
+  final transportCat = Category(
+    id: 'c-transport-1',
+    name: '택시',
+    type: 'EXPENSE',
+    isDefault: false,
+    displayOrder: 0,
+    groupId: 'g-transport',
+    createdAt: now,
+  );
+
+  final foodGroup = CategoryGroup(
+    id: 'g-food',
+    name: '식비',
+    budgetType: 'MONTHLY',
+    displayOrder: 0,
+    isDefault: false,
+    categories: [foodCat1, foodCat2],
+    createdAt: now,
+  );
+  final transportGroup = CategoryGroup(
+    id: 'g-transport',
+    name: '교통',
+    budgetType: 'MONTHLY',
+    displayOrder: 1,
+    isDefault: false,
+    categories: [transportCat],
+    createdAt: now,
+  );
+
+  setUpAll(() {
+    registerFallbackValue(const LoadCategoryGroups());
+    registerFallbackValue(const LoadCategories());
+    registerFallbackValue(const LoadFavorites());
+    registerFallbackValue(const LoadCouple());
+  });
+
+  setUp(() {
+    groupBloc = _MockCategoryGroupBloc();
+    categoryBloc = _MockCategoryBloc();
+    favoritesBloc = _MockFavoritesBloc();
+    coupleBloc = _MockCoupleBloc();
+
+    when(() => groupBloc.state)
+        .thenReturn(CategoryGroupLoaded([foodGroup, transportGroup]));
+    when(() => categoryBloc.state).thenReturn(const CategoryInitial());
+    when(() => favoritesBloc.state)
+        .thenReturn(const FavoritesLoaded(Favorites.empty));
+    when(() => coupleBloc.state).thenReturn(const CoupleInitial());
+
+    for (final type in [CategoryGroupBloc, CategoryBloc, FavoritesBloc, CoupleBloc]) {
+      // no-op placeholder for future typed unregister
+      type.toString();
+    }
+
+    if (getIt.isRegistered<CategoryGroupBloc>()) {
+      getIt.unregister<CategoryGroupBloc>();
+    }
+    if (getIt.isRegistered<CategoryBloc>()) {
+      getIt.unregister<CategoryBloc>();
+    }
+    if (getIt.isRegistered<FavoritesBloc>()) {
+      getIt.unregister<FavoritesBloc>();
+    }
+    if (getIt.isRegistered<CoupleBloc>()) {
+      getIt.unregister<CoupleBloc>();
+    }
+
+    getIt.registerSingleton<CategoryGroupBloc>(groupBloc);
+    getIt.registerSingleton<CategoryBloc>(categoryBloc);
+    getIt.registerSingleton<FavoritesBloc>(favoritesBloc);
+    getIt.registerSingleton<CoupleBloc>(coupleBloc);
+  });
+
+  tearDown(() {
+    if (getIt.isRegistered<CategoryGroupBloc>()) {
+      getIt.unregister<CategoryGroupBloc>();
+    }
+    if (getIt.isRegistered<CategoryBloc>()) {
+      getIt.unregister<CategoryBloc>();
+    }
+    if (getIt.isRegistered<FavoritesBloc>()) {
+      getIt.unregister<FavoritesBloc>();
+    }
+    if (getIt.isRegistered<CoupleBloc>()) {
+      getIt.unregister<CoupleBloc>();
+    }
+  });
+
+  Future<void> showMulti(
+    WidgetTester tester, {
+    Set<String> initialCategoryIds = const {},
+    Set<String> initialGroupIds = const {},
+    required void Function(Set<String>, Set<String>) onApplyMulti,
+  }) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (context) => Scaffold(
+            body: ElevatedButton(
+              onPressed: () => showDialog(
+                context: context,
+                builder: (_) => CategoryGroupSelectorSheet(
+                  categoryType: 'EXPENSE',
+                  mode: CategorySelectionMode.multiCategoryWithGroup,
+                  initialCategoryIds: initialCategoryIds,
+                  initialGroupIds: initialGroupIds,
+                  onApplyMulti: onApplyMulti,
+                ),
+              ),
+              child: const Text('Open'),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.text('Open'));
+    await tester.pumpAndSettle();
+  }
+
+  Future<void> showSingle(
+    WidgetTester tester, {
+    required ValueChanged<Category?> onSelected,
+  }) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (context) => Scaffold(
+            body: ElevatedButton(
+              onPressed: () => showDialog(
+                context: context,
+                builder: (_) => CategoryGroupSelectorSheet(
+                  categoryType: 'EXPENSE',
+                  onSelected: onSelected,
+                ),
+              ),
+              child: const Text('Open'),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.text('Open'));
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('multi: group checkbox cascades to child categories',
+      (tester) async {
+    Set<String>? captureCats;
+    Set<String>? captureGroups;
+    await showMulti(
+      tester,
+      onApplyMulti: (cats, groups) {
+        captureCats = cats;
+        captureGroups = groups;
+      },
+    );
+
+    // Food group row is visible; find its Checkbox (first Checkbox in group row).
+    // Food group has 2 children → count starts 0.
+    expect(find.text('적용 (0)'), findsOneWidget);
+
+    // Tap group header's Checkbox by tapping on "식비" folder row's checkbox.
+    // There are 2 group checkboxes (식비, 교통). Tap the first by tapping the
+    // Checkbox widget whose ancestor Row contains the text '식비'.
+    final foodGroupCheckbox = find.descendant(
+      of: find.ancestor(
+        of: find.text('식비'),
+        matching: find.byType(Row),
+      ),
+      matching: find.byType(Checkbox),
+    );
+    await tester.tap(foodGroupCheckbox.first);
+    await tester.pumpAndSettle();
+
+    // Group id 'g-food' + 2 child cats = 3 selected
+    expect(find.text('적용 (3)'), findsOneWidget);
+
+    await tester.tap(find.text('적용 (3)'));
+    await tester.pumpAndSettle();
+
+    expect(captureGroups, {'g-food'});
+    expect(captureCats, {'c-food-1', 'c-food-2'});
+  });
+
+  testWidgets('multi: individual category checkbox updates temp set',
+      (tester) async {
+    Set<String>? captureCats;
+    Set<String>? captureGroups;
+    await showMulti(
+      tester,
+      onApplyMulti: (cats, groups) {
+        captureCats = cats;
+        captureGroups = groups;
+      },
+    );
+
+    // Expand 교통 group first by tapping the header.
+    await tester.tap(find.text('교통'));
+    await tester.pumpAndSettle();
+
+    // Now 택시 tile is visible → tap it to toggle.
+    await tester.tap(find.text('택시'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('적용 (1)'), findsOneWidget);
+
+    await tester.tap(find.text('적용 (1)'));
+    await tester.pumpAndSettle();
+
+    expect(captureCats, {'c-transport-1'});
+    expect(captureGroups, isEmpty);
+  });
+
+  testWidgets('multi: apply fires with both sets correctly', (tester) async {
+    int callCount = 0;
+    late Set<String> cats;
+    late Set<String> groups;
+    await showMulti(
+      tester,
+      initialCategoryIds: const {'c-food-1'},
+      initialGroupIds: const {'g-transport'},
+      onApplyMulti: (c, g) {
+        callCount++;
+        cats = c;
+        groups = g;
+      },
+    );
+
+    // initial count: 1 cat + 1 group = 2
+    expect(find.text('적용 (2)'), findsOneWidget);
+
+    await tester.tap(find.text('적용 (2)'));
+    await tester.pumpAndSettle();
+
+    expect(callCount, 1);
+    expect(cats, {'c-food-1'});
+    expect(groups, {'g-transport'});
+  });
+
+  testWidgets('singleCategory regression: tap on category fires onSelected',
+      (tester) async {
+    Category? selected;
+    await showSingle(tester, onSelected: (c) => selected = c);
+
+    // Expand food group
+    await tester.tap(find.text('식비'));
+    await tester.pumpAndSettle();
+
+    // Apply button should NOT be present in single mode
+    expect(find.textContaining('적용 ('), findsNothing);
+
+    await tester.tap(find.text('카페'));
+    await tester.pumpAndSettle();
+
+    expect(selected?.id, 'c-food-1');
+  });
+}

--- a/frontend/test/core/widgets/item_selector_sheet_multi_test.dart
+++ b/frontend/test/core/widgets/item_selector_sheet_multi_test.dart
@@ -1,0 +1,193 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:bloc_test/bloc_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:budget_book/core/di/injection.dart';
+import 'package:budget_book/core/widgets/item_selector_sheet.dart';
+import 'package:budget_book/features/preference/domain/entities/favorites.dart';
+import 'package:budget_book/features/preference/presentation/bloc/favorites_bloc.dart';
+import 'package:budget_book/features/preference/presentation/bloc/favorites_event.dart';
+import 'package:budget_book/features/preference/presentation/bloc/favorites_state.dart';
+
+class _MockFavoritesBloc extends MockBloc<FavoritesEvent, FavoritesState>
+    implements FavoritesBloc {}
+
+void main() {
+  late _MockFavoritesBloc favoritesBloc;
+
+  setUpAll(() {
+    registerFallbackValue(const LoadFavorites());
+  });
+
+  setUp(() {
+    favoritesBloc = _MockFavoritesBloc();
+    when(() => favoritesBloc.state)
+        .thenReturn(const FavoritesLoaded(Favorites.empty));
+
+    if (getIt.isRegistered<FavoritesBloc>()) {
+      getIt.unregister<FavoritesBloc>();
+    }
+    getIt.registerSingleton<FavoritesBloc>(favoritesBloc);
+  });
+
+  tearDown(() {
+    if (getIt.isRegistered<FavoritesBloc>()) {
+      getIt.unregister<FavoritesBloc>();
+    }
+  });
+
+  final sampleItems = const [
+    SelectorItem(id: 'a', label: 'Alpha', leadingIcon: Icons.label, displayOrder: 0),
+    SelectorItem(id: 'b', label: 'Bravo', leadingIcon: Icons.label, displayOrder: 1),
+    SelectorItem(id: 'c', label: 'Charlie', leadingIcon: Icons.label, displayOrder: 2),
+  ];
+
+  Future<void> showMulti(
+    WidgetTester tester, {
+    Set<String> initial = const {},
+    required void Function(Set<String>) onApply,
+  }) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (context) => Scaffold(
+            body: ElevatedButton(
+              onPressed: () => showDialog(
+                context: context,
+                builder: (_) => ItemSelectorSheet(
+                  title: '테스트',
+                  items: sampleItems,
+                  mode: SelectionMode.multi,
+                  initialSelectedIds: initial,
+                  onApplyMulti: onApply,
+                ),
+              ),
+              child: const Text('Open'),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.text('Open'));
+    await tester.pumpAndSettle();
+  }
+
+  Future<void> showSingle(
+    WidgetTester tester, {
+    required ValueChanged<SelectorItem?> onSelected,
+    String? selectedId,
+  }) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (context) => Scaffold(
+            body: ElevatedButton(
+              onPressed: () => showDialog(
+                context: context,
+                builder: (_) => ItemSelectorSheet(
+                  title: '테스트',
+                  items: sampleItems,
+                  selectedId: selectedId,
+                  onSelected: onSelected,
+                ),
+              ),
+              child: const Text('Open'),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.text('Open'));
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('multi: checkbox tap adds id to temp set', (tester) async {
+    Set<String>? applied;
+    await showMulti(tester, onApply: (ids) => applied = ids);
+
+    // Apply button starts at "적용 (0)"
+    expect(find.text('적용 (0)'), findsOneWidget);
+
+    await tester.tap(find.text('Alpha'));
+    await tester.pump();
+    expect(find.text('적용 (1)'), findsOneWidget);
+
+    await tester.tap(find.text('Bravo'));
+    await tester.pump();
+    expect(find.text('적용 (2)'), findsOneWidget);
+
+    await tester.tap(find.text('적용 (2)'));
+    await tester.pumpAndSettle();
+
+    expect(applied, {'a', 'b'});
+  });
+
+  testWidgets('multi: apply is called exactly once with correct set', (tester) async {
+    int callCount = 0;
+    Set<String>? captured;
+    await showMulti(
+      tester,
+      initial: const {'c'},
+      onApply: (ids) {
+        callCount++;
+        captured = ids;
+      },
+    );
+
+    expect(find.text('적용 (1)'), findsOneWidget);
+
+    await tester.tap(find.text('Alpha'));
+    await tester.pump();
+    expect(find.text('적용 (2)'), findsOneWidget);
+
+    await tester.tap(find.text('적용 (2)'));
+    await tester.pumpAndSettle();
+
+    expect(callCount, 1);
+    expect(captured, {'a', 'c'});
+  });
+
+  testWidgets('multi: "전체 해제" clears temp set', (tester) async {
+    Set<String>? applied;
+    await showMulti(
+      tester,
+      initial: const {'a', 'b', 'c'},
+      onApply: (ids) => applied = ids,
+    );
+    expect(find.text('적용 (3)'), findsOneWidget);
+
+    await tester.tap(find.text('전체 해제'));
+    await tester.pump();
+    expect(find.text('적용 (0)'), findsOneWidget);
+
+    await tester.tap(find.text('적용 (0)'));
+    await tester.pumpAndSettle();
+    expect(applied, isEmpty);
+  });
+
+  testWidgets('single regression: tap fires onSelected and pops', (tester) async {
+    SelectorItem? selected;
+    bool called = false;
+    await showSingle(
+      tester,
+      onSelected: (item) {
+        called = true;
+        selected = item;
+      },
+    );
+
+    // Sheet is visible
+    expect(find.text('Bravo'), findsOneWidget);
+    // Apply bar should NOT appear in single mode
+    expect(find.textContaining('적용 ('), findsNothing);
+
+    await tester.tap(find.text('Bravo'));
+    await tester.pumpAndSettle();
+
+    expect(called, isTrue);
+    expect(selected?.id, 'b');
+    // Dialog popped
+    expect(find.text('Bravo'), findsNothing);
+  });
+}


### PR DESCRIPTION
## Summary
- `ItemSelectorSheet` 에 `SelectionMode.single | multi` 추가 — 체크박스 + 그룹 일괄 선택 + "적용" 버튼 + maxSelection=50
- `CategoryGroupSelectorSheet` 에 `CategorySelectionMode.singleCategory | multiCategoryWithGroup` 추가 — 그룹 체크박스(ID + 하위 자동 포함) + 카테고리 체크박스
- single / singleCategory 모드 100% 호환 (기존 호출처 7개 회귀 0)

## Test plan
- [x] flutter analyze lib/core/widgets/ — No issues found
- [x] flutter analyze lib/ (전체) — No issues found
- [x] flutter test test/core/widgets/ — 93 tests pass (신규 multi 8건 포함)
- [x] flutter build web --release — PASS (36.8s)

## Followups (PR-C 나머지)
- PR-C2: 호출처 마이그레이션 (UnifiedFilterBar, category_filter, payment_method_filter → multi 모드)
- PR-C3: UnifiedFilterState 단수 제거 + categoryGroupIds 추가
- PR-C4: Repository/DataSource Set 시그니처 + `.first` 전면 제거
- PR-C5: BE 다중/그룹 API + `findByGroupIdIn` 펼치기

Refs: docs/sessions/2026-04-20_6_plan.md PR-C 1단계

🤖 Generated with [Claude Code](https://claude.com/claude-code)