### PR TITLE
fix(transaction): ADJUSTMENT 음수 amount 허용 (Phase 22 T11)

### DIFF
--- a/backend/src/main/kotlin/com/budgetbook/transaction/dto/TransactionDtos.kt
+++ b/backend/src/main/kotlin/com/budgetbook/transaction/dto/TransactionDtos.kt
@@ -50,8 +50,10 @@ data class CreateTransactionRequest(
     @field:NotBlank
     val type: String,
 
+    // Phase 22 T11: @Min(0) 제거. ADJUSTMENT 는 잔액 하향 조정 시 음수 필요.
+    // 부호 검증은 TransactionService 에서 type 별로 수행한다.
     @field:NotNull
-    @field:Min(0)
+    @field:Min(-999_999_999)
     @field:Max(999_999_999)
     val amount: Long,
 
@@ -75,7 +77,9 @@ data class CreateTransactionRequest(
 )
 
 data class UpdateTransactionRequest(
-    @field:Min(0)
+    // Phase 22 T11: @Min(0) 제거. ADJUSTMENT 는 잔액 하향 조정 시 음수 필요.
+    // 부호 검증은 TransactionService 에서 type 별로 수행한다.
+    @field:Min(-999_999_999)
     @field:Max(999_999_999)
     val amount: Long? = null,
 

--- a/backend/src/main/kotlin/com/budgetbook/transaction/service/TransactionService.kt
+++ b/backend/src/main/kotlin/com/budgetbook/transaction/service/TransactionService.kt
@@ -214,6 +214,8 @@ class TransactionService(
             throw BusinessException("VALIDATION_ERROR", "Invalid transaction type: ${request.type}")
         }
 
+        validateAmountForType(transactionType, request.amount)
+
         val category = request.categoryId?.let { catId ->
             val cat = categoryRepository.findById(catId)
                 .orElseThrow { NotFoundException("CATEGORY_NOT_FOUND", "Specified category does not exist.") }
@@ -294,7 +296,10 @@ class TransactionService(
         OwnershipValidator.validateOwnership(transaction.couple.id, couple, "Transaction")
         validatePrivateOwner(transaction.visibility, transaction.owner?.id, userId)
 
-        request.amount?.let { transaction.amount = it }
+        request.amount?.let {
+            validateAmountForType(transaction.type, it)
+            transaction.amount = it
+        }
         request.description?.let { transaction.description = it }
         request.transactionDate?.let { transaction.transactionDate = it }
         request.memo?.let { transaction.memo = it.value }
@@ -493,6 +498,36 @@ class TransactionService(
             transactionCount = allItems.size,
             transactions = allItems
         )
+    }
+
+    /**
+     * Phase 22 T11: type 별 amount 부호 검증.
+     *
+     * - `EXPENSE` / `INCOME`: 양수만 허용 (> 0). DTO 의 `@Min(0)` 을 대체.
+     * - `ADJUSTMENT`: 부호 있는 증감값. 0 은 의미 없는 조정이므로 거부.
+     *
+     * DB CHECK 제약(`ck_transactions_amount`, V54) 과 일치하며,
+     * DTO 에서 일괄 `@Min(0)` 하는 대신 type 별로 정밀하게 검증한다.
+     */
+    private fun validateAmountForType(type: TransactionType, amount: Long) {
+        when (type) {
+            TransactionType.EXPENSE, TransactionType.INCOME -> {
+                if (amount <= 0) {
+                    throw BusinessException(
+                        "VALIDATION_ERROR",
+                        "${type.name} amount 는 0 보다 커야 합니다. (입력: $amount)"
+                    )
+                }
+            }
+            TransactionType.ADJUSTMENT -> {
+                if (amount == 0L) {
+                    throw BusinessException(
+                        "VALIDATION_ERROR",
+                        "ADJUSTMENT amount 는 0 이 될 수 없습니다. 잔액 조정 증감값을 입력하세요."
+                    )
+                }
+            }
+        }
     }
 
     private fun calculateSettlementDate(

--- a/backend/src/test/kotlin/com/budgetbook/transaction/service/TransactionServiceTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/transaction/service/TransactionServiceTest.kt
@@ -972,4 +972,145 @@ class TransactionServiceTest : BehaviorSpec({
             }
         }
     }
+
+    // --- Phase 22 T11: type 별 amount 부호 검증 ---
+
+    Given("a user in an active couple creating transactions with signed amounts") {
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
+        every { userRepository.findById(user1.id) } returns Optional.of(user1)
+
+        When("creating an EXPENSE with negative amount") {
+            val request = CreateTransactionRequest(
+                type = "EXPENSE", amount = -100, description = "잘못된 지출",
+                transactionDate = LocalDate.of(2024, 1, 15)
+            )
+
+            Then("throws BusinessException with VALIDATION_ERROR and does not persist") {
+                val ex = shouldThrow<com.budgetbook.common.exception.BusinessException> {
+                    service.createTransaction(user1.id, request)
+                }
+                ex.code shouldBe "VALIDATION_ERROR"
+                verify(exactly = 0) { transactionRepository.save(any()) }
+            }
+        }
+
+        When("creating an INCOME with zero amount") {
+            val request = CreateTransactionRequest(
+                type = "INCOME", amount = 0, description = "0원 수입",
+                transactionDate = LocalDate.of(2024, 1, 15)
+            )
+
+            Then("throws BusinessException with VALIDATION_ERROR") {
+                val ex = shouldThrow<com.budgetbook.common.exception.BusinessException> {
+                    service.createTransaction(user1.id, request)
+                }
+                ex.code shouldBe "VALIDATION_ERROR"
+                verify(exactly = 0) { transactionRepository.save(any()) }
+            }
+        }
+
+        When("creating an ADJUSTMENT with negative amount (잔액 하향 조정)") {
+            val request = CreateTransactionRequest(
+                type = "ADJUSTMENT", amount = -100, description = "실잔액 보정 (하향)",
+                transactionDate = LocalDate.of(2024, 1, 15)
+            )
+            val txSlot = slot<Transaction>()
+            every { transactionRepository.save(capture(txSlot)) } answers { txSlot.captured }
+
+            val result = service.createTransaction(user1.id, request)
+
+            Then("creates the transaction with negative amount — PaymentMethod 잔액 계산에서 -100 만큼 차감") {
+                result.type shouldBe "ADJUSTMENT"
+                result.amount shouldBe -100
+                // TransactionRepository.netAmountByPaymentMethodForCouple 은 ADJUSTMENT.amount 를
+                // 그대로 SUM 하므로 (V54 + plan §2.5), 음수 ADJUSTMENT 는 잔액을 그만큼 감소시킨다.
+                txSlot.captured.amount shouldBe -100
+                txSlot.captured.type shouldBe TransactionType.ADJUSTMENT
+                verify(exactly = 1) { transactionRepository.save(any()) }
+            }
+        }
+
+        When("creating an ADJUSTMENT with positive amount (잔액 상향 조정)") {
+            val request = CreateTransactionRequest(
+                type = "ADJUSTMENT", amount = 500, description = "실잔액 보정 (상향)",
+                transactionDate = LocalDate.of(2024, 1, 15)
+            )
+            val txSlot = slot<Transaction>()
+            every { transactionRepository.save(capture(txSlot)) } answers { txSlot.captured }
+
+            val result = service.createTransaction(user1.id, request)
+
+            Then("creates the transaction with positive signed amount") {
+                result.type shouldBe "ADJUSTMENT"
+                result.amount shouldBe 500
+                txSlot.captured.amount shouldBe 500
+            }
+        }
+
+        When("creating an ADJUSTMENT with zero amount") {
+            val request = CreateTransactionRequest(
+                type = "ADJUSTMENT", amount = 0, description = "의미 없는 조정",
+                transactionDate = LocalDate.of(2024, 1, 15)
+            )
+
+            Then("throws BusinessException with VALIDATION_ERROR and does not persist") {
+                val ex = shouldThrow<com.budgetbook.common.exception.BusinessException> {
+                    service.createTransaction(user1.id, request)
+                }
+                ex.code shouldBe "VALIDATION_ERROR"
+                verify(exactly = 0) { transactionRepository.save(any()) }
+            }
+        }
+    }
+
+    Given("an existing ADJUSTMENT transaction being updated") {
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
+        val tx = Transaction(
+            couple = couple, author = user1, type = TransactionType.ADJUSTMENT,
+            amount = 100, description = "잔액 보정", transactionDate = LocalDate.of(2024, 1, 15)
+        )
+        every { transactionRepository.findById(tx.id) } returns Optional.of(tx)
+        every { transactionRepository.save(tx) } returns tx
+
+        When("updateTransaction is called with amount = -200 (상→하향 전환)") {
+            val request = UpdateTransactionRequest(amount = -200)
+            val result = service.updateTransaction(user1.id, tx.id, request)
+
+            Then("accepts the negative amount") {
+                result.amount shouldBe -200
+            }
+        }
+
+        When("updateTransaction is called with amount = 0") {
+            val request = UpdateTransactionRequest(amount = 0)
+
+            Then("throws BusinessException with VALIDATION_ERROR") {
+                val ex = shouldThrow<com.budgetbook.common.exception.BusinessException> {
+                    service.updateTransaction(user1.id, tx.id, request)
+                }
+                ex.code shouldBe "VALIDATION_ERROR"
+            }
+        }
+    }
+
+    Given("an existing EXPENSE transaction being updated with negative amount") {
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
+        val tx = Transaction(
+            couple = couple, author = user1, type = TransactionType.EXPENSE,
+            amount = 15000, description = "지출", transactionDate = LocalDate.of(2024, 1, 15)
+        )
+        every { transactionRepository.findById(tx.id) } returns Optional.of(tx)
+
+        When("updateTransaction is called with amount = -100") {
+            val request = UpdateTransactionRequest(amount = -100)
+
+            Then("throws BusinessException with VALIDATION_ERROR and does not save") {
+                val ex = shouldThrow<com.budgetbook.common.exception.BusinessException> {
+                    service.updateTransaction(user1.id, tx.id, request)
+                }
+                ex.code shouldBe "VALIDATION_ERROR"
+                verify(exactly = 0) { transactionRepository.save(any()) }
+            }
+        }
+    }
 })


### PR DESCRIPTION
## Summary
잔액 수정 다이얼로그가 하향 조정(음수 amount) 시 `@Min(0)` 에 걸려 실패하던 버그 수정.

## 수정
- `CreateTransactionRequest.amount` / `UpdateTransactionRequest.amount`: `@Min(0)` → `@Min(-999_999_999)` (음수 허용 범위 확장, Max 유지)
- `TransactionService.validateAmountForType(type, amount)` 추가:
  - EXPENSE/INCOME: amount > 0 필수
  - ADJUSTMENT: 0 거부, 부호 무관 non-zero
- `createTransaction` / `updateTransaction` 둘 다 적용 (update 는 기존 엔티티 type 기준)

## Test
- ✅ `./gradlew test` — 806/0/0 (+7 scenarios)
  - EXPENSE amount=-100 → rejected
  - INCOME amount=0 → rejected
  - ADJUSTMENT amount=-100 → accepted (하향)
  - ADJUSTMENT amount=+500 → accepted (상향)
  - ADJUSTMENT amount=0 → rejected
  - update EXPENSE amount=-100 → rejected
  - update ADJUSTMENT amount=-200 → accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)