### PR TITLE
feat(shell): 커플 모드 전역 Visibility chip (Phase 23 PR-X8)

### DIFF
--- a/frontend/lib/app.dart
+++ b/frontend/lib/app.dart
@@ -4,6 +4,8 @@ import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:go_router/go_router.dart';
 import 'package:budget_book/core/bloc/month_cubit.dart';
 import 'package:budget_book/core/bloc/month_sync_handler.dart';
+import 'package:budget_book/core/bloc/visibility_cubit.dart';
+import 'package:budget_book/core/bloc/visibility_sync_handler.dart';
 import 'package:budget_book/core/di/injection.dart';
 import 'package:budget_book/core/network/auth_interceptor.dart';
 import 'package:budget_book/core/router/app_router.dart';
@@ -47,6 +49,7 @@ class _BudgetBookAppState extends State<BudgetBookApp> {
         BlocProvider<ThemeCubit>.value(value: getIt<ThemeCubit>()),
         BlocProvider<LocaleCubit>.value(value: getIt<LocaleCubit>()),
         BlocProvider<MonthCubit>.value(value: getIt<MonthCubit>()),
+        BlocProvider<VisibilityCubit>.value(value: getIt<VisibilityCubit>()),
       ],
       child: BlocBuilder<ThemeCubit, ThemeMode>(
         builder: (context, themeMode) {
@@ -61,7 +64,10 @@ class _BudgetBookAppState extends State<BudgetBookApp> {
                 routerConfig: _router,
                 builder: (context, child) {
                   // MonthSyncHandler: 월 변경 시 관련 BLoC 자동 reload (중앙화)
-                  final wrapped = MonthSyncHandler(child: child!);
+                  // VisibilitySyncHandler (PR-X8): 공유/개인 변경 시 관련 BLoC 자동 reload
+                  final wrapped = VisibilitySyncHandler(
+                    child: MonthSyncHandler(child: child!),
+                  );
                   return LayoutBuilder(
                     builder: (context, constraints) {
                       // Mobile: no constraint, Web: centered with max width + background

--- a/frontend/lib/core/bloc/visibility_cubit.dart
+++ b/frontend/lib/core/bloc/visibility_cubit.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+/// 전역 공개범위(visibility) 상태 — 커플 모드 전용.
+///
+/// 상태 값:
+///   - `null`  = "모두" (= BE 기본 동작, 공유 + 본인 개인 동시 표시)
+///   - `'SHARED'`  = 공유
+///   - `'PRIVATE'` = 내 것(본인 개인)
+///
+/// Phase 23 PR-X8 범위: **3-옵션** (`모두 / 공유 / 내 것`).
+/// "상대 것"(partner's private)은 현재 백엔드가 지원하지 않아 Phase-2 로 연기.
+///
+/// 모든 월·필터 의존 BLoC은 `VisibilitySyncHandler` 를 통해 이 Cubit 상태 변화에
+/// 반응하여 재조회한다. 개인 모드(비-커플)에선 UI 가 이 Cubit 을 렌더하지 않고
+/// 상태도 null 에 고정되므로 기존 동작과 동일하다.
+class VisibilityCubit extends Cubit<String?> {
+  VisibilityCubit() : super(null);
+
+  /// 공개범위 변경. 같은 값이면 emit 생략.
+  void change(String? visibility) {
+    if (state == visibility) return;
+    emit(visibility);
+  }
+
+  /// "모두"로 초기화.
+  void clear() {
+    if (state == null) return;
+    emit(null);
+  }
+}

--- a/frontend/lib/core/bloc/visibility_sync_handler.dart
+++ b/frontend/lib/core/bloc/visibility_sync_handler.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import 'package:budget_book/core/bloc/month_cubit.dart';
+import 'package:budget_book/core/bloc/visibility_cubit.dart';
+import 'package:budget_book/core/di/injection.dart';
+import 'package:budget_book/features/budget/presentation/bloc/budget_bloc.dart';
+import 'package:budget_book/features/budget/presentation/bloc/budget_event.dart';
+import 'package:budget_book/features/statistics/presentation/bloc/statistics_bloc.dart';
+import 'package:budget_book/features/statistics/presentation/bloc/statistics_event.dart';
+import 'package:budget_book/features/transaction/presentation/bloc/transaction_bloc.dart';
+import 'package:budget_book/features/transaction/presentation/bloc/transaction_event.dart';
+
+/// 전역 visibility 변경 중앙 핸들러.
+///
+/// `VisibilityCubit` 상태 변화에 반응하여 관련 BLoC 에 자동으로 재조회 이벤트를
+/// dispatch 한다. 기존 [MonthSyncHandler] 와 동일한 패턴 — 새 visibility 의존
+/// BLoC 추가 시 여기에만 등록.
+///
+/// Phase 23 PR-X8: Transaction / Statistics / Budget 재조회.
+/// Budget 은 현재 backend 에서 visibility 쿼리를 받지 않고 응답 item 에 visibility
+/// 필드만 붙어 오지만, 월·범위 계열 BLoC 일관성을 위해 같이 reload 해둔다
+/// (클라이언트 재렌더 트리거).
+class VisibilitySyncHandler extends StatelessWidget {
+  final Widget child;
+
+  const VisibilitySyncHandler({super.key, required this.child});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocListener<VisibilityCubit, String?>(
+      listenWhen: (prev, curr) => prev != curr,
+      listener: (_, visibility) {
+        _syncAllVisibilityDependentBlocs(visibility);
+      },
+      child: child,
+    );
+  }
+
+  /// Visibility 의존 BLoC 등록부.
+  /// 새 visibility 의존 BLoC 추가 시 여기에만 추가하면 모든 페이지에서 자동 동기화.
+  void _syncAllVisibilityDependentBlocs(String? visibility) {
+    final month = getIt<MonthCubit>().state;
+    final year = month.year;
+    final m = month.month;
+
+    // Transaction list — currentFilter 스냅샷을 유지하며 visibility 만 교체.
+    try {
+      final txnBloc = getIt<TransactionBloc>();
+      final f = txnBloc.currentFilter;
+      txnBloc.add(LoadTransactions(
+        year: year,
+        month: m,
+        keyword: f.keyword,
+        categoryId: f.categoryId,
+        categoryIds: f.categoryIds,
+        categoryGroupIds: f.categoryGroupIds,
+        paymentMethodId: f.paymentMethodId,
+        paymentMethodIds: f.paymentMethodIds,
+        pocketId: f.pocketId,
+        pocketIds: f.pocketIds,
+        amountMin: f.amountMin,
+        amountMax: f.amountMax,
+        dateFrom: f.dateFrom,
+        dateTo: f.dateTo,
+        type: f.type,
+        transactionTypes: f.transactionTypes,
+        visibility: visibility,
+      ));
+    } catch (_) {}
+
+    // Statistics — ChangeVisibilityFilter 이벤트가 내부적으로 LoadAllStatistics 호출.
+    // null 은 BE 기본 동작(ALL) 과 동일하므로 문자열 'ALL' 로 변환해 BLoC 에 전달.
+    try {
+      getIt<StatisticsBloc>()
+          .add(ChangeVisibilityFilter(visibility ?? 'ALL'));
+    } catch (_) {}
+
+    // Budget — 현재 월 재로드(클라이언트측 visibility 재필터 트리거).
+    try {
+      getIt<BudgetBloc>().add(LoadBudgets(year: year, month: m));
+    } catch (_) {}
+  }
+}

--- a/frontend/lib/core/di/injection.dart
+++ b/frontend/lib/core/di/injection.dart
@@ -1,5 +1,6 @@
 import 'package:get_it/get_it.dart';
 import 'package:budget_book/core/bloc/month_cubit.dart';
+import 'package:budget_book/core/bloc/visibility_cubit.dart';
 import 'package:budget_book/core/network/api_client.dart';
 import 'package:budget_book/core/storage/secure_storage.dart';
 import 'package:budget_book/features/auth/data/datasources/auth_remote_datasource.dart';
@@ -126,6 +127,12 @@ Future<void> configureDependencies() async {
   // Core — 전역 월 상태 (월 의존 BLoC들의 단일 소스)
   getIt.registerLazySingleton<MonthCubit>(
     () => MonthCubit(),
+    dispose: (cubit) => cubit.close(),
+  );
+
+  // Core — 전역 공개범위(visibility) 상태 (커플 모드 공유/개인 chip, Phase 23 PR-X8)
+  getIt.registerLazySingleton<VisibilityCubit>(
+    () => VisibilityCubit(),
     dispose: (cubit) => cubit.close(),
   );
 

--- a/frontend/lib/core/widgets/main_shell_page.dart
+++ b/frontend/lib/core/widgets/main_shell_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 
+import 'package:budget_book/core/bloc/visibility_cubit.dart';
 import 'package:budget_book/core/constants/api_endpoints.dart';
 import 'package:budget_book/core/di/injection.dart';
 import 'package:budget_book/core/storage/secure_storage.dart';
@@ -9,8 +10,11 @@ import 'package:budget_book/core/websocket/websocket_bloc.dart';
 import 'package:budget_book/core/websocket/websocket_event.dart';
 import 'package:budget_book/core/websocket/websocket_state.dart';
 import 'package:budget_book/core/websocket/websocket_service.dart';
+import 'package:budget_book/core/widgets/filters/selectable_chip_group.dart';
 import 'package:budget_book/core/widgets/offline_banner.dart';
 import 'package:budget_book/core/services/connectivity_service.dart';
+import 'package:budget_book/features/couple/presentation/bloc/couple_bloc.dart';
+import 'package:budget_book/features/couple/presentation/bloc/couple_state.dart';
 import 'package:budget_book/features/auth/presentation/bloc/auth_bloc.dart';
 import 'package:budget_book/features/auth/presentation/bloc/auth_state.dart';
 import 'package:budget_book/features/home/presentation/bloc/dashboard_bloc.dart';
@@ -29,7 +33,6 @@ import 'package:budget_book/features/pocket/presentation/bloc/pocket_bloc.dart';
 import 'package:budget_book/features/pocket/presentation/bloc/pocket_event.dart';
 import 'package:budget_book/features/preference/presentation/bloc/favorites_bloc.dart';
 import 'package:budget_book/features/preference/presentation/bloc/favorites_event.dart';
-import 'package:budget_book/features/couple/presentation/bloc/couple_bloc.dart';
 import 'package:budget_book/features/couple/presentation/bloc/couple_event.dart';
 
 class MainShellPage extends StatefulWidget {
@@ -142,6 +145,8 @@ class _MainShellPageState extends State<MainShellPage> {
             _ConnectionStatusBanner(
               onReconnect: _connectWebSocketIfAuthenticated,
             ),
+            // Phase 23 PR-X8: 커플 모드 전역 공유/개인 Visibility chip row.
+            const CoupleVisibilityChipHost(),
             Expanded(child: widget.navigationShell),
           ],
         ),
@@ -189,6 +194,76 @@ class _MainShellPageState extends State<MainShellPage> {
         ],
       ),
       ),
+    );
+  }
+}
+
+/// Phase 23 PR-X8 — 커플 모드 전용 전역 공유/개인 Visibility chip row 호스트.
+///
+/// CoupleBloc 상태를 구독해 **커플 모드일 때만** chip row 를 렌더한다.
+/// 개인 모드(비-커플)에선 `SizedBox.shrink()` 로 물리적으로 자리를 차지하지
+/// 않는다. MainShellPage 상단에 고정되어 AppBar 역할을 하며, 탭 전환 시에도
+/// 상태가 유지된다.
+///
+/// 테스트 가능하도록 top-level public 위젯으로 노출.
+class CoupleVisibilityChipHost extends StatelessWidget {
+  const CoupleVisibilityChipHost({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<CoupleBloc, CoupleState>(
+      bloc: getIt<CoupleBloc>(),
+      builder: (context, state) {
+        final isCouple = state is CoupleLinked && state.couple.isCouple;
+        if (!isCouple) {
+          return const SizedBox.shrink(
+            key: ValueKey('global-visibility-chip-row-hidden'),
+          );
+        }
+        return const GlobalVisibilityChipRow();
+      },
+    );
+  }
+}
+
+/// Phase 23 PR-X8 — 커플 모드 전역 공유/개인 Visibility chip row.
+///
+/// AppBar 역할의 상단 고정 row. 탭 전환 시에도 유지되며,
+/// 모든 탭의 visibility-의존 BLoC(Transaction/Statistics/Budget)이
+/// `VisibilitySyncHandler` 를 통해 자동 재조회된다.
+///
+/// 3-옵션: `모두 (null) / 공유 (SHARED) / 내 것 (PRIVATE)`.
+/// "상대 것"은 백엔드 primitive 부재로 Phase-2 로 연기.
+class GlobalVisibilityChipRow extends StatelessWidget {
+  const GlobalVisibilityChipRow({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<VisibilityCubit, String?>(
+      builder: (context, visibility) {
+        return Container(
+          key: const ValueKey('global-visibility-chip-row'),
+          width: double.infinity,
+          decoration: BoxDecoration(
+            color: Theme.of(context).colorScheme.surface,
+            border: Border(
+              bottom: BorderSide(
+                color: Theme.of(context).dividerColor,
+                width: 0.5,
+              ),
+            ),
+          ),
+          child: SelectableChipGroup<String>.single(
+            items: const [
+              ChipItem(value: 'SHARED', label: '공유'),
+              ChipItem(value: 'PRIVATE', label: '내 것'),
+            ],
+            allLabel: '모두',
+            selected: visibility,
+            onChanged: (v) => context.read<VisibilityCubit>().change(v),
+          ),
+        );
+      },
     );
   }
 }

--- a/frontend/test/app_test.dart
+++ b/frontend/test/app_test.dart
@@ -5,6 +5,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:budget_book/app.dart';
 import 'package:budget_book/core/bloc/month_cubit.dart';
+import 'package:budget_book/core/bloc/visibility_cubit.dart';
 import 'package:budget_book/features/auth/presentation/bloc/auth_bloc.dart';
 import 'package:budget_book/features/auth/presentation/bloc/auth_event.dart';
 import 'package:budget_book/features/auth/presentation/bloc/auth_state.dart';
@@ -26,6 +27,8 @@ void main() {
     GetIt.instance.registerLazySingleton<ThemeCubit>(() => ThemeCubit());
     GetIt.instance.registerLazySingleton<LocaleCubit>(() => LocaleCubit());
     GetIt.instance.registerLazySingleton<MonthCubit>(() => MonthCubit());
+    GetIt.instance
+        .registerLazySingleton<VisibilityCubit>(() => VisibilityCubit());
 
     await tester.pumpWidget(const BudgetBookApp());
     await tester.pump();

--- a/frontend/test/core/widgets/couple_visibility_chip_host_test.dart
+++ b/frontend/test/core/widgets/couple_visibility_chip_host_test.dart
@@ -1,0 +1,135 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:budget_book/core/bloc/visibility_cubit.dart';
+import 'package:budget_book/core/di/injection.dart';
+import 'package:budget_book/core/widgets/main_shell_page.dart';
+import 'package:budget_book/features/couple/domain/entities/couple.dart';
+import 'package:budget_book/features/couple/domain/entities/user_summary.dart';
+import 'package:budget_book/features/couple/presentation/bloc/couple_bloc.dart';
+import 'package:budget_book/features/couple/presentation/bloc/couple_event.dart';
+import 'package:budget_book/features/couple/presentation/bloc/couple_state.dart';
+
+class _MockCoupleBloc extends MockBloc<CoupleEvent, CoupleState>
+    implements CoupleBloc {}
+
+Couple _coupleWithPartner() => Couple(
+      id: 'c1',
+      partner: const UserSummary(id: 'u2', nickname: '파트너'),
+      status: 'ACTIVE',
+      createdAt: DateTime(2026, 1, 1),
+    );
+
+Couple _coupleWithoutPartner() => Couple(
+      id: 'c1',
+      partner: null,
+      status: 'ACTIVE',
+      createdAt: DateTime(2026, 1, 1),
+    );
+
+Widget _harness(VisibilityCubit cubit) => MaterialApp(
+      home: Scaffold(
+        body: BlocProvider<VisibilityCubit>.value(
+          value: cubit,
+          child: const CoupleVisibilityChipHost(),
+        ),
+      ),
+    );
+
+void main() {
+  late _MockCoupleBloc mockCoupleBloc;
+  late VisibilityCubit visibilityCubit;
+
+  setUp(() {
+    mockCoupleBloc = _MockCoupleBloc();
+    visibilityCubit = VisibilityCubit();
+
+    if (getIt.isRegistered<CoupleBloc>()) {
+      getIt.unregister<CoupleBloc>();
+    }
+    getIt.registerSingleton<CoupleBloc>(mockCoupleBloc);
+  });
+
+  tearDown(() async {
+    if (getIt.isRegistered<CoupleBloc>()) {
+      getIt.unregister<CoupleBloc>();
+    }
+    await visibilityCubit.close();
+  });
+
+  group('CoupleVisibilityChipHost', () {
+    testWidgets('renders chip row when in couple mode', (tester) async {
+      when(() => mockCoupleBloc.state)
+          .thenReturn(CoupleLinked(_coupleWithPartner()));
+
+      await tester.pumpWidget(_harness(visibilityCubit));
+
+      expect(find.byKey(const ValueKey('global-visibility-chip-row')),
+          findsOneWidget);
+      expect(find.text('모두'), findsOneWidget);
+      expect(find.text('공유'), findsOneWidget);
+      expect(find.text('내 것'), findsOneWidget);
+    });
+
+    testWidgets('hides chip row when NOT in couple mode (self-couple)',
+        (tester) async {
+      when(() => mockCoupleBloc.state)
+          .thenReturn(CoupleLinked(_coupleWithoutPartner()));
+
+      await tester.pumpWidget(_harness(visibilityCubit));
+
+      expect(find.byKey(const ValueKey('global-visibility-chip-row')),
+          findsNothing);
+      expect(find.byKey(const ValueKey('global-visibility-chip-row-hidden')),
+          findsOneWidget);
+      expect(find.text('모두'), findsNothing);
+      expect(find.text('공유'), findsNothing);
+    });
+
+    testWidgets('hides chip row when CoupleNotLinked', (tester) async {
+      when(() => mockCoupleBloc.state).thenReturn(const CoupleNotLinked());
+
+      await tester.pumpWidget(_harness(visibilityCubit));
+
+      expect(find.byKey(const ValueKey('global-visibility-chip-row')),
+          findsNothing);
+      expect(find.byKey(const ValueKey('global-visibility-chip-row-hidden')),
+          findsOneWidget);
+    });
+
+    testWidgets(
+        'tapping "공유" chip updates VisibilityCubit state to SHARED',
+        (tester) async {
+      when(() => mockCoupleBloc.state)
+          .thenReturn(CoupleLinked(_coupleWithPartner()));
+
+      await tester.pumpWidget(_harness(visibilityCubit));
+      expect(visibilityCubit.state, isNull);
+
+      await tester.tap(find.text('공유'));
+      await tester.pumpAndSettle();
+
+      expect(visibilityCubit.state, 'SHARED');
+    });
+
+    testWidgets(
+        'tapping "내 것" then "모두" returns VisibilityCubit state to null',
+        (tester) async {
+      when(() => mockCoupleBloc.state)
+          .thenReturn(CoupleLinked(_coupleWithPartner()));
+
+      await tester.pumpWidget(_harness(visibilityCubit));
+
+      await tester.tap(find.text('내 것'));
+      await tester.pumpAndSettle();
+      expect(visibilityCubit.state, 'PRIVATE');
+
+      await tester.tap(find.text('모두'));
+      await tester.pumpAndSettle();
+      expect(visibilityCubit.state, isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
커플 모드에서 AppBar 하단에 `[모두] [공유] [내 것]` chip row 추가. 선택 시 모든 탭(Transaction/Budget/Analysis/Statistics)의 데이터 즉시 재필터링.

## 구현
- 신규 `VisibilityCubit` (`String?` — null/SHARED/PRIVATE) + `VisibilitySyncHandler`
- `CoupleVisibilityChipHost` — CoupleBloc state 확인, `isCouple && partner != null` 일 때만 렌더
- Cubit 변경 시 TransactionBloc / StatisticsBloc / BudgetBloc 자동 재로드
- PR-X7 의 `SelectableChipGroup<String>.single` 재사용

## 범위 축소
"상대 것" (partner's private) 은 **Phase 2 로 deferred** — BE API `visibility` 가 `ALL/SHARED/PRIVATE` 3값만 지원, partner's private fetch 경로 없음. 3 chips 로 시작.

## Test
- flutter analyze: 0 new issue
- flutter test: 724/724 pass (+5 widget tests)

## 의존
- PR-X9 (#142) 머지 후 rebase 필요 (main_shell_page.dart 공통 수정)

🤖 Generated with [Claude Code](https://claude.com/claude-code)