### PR TITLE
feat(transaction): 거래 탭 홈 흡수 + 리스트/달력 toggle + 총잔액 미니카드 (Phase 23 PR-X5)

### DIFF
--- a/frontend/lib/features/transaction/presentation/pages/transaction_list_page.dart
+++ b/frontend/lib/features/transaction/presentation/pages/transaction_list_page.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:budget_book/core/constants/api_endpoints.dart';
 import 'package:budget_book/core/utils/currency_formatter.dart';
 import 'package:budget_book/core/bloc/month_cubit.dart';
@@ -21,6 +22,8 @@ import 'package:budget_book/features/transaction/presentation/bloc/transaction_b
 import 'package:budget_book/features/transaction/presentation/bloc/transaction_event.dart';
 import 'package:budget_book/features/transaction/presentation/bloc/transaction_state.dart';
 import 'package:budget_book/features/transaction/presentation/widgets/month_summary_bar.dart';
+import 'package:budget_book/features/transaction/presentation/widgets/total_balance_mini_card.dart';
+import 'package:budget_book/features/transaction/presentation/widgets/transaction_calendar_view.dart';
 import 'package:budget_book/features/transaction/presentation/widgets/transaction_list_tile.dart';
 import 'package:budget_book/features/transaction/presentation/widgets/transfer_list_tile.dart';
 import 'package:budget_book/features/transfer/domain/entities/transfer.dart';
@@ -55,6 +58,11 @@ class TransactionListPage extends StatefulWidget {
   State<TransactionListPage> createState() => _TransactionListPageState();
 }
 
+/// Phase 23 PR-X5: 거래 탭 view mode (리스트 / 달력).
+enum _TxViewMode { list, calendar }
+
+const _kTxViewModePrefKey = 'transaction_view_mode';
+
 class _TransactionListPageState extends State<TransactionListPage> {
   final TextEditingController _searchController = TextEditingController();
   final ScrollController _scrollController = ScrollController();
@@ -63,6 +71,7 @@ class _TransactionListPageState extends State<TransactionListPage> {
   Timer? _debounceTimer;
   bool _isSearching = false;
   String? _pendingScrollToDate;
+  _TxViewMode _viewMode = _TxViewMode.list;
 
   // Unified filter state
   late UnifiedFilterState _filterState = UnifiedFilterState(
@@ -89,6 +98,31 @@ class _TransactionListPageState extends State<TransactionListPage> {
           _filterState = _filterState.copyWith(paymentMethodName: name);
         });
       }
+    }
+    _loadViewModePref();
+  }
+
+  Future<void> _loadViewModePref() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final value = prefs.getString(_kTxViewModePrefKey);
+      if (value == 'calendar' && mounted) {
+        setState(() => _viewMode = _TxViewMode.calendar);
+      }
+    } catch (_) {
+      // Preference load is best-effort; default to list.
+    }
+  }
+
+  Future<void> _persistViewMode(_TxViewMode mode) async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString(
+        _kTxViewModePrefKey,
+        mode == _TxViewMode.calendar ? 'calendar' : 'list',
+      );
+    } catch (_) {
+      // In-memory update already applied via setState.
     }
   }
 
