### PR TITLE
feat(transaction): "잔액 조정" 가상 카테고리 → ADJUSTMENT 자동 전환 (Phase 23 PR-X3)

### DIFF
--- a/frontend/lib/core/widgets/category_group_selector_sheet.dart
+++ b/frontend/lib/core/widgets/category_group_selector_sheet.dart
@@ -17,6 +17,14 @@ import 'package:budget_book/features/preference/presentation/bloc/favorites_bloc
 import 'package:budget_book/features/preference/presentation/bloc/favorites_event.dart';
 import 'package:budget_book/features/preference/presentation/bloc/favorites_state.dart';
 
+/// Sentinel identifier used for the virtual "잔액 조정" (balance adjustment)
+/// category option. This value is never a real category UUID — when it is
+/// returned via [CategoryGroupSelectorSheet.onSelected], the caller must
+/// translate it into `type=ADJUSTMENT, categoryId=null` on submission.
+///
+/// Phase 23 PR-X3: "잔액 조정" 가상 카테고리.
+const String kAdjustmentSentinel = '__ADJUSTMENT__';
+
 /// Selection mode for [CategoryGroupSelectorSheet].
 ///
 /// - [singleCategory]: Legacy behavior — tapping a category fires
@@ -53,6 +61,14 @@ class CategoryGroupSelectorSheet extends StatefulWidget {
   /// Multi-mode apply callback with `(categoryIds, groupIds)`.
   final void Function(Set<String> categoryIds, Set<String> groupIds)? onApplyMulti;
 
+  /// Phase 23 PR-X3: when true, a pinned "잔액 조정" option is rendered at the
+  /// top of the single-select list. Selecting it invokes [onSelected] with a
+  /// sentinel Category whose id equals [kAdjustmentSentinel]; the caller must
+  /// translate this into `type=ADJUSTMENT, categoryId=null` at submit time.
+  ///
+  /// Ignored in multi-select mode.
+  final bool showAdjustmentOption;
+
   const CategoryGroupSelectorSheet({
     super.key,
     this.selectedCategoryId,
@@ -64,6 +80,7 @@ class CategoryGroupSelectorSheet extends StatefulWidget {
     this.initialCategoryIds = const {},
     this.initialGroupIds = const {},
     this.onApplyMulti,
+    this.showAdjustmentOption = false,
   })  : assert(
           mode == CategorySelectionMode.singleCategory ? onSelected != null : true,
           'CategorySelectionMode.singleCategory requires onSelected',
@@ -311,6 +328,14 @@ class _CategoryGroupSelectorSheetState
 
         final List<Widget> children = [];
 
+        // Phase 23 PR-X3: Pinned "잔액 조정" option at the very top (single mode).
+        // Selecting it returns a sentinel Category (id=kAdjustmentSentinel) that
+        // the caller must translate into type=ADJUSTMENT, categoryId=null.
+        if (!_isMulti && widget.showAdjustmentOption) {
+          children.add(_buildAdjustmentPinnedOption(context));
+          children.add(const Divider(height: 1));
+        }
+
         // Favorites section at the top
         if (favoriteCategories.isNotEmpty) {
           children.add(
@@ -501,6 +526,73 @@ class _CategoryGroupSelectorSheetState
           children: children,
         );
       },
+    );
+  }
+
+  /// Phase 23 PR-X3: Pinned "잔액 조정" option shown at the top of the sheet
+  /// when [CategoryGroupSelectorSheet.showAdjustmentOption] is true. Visually
+  /// distinct (tertiaryContainer pill) to signal it is a special option, not a
+  /// real category. On tap, invokes [CategoryGroupSelectorSheet.onSelected]
+  /// with a sentinel [Category] whose id is [kAdjustmentSentinel].
+  Widget _buildAdjustmentPinnedOption(BuildContext context) {
+    final theme = Theme.of(context);
+    final isSelected = widget.selectedCategoryId == kAdjustmentSentinel;
+    final sentinelCategory = Category(
+      id: kAdjustmentSentinel,
+      name: '잔액 조정',
+      type: 'ADJUSTMENT',
+      isDefault: true,
+      displayOrder: -1,
+      createdAt: DateTime.now(),
+    );
+
+    return Container(
+      margin: const EdgeInsets.fromLTRB(12, 8, 12, 4),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.tertiaryContainer.withValues(alpha: 0.4),
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(
+          color: isSelected
+              ? theme.colorScheme.tertiary
+              : theme.colorScheme.tertiary.withValues(alpha: 0.3),
+          width: isSelected ? 2 : 1,
+        ),
+      ),
+      child: ListTile(
+        key: const Key('adjustment-pinned-option'),
+        dense: true,
+        leading: CircleAvatar(
+          radius: 16,
+          backgroundColor: theme.colorScheme.tertiary.withValues(alpha: 0.2),
+          child: Icon(
+            Icons.tune,
+            color: theme.colorScheme.tertiary,
+            size: 18,
+          ),
+        ),
+        title: Text(
+          '잔액 조정',
+          style: TextStyle(
+            fontWeight: FontWeight.w700,
+            color: theme.colorScheme.onTertiaryContainer,
+          ),
+        ),
+        subtitle: Text(
+          '실제 잔액에 맞춰 증가/감소 기록 (통계 제외)',
+          style: theme.textTheme.bodySmall?.copyWith(
+            color: theme.colorScheme.onTertiaryContainer.withValues(alpha: 0.75),
+            fontSize: 11,
+          ),
+        ),
+        trailing: isSelected
+            ? Icon(Icons.check, size: 18, color: theme.colorScheme.tertiary)
+            : null,
+        onTap: () {
+          widget.onSelected!(sentinelCategory);
+          widget.onSelectedWithGroupName?.call(sentinelCategory, null);
+          Navigator.of(context).pop();
+        },
+      ),
     );
   }
 

