### PR TITLE
fix(transaction): transactionTypes 다중 파라미터 BE 지원 (Phase 22 T10)

### DIFF
--- a/backend/src/main/kotlin/com/budgetbook/common/dto/CommonFilterParams.kt
+++ b/backend/src/main/kotlin/com/budgetbook/common/dto/CommonFilterParams.kt
@@ -27,6 +27,10 @@ data class CommonFilterParams(
     val keyword: String? = null,
     val visibility: String? = null,
     val type: String? = null,
+    // 복수 타입 필터 (Phase 22 T10). FE 가 `transactionTypes=EXPENSE&transactionTypes=INCOME` 포맷으로 전송.
+    // 단수 `type` 과 병존 시 Service 계층에서 `transactionTypes` 우선 (FE `toQueryParams` 와 일치).
+    // 빈/null = 필터 없음. 유효 값: EXPENSE / INCOME / ADJUSTMENT (TRANSFER 는 FE 의사-타입).
+    val transactionTypes: List<String>? = null,
     val status: String? = null
 ) {
     /**

--- a/backend/src/main/kotlin/com/budgetbook/transaction/controller/TransactionController.kt
+++ b/backend/src/main/kotlin/com/budgetbook/transaction/controller/TransactionController.kt
@@ -66,7 +66,9 @@ class TransactionController(
             categoryIds = filter.categoryIds,
             categoryGroupIds = filter.categoryGroupIds,
             paymentMethodIds = filter.paymentMethodIds,
-            pocketIds = filter.pocketIds
+            pocketIds = filter.pocketIds,
+            // Phase 22 T10: 다중 타입 필터. `transactionTypes=EXPENSE&transactionTypes=INCOME`.
+            transactionTypes = filter.transactionTypes
         ))
     }
 

--- a/backend/src/main/kotlin/com/budgetbook/transaction/repository/TransactionSpecifications.kt
+++ b/backend/src/main/kotlin/com/budgetbook/transaction/repository/TransactionSpecifications.kt
@@ -32,7 +32,9 @@ object TransactionSpecifications {
         // 병존 시 호출자(Service) 에서 합집합 Set 을 만들어 단수는 null 로 넘기고 Set 만 사용하도록 권장.
         categoryIds: Set<UUID> = emptySet(),
         paymentMethodIds: Set<UUID> = emptySet(),
-        pocketIds: Set<UUID> = emptySet()
+        pocketIds: Set<UUID> = emptySet(),
+        // Phase 22 T10 다중 타입 필터. 단수 `type` 과 병존 시 호출자(Service) 에서 단수를 null 로 넘김.
+        types: Set<TransactionType> = emptySet()
     ): Specification<Transaction> {
         return Specification { root: Root<Transaction>, _: CriteriaQuery<*>, cb: CriteriaBuilder ->
             val predicates = mutableListOf<Predicate>()
@@ -42,6 +44,10 @@ object TransactionSpecifications {
 
             type?.let {
                 predicates.add(cb.equal(root.get<TransactionType>("type"), it))
+            }
+
+            if (types.isNotEmpty()) {
+                predicates.add(root.get<TransactionType>("type").`in`(types))
             }
 
             categoryId?.let {

--- a/backend/src/main/kotlin/com/budgetbook/transaction/service/TransactionService.kt
+++ b/backend/src/main/kotlin/com/budgetbook/transaction/service/TransactionService.kt
@@ -73,7 +73,10 @@ class TransactionService(
         categoryIds: List<UUID> = emptyList(),
         categoryGroupIds: List<UUID> = emptyList(),
         paymentMethodIds: List<UUID> = emptyList(),
-        pocketIds: List<UUID> = emptyList()
+        pocketIds: List<UUID> = emptyList(),
+        // Phase 22 T10: 다중 타입 필터. null/빈 리스트 = 필터 없음.
+        // 단수 `type` 과 병존 시 `transactionTypes` 우선 (FE toQueryParams 와 일치).
+        transactionTypes: List<String>? = null
     ): PageResponse<TransactionResponse> {
         val couple = getActiveCouple(userId)
 
@@ -92,6 +95,19 @@ class TransactionService(
             endDate = yearMonth.atEndOfMonth()
         }
 
+        // Phase 22 T10: 다중 타입 우선 파싱.
+        // 각 원소는 EXPENSE/INCOME/ADJUSTMENT 여야 하며, 그 외(예: FE-only TRANSFER) 는 400.
+        val effectiveTransactionTypes: Set<TransactionType> = transactionTypes
+            ?.filter { it.isNotBlank() }
+            ?.map { raw ->
+                try { TransactionType.valueOf(raw) } catch (e: IllegalArgumentException) {
+                    throw BusinessException("VALIDATION_ERROR", "Invalid transaction type: $raw")
+                }
+            }
+            ?.toSet()
+            ?: emptySet()
+
+        // 단수 `type` 파싱 — `transactionTypes` 가 비어있을 때만 의미 있음.
         val transactionType = type?.let {
             try { TransactionType.valueOf(it) } catch (e: IllegalArgumentException) {
                 throw BusinessException("VALIDATION_ERROR", "Invalid transaction type: $it")
@@ -130,7 +146,8 @@ class TransactionService(
         // (legacy JPQL 은 단일 categoryId/type 만 지원)
         val hasMultiFilters = effectiveCategoryIds.isNotEmpty() ||
             effectivePaymentMethodIds.isNotEmpty() ||
-            effectivePocketIds.isNotEmpty()
+            effectivePocketIds.isNotEmpty() ||
+            effectiveTransactionTypes.isNotEmpty()
         val hasExtendedFilters = keyword != null || paymentMethodId != null ||
             pocketId != null || amountMin != null || amountMax != null ||
             visibilityFilter != null || hasMultiFilters
@@ -138,14 +155,16 @@ class TransactionService(
         val result = if (hasExtendedFilters) {
             // 단수 categoryId 는 Set 에 이미 합쳐졌으므로 Spec 에는 Set 만 전달 (중복 조건 방지).
             // paymentMethod/pocket 도 동일하게 Set 에 합침.
+            // 단수 `type` 은 `transactionTypes` 가 비어있을 때만 사용 (FE `toQueryParams` 우선순위와 일치).
             val specCategoryId = if (effectiveCategoryIds.isNotEmpty()) null else categoryId
             val specPaymentMethodId = if (effectivePaymentMethodIds.isNotEmpty()) null else paymentMethodId
             val specPocketId = if (effectivePocketIds.isNotEmpty()) null else pocketId
+            val specType = if (effectiveTransactionTypes.isNotEmpty()) null else transactionType
             val spec = TransactionSpecifications.withFilters(
                 coupleId = couple.id,
                 startDate = startDate,
                 endDate = endDate,
-                type = transactionType,
+                type = specType,
                 categoryId = specCategoryId,
                 keyword = keyword,
                 paymentMethodId = specPaymentMethodId,
@@ -156,7 +175,8 @@ class TransactionService(
                 visibility = visibilityFilter,
                 categoryIds = effectiveCategoryIds,
                 paymentMethodIds = effectivePaymentMethodIds,
-                pocketIds = effectivePocketIds
+                pocketIds = effectivePocketIds,
+                types = effectiveTransactionTypes
             )
             transactionRepository.findAll(spec, pageable)
         } else {

--- a/backend/src/test/kotlin/com/budgetbook/transaction/controller/TransactionControllerTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/transaction/controller/TransactionControllerTest.kt
@@ -144,6 +144,44 @@ class TransactionControllerTest : FunSpec({
         }
     }
 
+    test("listTransactions forwards transactionTypes multi filter from filter to service (Phase 22 T10)") {
+
+        val pageResponse = PageResponse(
+            content = listOf(sampleTransactionResponse()),
+            page = 0, size = 20, totalElements = 1, totalPages = 1, first = true, last = true
+        )
+        every {
+            transactionService.listTransactions(
+                userId = testUserId, year = 2024, month = 1, type = null, categoryId = null,
+                keyword = null, paymentMethodId = null, pocketId = null,
+                amountMin = null, amountMax = null, dateFrom = null, dateTo = null,
+                visibility = null, page = 0, size = 20,
+                categoryIds = emptyList(), categoryGroupIds = emptyList(),
+                paymentMethodIds = emptyList(), pocketIds = emptyList(),
+                transactionTypes = listOf("EXPENSE", "INCOME")
+            )
+        } returns pageResponse
+
+        val filter = CommonFilterParams(
+            year = 2024, month = 1,
+            transactionTypes = listOf("EXPENSE", "INCOME")
+        )
+        val result = controller.listTransactions(testUserId, filter, 0, 20)
+
+        result.success shouldBe true
+        verify(exactly = 1) {
+            transactionService.listTransactions(
+                userId = testUserId, year = 2024, month = 1, type = null, categoryId = null,
+                keyword = null, paymentMethodId = null, pocketId = null,
+                amountMin = null, amountMax = null, dateFrom = null, dateTo = null,
+                visibility = null, page = 0, size = 20,
+                categoryIds = emptyList(), categoryGroupIds = emptyList(),
+                paymentMethodIds = emptyList(), pocketIds = emptyList(),
+                transactionTypes = listOf("EXPENSE", "INCOME")
+            )
+        }
+    }
+
     test("listTransactions forwards visibility='PRIVATE' from filter to service (P6)") {
 
         val pageResponse = PageResponse(

--- a/backend/src/test/kotlin/com/budgetbook/transaction/service/TransactionServiceTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/transaction/service/TransactionServiceTest.kt
@@ -842,4 +842,134 @@ class TransactionServiceTest : BehaviorSpec({
             }
         }
     }
+
+    // --- transactionTypes 다중 필터 (Phase 22 T10) ---
+
+    Given("transactions exist and transactionTypes=[EXPENSE, INCOME] multi filter is used") {
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
+
+        val expenseTx = Transaction(
+            couple = couple, author = user1, type = TransactionType.EXPENSE,
+            amount = 15000, description = "지출", transactionDate = LocalDate.of(2024, 1, 15)
+        )
+        val incomeTx = Transaction(
+            couple = couple, author = user2, type = TransactionType.INCOME,
+            amount = 3000000, description = "급여", transactionDate = LocalDate.of(2024, 1, 25)
+        )
+        val specSlot = slot<org.springframework.data.jpa.domain.Specification<Transaction>>()
+        val page = PageImpl(listOf(incomeTx, expenseTx), PageRequest.of(0, 20), 2)
+        every { transactionRepository.findAll(capture(specSlot), any<org.springframework.data.domain.Pageable>()) } returns page
+
+        When("listTransactions is called with transactionTypes=[EXPENSE, INCOME]") {
+            val result = service.listTransactions(
+                userId = user1.id, year = 2024, month = 1, type = null, categoryId = null,
+                keyword = null, paymentMethodId = null, pocketId = null,
+                amountMin = null, amountMax = null, dateFrom = null, dateTo = null,
+                visibility = null, page = 0, size = 20,
+                transactionTypes = listOf("EXPENSE", "INCOME")
+            )
+
+            Then("routes through Specification (IN-clause) and returns filtered results") {
+                result.content.size shouldBe 2
+                result.totalElements shouldBe 2
+                // Spec 경로가 실제로 호출되었는지 확인 (legacy JPQL 은 단일 type 만 지원하므로 호출되면 안됨)
+                verify(exactly = 1) { transactionRepository.findAll(any<org.springframework.data.jpa.domain.Specification<Transaction>>(), any<org.springframework.data.domain.Pageable>()) }
+                verify(exactly = 0) { transactionRepository.findByCoupleIdAndFilters(any(), any(), any(), any(), any(), any(), any()) }
+                specSlot.isCaptured shouldBe true
+            }
+        }
+    }
+
+    Given("transactionTypes contains FE-only TRANSFER value") {
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
+
+        When("listTransactions is called with transactionTypes=[TRANSFER]") {
+            Then("throws BusinessException with VALIDATION_ERROR (TRANSFER 는 FE 의사-타입)") {
+                val ex = shouldThrow<com.budgetbook.common.exception.BusinessException> {
+                    service.listTransactions(
+                        userId = user1.id, year = 2024, month = 1, type = null, categoryId = null,
+                        keyword = null, paymentMethodId = null, pocketId = null,
+                        amountMin = null, amountMax = null, dateFrom = null, dateTo = null,
+                        visibility = null, page = 0, size = 20,
+                        transactionTypes = listOf("TRANSFER")
+                    )
+                }
+                ex.code shouldBe "VALIDATION_ERROR"
+            }
+        }
+
+        When("listTransactions is called with transactionTypes=[EXPENSE, BOGUS]") {
+            Then("throws BusinessException with VALIDATION_ERROR (하나라도 잘못되면 400)") {
+                val ex = shouldThrow<com.budgetbook.common.exception.BusinessException> {
+                    service.listTransactions(
+                        userId = user1.id, year = 2024, month = 1, type = null, categoryId = null,
+                        keyword = null, paymentMethodId = null, pocketId = null,
+                        amountMin = null, amountMax = null, dateFrom = null, dateTo = null,
+                        visibility = null, page = 0, size = 20,
+                        transactionTypes = listOf("EXPENSE", "BOGUS")
+                    )
+                }
+                ex.code shouldBe "VALIDATION_ERROR"
+            }
+        }
+    }
+
+    Given("both singular `type` and multi `transactionTypes` are set") {
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
+
+        val tx = Transaction(
+            couple = couple, author = user1, type = TransactionType.INCOME,
+            amount = 3000000, description = "급여", transactionDate = LocalDate.of(2024, 1, 25)
+        )
+        val page = PageImpl(listOf(tx), PageRequest.of(0, 20), 1)
+        every { transactionRepository.findAll(any<org.springframework.data.jpa.domain.Specification<Transaction>>(), any<org.springframework.data.domain.Pageable>()) } returns page
+
+        When("listTransactions receives type=EXPENSE AND transactionTypes=[EXPENSE, INCOME]") {
+            val result = service.listTransactions(
+                userId = user1.id, year = 2024, month = 1, type = "EXPENSE", categoryId = null,
+                keyword = null, paymentMethodId = null, pocketId = null,
+                amountMin = null, amountMax = null, dateFrom = null, dateTo = null,
+                visibility = null, page = 0, size = 20,
+                transactionTypes = listOf("EXPENSE", "INCOME")
+            )
+
+            Then("multi `transactionTypes` takes precedence (matches FE toQueryParams)") {
+                // 단수 type=EXPENSE 는 무시되고 IN-clause(EXPENSE, INCOME) 로 조회.
+                // 결과로 INCOME 거래(급여) 가 포함됨 — 단수가 우선이었다면 걸러졌을 것.
+                result.content.size shouldBe 1
+                result.content[0].type shouldBe "INCOME"
+                verify(exactly = 1) { transactionRepository.findAll(any<org.springframework.data.jpa.domain.Specification<Transaction>>(), any<org.springframework.data.domain.Pageable>()) }
+            }
+        }
+    }
+
+    Given("transactionTypes is empty list") {
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
+
+        val tx = Transaction(
+            couple = couple, author = user1, type = TransactionType.EXPENSE,
+            amount = 15000, description = "점심", transactionDate = LocalDate.of(2024, 1, 15)
+        )
+        val page = PageImpl(listOf(tx), PageRequest.of(0, 20), 1)
+        every { transactionRepository.findByCoupleIdAndFilters(
+            couple.id, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 1, 31), null, null, user1.id, any()
+        ) } returns page
+
+        When("listTransactions is called with transactionTypes=emptyList()") {
+            val result = service.listTransactions(
+                userId = user1.id, year = 2024, month = 1, type = null, categoryId = null,
+                keyword = null, paymentMethodId = null, pocketId = null,
+                amountMin = null, amountMax = null, dateFrom = null, dateTo = null,
+                visibility = null, page = 0, size = 20,
+                transactionTypes = emptyList()
+            )
+
+            Then("falls back to legacy JPQL path (빈 리스트 = 필터 없음)") {
+                result.content.size shouldBe 1
+                verify { transactionRepository.findByCoupleIdAndFilters(
+                    couple.id, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 1, 31), null, null, user1.id, any()
+                ) }
+            }
+        }
+    }
 })


### PR DESCRIPTION
## Summary
2+ 타입 다중 선택 시 BE 가 필터를 무시하고 전체 반환하던 버그 수정.

## 원인
- FE 가 `?transactionTypes=EXPENSE&transactionTypes=INCOME` 전송
- BE `CommonFilterParams` 에 필드 부재 → Spring `@ModelAttribute` 무시
- 단일 선택만 우연히 동작 (FE 가 backward-compat `type=` 도 동시 전송)

## 수정
- `CommonFilterParams.transactionTypes: List<String>?` 필드 추가
- `TransactionController.listTransactions` → 서비스에 전달
- `TransactionService` 에서 파싱/검증 (EXPENSE/INCOME/ADJUSTMENT 만, TRANSFER 등 거부 400)
- `TransactionSpecifications.withFilters` 에 `types: Set<TransactionType>` + `root.get("type").in(types)` predicate
- 우선순위: `transactionTypes` 비어있지 않으면 IN 쿼리, 그 외 기존 `type =` 경로 유지

## Test
- ✅ `./gradlew test` — 804/0/0/0 (+6 new)
  - TransactionServiceTest: +5 sub-tests
  - TransactionControllerTest: +1 test

🤖 Generated with [Claude Code](https://claude.com/claude-code)