@@ -478,13 +512,68 @@ class _TransactionListPageState extends State<TransactionListPage> {
 
               return Column(
                 children: [
+                  // Phase 23 PR-X5: 총 자산 미니 카드 (홈 대시보드 흡수)
+                  const TotalBalanceMiniCard(),
                   MonthSummaryBar(
                     totalIncome: displayIncome,
                     totalExpense: displayExpense,
                     balance: displayIncome - displayExpense,
                     totalTransfer: displayTransfer > 0 ? displayTransfer : null,
                   ),
-                  if (state.filteredTransactions.isEmpty && listTransfers.isEmpty)
+                  // Phase 23 PR-X5: 리스트 / 달력 view toggle.
+                  _buildViewToggle(context),
+                  if (_viewMode == _TxViewMode.calendar)
+                    Expanded(
+                      child: TransactionCalendarView(
+                        year: state.year,
+                        month: state.month,
+                        transactions: state.filteredTransactions,
+                        transfers: listTransfers,
+                        onMonthChanged: (focused) {
+                          if (focused.year == state.year &&
+                              focused.month == state.month) {
+                            return;
+                          }
+                          context
+                              .read<MonthCubit>()
+                              .changeMonth(focused.year, focused.month);
+                          final kw = _searchController.text.trim().isEmpty
+                              ? null
+                              : _searchController.text.trim();
+                          final fmt = DateFormat('yyyy-MM-dd');
+                          context.read<TransactionBloc>().add(
+                                LoadTransactions(
+                                  year: focused.year,
+                                  month: focused.month,
+                                  keyword: kw,
+                                  categoryIds: _filterState.categoryIds,
+                                  categoryGroupIds:
+                                      _filterState.categoryGroupIds,
+                                  paymentMethodIds:
+                                      _filterState.paymentMethodIds,
+                                  pocketIds: _filterState.pocketIds,
+                                  amountMin: _filterState.amountMin,
+                                  amountMax: _filterState.amountMax,
+                                  dateFrom: _filterState.dateFrom != null
+                                      ? fmt.format(_filterState.dateFrom!)
+                                      : null,
+                                  dateTo: _filterState.dateTo != null
+                                      ? fmt.format(_filterState.dateTo!)
+                                      : null,
+                                  transactionTypes:
+                                      _filterState.transactionTypes,
+                                  visibility: _filterState.visibility,
+                                ),
+                              );
+                          context
+                              .read<TransferBloc>()
+                              .add(LoadTransfers(
+                                  year: focused.year, month: focused.month));
+                        },
+                      ),
+                    )
+                  else if (state.filteredTransactions.isEmpty &&
+                      listTransfers.isEmpty)
                     Expanded(child: _buildEmpty(context))
                   else
                     Expanded(child: _buildGroupedList(context, state, listTransfers)),
@@ -807,6 +896,39 @@ class _TransactionListPageState extends State<TransactionListPage> {
         curve: Curves.easeInOut,
       );
     }
+  }
+
+  /// Phase 23 PR-X5: SegmentedButton toggle between 리스트 / 달력 views.
+  Widget _buildViewToggle(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+      child: SegmentedButton<_TxViewMode>(
+        key: const Key('transaction-view-toggle'),
+        segments: const [
+          ButtonSegment<_TxViewMode>(
+            value: _TxViewMode.list,
+            label: Text('리스트'),
+            icon: Icon(Icons.list),
+          ),
+          ButtonSegment<_TxViewMode>(
+            value: _TxViewMode.calendar,
+            label: Text('달력'),
+            icon: Icon(Icons.calendar_month),
+          ),
+        ],
+        selected: {_viewMode},
+        onSelectionChanged: (selection) {
+          final next = selection.first;
+          if (next == _viewMode) return;
+          setState(() => _viewMode = next);
+          _persistViewMode(next);
+        },
+        style: const ButtonStyle(
+          visualDensity: VisualDensity.compact,
+          tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+        ),
+      ),
+    );
   }
 
   Widget _buildEmpty(BuildContext context) {

--- a/frontend/lib/features/transaction/presentation/widgets/total_balance_mini_card.dart
+++ b/frontend/lib/features/transaction/presentation/widgets/total_balance_mini_card.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
+import 'package:budget_book/core/di/injection.dart';
+import 'package:budget_book/core/utils/currency_formatter.dart';
+import 'package:budget_book/features/payment_method/presentation/bloc/payment_method_bloc.dart';
+import 'package:budget_book/features/payment_method/presentation/bloc/payment_method_state.dart';
+
+/// Phase 23 PR-X5: Single-line total balance (총자산) mini card.
+///
+/// Sum = (non-credit active balances) - (credit unpaid/pending amount).
+/// Falls back to only summing non-credit balances when settlement data
+/// is unavailable. Tapping navigates to the asset management page.
+class TotalBalanceMiniCard extends StatelessWidget {
+  const TotalBalanceMiniCard({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<PaymentMethodBloc, PaymentMethodState>(
+      bloc: getIt<PaymentMethodBloc>(),
+      builder: (context, state) {
+        if (state is! PaymentMethodLoaded) return const SizedBox.shrink();
+        return _buildCard(context, state);
+      },
+    );
+  }
+
+  Widget _buildCard(BuildContext context, PaymentMethodLoaded state) {
+    final theme = Theme.of(context);
+    final active = state.paymentMethods.where((pm) => pm.isActive).toList();
+    if (active.isEmpty) return const SizedBox.shrink();
+
+    int assetsSum = 0;
+    for (final pm in active) {
+      if (pm.isCredit) continue;
+      if (pm.balance != null) assetsSum += pm.balance!;
+    }
+
+    int creditUnpaid = 0;
+    final settlement = state.cardSettlementSummary;
+    if (settlement?.unpaidMonth != null) {
+      creditUnpaid = settlement!.unpaidMonth!.totalAmount;
+    }
+
+    final total = assetsSum - creditUnpaid;
+
+    return Material(
+      color: theme.colorScheme.surfaceContainerHigh,
+      child: InkWell(
+        onTap: () => context.push('/asset-management'),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+          child: Row(
+            children: [
+              Icon(
+                Icons.account_balance_wallet_outlined,
+                size: 18,
+                color: theme.colorScheme.primary,
+              ),
+              const SizedBox(width: 8),
+              Text(
+                '총 자산',
+                style: theme.textTheme.labelLarge?.copyWith(
+                  color: theme.colorScheme.onSurface.withValues(alpha: 0.7),
+                ),
+              ),
+              const Spacer(),
+              Text(
+                CurrencyFormatter.formatWithSign(total),
+                style: theme.textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.w700,
+                  color: total >= 0
+                      ? Colors.green.shade800
+                      : Colors.red.shade800,
+                ),
+              ),
+              const SizedBox(width: 4),
+              Icon(
+                Icons.chevron_right,
+                size: 18,
+                color: theme.colorScheme.onSurface.withValues(alpha: 0.4),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/lib/features/transaction/presentation/widgets/transaction_calendar_view.dart
+++ b/frontend/lib/features/transaction/presentation/widgets/transaction_calendar_view.dart
@@ -1,0 +1,332 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:intl/intl.dart';
+import 'package:table_calendar/table_calendar.dart';
+import 'package:budget_book/core/utils/currency_formatter.dart';
+import 'package:budget_book/features/transaction/domain/entities/transaction.dart';
+import 'package:budget_book/features/transaction/presentation/widgets/transaction_list_tile.dart';
+import 'package:budget_book/features/transaction/presentation/widgets/transfer_list_tile.dart';
+import 'package:budget_book/features/transfer/domain/entities/transfer.dart';
+
+/// Phase 23 PR-X5: Month-view calendar for the 거래 탭 달력 뷰.
+///
+/// Each day cell shows compressed income (green) and expense (red) totals
+/// aggregated from the already-loaded transactions. Tapping a day opens a
+/// bottom sheet with that day's transactions + transfers, reusing the
+/// same list tiles as the list view.
+class TransactionCalendarView extends StatefulWidget {
+  final int year;
+  final int month;
+  final List<Transaction> transactions;
+  final List<Transfer> transfers;
+  final void Function(DateTime focused) onMonthChanged;
+
+  const TransactionCalendarView({
+    super.key,
+    required this.year,
+    required this.month,
+    required this.transactions,
+    required this.transfers,
+    required this.onMonthChanged,
+  });
+
+  @override
+  State<TransactionCalendarView> createState() =>
+      _TransactionCalendarViewState();
+}
+
+class _TransactionCalendarViewState extends State<TransactionCalendarView> {
+  DateTime? _selectedDay;
+  late DateTime _focusedDay;
+
+  @override
+  void initState() {
+    super.initState();
+    _focusedDay = DateTime(widget.year, widget.month, 1);
+  }
+
+  @override
+  void didUpdateWidget(covariant TransactionCalendarView oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.year != widget.year || oldWidget.month != widget.month) {
+      _focusedDay = DateTime(widget.year, widget.month, 1);
+      _selectedDay = null;
+    }
+  }
+
+  /// Aggregates income / expense totals per day-of-month for the currently
+  /// loaded transactions. Transfers are intentionally omitted from the
+  /// income/expense markers but surfaced in the day bottom sheet.
+  Map<int, _DayTotals> _buildDayTotals() {
+    final result = <int, _DayTotals>{};
+    for (final t in widget.transactions) {
+      final date = DateTime.tryParse(t.transactionDate);
+      if (date == null) continue;
+      if (date.year != widget.year || date.month != widget.month) continue;
+      final slot = result.putIfAbsent(date.day, () => _DayTotals());
+      if (t.isIncome) {
+        slot.income += t.amount;
+      } else if (t.isExpense) {
+        slot.expense += t.amount;
+      }
+    }
+    return result;
+  }
+
+  void _showDaySheet(BuildContext context, DateTime day) {
+    final dateStr = DateFormat('yyyy-MM-dd').format(day);
+    final txs = widget.transactions
+        .where((t) => t.transactionDate == dateStr)
+        .toList();
+    final tfs =
+        widget.transfers.where((t) => t.transferDate == dateStr).toList();
+
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+      ),
+      builder: (ctx) {
+        return DraggableScrollableSheet(
+          expand: false,
+          initialChildSize: 0.6,
+          minChildSize: 0.3,
+          maxChildSize: 0.9,
+          builder: (_, controller) {
+            return SafeArea(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Container(
+                    width: 32,
+                    height: 4,
+                    margin: const EdgeInsets.symmetric(vertical: 12),
+                    decoration: BoxDecoration(
+                      color: Theme.of(ctx)
+                          .colorScheme
+                          .onSurfaceVariant
+                          .withValues(alpha: 0.3),
+                      borderRadius: BorderRadius.circular(2),
+                    ),
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 16),
+                    child: Row(
+                      children: [
+                        Text(
+                          DateFormat('M월 d일 (E)', 'ko').format(day),
+                          style: Theme.of(ctx)
+                              .textTheme
+                              .titleMedium
+                              ?.copyWith(fontWeight: FontWeight.w700),
+                        ),
+                        const Spacer(),
+                        TextButton.icon(
+                          onPressed: () {
+                            Navigator.pop(ctx);
+                            context.push('/transactions/create?date=$dateStr');
+                          },
+                          icon: const Icon(Icons.add, size: 18),
+                          label: const Text('추가'),
+                        ),
+                      ],
+                    ),
+                  ),
+                  const Divider(height: 1),
+                  Expanded(
+                    child: (txs.isEmpty && tfs.isEmpty)
+                        ? Center(
+                            child: Padding(
+                              padding: const EdgeInsets.all(32),
+                              child: Text(
+                                '기록된 거래가 없습니다',
+                                style: TextStyle(
+                                  color: Theme.of(ctx)
+                                      .colorScheme
+                                      .onSurface
+                                      .withValues(alpha: 0.6),
+                                ),
+                              ),
+                            ),
+                          )
+                        : ListView(
+                            controller: controller,
+                            children: [
+                              ...txs.map(
+                                (t) => TransactionListTile(
+                                  transaction: t,
+                                  onTap: () {
+                                    Navigator.pop(ctx);
+                                    context.push(
+                                      '/transactions/detail/${t.id}',
+                                    );
+                                  },
+                                ),
+                              ),
+                              ...tfs.map(
+                                (t) => TransferListTile(
+                                  transfer: t,
+                                  onTap: () {
+                                    Navigator.pop(ctx);
+                                    context
+                                        .push('/transfers/edit/${t.id}');
+                                  },
+                                ),
+                              ),
+                            ],
+                          ),
+                  ),
+                ],
+              ),
+            );
+          },
+        );
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final dayTotals = _buildDayTotals();
+
+    return SingleChildScrollView(
+      padding: const EdgeInsets.only(bottom: 88),
+      child: Column(
+        children: [
+          TableCalendar<void>(
+            firstDay: DateTime(2000, 1, 1),
+            lastDay: DateTime(2100, 12, 31),
+            focusedDay: _focusedDay,
+            selectedDayPredicate: (day) =>
+                _selectedDay != null && isSameDay(_selectedDay, day),
+            onDaySelected: (selected, focused) {
+              setState(() {
+                _selectedDay = selected;
+                _focusedDay = focused;
+              });
+              _showDaySheet(context, selected);
+            },
+            onPageChanged: (focused) {
+              _focusedDay = focused;
+              widget.onMonthChanged(focused);
+            },
+            headerStyle: const HeaderStyle(
+              titleCentered: true,
+              formatButtonVisible: false,
+            ),
+            calendarStyle: CalendarStyle(
+              outsideDaysVisible: false,
+              cellMargin: const EdgeInsets.all(2),
+              todayDecoration: BoxDecoration(
+                color: theme.colorScheme.primary.withValues(alpha: 0.2),
+                shape: BoxShape.circle,
+              ),
+              selectedDecoration: BoxDecoration(
+                color: theme.colorScheme.primary,
+                shape: BoxShape.circle,
+              ),
+            ),
+            calendarBuilders: CalendarBuilders(
+              defaultBuilder: (context, day, _) =>
+                  _buildCell(context, day, dayTotals[day.day], isToday: false),
+              todayBuilder: (context, day, _) =>
+                  _buildCell(context, day, dayTotals[day.day], isToday: true),
+              selectedBuilder: (context, day, _) => _buildCell(
+                context,
+                day,
+                dayTotals[day.day],
+                isSelected: true,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildCell(
+    BuildContext context,
+    DateTime day,
+    _DayTotals? totals, {
+    bool isToday = false,
+    bool isSelected = false,
+  }) {
+    final theme = Theme.of(context);
+    final inMonth =
+        day.year == widget.year && day.month == widget.month;
+    final dayColor = isSelected
+        ? theme.colorScheme.onPrimary
+        : (!inMonth
+            ? theme.colorScheme.onSurface.withValues(alpha: 0.3)
+            : theme.colorScheme.onSurface);
+
+    return Container(
+      margin: const EdgeInsets.all(2),
+      decoration: isSelected
+          ? BoxDecoration(
+              color: theme.colorScheme.primary,
+              borderRadius: BorderRadius.circular(8),
+            )
+          : (isToday
+              ? BoxDecoration(
+                  color: theme.colorScheme.primary.withValues(alpha: 0.15),
+                  borderRadius: BorderRadius.circular(8),
+                )
+              : null),
+      padding: const EdgeInsets.symmetric(vertical: 2),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            '${day.day}',
+            style: TextStyle(
+              fontSize: 12,
+              fontWeight: FontWeight.w600,
+              color: dayColor,
+            ),
+          ),
+          if (totals != null) ...[
+            if (totals.income > 0)
+              Text(
+                '+${_compact(totals.income)}',
+                style: TextStyle(
+                  fontSize: 9,
+                  color: isSelected
+                      ? theme.colorScheme.onPrimary
+                      : Colors.green.shade700,
+                  fontWeight: FontWeight.w600,
+                ),
+                overflow: TextOverflow.ellipsis,
+              ),
+            if (totals.expense > 0)
+              Text(
+                '-${_compact(totals.expense)}',
+                style: TextStyle(
+                  fontSize: 9,
+                  color: isSelected
+                      ? theme.colorScheme.onPrimary
+                      : Colors.red.shade700,
+                  fontWeight: FontWeight.w600,
+                ),
+                overflow: TextOverflow.ellipsis,
+              ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  String _compact(int amount) {
+    if (amount >= 10000000) return '${(amount / 10000000).toStringAsFixed(0)}천만';
+    if (amount >= 10000) return '${(amount / 10000).toStringAsFixed(0)}만';
+    if (amount >= 1000) return '${(amount / 1000).toStringAsFixed(0)}천';
+    return CurrencyFormatter.format(amount);
+  }
+}
+
+class _DayTotals {
+  int income = 0;
+  int expense = 0;
+}

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -36,6 +36,9 @@ dependencies:
   # Charts
   fl_chart: ^0.69.0
 
+  # Calendar (Phase 23 PR-X5: 거래 탭 달력 뷰)
+  table_calendar: ^3.1.2
+
   # UI
   shimmer: ^3.0.0
   cached_network_image: ^3.4.1


### PR DESCRIPTION
## Summary
거래 탭에 홈 대시보드 콘텐츠 흡수. 리스트/달력 두 뷰를 사용자가 toggle.

## 구현
- **총잔액 미니카드**: `총 자산 = Σ(비-카드 active) − unpaidMonth.totalAmount`, 탭 → /asset-management
- **View toggle** (리스트 | 달력): SharedPreferences 저장 (`transaction_view_mode`)
- **달력 뷰**: `table_calendar` (3.2.0) 추가, 각 일 셀에 +수입(green) / -지출(red) 마커
  - 일 탭 → DraggableScrollableSheet 에 해당 일 거래/이체 리스트
  - 월 변경 → MonthCubit 동기화

## Files
- `transaction_list_page.dart` (toggle + 달력 분기)
- `total_balance_mini_card.dart` (신규)
- `transaction_calendar_view.dart` (신규)
- `pubspec.yaml` (+ table_calendar)

## Test
- flutter analyze: 0 new issue
- flutter test: 714 pass
- flutter build web --release: 성공

## 범위 외 (X9 에서 처리)
- 홈 탭 제거, bottom nav 변경

🤖 Generated with [Claude Code](https://claude.com/claude-code)