### PR TITLE
fix(deploy): NAS buildx 미설치 → legacy builder fallback

### DIFF
--- a/.github/workflows/deploy-nas.yml
+++ b/.github/workflows/deploy-nas.yml
@@ -48,18 +48,15 @@ jobs:
           script: |
             set -e
             export PATH=/usr/local/bin:$PATH
-            export DOCKER_BUILDKIT=1
             cd /volume1/docker/budget-book
 
             git fetch origin main --depth=1
             git reset --hard origin/main
 
             cd backend
-            # BuildKit + cache reuse (이전 이미지 layer 활용)
-            docker build \
-              --cache-from bb-backend:latest \
-              --build-arg BUILDKIT_INLINE_CACHE=1 \
-              -t bb-backend:latest .
+            # NAS Docker 엔진에 buildx 미설치 → legacy builder 사용.
+            # 동일 태그 재사용으로 Docker 가 layer cache 자동 활용.
+            docker build -t bb-backend:latest .
 
             cat > /tmp/bb_env << 'ENVEOF'
             SPRING_PROFILES_ACTIVE=prod


### PR DESCRIPTION
## 문제
PR-B(#112) 머지 후 Deploy to NAS workflow 27초만에 실패:
```
ERROR: BuildKit is enabled but the buildx component is missing or broken.
Install the buildx component to build images with BuildKit:
https://docs.docker.com/go/buildx/
```

이전 커밋 `65fa8e0 chore(deploy): NAS 배포 시간 단축` 에서 도입한 `DOCKER_BUILDKIT=1` + `--cache-from` + `BUILDKIT_INLINE_CACHE=1` 조합이 NAS Docker 엔진과 호환 안 됨.

## 수정
- `DOCKER_BUILDKIT=1` 제거
- `--cache-from` / `--build-arg BUILDKIT_INLINE_CACHE=1` 제거
- `docker build -t bb-backend:latest .` 로 단순화 — 동일 태그 재사용으로 Docker 가 layer cache 자동 활용

## 영향
- 캐시 이점: 동일 Dockerfile + 변경 없는 layer → 재사용 유지됨 (Legacy builder 도 local layer cache 사용)
- 배포 시간: BuildKit parallel layer 빌드 대비 미미하게 길어질 수 있음 (수 초 단위)
- 후속(선택): NAS 에 buildx 설치 시 BuildKit 재도입 가능

## Test plan
- [ ] 머지 후 Deploy to NAS workflow 성공
- [ ] BE health check (`/actuator/health`) 200 응답
- [ ] PR-B 에서 추가된 visibility 필터 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)