### PR TITLE
chore(ci): required check pending 해소 + CI/배포 경량화

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -1,118 +1,75 @@
 name: Backend CI
 
-# PR only — feature 브랜치 push 와 PR 트리거 중복 제거
-# main push 는 deploy-nas.yml 의 health check 로 검증
+# 모든 PR 에서 실행 — 내부에서 paths-filter 로 실제 작업만 조건부 실행.
+# 이유: Branch protection required check 가 "PR 에서 무조건 보고" 되어야 하므로,
+# BE 변경 없는 PR 에서도 job 이 실행되어 즉시 success 로 끝나야 한다.
 on:
   pull_request:
     branches: [main]
-    paths: ['backend/**']
 
 permissions:
   contents: read
-  issues: write
 
 jobs:
-  build:
+  backend-ci:
     runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: backend
-
-    services:
-      postgres:
-        image: postgres:16-alpine
-        env:
-          POSTGRES_DB: budgetbook_test
-          POSTGRES_USER: budgetbook
-          POSTGRES_PASSWORD: budgetbook
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-
     steps:
       - uses: actions/checkout@v4
 
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            backend:
+              - 'backend/**'
+              - '.github/workflows/ci-backend.yml'
+
       - name: Setup JDK 21
+        if: steps.filter.outputs.backend == 'true'
         uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: 21
 
       - name: Setup Gradle
+        if: steps.filter.outputs.backend == 'true'
         uses: gradle/actions/setup-gradle@v3
         with:
           cache-read-only: ${{ github.ref != 'refs/heads/main' }}
 
-      # Task #15: Merged Build + Test into one step.
-      # ./gradlew build already runs all tests; running ./gradlew test separately
-      # caused a second full compilation cycle. Env vars are passed here so the
-      # test phase inside build can reach the Postgres service container.
-      #
-      # Task #29: No Redis service container is intentional.
-      # application.yml globally excludes RedisAutoConfiguration and
-      # RedisRepositoriesAutoConfiguration, so tests pass without Redis.
-      # Redis (Upstash) is only required at runtime in the prod environment.
+      # Postgres service container — `services:` 블록은 conditional 불가. 대체로 docker run 을
+      # 조건부로 실행한다. BE 변경 없을 때 컨테이너 미기동 → 리소스 절약.
+      - name: Start Postgres
+        if: steps.filter.outputs.backend == 'true'
+        run: |
+          docker run -d --name postgres-ci \
+            -e POSTGRES_DB=budgetbook_test \
+            -e POSTGRES_USER=budgetbook \
+            -e POSTGRES_PASSWORD=budgetbook \
+            -p 5432:5432 \
+            postgres:16-alpine
+          for i in $(seq 1 10); do
+            if docker exec postgres-ci pg_isready -U budgetbook -d budgetbook_test &>/dev/null; then
+              echo "Postgres ready (attempt $i)"
+              break
+            fi
+            sleep 1
+          done
+
+      # ./gradlew build 가 test + bootJar(assemble) 을 모두 수행.
+      # 기존 'Validate prod profile JAR assembly' 단계는 제거 — assemble 결과물은 profile 에
+      # 무관하고, runtime @Value/@ConfigurationProperties 검증은 deploy health check 에서 수행됨.
       - name: Build and Test
+        if: steps.filter.outputs.backend == 'true'
         run: ./gradlew build
         env:
           SPRING_DATASOURCE_URL: jdbc:postgresql://localhost:5432/budgetbook_test
           SPRING_DATASOURCE_USERNAME: budgetbook
           SPRING_DATASOURCE_PASSWORD: budgetbook
 
