### PR TITLE
[Phase 25 · Step 6] 거래 탭 총자산 미니카드

### DIFF
--- a/docs/sessions/2026-04-24_1_plan.md
+++ b/docs/sessions/2026-04-24_1_plan.md
@@ -1,0 +1,127 @@
+# Phase 25 · Step 6 — 거래 탭 총잔액 미니카드
+> 날짜: 2026-04-24 | 회차: 1 | 상태: **검증완료 / 승인대기**
+
+## 요청 내용
+Phase 25 점진 이행 계획의 Step 6 을 진행한다.
+- `transaction_list_page.dart` 상단에 `총 자산` 한 줄 카드 추가
+- 탭 시 `/assets` 이동 (자산 탭으로 전환)
+- 기존 MonthSummaryBar, 리스트, 필터 그대로 유지 (zero regression)
+
+## 영향 범위 분석
+### 변경 파일
+| 파일 | 변경 유형 | 이유 |
+|---|---|---|
+| `frontend/lib/core/widgets/total_asset_mini_card.dart` | 신규 | 재사용 가능한 mini card 위젯 (Step 7~ 에서도 활용 가능) |
+| `frontend/lib/features/transaction/presentation/pages/transaction_list_page.dart` | 수정 | `_buildLoaded` 최상단에 mini card 삽입 (MonthNavigator 위) |
+
+### 관련 기존 코드
+- **총자산 데이터 출처**: `asset_management_page.dart:1362-1364` `_AssetSummaryHeader`
+  - `PaymentMethodBloc` state.paymentMethods 중 CASH/DEBIT/BANK balance 합산 (null → 0)
+- **글로벌 PaymentMethodBloc 공급**: `main_shell_page.dart:53` 에서 `LoadPaymentMethods` 프리로드 → getIt singleton
+- **라우트**: `app_router.dart:349` `/assets` (StatefulShellBranch index=3)
+- **현재 _buildLoaded 상단 구조**: MonthNavigator → 검색바 → UnifiedFilterBar → (MonthSummaryBar + 리스트)
+
+### 기술적 제약
+- 거래 탭에는 `BlocProvider<PaymentMethodBloc>` 이 명시적으로 없음. 단, 동일 싱글턴이 getIt 으로 관리되어 위젯 트리 상위(shell 레벨)에는 존재. 따라서 `BlocBuilder<PaymentMethodBloc>` 사용 전 **context.read 가능 여부 확인** 필요.
+- `UnifiedFilterState.visibility` 로 공유/개인 필터 중이어도 총자산은 커플 전체 자산이므로 필터 무관 (현재 _AssetSummaryHeader 도 필터 없음).
+
+### 이전 세션 참고
+- Phase 23 PR-X5 (#140) 에서 유사 구조로 "총잔액 흡수" 한 적 있으나 회귀 발생 → #144 롤백됨
+- 이번에는 **카드 1장만 추가**, 기존 요소 제거/이동 없음 → 회귀 위험 0
+
+## 작업 계획
+| # | 작업 | 담당 | 파일 | 난이도 |
+|---|---|---|---|---|
+| 1 | `TotalAssetMiniCard` 위젯 신규 | FE | `core/widgets/total_asset_mini_card.dart` | S |
+| 2 | transaction 페이지 최상단에 삽입 | FE | `transaction_list_page.dart:321` 직전 | S |
+| 3 | `flutter analyze` / `test` / `build web` 통과 확인 | FE | - | S |
+
+## 성능 설계 (원칙 1.4)
+- **데이터 접근**: PaymentMethodBloc state 재사용. **추가 API 호출 0회**.
+  - MainShell 이 `LoadPaymentMethods` 를 이미 프리로드함. 거래 탭 진입 시점에는 캐시됨.
+- **예상 규모**: 결제수단 < 50건 (현실적 상한). `fold` 연산 O(N), 매 rebuild 시 < 1ms.
+- **리소스 제약**: 추가 메모리/네트워크 없음. BlocBuilder 가 PaymentMethodBloc 변경에만 rebuild.
+- **설계 결정**:
+  - BlocBuilder 사용 (ListenableBuilder 아님) — PaymentMethodBloc 상태가 결제수단 수정 시 emit 되므로 자연 sync.
+  - **별도 API 호출 추가 안 함** — 이미 프리로드된 state 를 읽기만. 총자산 최신성은 PaymentMethodBloc reload 타이밍에 의존 (결제수단 수정 화면 복귀 시 자동 refresh).
+
+## 하네스 Scope Audit 결과 (필수 — Step 1.5)
+- **실행 명령**: `pre-change-audit.sh . "ui_pattern,navigation_state"`
+- **분류 태그**: `ui_pattern`, `navigation_state`
+- **Scope Audit 발견**: 240 hits (광범위 매치, 이번 변경과 직접 관련 낮음)
+- **Recurrence Check**: ✅ **OK** — 이 프로젝트 과거 인시던트 0 건 (타 프로젝트 3 건은 month 파라미터 전달 누락 건으로 이번 변경(/assets 단순 이동)과 무관)
+- **재발 방지 조치**: 불필요. 단, 과거 navigation_state 교훈 재적용:
+  - `/assets` 이동 시 month 파라미터 전달 **불필요** (자산 탭은 현재 month 와 독립, MonthCubit 자동 sync)
+  - 별도 파라미터 없이 `context.go('/assets')` 로 충분
+
+## 사용자 검증 시나리오 (필수 — 신규 섹션)
+
+### A. 기능 검증 (신규 동작)
+| # | 경로 | 조작 | 기대 결과 |
+|---|---|---|---|
+| A1 | https://aiva-bb.duckdns.org/transactions | 페이지 진입 | `MonthNavigator` **위**에 "총 자산 ₩x,xxx,xxx" 미니카드 표시 |
+| A2 | 동일 페이지 | 미니카드 탭 | 자산 탭(하단 4번째 탭)으로 전환, URL `/assets` |
+| A3 | `/assets` 진입 | 총자산 3카드 확인 | A1 의 금액과 "총자산" 카드 숫자가 일치 |
+| A4 | `/assets` 에서 결제수단 탭 → 잔액 수정 → 거래 탭 복귀 | 미니카드 숫자 확인 | 수정된 잔액이 반영된 총자산으로 업데이트 |
+
+### B. 회귀 없음 확인 (Zero regression)
+| # | 확인 항목 | 기대 결과 |
+|---|---|---|
+| B1 | 거래 탭에서 MonthNavigator 월 전환 | 기존대로 동작, 리스트 갱신 |
+| B2 | 검색바에 키워드 입력 | 기존대로 필터링 |
+| B3 | UnifiedFilterBar 의 각 필터 (날짜/카테고리/결제수단/포켓/금액) | 기존대로 동작 |
+| B4 | MonthSummaryBar (수입/지출/이체) | 위치·동작 변화 없음 |
+| B5 | 거래 추가(+) → 수정 → 삭제 | 기존대로 동작 |
+| B6 | 거래 탭 ↔ 분석 탭 ↔ 자산 탭 ↔ 더보기 탭 전환 | 모든 탭 정상 |
+| B7 | 커플 visibility chip | 기존대로 공유/개인 필터 동작 |
+
+### C. 데이터 정합성
+| # | 확인 | 기대 |
+|---|---|---|
+| C1 | 결제수단 3개(현금 10만 + 체크 5만 + 은행 20만 = 35만) 있을 때 | 미니카드 "₩350,000" |
+| C2 | 결제수단 0개 | "₩0" 또는 "-" (시각적 안정) |
+| C3 | 잔액 null 인 결제수단 포함 | null → 0 처리, 계산 영향 없음 |
+
+## 배포 절차 (필수 — 신규 섹션)
+| # | 단계 | 주체 | 확인 방법 | 예상 소요 |
+|---|---|---|---|---|
+| 1 | feature 브랜치 생성 | AI | `git checkout -b phase25-step6-total-asset-card` | - |
+| 2 | 구현 & flutter analyze/test 통과 | AI | 로컬 실행 | ~2분 |
+| 3 | PR 생성 | AI | `gh pr create` | - |
+| 4 | CI (ci-frontend.yml) 통과 | 자동 | `gh pr checks <N>` 모두 ✅ | ~3분 |
+| 5 | 사용자 머지 승인 후 squash merge | 사용자 | PR Merge 버튼 | - |
+| 6 | `deploy-nas.yml` 트리거 (frontend path 변경 감지) | 자동 | `gh run list --workflow=deploy-nas.yml -L 1` | - |
+| 7 | Flutter web 빌드 + NAS rsync | 자동 | run `deploy-frontend` 단계 success | ~4분 |
+| 8 | 사용자 브라우저 캐시 무효화 | **사용자** | F12 → Network 탭 → **Disable cache** 체크 → 새로고침 | 즉시 |
+| 9 | A1~A4 기능 검증 | 사용자 | 본 기획서 §사용자 검증 시나리오 A | 1분 |
+| 10 | B1~B7 회귀 검증 | 사용자 | 본 기획서 §사용자 검증 시나리오 B | 2분 |
+
+### 롤백 조건
+- A 시나리오 실패 OR B 회귀 발견 시 즉시 `git revert <sha>` → main push → deploy 자동 재실행.
+- 각 Step 은 squash merge → 단일 SHA revert 만으로 복구 가능.
+
+## 검증 계획 (자동)
+- [ ] `cd frontend && flutter analyze` — 0 error/warning
+- [ ] `cd frontend && flutter test` — 모두 pass
+- [ ] `cd frontend && flutter build web --release` — 성공
+- [ ] BE 변경 없음 — BE 테스트 skip OK
+- [ ] API 명세 변경 없음 — Spec 검증 skip OK
+- [ ] 보안: 외부 입력 없음, 인증은 기존 AuthInterceptor 유지
+
+## 기획 검증 결과
+- ✅ **성능**: 추가 API 호출 0. PaymentMethodBloc 재사용. rebuild 비용 미미.
+- ✅ **보안**: 신규 endpoint/입력 없음. 기존 인증 흐름 유지.
+- ✅ **회귀 위험**: 0. 기존 요소 이동/제거 없이 최상단 삽입만.
+- ✅ **하네스 audit**: OK (gate open)
+- ✅ **A/B 병존 원칙**: 총자산 진입점이 자산 탭 + 미니카드 **둘 다** 존재 — Step 6 이후 삭제 예정 없음.
+- ✅ **이전 실수 회피**:
+  - Phase 23 X5 실패는 "흡수(이동)" 때문이었음. 이번은 "추가만".
+  - Navigation_state 과거 교훈 체크: /assets 이동은 month 파라미터 불필요.
+
+## 사용자 승인
+- [ ] 승인 → 구현 착수
+- [ ] 수정 요청: ___
+
+## 참고
+- Phase 25 전체 계획: `docs/sessions/2026-04-23_3_plan.md`
+- 이번 PR 머지 후 Step 7(리스트/달력 toggle) 은 별 세션에서 착수.

--- a/frontend/lib/core/widgets/total_asset_mini_card.dart
+++ b/frontend/lib/core/widgets/total_asset_mini_card.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
+
+import 'package:budget_book/core/utils/currency_formatter.dart';
+import 'package:budget_book/features/payment_method/presentation/bloc/payment_method_bloc.dart';
+import 'package:budget_book/features/payment_method/presentation/bloc/payment_method_state.dart';
+
+/// Phase 25 Step 6 — 거래 탭 상단 총잔액 미니카드.
+///
+/// 데이터 출처: `asset_management_page.dart` `_AssetSummaryHeader` 와 동일 로직.
+/// - 총자산: CASH / DEBIT / BANK 의 balance 합계 (null → 0)
+/// 추가 API 호출 없이 `PaymentMethodBloc` 프리로드 상태를 재사용한다.
+/// 탭 시 `/assets` 로 이동한다 (자산 탭으로 전환).
+class TotalAssetMiniCard extends StatelessWidget {
+  const TotalAssetMiniCard({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<PaymentMethodBloc, PaymentMethodState>(
+      builder: (context, state) {
+        if (state is! PaymentMethodLoaded) {
+          return const SizedBox(height: 48);
+        }
+
+        final totalAsset = state.paymentMethods
+            .where((pm) => pm.isActive && (pm.isCash || pm.isDebit || pm.isBank))
+            .fold<int>(0, (sum, pm) => sum + (pm.balance ?? 0));
+
+        final theme = Theme.of(context);
+        final bg = Colors.green.withValues(alpha: 0.08);
+        final fg = Colors.green.shade700;
+
+        return Padding(
+          padding: const EdgeInsets.fromLTRB(12, 8, 12, 0),
+          child: Material(
+            color: bg,
+            borderRadius: BorderRadius.circular(12),
+            child: InkWell(
+              onTap: () => context.go('/assets'),
+              borderRadius: BorderRadius.circular(12),
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+                child: Row(
+                  children: [
+                    Icon(Icons.account_balance_wallet, size: 18, color: fg),
+                    const SizedBox(width: 8),
+                    Text(
+                      '총 자산',
+                      style: theme.textTheme.bodyMedium?.copyWith(
+                        color: theme.colorScheme.onSurface.withValues(alpha: 0.75),
+                      ),
+                    ),
+                    const Spacer(),
+                    Text(
+                      '${CurrencyFormatter.format(totalAsset)}원',
+                      style: theme.textTheme.titleMedium?.copyWith(
+                        color: fg,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                    const SizedBox(width: 4),
+                    Icon(
+                      Icons.chevron_right,
+                      size: 18,
+                      color: theme.colorScheme.onSurface.withValues(alpha: 0.4),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/frontend/lib/features/transaction/presentation/pages/transaction_list_page.dart
+++ b/frontend/lib/features/transaction/presentation/pages/transaction_list_page.dart
@@ -34,6 +34,7 @@ import 'package:budget_book/core/widgets/skeleton_loader.dart';
 import 'package:budget_book/core/models/unified_filter_state.dart';
 import 'package:budget_book/core/widgets/filters/unified_filter_bar.dart';
 import 'package:budget_book/core/widgets/filters/payment_method_filter.dart';
+import 'package:budget_book/core/widgets/total_asset_mini_card.dart';
 import 'package:budget_book/features/payment_method/presentation/bloc/payment_method_bloc.dart';
 import 'package:budget_book/features/payment_method/presentation/bloc/payment_method_state.dart';
 
@@ -319,6 +320,8 @@ class _TransactionListPageState extends State<TransactionListPage> {
   Widget _buildLoaded(BuildContext context, TransactionLoaded state) {
     return Column(
       children: [
+        // Phase 25 Step 6 — 총 자산 미니카드 (탭 시 /assets 이동)
+        const TotalAssetMiniCard(),
         // Month navigator — MonthCubit.state를 자동 watch (year/month 파라미터 생략)
         MonthNavigator(
           onDatePicked: (picked) {


### PR DESCRIPTION
## Summary
- 거래 탭 상단에 "총 자산" 미니카드 추가 (탭 시 `/assets` 이동)
- `core/widgets/total_asset_mini_card.dart` 신규 — 재사용 가능 위젯
- `PaymentMethodBloc` 프리로드 상태 재사용 → **추가 API 호출 0**
- 기존 요소(MonthNavigator/검색/필터/리스트) 이동·제거 없음 — Phase 25 점진 이행 원칙 준수

## 설계
- 데이터: `CASH/DEBIT/BANK` active balance 합계 (null→0). `asset_management_page._AssetSummaryHeader` 와 동일 로직.
- 최신성: PaymentMethodBloc reload 타이밍에 자연 sync (결제수단 수정/탭 진입 시).
- 회귀 위험: 0 (추가만).

## 검증
- ✅ `flutter analyze` — 0 error/warning (신규 파일 기준)
- ✅ `flutter test` — 703 passed
- ✅ `flutter build web --release` — success
- ✅ 하네스 scope audit (`ui_pattern,navigation_state`) — 이 프로젝트 과거 인시던트 0, gate OPEN

## 사용자 검증 (머지 후)
**A. 기능**
- [ ] `/transactions` 진입 시 MonthNavigator **위**에 "총 자산 ₩x,xxx,xxx" 미니카드 표시
- [ ] 미니카드 탭 → 자산 탭으로 전환, URL `/assets`
- [ ] `/assets` 의 총자산 카드 숫자와 일치
- [ ] 결제수단 잔액 수정 → 거래 탭 복귀 시 미니카드 숫자 업데이트

**B. 회귀 없음**
- [ ] MonthNavigator 월 전환 정상
- [ ] 검색바 / UnifiedFilterBar 정상
- [ ] MonthSummaryBar 위치·동작 변화 없음
- [ ] 거래 추가/수정/삭제 정상
- [ ] 탭 간 전환 (거래↔분석↔자산↔더보기) 정상
- [ ] 커플 visibility chip 정상

## 배포 후 주의
브라우저 캐시 이슈 재발 방지:
**F12 → Network → Disable cache 체크 → 새로고침** 후 확인

## 기획서
`docs/sessions/2026-04-24_1_plan.md` — 하네스 audit, 성능 설계, 사용자 검증 시나리오, 배포 절차 포함

## 참고
- Phase 25 전체 계획: `docs/sessions/2026-04-23_3_plan.md`
- 이전 Step (#147): Steps 2-5 (자산 탭 + 총자산 3카드 + 결제수단 잔액 + MonthNav/3열)
- 다음 Step 7: 거래 탭 리스트/달력 toggle (별 세션)