--- a/frontend/lib/features/transaction/domain/adjustment_submission.dart
+++ b/frontend/lib/features/transaction/domain/adjustment_submission.dart
@@ -1,0 +1,50 @@
+import 'package:budget_book/core/widgets/category_group_selector_sheet.dart'
+    show kAdjustmentSentinel;
+
+/// Phase 23 PR-X3: Pure helper that translates the UI form state into the
+/// concrete fields that go onto [CreateTransaction] / [UpdateTransaction]
+/// events when the user picked the virtual "잔액 조정" category.
+///
+/// Kept as a static method so it can be unit-tested without a widget tree.
+///
+/// Rules:
+/// - If [selectedCategoryId] is [kAdjustmentSentinel] OR [selectedType] is
+///   `'ADJUSTMENT'`, the submission is an adjustment:
+///   - `type` is forced to `'ADJUSTMENT'`
+///   - `categoryId` becomes `null` (ADJUSTMENT has no user category)
+///   - `amount` sign is flipped when [isIncrease] is false (user entered a
+///     positive value on the form; the radio determines direction)
+/// - Otherwise the inputs pass through unchanged.
+class AdjustmentSubmission {
+  final String type;
+  final String? categoryId;
+  final int amount;
+
+  const AdjustmentSubmission({
+    required this.type,
+    required this.categoryId,
+    required this.amount,
+  });
+
+  static AdjustmentSubmission resolve({
+    required String selectedType,
+    required String? selectedCategoryId,
+    required int rawAmount,
+    required bool isIncrease,
+  }) {
+    final isAdjustment =
+        selectedCategoryId == kAdjustmentSentinel || selectedType == 'ADJUSTMENT';
+    if (!isAdjustment) {
+      return AdjustmentSubmission(
+        type: selectedType,
+        categoryId: selectedCategoryId,
+        amount: rawAmount,
+      );
+    }
+    return AdjustmentSubmission(
+      type: 'ADJUSTMENT',
+      categoryId: null,
+      amount: isIncrease ? rawAmount : -rawAmount,
+    );
+  }
+}

