### PR TITLE
feat(filter): 다중/그룹 필터 BE API (PR-C2)

### DIFF
--- a/backend/src/main/kotlin/com/budgetbook/category/repository/CategoryRepository.kt
+++ b/backend/src/main/kotlin/com/budgetbook/category/repository/CategoryRepository.kt
@@ -71,4 +71,11 @@ interface CategoryRepository : JpaRepository<Category, UUID> {
     fun findByCoupleIdAndGroupIsNull(coupleId: UUID): List<Category>
 
     fun findByCoupleIdAndNameIn(coupleId: UUID, names: List<String>): List<Category>
+
+    /**
+     * 다중 그룹 ID 로 속한 카테고리 일괄 조회 (PR-C2 다중/그룹 필터).
+     * 필터에서 "식비 그룹 전체" 같은 그룹 선택 시 하위 카테고리를 펼치기 위해 사용.
+     * 빈 리스트로 호출 시 빈 결과 반환 (호출부에서 체크하여 쿼리 호출 자체를 스킵하는 것을 권장).
+     */
+    fun findByGroupIdIn(groupIds: List<UUID>): List<Category>
 }

--- a/backend/src/main/kotlin/com/budgetbook/common/dto/CommonFilterParams.kt
+++ b/backend/src/main/kotlin/com/budgetbook/common/dto/CommonFilterParams.kt
@@ -12,9 +12,16 @@ data class CommonFilterParams(
     val dateTo: LocalDate? = null,
     val year: Int? = null,
     val month: Int? = null,
+    // 단수 필드 — 거래 상세 / 생성 / CSV export / period-summary 호환용. 유지.
     val categoryId: UUID? = null,
     val paymentMethodId: UUID? = null,
     val pocketId: UUID? = null,
+    // 복수 필드 — 다중/그룹 필터 (PR-C2). Spring 은 `categoryIds=a&categoryIds=b` 포맷 자동 바인딩.
+    // listTransactions / 통계 목록 쿼리에서 사용. 빈 리스트 = 필터 없음.
+    val categoryIds: List<UUID> = emptyList(),
+    val categoryGroupIds: List<UUID> = emptyList(),
+    val paymentMethodIds: List<UUID> = emptyList(),
+    val pocketIds: List<UUID> = emptyList(),
     val amountMin: Long? = null,
     val amountMax: Long? = null,
     val keyword: String? = null,

--- a/backend/src/main/kotlin/com/budgetbook/statistics/controller/StatisticsController.kt
+++ b/backend/src/main/kotlin/com/budgetbook/statistics/controller/StatisticsController.kt
@@ -91,7 +91,12 @@ class StatisticsController(
             visibility = filter.visibility ?: "ALL",
             categoryId = filter.categoryId,
             paymentMethodId = filter.paymentMethodId,
-            pocketId = filter.pocketId
+            pocketId = filter.pocketId,
+            // PR-C2 다중/그룹 필터 전달 (하위 Service 에서 합집합으로 처리)
+            categoryIds = filter.categoryIds,
+            categoryGroupIds = filter.categoryGroupIds,
+            paymentMethodIds = filter.paymentMethodIds,
+            pocketIds = filter.pocketIds
         ))
     }
 }

--- a/backend/src/main/kotlin/com/budgetbook/statistics/service/StatisticsService.kt
+++ b/backend/src/main/kotlin/com/budgetbook/statistics/service/StatisticsService.kt
@@ -2,6 +2,7 @@ package com.budgetbook.statistics.service
 
 import com.budgetbook.budget.domain.BudgetPeriod
 import com.budgetbook.budget.repository.MonthlyBudgetRepository
+import com.budgetbook.category.repository.CategoryRepository
 import com.budgetbook.common.exception.BusinessException
 import com.budgetbook.common.exception.NotFoundException
 import com.budgetbook.couple.domain.Couple
