### PR TITLE
[Phase 25 · Step 1] 설정 → 더보기 라벨 rename

### DIFF
--- a/docs/sessions/2026-04-23_3_plan.md
+++ b/docs/sessions/2026-04-23_3_plan.md
@@ -1,0 +1,185 @@
+# Phase 25 — 점진적 4탭 이행 (회귀 없음)
+> 날짜: 2026-04-23 | 회차: 3 | 상태: **검증완료 / 승인대기**
+
+## 0. 배경
+- Phase 23 에서 4탭 구조로 **한 번에 옮기려다** 19건 회귀 발생 → 전면 롤백(#144)
+- 사용자 지시: **4탭 목표 유지 + 점진적 개선**
+- 최종 목표: `[거래] [분석] [자산] [더보기]`
+- 방법: **각 단계 1 PR, 기존 기능 100% 보존, 라이브 검증 후 다음 단계**
+
+## 1. 핵심 원칙 (절대 준수)
+1. **Zero regression** — 기존에 있던 UI/동작/진입점 단 1개라도 사라지면 안 됨
+2. **Replace before remove** — 신규 위치에 기능이 노출된 후에만 옛 위치 제거
+3. **Single concept per PR** — 1 PR 에 1 아이디어만. 탭 구조 + 콘텐츠 개편 섞지 않음
+4. **Live verify gate** — 각 PR 머지 후 라이브 확인 전까지 다음 PR 착수 금지
+5. **Overlap 허용 중간 상태** — 탭이 5개→6개→7개 일시적 증가 OK. 최종 축소는 마지막
+
+## 2. 구조적 수정 (S1-S3 재생 방지)
+
+### S1. 사전 Feature Inventory 의무화
+각 단계 시작 전 `docs/sessions/inventories/<step>.md` 로 현 탭/페이지의 **모든 위젯·액션·네비 진입점**을 나열.
+신규 탭/페이지에 이식 시 이 목록을 **체크리스트로** 확인.
+
+### S2. "A/B 병존" 단계 포함
+탭 제거 전 반드시 "신규 탭 + 구 탭 둘 다 유지" 단계를 1회 이상 가짐.
+
+### S3. Flyway 대칭 정책
+BE 스키마 변경 동반 시 **단일 PR 로 격리**. UI PR 과 섞지 않음.
+
+## 3. 단계별 계획
+
+### Step 1 — 설정 → 더보기 리네임 (Trivial, S)
+- `main_shell_page.dart` 설정 destination label `'설정'` → `'더보기'` (icon 유지 OK)
+- 기존 SettingsPage 내부 **그대로 유지**
+- 라우트 `/settings` 그대로
+- **목적**: 4탭 네이밍 언어 통일 준비
+
+### Step 2 — 자산 탭 승격 (M)
+- main_shell 에 `자산` destination **추가** (5→6탭)
+- 라우트 `/assets` 신규 branch → AssetManagementPage
+- **기존 `/asset-management` 라우트 그대로 유지** (redirect 없음, 이중 진입점 허용)
+- SettingsPage 의 "자산 관리" 메뉴 **삭제하지 않음** (사용자가 기존 경로 계속 사용 가능)
+- **추가만, 제거 없음**
+
+### Step 3 — 자산 탭에 총자산 summary 추가 (S)
+- AssetManagementPage 상단에 총자산/부채/순자산 3 카드
+- 탭 내용(카테고리/결제수단/포켓) 그대로
+- PaymentMethodPage standalone **유지**
+
+### Step 4 — 자산 탭 결제수단 잔액 표시 강화 (M)
+- `_PaymentMethodTab._buildPaymentMethodTile` subtitle 확장
+  - 비-카드: `잔액: ±N원` (null 이면 `잔액: 0원` fallback)
+  - 카드: `미결제: N원   이번달 사용: N원`
+- 잔액 수정은 **popup 내부에 "잔액 수정" 항목** (v1.0 PaymentMethodPage 의 popup 그대로 이식)
+- 별도 tune IconButton **없음** (v2.0 실수 반복 방지)
+
+### Step 5 — 자산 탭에 MonthNavigator + 3열 카드 summary (M)
+- AssetManagementPage 상단 카드와 결제수단 탭 사이에 MonthNavigator
+- 3열 카드 summary (전월 / 미결제 / 이번달) — v1.0 PaymentMethodPage:351-440 그대로 이식
+- PaymentMethodPage standalone **여전히 유지**
+
+### Step 6 — 거래 탭 총잔액 미니카드 (S)
+- `transaction_list_page.dart` 상단에 `총 자산` 한 줄 카드 추가
+- 탭 시 `/assets` 이동
+- 기존 MonthSummaryBar, 리스트 그대로
+
+### Step 7 — 거래 탭 리스트/달력 toggle **필터 바 같은 행에** (M)
+- `UnifiedFilterBar` 우측 slot 에 `리스트 | 달력` toggle 배치
+- SharedPreferences 저장
+- 달력 뷰 — `table_calendar` 로 일별 수입/지출 마커 + 일 탭 시 바텀시트
+- 리스트 뷰 = 기존 그대로 (변경 없음)
+- 홈 탭 그대로
+
+### Step 8 — 홈 탭 기능을 거래 탭 요약 영역에 **복제** (L, A/B 병존)
+- 거래 탭에 "요약" 영역 추가 (리스트 뷰 상단, MonthSummaryBar 아래)
+  - AccountBalanceCard (홈 위젯 재사용)
+  - 최근 거래 N건
+  - 필요 시 AI 인사이트 / 공지 / quick actions 일부 노출
+- **홈 탭 여전히 유지** — 동일 위젯 양쪽에 렌더
+- 사용자가 **둘 중 무엇을 써도** 동일 정보 접근
+
+### Step 9 — 라이브 검증: 거래 탭만 써도 홈 필요 없는지 확인 (검증 게이트)
+- 사용자가 1~3일 사용
+- 불편한 점 없으면 Step 10 진행
+- 누락 기능 있으면 Step 8a/b 로 보완
+
+### Step 10 — 홈 탭 제거 (S)
+- `main_shell_page.dart` 홈 destination 삭제
+- `/` → `/transactions` redirect
+- `/home` → `/transactions` redirect
+- 라우터 이후 `DashboardPage` 는 파일만 남겨두되 destination 없음
+- **5→4탭 중 1차 축소** (거래/예산/통계/자산/더보기 = 5탭)
+
+### Step 11 — 분석 탭 신규 (분석 페이지만 생성, 예산/통계 유지) (L, A/B 병존)
+- 신규 `analysis_page.dart` — 이번엔 v1.0 페이지들의 **모든 섹션을 그대로 이식**
+- `/analysis` 라우트 + main_shell destination 추가 (5→6탭)
+- 포함 섹션 (필수, 누락 금지):
+  - BudgetSummaryCard (총 예산/사용/남음)
+  - **개별 예산 리스트** (`_buildBudgetTile` + Dismissible + popup)
+  - 월/주 전환 (Weekly tab 합침 또는 탭 내 segmented)
+  - 전월 복사 action
+  - 카테고리 지출 (Expense/Income 전환 + 그룹/드릴다운 + onTap → 거래 필터)
+  - 월별 추이 bar + 잔액 라인 옵션
+  - 결제수단별 도넛 + drilldown
+  - 전년 비교
+  - 기간 범위 picker + `/period-summary` 진입
+- **예산/통계 탭 그대로 유지** — A/B 병존
+
+### Step 12 — 라이브 검증: 분석 탭이 예산+통계 대체 가능한지 (검증 게이트)
+- 사용자가 분석 탭만 써보고 누락 없는지 확인
+- 누락 있으면 Step 11 보완 반복
+- 완벽하면 Step 13
+
+### Step 13 — 예산 탭 제거 (S)
+- main_shell 에서 예산 destination 삭제
+- `/budgets` → `/analysis` redirect
+- budget_list_page 파일 제거 (기능은 분석 탭에 있음)
+- 6→5탭
+
+### Step 14 — 통계 탭 제거 (S)
+- main_shell 에서 통계 destination 삭제
+- `/statistics` → `/analysis` redirect
+- statistics_page 파일 제거
+- 5→4탭 **최종 도달**
+
+### Step 15 — 커플 visibility 통합 (M)
+- 글로벌 AppBar chip 추가
+- **UnifiedFilterState.visibility 필드 기반으로 전역 동기화**
+- 필터 바 내부 visibility 제거 (라벨 통일: `전체/공유/개인`)
+- 커플 모드만 렌더
+
+### Step 16 — 검증 + 정리 PR
+- Orphan BLoC/위젯 감사
+- 각 탭 기능 체크리스트 (docs/CODEMAPS/NAVIGATION.md)
+
+## 4. 단계별 PR 사이즈 예상
+
+| Step | PR | Size | 회귀 위험 |
+|---|---|---|---|
+| 1 | rename 설정→더보기 | S | 0% |
+| 2 | 자산 탭 추가 (삭제 없음) | M | 0% — 추가만 |
+| 3 | 자산 상단 총자산 카드 | S | 0% |
+| 4 | 결제수단 잔액 표시 + popup | M | 저 — v1.0 popup 이식 |
+| 5 | 자산 MonthNav + 3열 카드 | M | 저 — v1.0 위젯 이식 |
+| 6 | 거래 총잔액 미니카드 | S | 0% |
+| 7 | 거래 리스트/달력 toggle | M | 저 — UI 만 추가 |
+| 8 | 거래 요약 영역 (A/B 병존) | L | 0% — 복제만 |
+| 9 | (검증 게이트) | - | - |
+| 10 | 홈 탭 제거 | S | 저 — 검증 후 |
+| 11 | 분석 탭 신규 (A/B 병존) | L | 0% — 추가만 |
+| 12 | (검증 게이트) | - | - |
+| 13 | 예산 탭 제거 | S | 저 — 검증 후 |
+| 14 | 통계 탭 제거 | S | 저 — 검증 후 |
+| 15 | 커플 visibility 통합 | M | 저 |
+| 16 | 정리 | S | - |
+
+## 5. 진행 리듬
+- **1 PR / 세션** 기본 (사용자 확인 속도에 맞춤)
+- **라이브 검증 전까지** 다음 PR 착수 금지
+- 문제 발생 시 해당 PR 만 revert — 전체 롤백 불필요 (각 PR 독립)
+
+## 6. 롤백 플랜
+- 각 PR 은 squash merge → 1 SHA 로 revert 쉬움
+- `git revert <sha>` 만으로 이전 상태 복귀
+- 탭 추가/제거는 main_shell_page + router 만 변경 → revert 안전
+
+## 7. 하네스 Scope Audit
+- 실행: `pre-change-audit.sh . "ui_pattern,navigation_state"`
+- 판정: STRUCTURAL_FIX_REQUIRED → S1~S3 로 대응
+- 각 Step 시작 시 재실행 + 필요 시 acknowledge
+
+## 8. 검증 계획 (각 Step 공통)
+- [ ] `flutter analyze` 0 error/warning
+- [ ] `flutter test` 모두 pass
+- [ ] `flutter build web` 성공
+- [ ] 라이브: 해당 PR 기능 외에 **기존 동작 변화 없음** 확인
+- [ ] 사용자 보고 후 다음 단계
+
+## 9. 승인
+- [ ] 승인 → Step 1 부터 순차 착수
+- [ ] 수정 요청: ___
+
+## 10. 주의
+- **4탭 도달은 Step 14 완료 시점** — 최소 14개 PR 필요 (14+2 검증 게이트)
+- 시간 투자 크지만 **회귀 0 보장** 이 목표
+- 각 단계 종료 시 라이브 확인 대기하므로 사용자와의 소통 빈도↑

--- a/frontend/lib/core/widgets/main_shell_page.dart
+++ b/frontend/lib/core/widgets/main_shell_page.dart
@@ -151,7 +151,7 @@ class _MainShellPageState extends State<MainShellPage> {
           NavigationDestination(
             icon: Icon(Icons.settings_outlined),
             selectedIcon: Icon(Icons.settings),
-            label: '설정',
+            label: '더보기',
           ),
         ],
       ),


