### PR TITLE
feat(transaction): Tab 2 이체 종류 드롭다운 + PM 중복 방지 + 자동추천 제거 (Phase 23 PR-X2)

### DIFF
--- a/frontend/lib/features/transaction/presentation/pages/transaction_form_page.dart
+++ b/frontend/lib/features/transaction/presentation/pages/transaction_form_page.dart
@@ -42,6 +42,7 @@ import 'package:budget_book/features/ai/domain/entities/ai_classify_result.dart'
 import 'package:budget_book/features/transaction/presentation/bloc/transaction_bloc.dart';
 import 'package:budget_book/features/transaction/presentation/bloc/transaction_event.dart';
 import 'package:budget_book/features/transaction/presentation/bloc/transaction_state.dart';
+import 'package:budget_book/features/transfer/domain/entities/transfer.dart';
 import 'package:budget_book/features/transfer/presentation/bloc/transfer_bloc.dart';
 import 'package:budget_book/features/transfer/presentation/bloc/transfer_event.dart';
 import 'package:budget_book/features/transfer/presentation/bloc/transfer_state.dart';
@@ -134,6 +135,9 @@ class _TransactionFormPageState extends State<TransactionFormPage>
   late DateTime _transferDate;
   bool _isTransferSubmitting = false;
   int _swapCounter = 0;
+  // Phase 23 PR-X2: TransferKind dropdown in embedded Tab 2.
+  // Default GENERIC; no auto-recommendation (user-driven choice).
+  TransferKind _transferKind = TransferKind.generic;
 
   bool get isEditing => widget.transactionId != null;
 
@@ -870,6 +874,7 @@ class _TransactionFormPageState extends State<TransactionFormPage>
       description: description,
       transferDate: dateStr,
       memo: memo,
+      kind: _transferKind,
     ));
   }
 
@@ -893,9 +898,11 @@ class _TransactionFormPageState extends State<TransactionFormPage>
     final destIsCredit = selectedDest?.isCredit ?? false;
     final sourceIsCredit = selectedSource?.isCredit ?? false;
 
-    final sourceMethods = destIsCredit
-        ? methods.where((pm) => !pm.isCredit).toList()
-        : methods;
+    // Bidirectional same-PM filter: exclude the other side's selection.
+    final sourceMethods = methods
+        .where((pm) => pm.id != _transferDestinationPaymentMethodId)
+        .where((pm) => !destIsCredit || !pm.isCredit)
+        .toList();
     final destMethods = methods
         .where((pm) => pm.id != _transferSourcePaymentMethodId)
         .where((pm) => !sourceIsCredit || !pm.isCredit)
