### PR TITLE
[Phase 25 · Step 0] NAS nginx gzip 영속화 — 첫 로드 5.3s→1.7s

### DIFF
--- a/.github/workflows/deploy-nas.yml
+++ b/.github/workflows/deploy-nas.yml
@@ -18,6 +18,7 @@ jobs:
     outputs:
       backend: ${{ steps.filter.outputs.backend }}
       frontend: ${{ steps.filter.outputs.frontend }}
+      nginx: ${{ steps.filter.outputs.nginx }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -29,6 +30,9 @@ jobs:
               - '.github/workflows/deploy-nas.yml'
             frontend:
               - 'frontend/**'
+              - '.github/workflows/deploy-nas.yml'
+            nginx:
+              - 'ops/nas-nginx/**'
               - '.github/workflows/deploy-nas.yml'
 
   # ── Backend 배포 (변경 시에만) ──
@@ -142,3 +146,41 @@ jobs:
           ssh -i ~/.ssh/nas_key -p ${{ secrets.NAS_SSH_PORT }} \
             ${{ secrets.NAS_USERNAME }}@${{ secrets.NAS_HOST }} \
             "sudo rm -rf /var/services/web_bb/* && cd /var/services/web_bb && sudo tar xzf /tmp/bb-web.tar.gz && sudo chown -R admin:users /var/services/web_bb && rm /tmp/bb-web.tar.gz && test -f /var/services/web_bb/index.html && echo 'Frontend deployed'"
+
+  # ── Nginx vhost 동기화 (ops/nas-nginx/ 변경 시) ──
+  # DSM Web Station / ssl.compress.conf 의 global gzip off 를 vhost 레벨에서 override.
+  # repo 에 단일 진실원(ops/nas-nginx/aiva-bb.conf) 을 두어 DSM 업데이트/재설정 drift 방지.
+  sync-nginx:
+    needs: changes
+    if: needs.changes.outputs.nginx == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup SSH key
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.NAS_SSH_KEY }}" > ~/.ssh/nas_key
+          chmod 600 ~/.ssh/nas_key
+          ssh-keyscan -p ${{ secrets.NAS_SSH_PORT }} ${{ secrets.NAS_HOST }} >> ~/.ssh/known_hosts 2>/dev/null
+
+      - name: Sync aiva-bb.conf to NAS + test + reload
+        run: |
+          scp -O -i ~/.ssh/nas_key -P ${{ secrets.NAS_SSH_PORT }} \
+            ops/nas-nginx/aiva-bb.conf \
+            ${{ secrets.NAS_USERNAME }}@${{ secrets.NAS_HOST }}:/tmp/aiva-bb.conf
+          ssh -i ~/.ssh/nas_key -p ${{ secrets.NAS_SSH_PORT }} \
+            ${{ secrets.NAS_USERNAME }}@${{ secrets.NAS_HOST }} \
+            "set -e; \
+             TARGET=/usr/local/etc/nginx/sites-available/aiva-bb.conf; \
+             if ! sudo diff -q /tmp/aiva-bb.conf \$TARGET >/dev/null 2>&1; then \
+               sudo cp \$TARGET \$TARGET.bak.\$(date +%Y%m%d_%H%M%S); \
+               sudo mv /tmp/aiva-bb.conf \$TARGET; \
+               sudo chown root:root \$TARGET; \
+               sudo chmod 644 \$TARGET; \
+               sudo nginx -t && sudo nginx -s reload; \
+               echo 'nginx vhost reloaded'; \
+             else \
+               rm /tmp/aiva-bb.conf; \
+               echo 'nginx vhost unchanged'; \
+             fi"