-      # Validates that prod profile can assemble a bootable JAR.
-      # Note: This does NOT validate runtime @Value/@ConfigurationProperties bindings
-      # (those resolve at Spring container startup, not at build time).
-      # It does catch: missing classes, resource filtering issues, manifest errors.
-      - name: Validate prod profile JAR assembly
-        run: ./gradlew bootJar
-        env:
-          SPRING_PROFILES_ACTIVE: prod
-          JWT_SECRET: ci-test-secret-key-that-is-at-least-256-bits-long-for-validation
-          DB_HOST: localhost
-          DB_PORT: 5432
-          DB_NAME: budgetbook_test
-          DB_USERNAME: budgetbook
-          DB_PASSWORD: budgetbook
-          FRONTEND_URL: http://localhost:5000
-          GOOGLE_CLIENT_ID: fake-google-id
-          GOOGLE_CLIENT_SECRET: fake-google-secret
-          KAKAO_CLIENT_ID: fake-kakao-id
-          KAKAO_CLIENT_SECRET: fake-kakao-secret
-
-      - name: Create Issue on Failure (main only, skip if open issue exists)
-        if: failure() && github.ref == 'refs/heads/main'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const {data: issues} = await github.rest.issues.listForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              labels: 'ci-failure,backend',
-              state: 'open',
-              per_page: 1,
-            });
-            if (issues.length > 0) {
-              console.log(`Skipping: open issue #${issues[0].number} already exists`);
-              return;
-            }
-            const title = `[CI FAIL] Backend - ${context.sha.substring(0, 7)}`;
-            const body = [
-              '## CI Failure Report',
-              '',
-              `**Commit:** ${context.sha}`,
-              `**Run:** ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
-              '',
-              '### Action Required',
-              '- [ ] 에러 로그 확인 후 수정',
-            ].join('\n');
-            await github.rest.issues.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              title,
-              body,
-              labels: ['ci-failure', 'backend'],
-            });
+      - name: Skipped (no backend changes)
+        if: steps.filter.outputs.backend != 'true'
+        run: echo "No backend changes — skipped."

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -1,19 +1,20 @@
 name: Frontend CI
 
-# PR 에서만 실행 (main push 는 deploy-nas.yml 이 test-frontend + build 수행 — 중복 제거).
-# build 는 deploy-nas 에서만. CI 는 analyze/test 만 → 수 분 → 1분 내외.
+# 모든 PR 에서 실행 (paths 제거) — 내부에서 paths-filter 로 실제 작업만 조건부 실행.
+# 이유: Branch protection required check 가 "PR 에서 무조건 보고" 되어야 하므로,
+# FE 변경 없는 PR 에서도 job 이 실행되어 즉시 success 로 끝나야 한다.
+# 기존: FE 변경 없을 때 workflow 미트리거 → required check 영원히 pending → PR 블록.
 on:
   pull_request:
     branches: [main]
-    paths: ['frontend/**']
 
 permissions:
   contents: read
-  issues: write
 
 jobs:
-  # analyze / test 를 독립 job 으로 분리 → 병렬 실행 (GitHub 가 자동 병렬)
-  analyze:
+  # 단일 job 으로 통합 (기존 analyze / test 분리 → Setup Flutter + pub get 반복으로 시간 낭비).
+  # Setup 1회, analyze + test 순차 실행.
+  frontend-ci:
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -21,7 +22,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            frontend:
+              - 'frontend/**'
+              - '.github/workflows/ci-frontend.yml'
+
       - name: Setup Flutter
+        if: steps.filter.outputs.frontend == 'true'
         uses: subosito/flutter-action@v2
         with:
           channel: stable
@@ -30,31 +40,15 @@ jobs:
           pub-cache-key: 'flutter-pub-:os:-:channel:-:version:-:arch:-:hash:'
 
       - name: Install dependencies
+        if: steps.filter.outputs.frontend == 'true'
         run: flutter pub get
 
       - name: Analyze
+        if: steps.filter.outputs.frontend == 'true'
         run: flutter analyze --no-fatal-infos --no-congratulate
 
-  test:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: frontend
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Flutter
-        uses: subosito/flutter-action@v2
-        with:
-          channel: stable
-          cache: true
-          cache-key: 'flutter-:os:-:channel:-:version:-:arch:-:hash:'
-          pub-cache-key: 'flutter-pub-:os:-:channel:-:version:-:arch:-:hash:'
-
-      - name: Install dependencies
-        run: flutter pub get
-
       - name: Test
+        if: steps.filter.outputs.frontend == 'true'
         run: |
           if find test -name "*_test.dart" | grep -q .; then
             flutter test --no-pub --concurrency=4
@@ -62,6 +56,6 @@ jobs:
             echo "No test files found, skipping"
           fi
 
-  # 둘 다 실패 시에만 한 번의 CI 실패 이슈 (main 에서만).
-  # 현재 workflow 는 PR 전용이므로 이슈 자동 생성은 제거
-  # (리뷰어가 PR 체크 상태로 확인 가능).
+      - name: Skipped (no frontend changes)
+        if: steps.filter.outputs.frontend != 'true'
+        run: echo "No frontend changes — skipped."

--- a/.github/workflows/deploy-nas.yml
+++ b/.github/workflows/deploy-nas.yml
@@ -150,9 +150,10 @@ jobs:
     steps:
       - name: Verify live site
         run: |
-          sleep 5
-          STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 15 https://aiva-bb.duckdns.org/ || echo "000")
-          API=$(curl -s -o /dev/null -w "%{http_code}" --max-time 15 https://aiva-bb.duckdns.org/actuator/health || echo "000")
+          # nginx reload / JVM warm-up 대기 (기존 5초 → 2초)
+          sleep 2
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 https://aiva-bb.duckdns.org/ || echo "000")
+          API=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 https://aiva-bb.duckdns.org/actuator/health || echo "000")
           echo "Site=$STATUS API=$API"
           [ "$STATUS" = "200" ] && [ "$API" = "200" ]
 


### PR DESCRIPTION
## 문제
Branch protection 의 required status(`analyze`, `test`)가 FE 변경 없는 PR 에서 영원히 \"Expected — Waiting for status to be reported\" pending → PR 블록 (#115 에서 발생).

**원인**: 기존 `ci-frontend.yml` 이 `paths: ['frontend/**']` 로 필터링되어 BE-only PR 에서 workflow 자체가 미트리거 → required check 보고되지 않음.

## 수정

### required check pending 해소 (핵심)
- `paths:` 를 workflow trigger 에서 제거하고 job 내부 `dorny/paths-filter` 로 이동
- FE/BE 변경 없는 PR 에서도 workflow 는 실행되지만 step 이 모두 skip → 즉시 success → required check 충족

### CI 경량화
- **ci-frontend**: `analyze` + `test` 분리 job → 단일 `frontend-ci` job 통합. Setup Flutter/`pub get` 1회로 중복 제거. 기존 2분+ → ~1분 목표.
- **ci-backend**:
  - \"Validate prod profile JAR assembly\" 제거 — `assemble` 은 profile 무관하고 runtime `@Value` 검증은 deploy health check 에서 수행됨
  - \"Create Issue on Failure (main only)\" 제거 — workflow 가 `pull_request` 전용이라 dead code
  - Postgres `services:` → `docker run` 으로 변경해 조건부 기동
- 두 workflow 모두 job 이름 `frontend-ci` / `backend-ci` 로 통일 (branch protection 재설정 시 이 이름 사용)

### Deploy 경량화
- `deploy-nas.yml` verify: `sleep 5→2`, `curl --max-time 15→10` (~10초 단축)

## ⚠️ 머지 후 필수 조치
Branch protection required check 를 새 job 이름으로 재설정:
```bash
GH_TOKEN=\$(gh auth token -u kdh-92) gh api --method PATCH \\
  repos/AIVA-SaaS/budget-book/branches/main/protection/required_status_checks \\
  --input - <<EOFF
{\"strict\": false, \"checks\": [{\"context\": \"frontend-ci\", \"app_id\": -1}, {\"context\": \"backend-ci\", \"app_id\": -1}]}
EOFF
```
(또는 GitHub UI Settings → Branches → main 에서 analyze/test 제거, frontend-ci/backend-ci 추가)

## 영향
- 기존 `analyze` / `test` 체크 이름 사라짐 → 이 PR 자신도 구 protection 에 의해 일시 pending. 머지 후 재설정로 해소.
- Docker 이미지 / NAS 배포 스크립트 변경 없음.

## Test plan
- [ ] 머지 후 다음 PR 에서 `frontend-ci` + `backend-ci` 두 체크 즉시 보고 확인
- [ ] BE-only / FE-only / docs-only PR 모두 required check success
- [ ] deploy-nas.yml 머지 후 실제 main push 시 verify 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)