--- a/frontend/lib/features/transaction/presentation/pages/transaction_form_page.dart
+++ b/frontend/lib/features/transaction/presentation/pages/transaction_form_page.dart
@@ -29,6 +29,7 @@ import 'package:budget_book/features/payment_method/presentation/bloc/payment_me
 import 'package:budget_book/features/payment_method/presentation/widgets/payment_method_form_sheet.dart';
 import 'package:budget_book/features/pocket/presentation/bloc/pocket_event.dart';
 import 'package:budget_book/features/pocket/presentation/widgets/pocket_form_sheet.dart';
+import 'package:budget_book/features/transaction/domain/adjustment_submission.dart';
 import 'package:budget_book/features/transaction/domain/entities/transaction.dart'
     as tx_entity;
 import 'package:budget_book/core/di/injection.dart';
@@ -124,6 +125,13 @@ class _TransactionFormPageState extends State<TransactionFormPage>
   // Tab controller for expense/income/transfer tabs
   late final TabController _tabController;
 
+  /// Phase 23 PR-X3: "잔액 조정" direction when the virtual ADJUSTMENT category
+  /// is selected. UX decision — simple radio (증가/감소) + positive amount
+  /// input; sign is flipped at submit time. This avoids extending the
+  /// CalculatorAmountField to parse leading '-', and keeps mental model clear
+  /// for users who are not comfortable typing negative numbers.
+  bool _adjustmentIsIncrease = true;
+
   // Transfer form fields (used when tab index == 2)
   final _transferFormKey = GlobalKey<FormState>();
   late final TextEditingController _transferAmountController;
@@ -136,6 +144,13 @@ class _TransactionFormPageState extends State<TransactionFormPage>
   int _swapCounter = 0;
 
   bool get isEditing => widget.transactionId != null;
