### PR TITLE
fix(transaction): 카드 결제 이중 계산 차단 (PR-A 핫픽스, Phase 22)

### DIFF
--- a/frontend/lib/features/transaction/presentation/pages/transaction_list_page.dart
+++ b/frontend/lib/features/transaction/presentation/pages/transaction_list_page.dart
@@ -444,9 +444,16 @@ class _TransactionListPageState extends State<TransactionListPage> {
                     }).toList();
 
               // Calculate transfer in/out relative to current payment method filter
+              // Card settlement (BANK→CREDIT): BE 가 이미 원본 EXPENSE 를 지출로 집계함.
+              // 집계에서 제외해 이중 계산 방지. (Phase 22 PR-A hotfix)
               int transferIn = 0;
               int transferOut = 0;
               for (final t in searchedTransfers) {
+                final isCardSettlement = t.sourcePaymentMethod.type == 'BANK' &&
+                    t.destinationPaymentMethod.type == 'CREDIT';
+                if (isCardSettlement) {
+                  continue;
+                }
                 if (filterPmId != null) {
                   // Per-payment-method view: in/out relative to this method
                   if (t.sourcePaymentMethod.id == filterPmId) {


### PR DESCRIPTION
## Summary
- 필터 활성 시 FE 집계가 BANK→CREDIT 이체(카드 결제)를 지출에 합산하여 BE 가 이미 계산한 원본 EXPENSE 와 이중 계산되던 문제 수정
- Transfer src/dst type 조합으로 결제 판정 (BANK→CREDIT), DTO 변경 없는 FE-only 핫픽스
- PR-B 머지 후 kind == CARD_SETTLEMENT 기준으로 교체 예정

## Test plan
- [x] flutter analyze 통과
- [ ] 라이브: 필터 활성 후 MonthSummaryBar 지출이 EXPENSE 1회만 반영되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)