--- a/ops/nas-nginx/aiva-bb.conf
+++ b/ops/nas-nginx/aiva-bb.conf
@@ -1,0 +1,108 @@
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+
+    server_name aiva-bb.duckdns.org;
+
+    ssl_certificate /usr/syno/etc/certificate/_archive/AIVABB/fullchain.pem;
+    ssl_certificate_key /usr/syno/etc/certificate/_archive/AIVABB/privkey.pem;
+
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers HIGH:!aNULL:!MD5;
+
+    root /var/services/web_bb;
+    index index.html;
+
+    # API proxy
+    location ^~ /api/ {
+        proxy_connect_timeout 60;
+        proxy_read_timeout 60;
+        proxy_send_timeout 60;
+        proxy_intercept_errors off;
+        proxy_http_version 1.1;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_pass http://localhost:8081;
+    }
+
+    # OAuth2 proxy
+    location ^~ /oauth2/ {
+        proxy_connect_timeout 60;
+        proxy_read_timeout 60;
+        proxy_send_timeout 60;
+        proxy_intercept_errors off;
+        proxy_http_version 1.1;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_pass http://localhost:8081;
+    }
+
+    # Login OAuth2 callback
+    location ^~ /login/ {
+        proxy_connect_timeout 60;
+        proxy_read_timeout 60;
+        proxy_send_timeout 60;
+        proxy_intercept_errors off;
+        proxy_http_version 1.1;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_pass http://localhost:8081;
+    }
+
+    # Actuator
+    location ^~ /actuator/ {
+        proxy_pass http://localhost:8081;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+
+    # WebSocket
+    location ^~ /ws {
+        proxy_pass http://localhost:8081;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection upgrade;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+    # ── Override global gzip off (ssl.compress.conf) for static assets ──
+    # 관리: repo ops/nas-nginx/aiva-bb.conf (Phase 25 성능 회복)
+    gzip on;
+    gzip_vary on;
+    gzip_min_length 1000;
+    gzip_comp_level 6;
+    gzip_proxied any;
+    gzip_types
+        text/plain
+        text/css
+        text/xml
+        text/javascript
+        application/javascript
+        application/x-javascript
+        application/json
+        application/xml
+        application/xml+rss
+        image/svg+xml
+        font/ttf
+        font/otf;
+
+    # SPA fallback
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}
+
+server {
+    listen 80;
+    listen [::]:80;
+    server_name aiva-bb.duckdns.org;
+    return 301 https://$host$request_uri;
+}


### PR DESCRIPTION
## 배경
Step 1 (#145) 머지 후 사용자가 "라이브가 느려졌다" 보고. 조사 결과:

- **repo 변경 없음** — 코드 59168→59112줄(동일), pubspec 동일, deploy 스크립트도 serving 관련 변경 없음
- **NAS 측 원인 확정** — `/etc/nginx/conf.d/ssl.compress.conf` 의 `gzip off;` 가 전역 적용되어 HTTPS 응답 모두 비압축 전송
- **"이전에 빨랐다" 의 정체** — Service Worker 캐시 적중이 체감을 가려왔음. 연속 배포로 SW 무효화되며 원래 slow cold-load 가 드러난 것

즉 **회귀가 아니라 처음부터 덜 최적화 상태**. 이번 기회에 근본 해결 + 재발 방지.

## 변경
1. **`ops/nas-nginx/aiva-bb.conf` 신규** — 기존 수동 관리 vhost 를 git 에 반영 + `gzip on` 추가
2. **`deploy-nas.yml`**
   - `changes` 필터에 `nginx` 추가 (`ops/nas-nginx/**`)
   - `sync-nginx` job 신규 — scp + diff 체크 + 백업 + `nginx -t && reload`

## 효과 (NAS 에 이미 수동 반영, 이 PR 은 선언적 관리 정착)

| 항목 | 이전 | 현재 |
|---|---|---|
| main.dart.js wire | 5,289,498 B | **1,457,997 B** (-72%) |
| 다운로드 시간 | 5~6초 | **1.68초** |
| content-encoding | — | gzip |

## 재발 방지
- DSM 업데이트/재설정으로 drift 발생해도 다음 main push 가 자동 복구
- conf 변경은 PR 리뷰 통과 후에만 반영 + `nginx -t` 자동 검증
- 타임스탬프 백업으로 즉시 롤백 가능

## Phase 25 진행 영향
- Step 1 (#145) 는 이미 머지·배포 완료. 이 Step 0 은 **병렬 infra 복구** 성격
- 이 PR 머지 후 Step 2 (자산 탭 추가) 착수 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)