@@ -33,7 +34,8 @@ class StatisticsService(
     private val transferRepository: TransferRepository,
     override val coupleResolver: CoupleResolver,
     private val budgetRepository: MonthlyBudgetRepository,
-    private val spendingPlanRepository: SpendingPlanRepository
+    private val spendingPlanRepository: SpendingPlanRepository,
+    private val categoryRepository: CategoryRepository
 ) : CoupleAwareService {
 
     companion object {
@@ -250,11 +252,32 @@ class StatisticsService(
         visibility: String = "ALL",
         categoryId: UUID? = null,
         paymentMethodId: UUID? = null,
-        pocketId: UUID? = null
+        pocketId: UUID? = null,
+        // PR-C2 다중/그룹 필터. 단수 필드와 합쳐 Set 으로 전달됨.
+        categoryIds: List<UUID> = emptyList(),
+        categoryGroupIds: List<UUID> = emptyList(),
+        paymentMethodIds: List<UUID> = emptyList(),
+        pocketIds: List<UUID> = emptyList()
     ): PeriodSummaryResponse {
         val couple = getActiveCouple(userId)
         val visFilter = validateVisibility(visibility)
-        val hasFilters = categoryId != null || paymentMethodId != null || pocketId != null
+
+        // PR-C2: 단수 + 복수 병합, 그룹 펼치기
+        val effectiveCategoryIds = categoryIds.toMutableSet().also { set ->
+            categoryId?.let { set.add(it) }
+            if (categoryGroupIds.isNotEmpty()) {
+                set.addAll(categoryRepository.findByGroupIdIn(categoryGroupIds).map { it.id })
+            }
+        }
+        val effectivePaymentMethodIds = paymentMethodIds.toMutableSet().also { set ->
+            paymentMethodId?.let { set.add(it) }
+        }
+        val effectivePocketIds = pocketIds.toMutableSet().also { set ->
+            pocketId?.let { set.add(it) }
+        }
+        val hasFilters = effectiveCategoryIds.isNotEmpty() ||
+            effectivePaymentMethodIds.isNotEmpty() ||
+            effectivePocketIds.isNotEmpty()
 
         var totalIncome: Long
         var totalExpense: Long
@@ -264,15 +287,21 @@ class StatisticsService(
             // Use Specifications-based query when filters are applied
             val incomeSpec = TransactionSpecifications.withFilters(
                 coupleId = couple.id, startDate = dateFrom, endDate = dateTo,
-                type = TransactionType.INCOME, categoryId = categoryId, keyword = null,
-                paymentMethodId = paymentMethodId, pocketId = pocketId,
-                amountMin = null, amountMax = null, userId = userId
+                type = TransactionType.INCOME, categoryId = null, keyword = null,
+                paymentMethodId = null, pocketId = null,
+                amountMin = null, amountMax = null, userId = userId,
+                categoryIds = effectiveCategoryIds,
+                paymentMethodIds = effectivePaymentMethodIds,
+                pocketIds = effectivePocketIds
             )
             val expenseSpec = TransactionSpecifications.withFilters(
                 coupleId = couple.id, startDate = dateFrom, endDate = dateTo,
-                type = TransactionType.EXPENSE, categoryId = categoryId, keyword = null,
-                paymentMethodId = paymentMethodId, pocketId = pocketId,
-                amountMin = null, amountMax = null, userId = userId
+                type = TransactionType.EXPENSE, categoryId = null, keyword = null,
+                paymentMethodId = null, pocketId = null,
+                amountMin = null, amountMax = null, userId = userId,
+                categoryIds = effectiveCategoryIds,
+                paymentMethodIds = effectivePaymentMethodIds,
+                pocketIds = effectivePocketIds
             )
 
             val incomeTransactions = transactionRepository.findAll(incomeSpec)

--- a/backend/src/main/kotlin/com/budgetbook/transaction/controller/TransactionController.kt
+++ b/backend/src/main/kotlin/com/budgetbook/transaction/controller/TransactionController.kt
@@ -47,9 +47,26 @@ class TransactionController(
         @RequestParam(defaultValue = "20") size: Int
     ): ApiResponse<PageResponse<TransactionResponse>> {
         return ApiResponse.ok(transactionService.listTransactions(
-            userId, filter.year, filter.month, filter.type, filter.categoryId,
-            filter.keyword, filter.paymentMethodId, filter.pocketId, filter.amountMin, filter.amountMax,
-            filter.dateFrom, filter.dateTo, filter.visibility, page, size
+            userId = userId,
+            year = filter.year,
+            month = filter.month,
+            type = filter.type,
+            categoryId = filter.categoryId,
+            keyword = filter.keyword,
+            paymentMethodId = filter.paymentMethodId,
+            pocketId = filter.pocketId,
+            amountMin = filter.amountMin,
+            amountMax = filter.amountMax,
+            dateFrom = filter.dateFrom,
+            dateTo = filter.dateTo,
+            visibility = filter.visibility,
+            page = page,
+            size = size,
+            // PR-C2 다중/그룹 필터 (Spring `categoryIds=a&categoryIds=b` 자동 바인딩)
+            categoryIds = filter.categoryIds,
+            categoryGroupIds = filter.categoryGroupIds,
+            paymentMethodIds = filter.paymentMethodIds,
+            pocketIds = filter.pocketIds
         ))
     }
 

--- a/backend/src/main/kotlin/com/budgetbook/transaction/repository/TransactionSpecifications.kt
+++ b/backend/src/main/kotlin/com/budgetbook/transaction/repository/TransactionSpecifications.kt
@@ -27,7 +27,12 @@ object TransactionSpecifications {
         userId: UUID? = null,
         // null/"ALL": 기본 동작(공유 + 본인 개인). "SHARED": 공유 거래만. "PRIVATE": 본인 개인만.
         // 호출자(Service) 단계에서 이미 uppercase 정규화 + 유효성 검증된 값.
-        visibility: String? = null
+        visibility: String? = null,
+        // PR-C2 다중/그룹 필터. 빈 Set 은 무조건부 (필터 없음). 단수 categoryId/paymentMethodId/pocketId 와
+        // 병존 시 호출자(Service) 에서 합집합 Set 을 만들어 단수는 null 로 넘기고 Set 만 사용하도록 권장.
+        categoryIds: Set<UUID> = emptySet(),
+        paymentMethodIds: Set<UUID> = emptySet(),
+        pocketIds: Set<UUID> = emptySet()
     ): Specification<Transaction> {
         return Specification { root: Root<Transaction>, _: CriteriaQuery<*>, cb: CriteriaBuilder ->
             val predicates = mutableListOf<Predicate>()
@@ -43,6 +48,10 @@ object TransactionSpecifications {
                 predicates.add(cb.equal(root.get<Any>("category").get<UUID>("id"), it))
             }
 
+            if (categoryIds.isNotEmpty()) {
+                predicates.add(root.get<Any>("category").get<UUID>("id").`in`(categoryIds))
+            }
+
             keyword?.takeIf { it.isNotBlank() }?.let {
                 predicates.add(cb.like(cb.lower(root.get("description")), "%${it.lowercase()}%"))
             }
@@ -51,8 +60,16 @@ object TransactionSpecifications {
                 predicates.add(cb.equal(root.get<Any>("paymentMethod").get<UUID>("id"), it))
             }
 
+            if (paymentMethodIds.isNotEmpty()) {
+                predicates.add(root.get<Any>("paymentMethod").get<UUID>("id").`in`(paymentMethodIds))
+            }
+
             pocketId?.let {
                 predicates.add(cb.equal(root.get<Any>("pocket").get<UUID>("id"), it))
+            }
+
+            if (pocketIds.isNotEmpty()) {
+                predicates.add(root.get<Any>("pocket").get<UUID>("id").`in`(pocketIds))
             }
 
             amountMin?.let {

--- a/backend/src/main/kotlin/com/budgetbook/transaction/service/TransactionService.kt
+++ b/backend/src/main/kotlin/com/budgetbook/transaction/service/TransactionService.kt
@@ -67,7 +67,13 @@ class TransactionService(
         dateTo: LocalDate? = null,
         visibility: String? = null,
         page: Int,
-        size: Int
+        size: Int,
+        // PR-C2 다중/그룹 필터. 단수 파라미터는 호환성을 위해 유지되며,
+        // 내부에서 Set 으로 합쳐 TransactionSpecifications 에 전달된다.
+        categoryIds: List<UUID> = emptyList(),
+        categoryGroupIds: List<UUID> = emptyList(),
+        paymentMethodIds: List<UUID> = emptyList(),
+        pocketIds: List<UUID> = emptyList()
     ): PageResponse<TransactionResponse> {
         val couple = getActiveCouple(userId)
 
@@ -99,29 +105,58 @@ class TransactionService(
             throw BusinessException("VALIDATION_ERROR", "Invalid visibility: $visibility")
         }
 
+        // PR-C2: 다중/그룹 필터 병합.
+        // 단수 파라미터는 복수 Set 에 합쳐 TransactionSpecifications 로 한 번에 전달.
+        // categoryGroupIds 는 BE 에서 하위 카테고리로 펼친 뒤 categoryIds Set 에 합쳐 IN-clause 적용 (원칙 1.4 — B-tree 인덱스 스캔 1회).
+        val effectiveCategoryIds = categoryIds.toMutableSet().also { set ->
+            categoryId?.let { set.add(it) }
+            if (categoryGroupIds.isNotEmpty()) {
+                // 그룹 펼치기: SELECT id FROM categories WHERE group_id IN (:groupIds) 한 번 호출.
+                set.addAll(categoryRepository.findByGroupIdIn(categoryGroupIds).map { it.id })
+            }
+        }
+        val effectivePaymentMethodIds = paymentMethodIds.toMutableSet().also { set ->
+            paymentMethodId?.let { set.add(it) }
+        }
+        val effectivePocketIds = pocketIds.toMutableSet().also { set ->
+            pocketId?.let { set.add(it) }
+        }
+
         val pageSize = size.coerceIn(1, 100)
         val sort = Sort.by(Sort.Order.desc("transactionDate"), Sort.Order.desc("createdAt"))
         val pageable = PageRequest.of(page, pageSize, sort)
 
-        // SHARED/PRIVATE visibility 필터가 들어오면 legacy JPQL 경로는 지원하지 않으므로 Spec 경로로 강제.
+        // SHARED/PRIVATE visibility 필터, extended 필터, 또는 다중/그룹 필터가 들어오면 Spec 경로로 강제.
+        // (legacy JPQL 은 단일 categoryId/type 만 지원)
+        val hasMultiFilters = effectiveCategoryIds.isNotEmpty() ||
+            effectivePaymentMethodIds.isNotEmpty() ||
+            effectivePocketIds.isNotEmpty()
         val hasExtendedFilters = keyword != null || paymentMethodId != null ||
             pocketId != null || amountMin != null || amountMax != null ||
-            visibilityFilter != null
+            visibilityFilter != null || hasMultiFilters
 
         val result = if (hasExtendedFilters) {
+            // 단수 categoryId 는 Set 에 이미 합쳐졌으므로 Spec 에는 Set 만 전달 (중복 조건 방지).
+            // paymentMethod/pocket 도 동일하게 Set 에 합침.
+            val specCategoryId = if (effectiveCategoryIds.isNotEmpty()) null else categoryId
+            val specPaymentMethodId = if (effectivePaymentMethodIds.isNotEmpty()) null else paymentMethodId
+            val specPocketId = if (effectivePocketIds.isNotEmpty()) null else pocketId
             val spec = TransactionSpecifications.withFilters(
                 coupleId = couple.id,
                 startDate = startDate,
                 endDate = endDate,
                 type = transactionType,
-                categoryId = categoryId,
+                categoryId = specCategoryId,
                 keyword = keyword,
-                paymentMethodId = paymentMethodId,
-                pocketId = pocketId,
+                paymentMethodId = specPaymentMethodId,
+                pocketId = specPocketId,
                 amountMin = amountMin,
                 amountMax = amountMax,
                 userId = userId,
-                visibility = visibilityFilter
+                visibility = visibilityFilter,
+                categoryIds = effectiveCategoryIds,
+                paymentMethodIds = effectivePaymentMethodIds,
+                pocketIds = effectivePocketIds
             )
             transactionRepository.findAll(spec, pageable)
         } else {

--- a/backend/src/test/kotlin/com/budgetbook/statistics/service/StatisticsServiceTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/statistics/service/StatisticsServiceTest.kt
@@ -3,6 +3,7 @@ package com.budgetbook.statistics.service
 import com.budgetbook.auth.domain.AuthProvider
 import com.budgetbook.auth.domain.User
 import com.budgetbook.budget.repository.MonthlyBudgetRepository
+import com.budgetbook.category.repository.CategoryRepository
 import com.budgetbook.common.exception.BusinessException
 import com.budgetbook.common.exception.NotFoundException
 import com.budgetbook.couple.domain.Couple
@@ -33,7 +34,8 @@ class StatisticsServiceTest : BehaviorSpec({
     val coupleResolver = mockk<CoupleResolver>()
     val budgetRepository = mockk<MonthlyBudgetRepository>()
     val spendingPlanRepository = mockk<SpendingPlanRepository>()
-    val service = StatisticsService(transactionRepository, transferRepository, coupleResolver, budgetRepository, spendingPlanRepository)
+    val categoryRepository = mockk<CategoryRepository>()
+    val service = StatisticsService(transactionRepository, transferRepository, coupleResolver, budgetRepository, spendingPlanRepository, categoryRepository)
 
     val user1 = User(email = "u1@test.com", nickname = "U1", provider = AuthProvider.GOOGLE, providerId = "g1")
     val user2 = User(email = "u2@test.com", nickname = "U2", provider = AuthProvider.KAKAO, providerId = "k2")


### PR DESCRIPTION
## Summary
- `CommonFilterParams` 에 `categoryIds`/`categoryGroupIds`/`paymentMethodIds`/`pocketIds` 복수 필드 추가 (Spring `@ModelAttribute` multi-value 자동 바인딩)
- `TransactionService.listTransactions`: 복수 ID 합집합 + `categoryGroupIds` → 하위 카테고리 펼치기 (`CategoryRepository.findAllByGroupIdIn`)
- `TransactionSpecifications.withFilters`: `category.id IN (:ids)` / `paymentMethod.id IN` / `pocket.id IN` 조건 추가
- `StatisticsController`/`StatisticsService`: 동일 확장
- 단수 `categoryId`/`paymentMethodId`/`pocketId` 유지 — 거래 상세/생성/CSV export/period-summary 호환

## 설계 결정
- 단수 + 복수 병존: FE 마이그레이션 중 단수 호출처(거래 폼 등)가 있어 즉시 제거 불가. PR-C3 (FE 전환) 완료 후 필요 시 단수 필드 deprecate.
- 그룹 펼치기는 BE 책임: 클라이언트가 group→categories 매핑을 들고 있어도 정합성 보장 어려움 → BE 가 `findAllByGroupIdIn` 으로 1회 조회 후 합집합.

## Test plan
- [x] `./gradlew compileKotlin compileTestKotlin` — BUILD SUCCESSFUL
- [x] `./gradlew test --tests "*Transaction*" --tests "*Statistics*"` — BUILD SUCCESSFUL
- [ ] 머지 후 Deploy to NAS — BE health check 200

## 후속
- PR-C3: FE 모델 Set + Repository/DataSource/UI 호출처 multi 전환 → 사용자가 UI 공통화 실제 체감

Refs: docs/sessions/2026-04-20_6_plan.md PR-C 2단계

🤖 Generated with [Claude Code](https://claude.com/claude-code)