### PR DESCRIPTION
## Phase 25 · Step 1 / 16

4탭 구조로 **점진적** 이행의 첫 단계. 회귀 위험 0%.

기획서: `docs/sessions/2026-04-23_3_plan.md` (이 PR 에 동반 포함)

## 변경
- `main_shell_page.dart`: NavigationDestination label `'설정'` → `'더보기'`
- 그 외 일절 변경 없음 — icon/route(`/settings`)/SettingsPage 내부 전부 유지

## 목적
4탭 네이밍 언어 통일 준비 (이후 Step 에서 자산 탭 추가 · 결제수단 이식 등 진행)

## 검증
- [x] `flutter analyze` — 0 error (기존 info 3건 유지)
- [x] `flutter test` — 703 passed
- [x] `flutter build web --release` — 성공
- [ ] 라이브: 하단 탭 4번째 라벨이 `더보기` 로 표시되는지, 탭 시 설정 페이지 정상 진입 확인

## 태그
- 머지 대상 커밋 이전 `main` 지점은 `v2.1` 태그로 고정 (baseline)
- 머지 후 이 커밋에 `v2.1.1` 태그 예정

## 다음 단계
Step 2 — 자산 탭 추가 (5→6탭, 제거 없음). 이 PR 라이브 검증 완료 후 착수.

🤖 Generated with [Claude Code](https://claude.com/claude-code)