@@ -957,6 +964,11 @@ class _TransactionFormPageState extends State<TransactionFormPage>
               onChanged: (value) {
                 setState(() {
                   _transferSourcePaymentMethodId = value;
+                  // Clear dest if it matches new source (bidirectional guard).
+                  if (value != null &&
+                      _transferDestinationPaymentMethodId == value) {
+                    _transferDestinationPaymentMethodId = null;
+                  }
                   final newSource =
                       methods.where((pm) => pm.id == value).firstOrNull;
                   if (newSource?.isCredit == true &&
@@ -1009,6 +1021,12 @@ class _TransactionFormPageState extends State<TransactionFormPage>
               onChanged: (value) {
                 setState(() {
                   _transferDestinationPaymentMethodId = value;
+                  // Clear source if it matches new dest (bidirectional guard).
+                  if (value != null &&
+                      _transferSourcePaymentMethodId == value) {
+                    _transferSourcePaymentMethodId = null;
+                    _swapCounter++;
+                  }
                   final newDest =
                       methods.where((pm) => pm.id == value).firstOrNull;
                   if (newDest?.isCredit == true &&
@@ -1020,6 +1038,37 @@ class _TransactionFormPageState extends State<TransactionFormPage>
               },
               validator: (value) =>
                   value == null ? '입금 결제수단을 선택하세요' : null,
+            ),
+            const SizedBox(height: 16),
+            // Transfer kind (Phase 23 PR-X2) — matches transfer_form_page.
+            // Default GENERIC; no auto-recommendation. Card settlement
+            // (BANK→CREDIT) is handled via its dedicated flow.
+            DropdownButtonFormField<TransferKind>(
+              initialValue: _transferKind,
+              decoration: const InputDecoration(
+                labelText: '종류',
+                prefixIcon: Icon(Icons.category_outlined),
+                helperText: '이체의 성격을 선택하세요. 기본은 "순수 이체" 입니다.',
+              ),
+              isExpanded: true,
+              items: const [
+                DropdownMenuItem(
+                  value: TransferKind.generic,
+                  child: Text('순수 이체 (통계 제외)'),
+                ),
+                DropdownMenuItem(
+                  value: TransferKind.expenseTransfer,
+                  child: Text('지출로 반영'),
+                ),
+                DropdownMenuItem(
+                  value: TransferKind.incomeTransfer,
+                  child: Text('수입으로 반영'),
+                ),
+              ],
+              onChanged: (value) {
+                if (value == null) return;
+                setState(() => _transferKind = value);
+              },
             ),
             const SizedBox(height: 16),
             // Description

--- a/frontend/lib/features/transfer/presentation/pages/transfer_form_page.dart
+++ b/frontend/lib/features/transfer/presentation/pages/transfer_form_page.dart
@@ -42,9 +42,6 @@ class _TransferFormPageState extends State<TransferFormPage> {
   // INCOME_TRANSFER (수입으로 반영). CARD_SETTLEMENT is set via the dedicated
   // card settlement flow (payment_method card settlement page), not this form.
   TransferKind _kind = TransferKind.generic;
-  // Whether the user has manually overridden the auto-recommended kind.
-  // Once true, we stop auto-recommending on source/dest changes.
-  bool _kindOverridden = false;
 
   bool get isEditing => widget.transferId != null;
 
@@ -82,38 +79,9 @@ class _TransferFormPageState extends State<TransferFormPage> {
     _sourcePaymentMethodId = transfer.sourcePaymentMethod.id;
     _destinationPaymentMethodId = transfer.destinationPaymentMethod.id;
     _kind = transfer.kind;
-    // Editing a transfer should preserve the stored kind unless the user
-    // changes it, even if source/dest happen to differ.
-    _kindOverridden = true;
     try {
       _selectedDate = DateTime.parse(transfer.transferDate);
     } catch (_) {}
-  }
-
-  /// Recommend a kind based on source/destination payment method types.
-  /// Only GENERIC is auto-picked here; EXPENSE_TRANSFER / INCOME_TRANSFER
-  /// are user-driven. CARD_SETTLEMENT is out of scope for this form.
-  TransferKind _recommendKind({
-    required String? sourceType,
-    required String? destType,
-  }) {
-    // We default to GENERIC; the user can override to EXPENSE/INCOME_TRANSFER.
-    // (BANK → CREDIT should go through the card settlement page, not here.)
-    return TransferKind.generic;
-  }
-
-  void _maybeAutoRecommendKind({
-    required String? sourceType,
-    required String? destType,
-  }) {
-    if (_kindOverridden) return;
-    final recommended = _recommendKind(
-      sourceType: sourceType,
-      destType: destType,
-    );
-    if (recommended != _kind) {
-      setState(() => _kind = recommended);
-    }
   }
 
   @override
@@ -392,13 +360,6 @@ class _TransferFormPageState extends State<TransferFormPage> {
                   _destinationPaymentMethodId = null;
                 }
               });
-              _maybeAutoRecommendKind(
-                sourceType: methods
-                    .where((pm) => pm.id == value)
-                    .firstOrNull
-                    ?.type,
-                destType: selectedDest?.type,
-              );
             },
             validator: (value) =>
                 value == null ? '출금 결제수단을 선택하세요' : null,
@@ -449,13 +410,6 @@ class _TransferFormPageState extends State<TransferFormPage> {
                   _swapCounter++;
                 }
               });
-              _maybeAutoRecommendKind(
-                sourceType: selectedSource?.type,
-                destType: methods
-                    .where((pm) => pm.id == value)
-                    .firstOrNull
-                    ?.type,
-              );
             },
             validator: (value) =>
                 value == null ? '입금 결제수단을 선택하세요' : null,
@@ -488,10 +442,7 @@ class _TransferFormPageState extends State<TransferFormPage> {
             ],
             onChanged: (value) {
               if (value == null) return;
-              setState(() {
-                _kind = value;
-                _kindOverridden = true;
-              });
+              setState(() => _kind = value);
             },
           ),
           const SizedBox(height: 16),


### PR DESCRIPTION
## Summary
- Tab 2 embedded 이체 폼에 `TransferKind` 드롭다운 이식 (순수 이체 / 지출로 반영 / 수입으로 반영)
- 출금↔입금 결제수단 **양방향 중복 방지** (source 선택하면 dest 리스트에서 제외, 역도)
- Same-PM swap race: 같은 PM 재선택 시 반대 쪽 자동 초기화 + dropdown re-key
- `transfer_form_page.dart` 에서 `_recommendKind` / `_kindOverridden` 삭제 (자동 추천 제거, 기본 GENERIC 고정)

## Files
- `transaction_form_page.dart`: +52/-3
- `transfer_form_page.dart`: +1/-50

## Test
- flutter analyze: 0 new issue
- flutter test: 703/703 pass

## Follow-up
TRANSFER_SYSTEM codemap 의 `_recommendKind` 참조는 X5/X6 시점에 정리 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)