+
+  /// Phase 23 PR-X3: true when the user picked the virtual "잔액 조정"
+  /// option from the category sheet. Drives: tab-bar lock, adjustment
+  /// direction radio visibility, type='ADJUSTMENT' on submit.
+  bool get _isAdjustmentSelected =>
+      _selectedCategoryId == kAdjustmentSentinel ||
+      _selectedType == 'ADJUSTMENT';
 
   int _resolveInitialTabIndex() {
     // When editing, determine tab from transaction type (no transfer tab for edit)
@@ -214,6 +229,8 @@ class _TransactionFormPageState extends State<TransactionFormPage>
     if (!_tabController.indexIsChanging) {
       setState(() {
         if (_tabController.index == 0) {
+          // Leaving tab forcibly clears any ADJUSTMENT virtual selection so
+          // EXPENSE/INCOME flows do not carry the sentinel categoryId.
           _selectedType = 'EXPENSE';
           _selectedCategoryId = null;
           _selectedCategoryDisplayName = null;
@@ -673,6 +690,11 @@ class _TransactionFormPageState extends State<TransactionFormPage>
                       child: _buildCategoryPicker(context),
                     ),
                   ),
+                  // Phase 23 PR-X3: ADJUSTMENT lock banner + direction radio.
+                  if (_isAdjustmentSelected) ...[
+                    const SizedBox(height: 12),
+                    _buildAdjustmentBanner(context),
+                  ],
                   const SizedBox(height: 16),
                   // Payment method picker with keyboard support
                   FocusTraversalOrder(
@@ -1222,6 +1244,83 @@ class _TransactionFormPageState extends State<TransactionFormPage>
   }
 
 
+  /// Phase 23 PR-X3: ADJUSTMENT mode banner + direction radio.
+  /// Shown when the virtual "잔액 조정" category is selected. It:
+  /// 1) tells the user the type is locked to 조정 (stats excluded, balance still affected);
+  /// 2) lets the user choose 증가 or 감소 — sign is flipped on submit.
+  Widget _buildAdjustmentBanner(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      key: const Key('adjustment-banner'),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.tertiaryContainer.withValues(alpha: 0.35),
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(
+          color: theme.colorScheme.tertiary.withValues(alpha: 0.5),
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(Icons.tune,
+                  size: 18, color: theme.colorScheme.tertiary),
+              const SizedBox(width: 6),
+              Text(
+                '잔액 조정 모드',
+                style: theme.textTheme.labelLarge?.copyWith(
+                  fontWeight: FontWeight.w700,
+                  color: theme.colorScheme.onTertiaryContainer,
+                ),
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  '통계 집계 제외 · 잔액 계산 포함',
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: theme.colorScheme.onTertiaryContainer
+                        .withValues(alpha: 0.7),
+                    fontSize: 11,
+                  ),
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          // 증가 / 감소 toggle (direction → sign on submit).
+          // ChoiceChip is used to avoid the deprecated RadioListTile.groupValue
+          // API (Flutter ≥ 3.32). Semantically still a single-choice pair.
+          Row(
+            children: [
+              Expanded(
+                child: ChoiceChip(
+                  key: const Key('adjustment-direction-increase'),
+                  label: const Center(child: Text('증가 (+)')),
+                  selected: _adjustmentIsIncrease,
+                  onSelected: (_) =>
+                      setState(() => _adjustmentIsIncrease = true),
+                ),
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: ChoiceChip(
+                  key: const Key('adjustment-direction-decrease'),
+                  label: const Center(child: Text('감소 (-)')),
+                  selected: !_adjustmentIsIncrease,
+                  onSelected: (_) =>
+                      setState(() => _adjustmentIsIncrease = false),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
   Widget _buildCategoryPicker(BuildContext context) {
     return BlocBuilder<CategoryBloc, CategoryState>(
       builder: (context, catState) {
@@ -1331,26 +1430,22 @@ class _TransactionFormPageState extends State<TransactionFormPage>
   }
 
   void _showCategorySelectorSheet(BuildContext context, List<Category> categories) {
+    // Phase 23 PR-X3: expose virtual "잔액 조정" option only for new (non-edit)
+    // transactions where the type is not locked by the transfer tab. Editing
+    // ADJUSTMENT transactions is out of scope — use delete + re-create.
+    final canShowAdjustment = !isEditing;
+
     showDialog(
       context: context,
       builder: (_) => CategoryGroupSelectorSheet(
         selectedCategoryId: _selectedCategoryId,
-        categoryType: _selectedType,
+        categoryType: _selectedType == 'ADJUSTMENT' ? 'EXPENSE' : _selectedType,
+        showAdjustmentOption: canShowAdjustment,
         onSelected: (category) {
-          setState(() {
-            _selectedCategoryId = category?.id;
-            _selectedCategoryDisplayName = null;
-          });
+          _applyCategorySelection(category, null);
         },
         onSelectedWithGroupName: (category, groupName) {
-          setState(() {
-            _selectedCategoryId = category?.id;
-            if (category != null && groupName != null && groupName.isNotEmpty) {
-              _selectedCategoryDisplayName = '$groupName > ${category.name}';
-            } else {
-              _selectedCategoryDisplayName = category?.name;
-            }
-          });
+          _applyCategorySelection(category, groupName);
         },
         onDelete: (id) {
           if (_selectedCategoryId == id) {
@@ -1359,6 +1454,33 @@ class _TransactionFormPageState extends State<TransactionFormPage>
         },
       ),
     );
+  }
+
+  /// Phase 23 PR-X3: central handler for category selection. Detects the
+  /// [kAdjustmentSentinel] and forces type='ADJUSTMENT' (which also locks the
+  /// tab bar). Normal categories just update the selection and keep the
+  /// current type.
+  void _applyCategorySelection(Category? category, String? groupName) {
+    setState(() {
+      if (category?.id == kAdjustmentSentinel) {
+        _selectedCategoryId = kAdjustmentSentinel;
+        _selectedCategoryDisplayName = '잔액 조정';
+        _selectedType = 'ADJUSTMENT';
+        _categoryError = null;
+      } else {
+        // Clearing sentinel back to a normal category: restore type from the
+        // currently-active tab so EXPENSE/INCOME flows work again.
+        if (_selectedType == 'ADJUSTMENT') {
+          _selectedType = _tabController.index == 1 ? 'INCOME' : 'EXPENSE';
+        }
+        _selectedCategoryId = category?.id;
+        if (category != null && groupName != null && groupName.isNotEmpty) {
+          _selectedCategoryDisplayName = '$groupName > ${category.name}';
+        } else {
+          _selectedCategoryDisplayName = category?.name;
+        }
+      }
+    });
   }
 
   void _showPaymentMethodSelectorSheet(BuildContext context, List<PaymentMethod> methods) {
@@ -1650,6 +1772,11 @@ class _TransactionFormPageState extends State<TransactionFormPage>
         _selectedPaymentMethodId = null;
         _selectedPocketId = null;
         _loadDefaultPaymentMethod();
+        // Phase 23 PR-X3: exit ADJUSTMENT mode on continue (unless kept).
+        if (_selectedType == 'ADJUSTMENT') {
+          _selectedType = _tabController.index == 1 ? 'INCOME' : 'EXPENSE';
+        }
+        _adjustmentIsIncrease = true;
       }
       // _selectedDate and _selectedType are always kept
     });
@@ -1682,19 +1809,34 @@ class _TransactionFormPageState extends State<TransactionFormPage>
     }
 
     setState(() => _isSubmitting = true);
-    final amount = CurrencyFormatter.parse(_amountController.text.trim())!;
+    final rawAmount = CurrencyFormatter.parse(_amountController.text.trim())!;
     final description = _descriptionController.text.trim();
     final dateStr = DateFormat('yyyy-MM-dd').format(_selectedDate);
     final memo =
         _memoController.text.trim().isEmpty ? null : _memoController.text.trim();
     final bloc = context.read<TransactionBloc>();
 
+    // Phase 23 PR-X3: translate the virtual "잔액 조정" sentinel into a proper
+    // ADJUSTMENT create request. User-typed amount is always positive; sign is
+    // flipped here based on the 증가/감소 toggle. categoryId is nulled because
+    // ADJUSTMENT transactions do not map to a user category (BE accepts null).
+    // Logic delegated to AdjustmentSubmission for unit-test coverage.
+    final submission = AdjustmentSubmission.resolve(
+      selectedType: _selectedType,
+      selectedCategoryId: _selectedCategoryId,
+      rawAmount: rawAmount,
+      isIncrease: _adjustmentIsIncrease,
+    );
+    final String effectiveType = submission.type;
+    final String? effectiveCategoryId = submission.categoryId;
+    final int effectiveAmount = submission.amount;
+
     if (isEditing) {
       bloc.add(UpdateTransaction(
         id: widget.transactionId!,
-        amount: amount,
+        amount: effectiveAmount,
         description: description,
-        categoryId: _selectedCategoryId,
+        categoryId: effectiveCategoryId,
         transactionDate: dateStr,
         memo: memo,
         clearMemo: memo == null,
@@ -1703,10 +1845,10 @@ class _TransactionFormPageState extends State<TransactionFormPage>
       ));
     } else {
       bloc.add(CreateTransaction(
-        type: _selectedType,
-        amount: amount,
+        type: effectiveType,
+        amount: effectiveAmount,
         description: description,
-        categoryId: _selectedCategoryId,
+        categoryId: effectiveCategoryId,
         transactionDate: dateStr,
         memo: memo,
         paymentMethodId: _selectedPaymentMethodId,

--- a/frontend/test/core/widgets/category_group_selector_sheet_adjustment_test.dart
+++ b/frontend/test/core/widgets/category_group_selector_sheet_adjustment_test.dart
@@ -1,0 +1,194 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:bloc_test/bloc_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:budget_book/core/di/injection.dart';
+import 'package:budget_book/core/widgets/category_group_selector_sheet.dart';
+import 'package:budget_book/features/category/domain/entities/category.dart';
+import 'package:budget_book/features/category/presentation/bloc/category_bloc.dart';
+import 'package:budget_book/features/category/presentation/bloc/category_event.dart';
+import 'package:budget_book/features/category/presentation/bloc/category_state.dart';
+import 'package:budget_book/features/category_group/domain/entities/category_group.dart';
+import 'package:budget_book/features/category_group/presentation/bloc/category_group_bloc.dart';
+import 'package:budget_book/features/category_group/presentation/bloc/category_group_event.dart';
+import 'package:budget_book/features/category_group/presentation/bloc/category_group_state.dart';
+import 'package:budget_book/features/couple/presentation/bloc/couple_bloc.dart';
+import 'package:budget_book/features/couple/presentation/bloc/couple_event.dart';
+import 'package:budget_book/features/couple/presentation/bloc/couple_state.dart';
+import 'package:budget_book/features/preference/domain/entities/favorites.dart';
+import 'package:budget_book/features/preference/presentation/bloc/favorites_bloc.dart';
+import 'package:budget_book/features/preference/presentation/bloc/favorites_event.dart';
+import 'package:budget_book/features/preference/presentation/bloc/favorites_state.dart';
+
+class _MockCategoryGroupBloc
+    extends MockBloc<CategoryGroupEvent, CategoryGroupState>
+    implements CategoryGroupBloc {}
+
+class _MockCategoryBloc extends MockBloc<CategoryEvent, CategoryState>
+    implements CategoryBloc {}
+
+class _MockFavoritesBloc extends MockBloc<FavoritesEvent, FavoritesState>
+    implements FavoritesBloc {}
+
+class _MockCoupleBloc extends MockBloc<CoupleEvent, CoupleState>
+    implements CoupleBloc {}
+
+/// Phase 23 PR-X3 — tests for the pinned "잔액 조정" virtual option in the
+/// category selector sheet.
+void main() {
+  late _MockCategoryGroupBloc groupBloc;
+  late _MockCategoryBloc categoryBloc;
+  late _MockFavoritesBloc favoritesBloc;
+  late _MockCoupleBloc coupleBloc;
+
+  final now = DateTime(2026, 4, 22);
+
+  final foodCat = Category(
+    id: 'c-food-1',
+    name: '카페',
+    type: 'EXPENSE',
+    isDefault: false,
+    displayOrder: 0,
+    groupId: 'g-food',
+    createdAt: now,
+  );
+  final foodGroup = CategoryGroup(
+    id: 'g-food',
+    name: '식비',
+    budgetType: 'MONTHLY',
+    displayOrder: 0,
+    isDefault: false,
+    categories: [foodCat],
+    createdAt: now,
+  );
+
+  setUpAll(() {
+    registerFallbackValue(const LoadCategoryGroups());
+    registerFallbackValue(const LoadCategories());
+    registerFallbackValue(const LoadFavorites());
+    registerFallbackValue(const LoadCouple());
+  });
+
+  setUp(() {
+    groupBloc = _MockCategoryGroupBloc();
+    categoryBloc = _MockCategoryBloc();
+    favoritesBloc = _MockFavoritesBloc();
+    coupleBloc = _MockCoupleBloc();
+
+    when(() => groupBloc.state).thenReturn(CategoryGroupLoaded([foodGroup]));
+    when(() => categoryBloc.state).thenReturn(const CategoryInitial());
+    when(() => favoritesBloc.state)
+        .thenReturn(const FavoritesLoaded(Favorites.empty));
+    when(() => coupleBloc.state).thenReturn(const CoupleInitial());
+
+    if (getIt.isRegistered<CategoryGroupBloc>()) {
+      getIt.unregister<CategoryGroupBloc>();
+    }
+    if (getIt.isRegistered<CategoryBloc>()) {
+      getIt.unregister<CategoryBloc>();
+    }
+    if (getIt.isRegistered<FavoritesBloc>()) {
+      getIt.unregister<FavoritesBloc>();
+    }
+    if (getIt.isRegistered<CoupleBloc>()) {
+      getIt.unregister<CoupleBloc>();
+    }
+
+    getIt.registerSingleton<CategoryGroupBloc>(groupBloc);
+    getIt.registerSingleton<CategoryBloc>(categoryBloc);
+    getIt.registerSingleton<FavoritesBloc>(favoritesBloc);
+    getIt.registerSingleton<CoupleBloc>(coupleBloc);
+  });
+
+  tearDown(() {
+    if (getIt.isRegistered<CategoryGroupBloc>()) {
+      getIt.unregister<CategoryGroupBloc>();
+    }
+    if (getIt.isRegistered<CategoryBloc>()) {
+      getIt.unregister<CategoryBloc>();
+    }
+    if (getIt.isRegistered<FavoritesBloc>()) {
+      getIt.unregister<FavoritesBloc>();
+    }
+    if (getIt.isRegistered<CoupleBloc>()) {
+      getIt.unregister<CoupleBloc>();
+    }
+  });
+
+  Future<void> showSheet(
+    WidgetTester tester, {
+    required bool showAdjustmentOption,
+    required ValueChanged<Category?> onSelected,
+  }) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (context) => Scaffold(
+            body: ElevatedButton(
+              onPressed: () => showDialog(
+                context: context,
+                builder: (_) => CategoryGroupSelectorSheet(
+                  categoryType: 'EXPENSE',
+                  showAdjustmentOption: showAdjustmentOption,
+                  onSelected: onSelected,
+                ),
+              ),
+              child: const Text('Open'),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.text('Open'));
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets(
+    'pinned "잔액 조정" option is rendered when showAdjustmentOption=true',
+    (tester) async {
+      await showSheet(
+        tester,
+        showAdjustmentOption: true,
+        onSelected: (_) {},
+      );
+
+      expect(find.byKey(const Key('adjustment-pinned-option')), findsOneWidget);
+      expect(find.text('잔액 조정'), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'pinned option is NOT rendered when showAdjustmentOption=false',
+    (tester) async {
+      await showSheet(
+        tester,
+        showAdjustmentOption: false,
+        onSelected: (_) {},
+      );
+
+      expect(find.byKey(const Key('adjustment-pinned-option')), findsNothing);
+      expect(find.text('잔액 조정'), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'tapping "잔액 조정" fires onSelected with sentinel category',
+    (tester) async {
+      Category? captured;
+      await showSheet(
+        tester,
+        showAdjustmentOption: true,
+        onSelected: (c) => captured = c,
+      );
+
+      await tester.tap(find.byKey(const Key('adjustment-pinned-option')));
+      await tester.pumpAndSettle();
+
+      expect(captured, isNotNull);
+      expect(captured!.id, kAdjustmentSentinel);
+      expect(captured!.type, 'ADJUSTMENT');
+      expect(captured!.name, '잔액 조정');
+    },
+  );
+}

--- a/frontend/test/features/transaction/domain/adjustment_submission_test.dart
+++ b/frontend/test/features/transaction/domain/adjustment_submission_test.dart
@@ -1,0 +1,107 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:budget_book/core/widgets/category_group_selector_sheet.dart'
+    show kAdjustmentSentinel;
+import 'package:budget_book/features/transaction/domain/adjustment_submission.dart';
+
+/// Phase 23 PR-X3 — unit tests for the pure translation logic that converts
+/// form-state (selected type + selected category id + amount + direction)
+/// into the concrete (type, categoryId, amount) that is sent to the BE.
+void main() {
+  group('AdjustmentSubmission.resolve', () {
+    test(
+      'non-adjustment EXPENSE passes through unchanged',
+      () {
+        final result = AdjustmentSubmission.resolve(
+          selectedType: 'EXPENSE',
+          selectedCategoryId: 'cat-1',
+          rawAmount: 15000,
+          isIncrease: true, // ignored
+        );
+        expect(result.type, 'EXPENSE');
+        expect(result.categoryId, 'cat-1');
+        expect(result.amount, 15000);
+      },
+    );
+
+    test(
+      'non-adjustment INCOME passes through unchanged',
+      () {
+        final result = AdjustmentSubmission.resolve(
+          selectedType: 'INCOME',
+          selectedCategoryId: 'cat-income',
+          rawAmount: 2500000,
+          isIncrease: false, // ignored
+        );
+        expect(result.type, 'INCOME');
+        expect(result.categoryId, 'cat-income');
+        expect(result.amount, 2500000);
+      },
+    );
+
+    test(
+      'sentinel category triggers ADJUSTMENT: type forced, categoryId nulled, '
+      'amount kept positive when isIncrease=true',
+      () {
+        final result = AdjustmentSubmission.resolve(
+          selectedType: 'EXPENSE',
+          selectedCategoryId: kAdjustmentSentinel,
+          rawAmount: 10000,
+          isIncrease: true,
+        );
+        expect(result.type, 'ADJUSTMENT');
+        expect(result.categoryId, isNull);
+        expect(result.amount, 10000);
+      },
+    );
+
+    test(
+      'sentinel category with isIncrease=false flips the sign to negative',
+      () {
+        final result = AdjustmentSubmission.resolve(
+          selectedType: 'EXPENSE',
+          selectedCategoryId: kAdjustmentSentinel,
+          rawAmount: 7500,
+          isIncrease: false,
+        );
+        expect(result.type, 'ADJUSTMENT');
+        expect(result.categoryId, isNull);
+        expect(result.amount, -7500);
+      },
+    );
+
+    test(
+      'selectedType==ADJUSTMENT alone also triggers translation '
+      '(defensive: in case sentinel was cleared but type still set)',
+      () {
+        final result = AdjustmentSubmission.resolve(
+          selectedType: 'ADJUSTMENT',
+          selectedCategoryId: null,
+          rawAmount: 20000,
+          isIncrease: false,
+        );
+        expect(result.type, 'ADJUSTMENT');
+        expect(result.categoryId, isNull);
+        expect(result.amount, -20000);
+      },
+    );
+
+    test(
+      'ADJUSTMENT submission never carries a real categoryId '
+      '(even if sentinel was replaced mid-flight)',
+      () {
+        // If selectedType is still ADJUSTMENT but somehow a real categoryId
+        // snuck in, we still null it — BE forbids ADJUSTMENT + category.
+        final result = AdjustmentSubmission.resolve(
+          selectedType: 'ADJUSTMENT',
+          selectedCategoryId: 'stale-cat-id',
+          rawAmount: 5000,
+          isIncrease: true,
+        );
+        expect(result.type, 'ADJUSTMENT');
+        expect(result.categoryId, isNull);
+        expect(result.amount, 5000);
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary
거래 폼 카테고리 시트 상단에 "잔액 조정" 고정 옵션. 선택 시 자동으로 `type=ADJUSTMENT`, `categoryId=null` 저장. DB 엔티티 생성 없이 가상 옵션 (const sentinel).

## UX
- 증가/감소 ChoiceChip + 양수 amount 입력 → 제출 시 부호 반전 (AdjustmentSubmission.resolve helper)
- 선택 시 배너 + 다른 type 탭 탭 시 조정 모드 자동 해제
- 수정 모드엔 옵션 미표시 (plan scope 외)

## Files
- `category_group_selector_sheet.dart` (sentinel + pinned tile)
- `adjustment_submission.dart` (신규 helper)
- `transaction_form_page.dart` (wire + banner)
- tests: 6 unit + 3 widget (신규)

## Test
- flutter analyze 0 new issue
- flutter test 712/712 pass (+9)

## BE 변경
없음. T11 음수 amount + V54 ADJUSTMENT CHECK + 조정 뱃지 렌더링 모두 기존.

🤖 Generated with [Claude Code](https://claude.com/claude-code)