### PR TITLE
feat(nav): 자산 탭 탑레벨 승격 + 총자산/부채/순자산 카드 (Phase 23 PR-X6)

### DIFF
--- a/frontend/lib/core/router/app_router.dart
+++ b/frontend/lib/core/router/app_router.dart
@@ -341,7 +341,50 @@ GoRouter createAppRouter(AuthBloc authBloc) => GoRouter(
             ),
           ],
         ),
-        // Tab 4: Settings
+        // Tab 4: Assets (Phase 23 PR-X6 — promoted from Settings submenu)
+        StatefulShellBranch(
+          routes: [
+            GoRoute(
+              path: '/assets',
+              builder: (context, state) {
+                final yearParam = int.tryParse(state.uri.queryParameters['year'] ?? '');
+                final monthParam = int.tryParse(state.uri.queryParameters['month'] ?? '');
+                final tabParam = int.tryParse(state.uri.queryParameters['tab'] ?? '') ?? 0;
+                final now = DateTime.now();
+                final year = yearParam ?? now.year;
+                final month = monthParam ?? now.month;
+                getIt<CategoryBloc>().add(const LoadCategories());
+                getIt<PaymentMethodBloc>().add(const LoadPaymentMethods());
+                getIt<PaymentMethodBloc>()
+                    .add(LoadCardSettlementSummary(year: year, month: month));
+                getIt<PocketBloc>().add(const LoadPockets());
+                getIt<CategoryGroupBloc>().add(const LoadCategoryGroups());
+                return MultiBlocProvider(
+                  providers: [
+                    BlocProvider<CategoryBloc>.value(
+                      value: getIt<CategoryBloc>(),
+                    ),
+                    BlocProvider<PaymentMethodBloc>.value(
+                      value: getIt<PaymentMethodBloc>(),
+                    ),
+                    BlocProvider<PocketBloc>.value(
+                      value: getIt<PocketBloc>(),
+                    ),
+                    BlocProvider<CategoryGroupBloc>.value(
+                      value: getIt<CategoryGroupBloc>(),
+                    ),
+                  ],
+                  child: AssetManagementPage(
+                    initialYear: year,
+                    initialMonth: month,
+                    initialTabIndex: tabParam,
+                  ),
+                );
+              },
+            ),
+          ],
+        ),
+        // Tab 5: Settings
         StatefulShellBranch(
           routes: [
             GoRoute(
@@ -682,42 +725,18 @@ GoRouter createAppRouter(AuthBloc authBloc) => GoRouter(
       parentNavigatorKey: _rootNavigatorKey,
       builder: (context, state) => const AppInfoPage(),
     ),
-    // Asset Management (unified category + payment method + pocket management)
+    // Asset Management — legacy alias. Phase 23 PR-X6 promoted 자산 to a
+    // top-level nav tab at /assets. Preserve /asset-management deep links
+    // (e.g. /payment-methods redirect chain, legacy category/PM links) by
+    // redirecting to /assets with the same query string.
     GoRoute(
       path: '/asset-management',
       parentNavigatorKey: _rootNavigatorKey,
-      builder: (context, state) {
-        final yearParam = int.tryParse(state.uri.queryParameters['year'] ?? '');
-        final monthParam = int.tryParse(state.uri.queryParameters['month'] ?? '');
-        final tabParam = int.tryParse(state.uri.queryParameters['tab'] ?? '') ?? 0;
-        getIt<CategoryBloc>().add(const LoadCategories());
-        getIt<PaymentMethodBloc>().add(const LoadPaymentMethods());
-        if (yearParam != null && monthParam != null) {
-          getIt<PaymentMethodBloc>().add(LoadCardSettlementSummary(year: yearParam, month: monthParam));
-        }
-        getIt<PocketBloc>().add(const LoadPockets());
-        getIt<CategoryGroupBloc>().add(const LoadCategoryGroups());
-        return MultiBlocProvider(
-          providers: [
-            BlocProvider<CategoryBloc>.value(
-              value: getIt<CategoryBloc>(),
-            ),
-            BlocProvider<PaymentMethodBloc>.value(
-              value: getIt<PaymentMethodBloc>(),
-            ),
-            BlocProvider<PocketBloc>.value(
-              value: getIt<PocketBloc>(),
-            ),
-            BlocProvider<CategoryGroupBloc>.value(
-              value: getIt<CategoryGroupBloc>(),
-            ),
-          ],
-          child: AssetManagementPage(
-            initialYear: yearParam,
-            initialMonth: monthParam,
-            initialTabIndex: tabParam,
-          ),
-        );
+      redirect: (context, state) {
+        final qp = state.uri.queryParameters;
+        if (qp.isEmpty) return '/assets';
+        final query = Uri(queryParameters: qp).query;
+        return '/assets?$query';
       },
     ),
     // Money Pockets

--- a/frontend/lib/core/widgets/main_shell_page.dart
+++ b/frontend/lib/core/widgets/main_shell_page.dart
@@ -23,6 +23,8 @@ import 'package:budget_book/features/category_group/presentation/bloc/category_g
 import 'package:budget_book/features/category_group/presentation/bloc/category_group_event.dart';
 import 'package:budget_book/features/payment_method/presentation/bloc/payment_method_bloc.dart';
 import 'package:budget_book/features/payment_method/presentation/bloc/payment_method_event.dart';
+import 'package:budget_book/features/pocket/presentation/bloc/pocket_bloc.dart';
+import 'package:budget_book/features/pocket/presentation/bloc/pocket_event.dart';
 import 'package:budget_book/features/preference/presentation/bloc/favorites_bloc.dart';
 import 'package:budget_book/features/preference/presentation/bloc/favorites_event.dart';
 import 'package:budget_book/features/couple/presentation/bloc/couple_bloc.dart';
@@ -88,7 +90,15 @@ class _MainShellPageState extends State<MainShellPage> {
           getIt<BudgetBloc>()
               .add(LoadBudgets(year: now.year, month: now.month));
         // Tab 3 (Statistics) uses factory, loaded fresh by its builder
-        // Tab 4 (Settings) needs no refresh
+        case 4:
+          // Tab 4 (Assets): preload PM, card settlement summary, pockets
+          // so the 총자산/부채/순자산 header card has data on first paint.
+          getIt<PaymentMethodBloc>().add(const LoadPaymentMethods());
+          getIt<PaymentMethodBloc>().add(
+            LoadCardSettlementSummary(year: now.year, month: now.month),
+          );
+          getIt<PocketBloc>().add(const LoadPockets());
+        // Tab 5 (Settings) needs no refresh
       }
     }
 
@@ -147,6 +157,11 @@ class _MainShellPageState extends State<MainShellPage> {
             icon: Icon(Icons.bar_chart_outlined),
             selectedIcon: Icon(Icons.bar_chart),
             label: '통계',
+          ),
+          NavigationDestination(
+            icon: Icon(Icons.account_balance_outlined),
+            selectedIcon: Icon(Icons.account_balance),
+            label: '자산',
           ),
           NavigationDestination(
             icon: Icon(Icons.settings_outlined),

--- a/frontend/lib/features/settings/presentation/pages/asset_management_page.dart
+++ b/frontend/lib/features/settings/presentation/pages/asset_management_page.dart
@@ -63,11 +63,18 @@ class AssetManagementPage extends StatelessWidget {
                 ],
               ),
             ),
-            body: const TabBarView(
+            body: const Column(
               children: [
-                _CategoryTab(),
-                _PaymentMethodTab(),
-                _PocketTab(),
+                _AssetSummaryHeader(),
+                Expanded(
+                  child: TabBarView(
+                    children: [
+                      _CategoryTab(),
+                      _PaymentMethodTab(),
+                      _PocketTab(),
+                    ],
+                  ),
+                ),
               ],
             ),
             floatingActionButton: _buildFab(context),
@@ -1322,6 +1329,142 @@ class _PocketTab extends StatelessWidget {
     );
   }
 
+}
+
+/// Top-of-page summary showing 총 자산 / 부채(미결제) / 순자산.
+///
+/// **Computation** (aggregated from `PaymentMethodBloc` state):
+/// - 총 자산 = sum of `PaymentMethod.balance` for non-credit active methods
+///   (CASH/BANK/DEBIT) whose balance is non-null. Matches
+///   `AccountBalanceCard` which is the existing "자산 현황" aggregate.
+/// - 부채(미결제) = sum of unpaid-month amounts across credit cards from
+///   `cardSettlementSummary.unpaidMonth.cards` (paid_at IS NULL filter).
+/// - 순자산 = 총 자산 − 부채.
+///
+/// The widget rebuilds on PaymentMethodBloc state changes, so month
+/// switches / new transactions propagate automatically.
+class _AssetSummaryHeader extends StatelessWidget {
+  const _AssetSummaryHeader();
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<PaymentMethodBloc, PaymentMethodState>(
+      builder: (context, state) {
+        int totalAssets = 0;
+        int totalDebt = 0;
+        if (state is PaymentMethodLoaded) {
+          for (final pm in state.paymentMethods) {
+            if (!pm.isActive) continue;
+            if (!pm.isCredit && pm.balance != null) {
+              totalAssets += pm.balance!;
+            }
+          }
+          final unpaid = state.cardSettlementSummary?.unpaidMonth;
+          if (unpaid != null) {
+            for (final card in unpaid.cards) {
+              totalDebt += card.amount;
+            }
+          }
+        }
+        final netWorth = totalAssets - totalDebt;
+
+        return Padding(
+          key: const Key('asset_summary_header'),
+          padding: const EdgeInsets.fromLTRB(12, 12, 12, 4),
+          child: Row(
+            children: [
+              Expanded(
+                child: _SummaryCard(
+                  label: '총 자산',
+                  amount: totalAssets,
+                  color: Colors.green.shade700,
+                  icon: Icons.savings_outlined,
+                ),
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: _SummaryCard(
+                  label: '부채',
+                  amount: totalDebt,
+                  color: Colors.red.shade700,
+                  icon: Icons.credit_card_outlined,
+                ),
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: _SummaryCard(
+                  label: '순자산',
+                  amount: netWorth,
+                  color: netWorth >= 0
+                      ? Colors.blue.shade700
+                      : Colors.red.shade700,
+                  icon: Icons.account_balance_wallet_outlined,
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _SummaryCard extends StatelessWidget {
+  final String label;
+  final int amount;
+  final Color color;
+  final IconData icon;
+
+  const _SummaryCard({
+    required this.label,
+    required this.amount,
+    required this.color,
+    required this.icon,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: EdgeInsets.zero,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 10),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Row(
+              children: [
+                Icon(icon, size: 14, color: color),
+                const SizedBox(width: 4),
+                Flexible(
+                  child: Text(
+                    label,
+                    style: TextStyle(
+                      fontSize: 12,
+                      fontWeight: FontWeight.w600,
+                      color: color,
+                    ),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 4),
+            Text(
+              '${CurrencyFormatter.format(amount)}원',
+              style: TextStyle(
+                fontSize: 14,
+                fontWeight: FontWeight.w700,
+                color: color,
+              ),
+              overflow: TextOverflow.ellipsis,
+              maxLines: 1,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
 }
 
 /// Helper class for mixed list of headers and payment methods.

--- a/frontend/lib/features/settings/presentation/pages/settings_page.dart
+++ b/frontend/lib/features/settings/presentation/pages/settings_page.dart
@@ -114,15 +114,9 @@ class _SettingsPageState extends State<SettingsPage> {
               onTap: () => context.push('/settings/partner'),
             ),
             const Divider(),
-            // Asset Management (categories + payment methods + pockets)
-            ListTile(
-              leading: const Icon(Icons.account_balance),
-              title: const Text('자산 관리'),
-              subtitle: const Text('카테고리, 결제수단, 포켓'),
-              trailing: const Icon(Icons.chevron_right),
-              onTap: () => context.push('/asset-management'),
-            ),
-            // Category Groups - removed: merged into 자산 관리 카테고리 탭
+            // "자산 관리" ListTile removed — promoted to top-level 자산 tab
+            // in bottom nav (Phase 23 PR-X6). Category/payment-method/pocket
+            // editing is accessible via the 자산 탭.
             // Spending Plans
             ListTile(
               leading: const Icon(Icons.event_note),


### PR DESCRIPTION
## Summary
- Bottom nav 에 **자산** 탭 추가 (6탭 과도기: 홈/거래/예산/통계/자산/설정)
- `AssetManagementPage` 상단에 **총 자산 / 부채 / 순자산** 3카드
- 설정에서 "자산 관리" 메뉴 제거 (탭으로 승격)
- `/asset-management` → `/assets` alias redirect (deep link 보존)
- `/payment-methods → /asset-management → /assets?tab=1` 체인 유지

## 카드 공식
- 총 자산 = Σ (비-카드, 활성, balance non-null)
- 부채 = Σ (unpaidMonth.cards[].amount)
- 순자산 = 총 자산 − 부채 (음수면 red)

## Test
- flutter analyze 0 new issue
- flutter test 714 pass
- flutter build web 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)