### PR TITLE
[Phase 25 · Step 0.6] nginx no-cache 엔트리 포인트 + /assets 라우트 충돌 해소

### DIFF
--- a/ops/nas-nginx/aiva-bb.conf
+++ b/ops/nas-nginx/aiva-bb.conf
@@ -94,6 +94,34 @@ server {
         font/ttf
         font/otf;
 
+    # ── Cache policy (Phase 25 Step 0.6) ──
+    # Flutter web 은 main.dart.js 파일명이 고정이라 브라우저가 stale 번들을
+    # 계속 서빙하는 문제가 있음. 엔트리 포인트만 no-cache 로 설정해 배포 즉시
+    # 새 버전 감지. ETag 기반 304 응답으로 실제 전송량은 최소화.
+    #
+    # location = /index.html 은 try_files 가 SPA fallback 으로 넘길 때
+    # 내부 재매칭되어 deep link 도 no-cache 헤더가 붙음.
+
+    location = /index.html {
+        add_header Cache-Control "no-cache, must-revalidate" always;
+        add_header Pragma "no-cache" always;
+    }
+
+    location ~ ^/(flutter_bootstrap\.js|flutter_service_worker\.js|version\.json)$ {
+        add_header Cache-Control "no-cache, must-revalidate" always;
+        add_header Pragma "no-cache" always;
+    }
+
+    # /assets 라우트 충돌 해소 (Phase 25 Step 2 — Flutter 라우트 vs 빌드 산출물 디렉터리)
+    # Flutter 빌드의 /assets/ 디렉터리는 정적 리소스 (이미지/폰트). 그대로 두면
+    # /assets → 301 → /assets/ → 403 디렉터리 접근 차단됨. exact match 로 override.
+    # /assets/<file> 는 `location /` try_files 로 기존대로 서빙 (변화 없음).
+    location = /assets {
+        add_header Cache-Control "no-cache, must-revalidate" always;
+        add_header Pragma "no-cache" always;
+        try_files /index.html =404;
+    }
+
     # SPA fallback
     location / {
         try_files $uri $uri/ /index.html;


### PR DESCRIPTION
## 배경
오늘 배포 2건(#145, #147) 에서 연속으로 사용자가 "변경 안 보임" 보고.
원인: 브라우저 HTTP cache + Service Worker 캐시. 사용자가 DevTools 에서
수동으로 "Disable cache" 체크해야 해결.

추가로 Steps 2-5 머지 후 발견: Phase 25 Step 2 에서 신설한 `/assets`
Flutter 라우트가 Flutter 빌드 산출물의 `/assets/` 디렉터리와 이름 충돌.
- `/assets` 요청 → nginx 자동 301 → `/assets/` → 403 Forbidden
- 직접 URL 접근 / 새로고침 / 북마크 모두 failure
- 클라이언트 내부 탭 이동은 괜찮음 (서버 라운드트립 없음)

## 변경 — `ops/nas-nginx/aiva-bb.conf`

### 1. 엔트리 포인트 no-cache
```nginx
location = /index.html {
    add_header Cache-Control "no-cache, must-revalidate" always;
    add_header Pragma "no-cache" always;
}
location ~ ^/(flutter_bootstrap\.js|flutter_service_worker\.js|version\.json)$ {
    add_header Cache-Control "no-cache, must-revalidate" always;
    ...
}
```
SPA fallback(`try_files $uri $uri/ /index.html`) 이 내부 재매칭되어
`location = /index.html` 을 hit → deep link refresh 도 no-cache 적용.

### 2. /assets 라우트 충돌 해소
```nginx
location = /assets {
    add_header Cache-Control "no-cache, must-revalidate" always;
    try_files /index.html =404;
}
```
exact match 가 directory auto-redirect 보다 우선 → /assets 직접 접근 시
index.html 서빙 → Flutter 라우터가 /assets 탭으로 이동.
/assets/<file> 은 `location /` 로 기존처럼 정적 서빙 (변화 없음).

## 효과
- **배포 후 첫 방문에서 자동으로 새 번들 감지** (사용자 개입 불필요)
- main.dart.js(5.3MB) 같은 큰 자산은 ETag 304 조건부 응답 → 전송량 그대로
- `/assets` 라우트: 새로고침/북마크/공유 모두 정상
- 정적 리소스 서빙 무영향

## 검증 (NAS 에 이미 수동 반영 + 이 PR 이 선언적 sync 보장)

| 경로 | 결과 | 헤더 |
|---|---|---|
| `/` | 200 (index.html, 568B) | no-cache ✅ |
| `/index.html` | 200 | no-cache ✅ |
| `/flutter_bootstrap.js` | 200 (9.9KB) | no-cache ✅ |
| `/flutter_service_worker.js` | 200 | no-cache ✅ |
| `/version.json` | 200 | no-cache ✅ |
| `/assets` (Flutter 라우트) | 200 (SPA) | no-cache ✅ |
| `/transactions` (기존 라우트) | 200 (SPA) | no-cache ✅ |
| `/main.dart.js` | 200 (5.3MB → gzip 1.46MB) | 기본 cache (ETag) ✅ |
| `/assets/AssetManifest.bin.json` | 200 (application/json, 262B) | 기본 cache ✅ |
| `/assets/NOTICES` | 200 (octet-stream, 1.4MB) | 기본 cache ✅ |
| `/canvaskit/canvaskit.wasm` | 200 (7.1MB) | 기본 cache ✅ |

## 재발 방지
- Step 0 에서 확립한 `sync-nginx` job 이 자동으로 NAS 에 반영
- repo = 단일 진실원, DSM drift 시에도 다음 push 로 복구

🤖 Generated with [Claude Code](https://claude.com/claude-code)