### PR TITLE
docs(session): Phase 23 기획 확정 — 결제수단/ADJUSTMENT/예산/4탭 네비

### DIFF
--- a/docs/sessions/2026-04-23_1_plan.md
+++ b/docs/sessions/2026-04-23_1_plan.md
@@ -1,0 +1,385 @@
+# Phase 23 — 결제수단/이체 통합 UX + ADJUSTMENT 카테고리 + 예산 월별 분리
+> 날짜: 2026-04-23 | 회차: 1 | 상태: **검증완료 / 승인대기**
+
+## 0. 배경
+Phase 22 라이브 검증 결과:
+- 이체 폼 진입점 2개 (transaction Tab 2 / transfer standalone) 중 **한쪽만** "종류" 드롭다운 반영
+- 결제수단 페이지 2개 (AssetManagement 탭 / PaymentMethodPage standalone) 중 **한쪽만** "잔액 수정" 노출
+- 자산 관리 탭엔 **잔액 표시 자체가 없음** (이름+타입만)
+- ADJUSTMENT 거래 생성 경로가 UI 에 없음
+- 자동 추천(`_recommendKind`) 불필요
+
+신규 버그: **월별 예산 편집 시 다른 달에 전파됨** — 각 월 독립 수정이 안 됨.
+
+## 1. 결정 확정 (사용자 2026-04-23)
+| Q | 결정 |
+|---|---|
+| Q1 이체 폼 통일 | **(a) Tab 2 embedded 에 드롭다운 이식** |
+| Q2 ADJUSTMENT UX | **(a) 특수 카테고리 "잔액 조정"** — 선택 시 내부적으로 type=ADJUSTMENT 저장 |
+| Q3 결제수단 탭 표시 | 현 시점 총 잔액 + 미결제 금액 + **이번 달 사용 금액** 3종 표시 |
+| Q4 페이지 통합 | AssetManagementPage 로 통합, PaymentMethodPage standalone 제거. 이체는 양방향 가능, 출금 선택 시 입금 셀렉터에서 동일 PM 제외 (기본 검증) |
+| 자동 추천 | **제거** (`_recommendKind` + `_kindOverridden` 삭제) |
+
+## 2. 영역별 설계
+
+### G1. 이체 폼 통일
+- `transaction_form_page.dart` Tab 2 "이체" embedded 폼에 TransferKind 드롭다운 추가
+  - 옵션: `순수 이체 / 지출로 반영 / 수입으로 반영`
+  - 기본값 `TransferKind.generic`, 자동 추천 없음
+  - 같은 결제수단 출금↔입금 선택 방지: 출금 선택 시 입금 셀렉터 리스트에서 해당 PM 숨김 (기본 검증)
+- `TransferFormPage` (standalone) 에서 `_recommendKind` / `_kindOverridden` 삭제. 기본 GENERIC 유지.
+- 두 폼 모두 `CreateTransfer(kind: _kind)` / `UpdateTransfer(kind: _kind)` 동일 이벤트 유지.
+
+### G2. AssetManagementPage 결제수단 탭 개편
+**표시 확장** (`_PaymentMethodTab._buildPaymentMethodTile`):
+- 비-카드(BANK/CASH/DEBIT): **현재 잔액** 표시
+- 카드(CREDIT): **미결제 금액** + **이번 달 사용 금액** (이번 달 EXPENSE 합계)
+- 잔액 수정 아이콘 버튼 (비-카드만, popup 메뉴와 별도로 명시적 tune 아이콘)
+
+**Popup 메뉴 합치기** (G4 통합):
+- PaymentMethodPage 의 완전한 popup (내역 보기 / 잔액 수정 / 수정 / 삭제) 을 AssetManagementPage 탭으로 이식
+- PaymentMethodPage standalone 파일/라우트 **삭제**
+
+**BE 확장**:
+- `PaymentMethodResponse` 에 `currentBalance`, `pendingAmount`, `monthUsage` 필드 포함 (현재 일부 존재, 누락분 추가)
+- `/api/v1/payment-methods?year=YYYY&month=MM` 파라미터로 월별 usage 조회 지원 (이미 유사 구조 있을 수 있음 — 확인 필요)
+
+### G3. ADJUSTMENT 특수 카테고리
+**요구**: 거래 폼에서 **"잔액 조정"** 카테고리 선택 시 자동으로 `type=ADJUSTMENT` 로 저장 → 수입/지출 집계 제외.
+
+**설계**:
+1. V57 마이그레이션: 커플당 시스템 카테고리 "잔액 조정" 자동 생성 (system-owned, 삭제 불가). 또는 카테고리 레코드 없이 가상 특수 값(`category_id=null + type=ADJUSTMENT`) 처리.
+2. FE 거래 폼에서 카테고리 선택 sheet 상단에 "잔액 조정" 고정 옵션 노출 (type 과 무관하게). 선택 시:
+   - `type` 필드 강제로 `ADJUSTMENT` 로 전환
+   - Amount 입력은 부호 허용 (양수=증가, 음수=감소), 또는 UI 에서 "증가/감소" 라디오 + 양수 입력
+   - 저장 시 `type=ADJUSTMENT, category=null(또는 system)` 으로 POST
+3. 거래 목록에서 ADJUSTMENT 는 "조정" 뱃지 표시 (PR-C 에서 이미 구현됨 — 회귀 확인만)
+
+**권장**: 카테고리 레코드 생성 없이 **가상 옵션** 방식 (옵션 선택 사전 확인 필요 — 단순). 시스템 카테고리 접근은 스키마/권한 복잡도 증가.
+
+### G4. PaymentMethodPage standalone 제거
+- 라우터 `/payment_method/*` 경로 제거 (사용처 grep → 0 예상, 대부분 `/asset-management` 경유)
+- `PaymentMethodPage` 파일 + test 삭제
+- 기존 PaymentMethodPage 고유 기능(잔액 수정 popup) 을 AssetManagementPage `_PaymentMethodTab` 에 포함
+
+### G5. 예산 템플릿 + 월별 오버라이드 (편한 가계부 패턴) — **신규**
+**사용자 의도 재정의** (2026-04-23 확정):
+> "특정 범위에 대한 예산 금액과 type을 만들고, 특정 월만 존재하면 특정 월 정보를 우선 노출"
+
+**개념 모델** (template + override):
+- **템플릿(Range row)**: `(couple, category, group)` 당 1건. `start_ym` 부터 `end_ym` (nullable=무기한) 범위에서 기본 예산 제공.
+- **오버라이드(Month row)**: 특정 `year_month` 단일 월만 덮어쓰는 row. 사용자가 그 월 금액을 수정하면 생성.
+- **조회 우선순위**: 오버라이드 > 템플릿.
+- **수정**: 기본적으로 **오버라이드만 생성/업데이트** — 템플릿 불변 → 다른 월 영향 없음.
+- **삭제**:
+  - "이번 달만 삭제" = 오버라이드 삭제(있으면) 또는 amount=0 marker
+  - "이후 달도 삭제" = 템플릿 `end_ym = M-1` 로 단축 + M 이후 오버라이드 전부 삭제
+
+**스키마 변경 (V57)**:
+```sql
+-- 기존 monthly_budgets 재활용. year_month 는 "적용 시작월" 역할로 semantic 확장.
+ALTER TABLE monthly_budgets ADD COLUMN end_year_month VARCHAR(7);
+ALTER TABLE monthly_budgets ADD COLUMN row_kind VARCHAR(10) NOT NULL DEFAULT 'OVERRIDE'
+    CHECK (row_kind IN ('TEMPLATE', 'OVERRIDE'));
+
+-- 데이터 마이그레이션: 기존 per-month row 는 모두 OVERRIDE 로 유지
+-- end_year_month = year_month (단일월) 로 백필
+UPDATE monthly_budgets SET end_year_month = year_month, row_kind = 'OVERRIDE'
+  WHERE end_year_month IS NULL;
+
+-- 기존 유니크 인덱스 유지 (OVERRIDE 단일월 보장).
+-- TEMPLATE 은 (couple, category, group) 당 1건 제약 — partial unique:
+CREATE UNIQUE INDEX uk_monthly_budgets_template
+  ON monthly_budgets (couple_id, COALESCE(category_id, '00000000-0000-0000-0000-000000000000'),
+                      COALESCE(group_id, '00000000-0000-0000-0000-000000000000'))
+  WHERE row_kind = 'TEMPLATE';
+```
+
+**읽기 로직** (`BudgetService.getBudgetsByMonth(M)`):
+```kotlin
+val templates = repo.findTemplatesCovering(coupleId, M)  // start_ym <= M AND (end_ym IS NULL OR end_ym >= M)
+val overrides = repo.findOverridesForMonth(coupleId, M)  // row_kind=OVERRIDE AND year_month=M
+// 병합: 각 (category, group) 키마다 override 우선, 없으면 template
+return (templates + overrides).groupBy { it.key }.map { (_, rows) ->
+    rows.firstOrNull { it.rowKind == OVERRIDE } ?: rows.first()
+}
+```
+
+**쓰기 로직**:
+- `PUT /budgets?yearMonth=M` — 기본은 **오버라이드 upsert** (템플릿 불변)
+- `PUT /budgets?yearMonth=M&scope=TEMPLATE` — 템플릿 자체 수정 (모든 미오버라이드 월 영향, 사용자 명시적 선택 시만 노출 — Phase 23 범위 밖, 나중에 추가)
+- `POST /budgets` — 신규 생성: `end_ym=null` (무기한) 템플릿 또는 사용자가 `end_ym` 지정
+
+**삭제 로직**:
+- `DELETE /budgets/{overrideId}` — 오버라이드 row 제거 (템플릿으로 복귀)
+- `DELETE /budgets?couple=...&category=...&yearMonth=M&cascadeFuture=true` — 템플릿 end 단축 + M 이후 override 정리
+- FE: 삭제 다이얼로그에 체크박스 "이후 달도 삭제"
+
+**API 시나리오 예시**:
+```
+1. 신규 생성: POST /budgets { category=식비, amount=150000, yearMonth=2026-02 }
+   → TEMPLATE (start=2026-02, end=null, amount=150000)
+2. 3월 화면 진입: GET /budgets?year=2026&month=3
+   → TEMPLATE 조회 → 150000 표시 (암시적 전파)
+3. 3월만 300000 으로 수정: PUT /budgets?yearMonth=2026-03 { amount: 300000 }
+   → OVERRIDE 생성 (year_month=2026-03, end_ym=2026-03, amount=300000)
+4. 2월 조회: 여전히 TEMPLATE → 150000 ✅ (영향 없음)
+5. 4월 이후 예산 삭제: DELETE /budgets?category=식비&yearMonth=2026-04&cascadeFuture=true
+   → TEMPLATE.end_ym = 2026-03, 2026-04 이후 override 삭제
+```
+
+**FE 변경**:
+- `budget_list_page.dart`: MonthCubit 구독으로 자동 재로드 (누락 시 추가 — S4 검증)
+- `budget_form_page.dart`: 신규 생성 시 `endYearMonth` 입력 (기본 "무기한")
+- 수정 화면: "템플릿 수정" vs "이번 달만 수정" 선택은 Phase 23 범위 밖 (기본은 오버라이드 생성)
+- 삭제 다이얼로그: `[x] 이후 달도 삭제` 체크박스
+
+**이전: propagate cap 12개월 논쟁 해결**: template + override 구조에서는 row 폭증이 원천 차단됨 — cap 불필요.
+
+## 3. 구조적 수정 (재발 방지)
+
+하네스 audit: STRUCTURAL_FIX_REQUIRED (`navigation_state` 3회+, `amount_calculation` 3회+, `db_schema` 경고, `ui_pattern` 경고)
+
+### S1. 폼 공통 진입점 통일 — "중복 구현" 패턴 제거
+- Transfer 폼은 **하나의** `TransferFormContent` 위젯으로 추출 (embedded/standalone 공용)
+- PaymentMethod 리스트는 **하나의** `PaymentMethodListTile` 위젯만 존재 (AssetManagementPage 소유)
+
+### S2. ADJUSTMENT 진입점 단일화
+- 거래 폼에서만 ADJUSTMENT 생성 (balance_adjustment_dialog 와 경로 통합)
+- 기존 `balance_adjustment_dialog.dart` 는 shortcut 으로 유지하되 내부적으로 동일 API 호출
+
+### S3. 예산 전파/삭제 규칙 문서화
+- `docs/CODEMAPS/BUDGET_SYSTEM.md` (신규) 또는 TRANSFER_SYSTEM codemap 옆에 BUDGET 파일 추가
+- 전파/cascade 규칙 명시 — 재발 방지
+
+### S4. 월 변경 재로딩 계약
+- `navigation_state` 3회 반복 → MonthCubit 구독 패턴이 모든 BLoC (Budget 포함) 에 적용됐는지 전수 검토. 누락 시 추가 구독.
+
+## 4. 영향 범위
+### BE (예상 8 파일)
+| 파일 | 변경 |
+|---|---|
+| `budget/dto/BudgetDtos.kt` | `CreateBudgetRequest.propagateUntil: String?` 추가, `DeleteBudget` 에 `cascadeFuture: Boolean` |
+| `budget/service/BudgetService.kt` | 생성 시 범위 반복 저장, 삭제 시 cascade |
+| `budget/controller/BudgetController.kt` | query param `cascadeFuture` |
+| `budget/repository/MonthlyBudgetRepository.kt` | `deleteByCoupleIdAndCategoryAndGroupAndYearMonthGte` 메서드 |
+| `paymentmethod/dto/PaymentMethodDtos.kt` | monthUsage 필드 포함 확인/추가 |
+| `paymentmethod/service/PaymentMethodService.kt` | 월별 사용 금액 집계 (이미 유사 로직 있으면 재사용) |
+| `transaction/dto/TransactionDtos.kt` | 특수 카테고리 ADJUSTMENT 요청 경로 검증 |
+| test | Budget 전파/삭제 + PM 확장 응답 테스트 |
+
+### FE (예상 10 파일)
+| 파일 | 변경 |
+|---|---|
+| `features/transaction/presentation/pages/transaction_form_page.dart` | Tab 2 embedded 에 TransferKind 드롭다운 + 출금/입금 PM 중복 방지 |
+| `features/transfer/presentation/pages/transfer_form_page.dart` | `_recommendKind`/`_kindOverridden` 삭제 |
+| `features/settings/presentation/pages/asset_management_page.dart` | `_PaymentMethodTab._buildPaymentMethodTile` 에 잔액/미결제/이번달 사용 + 잔액 수정 popup |
+| `features/payment_method/presentation/pages/payment_method_page.dart` | **삭제** (또는 redirect) |
+| `core/router/app_router.dart` | `/payment_method` 라우트 제거 (사용처 치환) |
+| `features/budget/presentation/pages/budget_form_page.dart` | "propagateUntil" 옵션 — 기본 "무기한" / 특정 월까지 / 이번 달만 |
+| `features/budget/presentation/pages/budget_list_page.dart` | 삭제 다이얼로그에 "이후 달도 삭제" 체크박스 |
+| `features/budget/presentation/bloc/budget_bloc.dart` | 월 변경 구독/재로드 누락 여부 검증 + 수정 |
+| `features/transaction/presentation/pages/transaction_form_page.dart` | 카테고리 선택 시트 상단에 "잔액 조정" 고정 항목 + 선택 시 type=ADJUSTMENT 자동 전환 |
+| `features/payment_method/presentation/widgets/balance_adjustment_dialog.dart` | 내부적으로 ADJUSTMENT Transaction API 호출 (기존 유지) |
+
+## 5. 성능 설계
+- G2: PM 응답에 월별 usage 집계 추가 — 결제수단 n개 × 1쿼리/월 또는 1쿼리로 group by. 기존 StatisticsService.byPaymentMethod 재사용 가능.
+- G5 예산 전파: 기본 무기한 = 지정한 yearMonth 부터 `min(그날 + 5년, 임의 cap)` 까지 또는 FE 진입 시 lazy 생성 (권장). 실제로 사용자 요구는 "이번 달 이후 자동"이므로 **현재 보는 월까지만 보장** 방식 고려:
+  - 권장: FE 가 월 전환 시 해당 월 예산 부재 + 이전 월 존재 → BE 에 `/budgets/ensure-month` 호출해 lazy 생성 (카피)
+  - 또는 명시적 전파 옵션 (사용자 선택): 무기한이면 범위 cap (기본 12개월) 까지 생성 후 추가 cap 만료 시 다시 자동 lazy
+- cascade delete: `yearMonth >= :from` 단일 DELETE — 작업 시간 수십 ms
+
+## 6. 하네스 Scope Audit (Step 1.5, 2026-04-23)
+- 실행: `pre-change-audit.sh . "ui_pattern,navigation_state,amount_calculation,db_schema"`
+- 판정: 🚫 STRUCTURAL_FIX_REQUIRED → S1~S4 로 대응
+- Acknowledge 완료
+
+## 7. 단계 분할
+| PR | 내용 | 규모 |
+|---|---|---|
+| **PR-X1** | G2 결제수단 탭 잔액/사용 표시 + PaymentMethodPage 제거 + popup 이식 | L |
+| **PR-X2** | G1 이체 폼 통일 (Tab 2 드롭다운 이식) + G4 자동 추천 제거 | M |
+| **PR-X3** | G3 ADJUSTMENT 특수 카테고리 (FE 거래 폼 + BE 검증) | M |
+| **PR-X4** | G5 예산 월별 독립 (BE 전파/삭제 + FE UI + bloc 월 재로드) | L |
+
+## 8. 검증 계획
+- [ ] flutter analyze 0 error
+- [ ] flutter test 모든 기존 pass
+- [ ] backend ./gradlew test 전체 pass
+- [ ] 라이브:
+  - [ ] 거래 폼 Tab 2 이체에 "종류" 드롭다운 노출
+  - [ ] 출금 선택 후 입금 셀렉터에서 동일 PM 제외
+  - [ ] 자산 관리 > 결제수단 탭: 잔액/미결제/이번달 사용 표시
+  - [ ] 잔액 수정 buttons 직접 노출 + 저장 시 ADJUSTMENT 생성
+  - [ ] `/payment_method` 라우트 진입 시 정상 리다이렉트(또는 404 없이 자산 관리로 안내)
+  - [ ] 거래 폼 카테고리 sheet 상단에 "잔액 조정" + 선택 시 type=ADJUSTMENT 자동 전환
+  - [ ] 예산: 2월 154,100 설정 → 3월 자동 동기 생성 → 3월 수정 → 2월 불변
+  - [ ] 예산: 삭제 시 "이후 달도 삭제" 체크박스 동작
+
+## 9. 승인
+- [ ] 승인 / 수정 요청: ___
+
+## 10. 확정 사항 (2026-04-23 추가 답변 반영)
+- **G5 저장 모델**: 편한 가계부 스타일 템플릿+오버라이드로 변경. row 폭증 없음. cap 불필요.
+- **G3 "잔액 조정" 실체**: **가상 옵션 방식** 확정 (확인2:a). 카테고리 sheet 상단 고정 항목, DB 레코드 없이 `type=ADJUSTMENT & category=null` 로 저장.
+
+---
+
+## 11. G6. 편한 가계부 UX 구조 반영 — 네비게이션 재구성
+
+### 11.1 사용자 문제 정의
+- **홈 ↔ 거래**: 두 탭이 비슷한 월 요약 + 리스트 보여 기능 중복
+- **예산 ↔ 통계**: 예산에도 진행률 차트, 통계에도 예산 대비 차트가 있어 혼동
+- **설정 내 중복**: 자산 관리(카테고리/결제수단/포켓) 가 설정 하위에 묻혀 접근 불편
+
+사용자 요구: 편한 가계부의 **배치/구성 개념** 만 가져와 우리 시스템 재배치. 디자인은 현 상태 유지.
+
+### 11.2 편한 가계부 구조 분석 (배치·구성 관점)
+
+| 탭 | 편한 가계부 역할 | 현재 우리 앱 매핑 |
+|---|---|---|
+| 거래 | **기본 홈** — 월 요약 + 날짜별 그룹 리스트 + 달력 옵션 + FAB 빠른 추가 | 분산: 홈(대시보드) + 거래(목록) 2탭 |
+| 자산 | 계좌/카드 통합 — 은행/카드/현금 그룹 헤더 + 총 자산/부채 카드 + 잔액 수정 + 이체 진입 | 설정 하위 "자산 관리" 에 묻힘 |
+| 예산 | 예산 설정 + 이번달 진행률 + 초과 경보 전용 | "예산" 탭 (진행률/통계 혼재) |
+| 통계 | 순수 차트 — 카테고리/결제수단별 지출·수입, 일/주/월/년 기간 전환 | "통계" 탭 (예산 대비 일부 혼재) |
+| 더보기 | 커플/가족 설정, 백업, 알림, 앱 정보 | "설정" (자산관리/카테고리 등 섞임) |
+
+**원칙**:
+1. 탭 1개 = 한 가지 목적 (overlap 금지)
+2. "홈" 을 별도 탭으로 두지 않고 **거래 탭 상단이 대시보드 역할**
+3. "자산" 을 탑레벨로 승격 (설정에서 분리)
+4. 예산/통계는 **설정 vs 분석** 관점으로 분리 (예산=설정·진행, 통계=차트·비교)
+
+### 11.3 최종 Bottom Nav (2026-04-23 확정 — 🅑 태스크 중심 4탭)
+
+```
+[거래]        [분석]        [자산]        [더보기]
+```
+
+편한가계부 4탭 구조를 **참고**하되, 우리 앱 목표(개인+커플 공용)에 맞게 재배치.
+**차별점**: 예산+통계 병합(분석 탭) + 커플 전역 공유/개인 toggle + 잔액 수정 직접 노출.
+
+### 11.3.1 전역 헤더 (모든 탭 공통)
+- **월 네비게이터** — MonthCubit 단일 소스
+- **공유/개인 Visibility chip** (커플 모드에서만) — `[모두] [공유] [내 것] [상대 것]`
+  - AppBar 하단 row 에 고정, 탭 전환 시 상태 유지 (UnifiedFilterState.visibility)
+  - 개인 모드에선 렌더 안 됨
+  - 선택 시 모든 탭(거래/분석/자산)의 데이터 즉시 필터
+- WebSocket 상태 배너 (기존)
+
+### 11.3.2 거래 탭 — 단일 스크롤 + View toggle
+**상단 toggle**: `리스트 | 달력` (사용자 선호 저장)
+
+**리스트 뷰** (기본):
+1. 상단 카드: 이번달 **수입 / 지출 / 이체 / 합계** 4칸 (MonthSummaryBar)
+2. **총 잔액 미니 카드** (1줄, 탭 → 자산 탭 deeplink) — 매일 확인하는 정보 노출
+3. 날짜 그룹 거래 리스트 (거래/이체 ledger 통합)
+4. 무한 스크롤
+
+**달력 뷰**:
+1. 월 달력 — 각 날짜 셀에 일별 수입/지출 합계 마커
+2. 날짜 선택 시 해당 일 거래 리스트 하단 바텀시트
+
+FAB "+": 지출 / 수입 / 이체 / 조정 4가지 (G3 조정 포함)
+
+### 11.3.3 분석 탭 — 예산 + 통계 병합 (수직 스크롤)
+상단 chip: `월 / 주 / 연` (기간 전환, 기본 월)
+
+섹션:
+1. **예산 진행 카드** — 이번달 총 예산 / 사용 / 남음 + 초과 카테고리 pill
+2. **카테고리별 지출** — 파이 차트 + 예산 있으면 bar overlay
+3. **월별 비교** — bar (수입·지출·이체)
+4. **결제수단별 분포** — 도넛
+5. 하단 버튼: **예산 편집** → BudgetFormPage (템플릿/오버라이드)
+
+### 11.3.4 자산 탭
+- 상단: **총 자산 / 부채(미결제) / 순자산** 3 카드
+- sub-tabs: `결제수단 | 포켓 | 카테고리`
+- 결제수단 탭에 G2 확장 (잔액/미결제/이번달 사용) + **잔액 수정 직접 아이콘 버튼** (popup 아닌 명시적 노출)
+- 이체 아이콘 tap → TransactionFormPage 이체 탭 pre-filled
+
+### 11.3.5 더보기 탭
+- 커플 관리 (초대·권한·공유 기본값)
+- 알림 설정
+- 백업/복원 / CSV 다운로드
+- 앱 설정 (테마)
+- 로그아웃
+- 앱 버전/고지
+
+### 11.4 영역별 구체 변경
+
+#### 11.4.1 거래 탭 — 4 top-tabs (홈 흡수)
+- 신규 `transaction_home_page.dart` (또는 기존 파일 확장) — `DefaultTabController(length: 4)` 으로 top-tab 4개 구성
+- **일일**: 기존 `transaction_list_page.dart` 를 이 탭의 body 로 재사용
+- **달력**: `TableCalendar` 기반 월 달력, 일별 수입/지출 합계 마커 (Phase 23 범위 — 기본 월 뷰만, 주 뷰 선택은 scope 외)
+- **월별**: 월별 요약 리스트 (수입/지출/합계), 항목 탭 시 해당 월 `일일` 탭으로 이동
+- **요약**: 기존 홈 페이지 대시보드 위젯 흡수 — `AccountBalanceCard`(간단 모드), 카테고리별 top N 지출
+- 상단 `MonthNavigator` + 필터 바 공통
+- FAB "+": TransactionFormPage (지출/수입/이체/조정)
+
+#### 11.4.2 자산 탭 승격
+- 라우트: `/assets` (기존 `/asset-management` alias 유지)
+- Bottom nav 에서 직접 진입
+- 상단 3칸 카드: **총 자산 / 총 부채(미결제) / 순자산**
+- Sub-tabs: `결제수단 | 포켓 | 카테고리` (현재 AssetManagementPage 그대로)
+- 결제수단 탭 안에 G2 에서 확장한 잔액/미결제/이번달 사용 표시 + 잔액 수정 버튼
+- 이체는 결제수단 타일 우측 "⇄" 아이콘 → TransactionFormPage Tab 2 로 deeplink
+
+#### 11.4.3 통계 탭 — "통계 + 예산" 병합 (편한 가계부 구조)
+- 신규 `statistics_home_page.dart` — `DefaultTabController(length: 2)`
+- **통계 top-tab**: 카테고리 파이, 월별 비교 bar, 결제수단별 분포 (기존 statistics_page 흡수)
+- **예산 top-tab**: 이번달 예산 카드 (총/사용/남음) + 카테고리 진행률 bar + 초과 알림 + 주간 예산 + "편집" 버튼 → BudgetFormPage
+- 상단 공통: **기간 전환기 chip row** `[월별] [주별] [연별]` — 두 top-tab 모두 공유
+- 기존 `budget_list_page.dart` 은 예산 top-tab 의 body 로 재사용 (차트 영역 제거)
+- 기존 `dashboard_page.dart` / 홈 탭 연관 예산 위젯은 통계 탭으로 흡수
+
+#### 11.4.4 더보기 (설정) 정리
+- 제거 (자산 탭으로 승격): 자산 관리 하위
+- 유지: 커플 설정, 알림, 백업/복원, 다운로드 CSV, 로그아웃, 앱 버전
+- 카테고리 편집 진입은 `자산 > 카테고리` 탭으로
+
+### 11.5 구조적 수정 (S5 추가)
+**S5. 탭 간 기능 중복 패턴 금지**
+- 새 위젯/차트 추가 시 "어느 탭에 속하는가" 기준 문서화 (§11.2 매트릭스)
+- PR 리뷰 체크리스트에 "탭 역할 확인" 항목
+- `docs/CODEMAPS/NAVIGATION.md` (신규) — 각 탭 책임 명시
+
+### 11.6 영향 범위 (추가, 총 +15~20 파일)
+| 파일 | 변경 |
+|---|---|
+| `frontend/lib/core/widgets/main_shell_page.dart` | Bottom nav 5탭 재구성 |
+| `frontend/lib/core/router/app_router.dart` | `/` 홈 라우트 → `/transactions` redirect, `/assets` 신규 branch |
+| `frontend/lib/features/home/*` | `dashboard_page.dart` 제거 또는 deprecated (위젯만 추출) |
+| `frontend/lib/features/transaction/presentation/pages/transaction_list_page.dart` | 상단 대시보드 영역 (AccountBalanceCard 등) 병합 |
+| `frontend/lib/features/settings/presentation/pages/asset_management_page.dart` | 탑레벨로 승격, 상단 총자산 카드 추가 |
+| `frontend/lib/features/settings/presentation/pages/settings_page.dart` | "자산 관리" 메뉴 제거, "더보기" 로 리네임 |
+| `frontend/lib/features/budget/presentation/pages/budget_list_page.dart` | 차트 영역 축소, 진행률·경보만 |
+| `frontend/lib/features/statistics/presentation/pages/statistics_page.dart` | 기간 전환기 추가, 차트 보강, 예산 대비 제거 |
+| `frontend/lib/core/widgets/account_balance_card.dart` | 거래 탭 상단으로 배치 이동 |
+| `docs/CODEMAPS/NAVIGATION.md` (신규) | 탭 역할 매트릭스 |
+
+### 11.7 단계 분할 — 최종 PR 맵 (🅑 확정)
+| PR | 내용 | 규모 |
+|---|---|---|
+| **PR-X5** | 거래 탭 — 홈 대시보드 흡수, 리스트/달력 toggle, 총잔액 미니카드, FAB 4분기 (조정 추가) | L |
+| **PR-X6** | 자산 탭 탑레벨 승격 + 총자산/부채/순자산 카드 + 이체 아이콘 → Transfer pre-filled | L |
+| **PR-X7** | 분석 탭 (예산+통계 병합), 기간 전환 chip, 예산/통계 기존 탭 페이지 정리 | L |
+| **PR-X8** | 커플 전역 공유/개인 Visibility chip — AppBar 고정, 모든 탭 필터 동기화 | M |
+| **PR-X9** | Bottom nav 5탭 → 4탭 축소 (거래/분석/자산/더보기), 홈·예산·통계 탭 제거, 라우트 redirect | M |
+
+**순서**: X1~X4 병렬 → X5/X6/X7 순차 → X8 + X9 마감
+
+### 11.8 검증 추가
+- [ ] Bottom nav `거래/자산/예산/통계/더보기` 노출
+- [ ] 거래 탭 상단 대시보드(AccountBalanceCard + MonthSummaryBar) 표시
+- [ ] `/` 진입 시 거래 탭으로 리다이렉트
+- [ ] 자산 탭 상단 총자산/부채/순자산 카드 표시
+- [ ] 예산 탭에서 통계 차트 제거 확인
+- [ ] 통계 탭에 일/주/월/년 기간 전환기 노출 + 각 기간 차트 정상
+- [ ] 더보기(설정) 에서 자산 관리 메뉴 없음
+- [ ] 카테고리 편집 진입이 `자산 > 카테고리` 에서 가능
+
+### 11.9 주의 사항
+- 홈 탭 제거는 **사용자 근육 기억** 변경 — 첫 진입 시 "홈 → 거래" 경로 학습 필요. 초회 안내 스낵바 1회 고려.
+- 자산 탭 승격으로 settings_page 가 매우 얇아짐 — 허용 (편한 가계부 "더보기" 탭도 마찬가지)
+- 라우트 이름 하위 호환: `/asset-management` 는 `/assets` 로 리다이렉트로 기존 deep link 보존


### PR DESCRIPTION
## Summary
- G1-G4 Phase 22 검증 gap 대응 (이체 폼 통일 / 결제수단 탭 잔액 표시 / PaymentMethodPage 통합 / 자동추천 제거 / ADJUSTMENT 가상 카테고리)
- G5 예산 템플릿+오버라이드 모델 (편한가계부 패턴) — row 폭증 없음
- G6 태스크 중심 4탭 네비 (거래 / 분석 / 자산 / 더보기) — 예산+통계 분석 탭 병합, 커플 전역 공유/개인 toggle, 거래 탭 리스트/달력 사용자 toggle

## PR map (9건)
PR-X1~X4 (Phase 22 gap 대응) 병렬 → X5/X6/X7 (탭 개편) 순차 → X8 (커플 toggle) / X9 (4탭 축소) 마감

🤖 Generated with [Claude Code](https://claude.com/claude-code)