### PR TITLE
fix(nginx): 폰트 location URL 매칭 + MIME override — P-6 재시도

### DIFF
--- a/docs/project-audit.md
+++ b/docs/project-audit.md
@@ -103,7 +103,7 @@
 | P-3 | `backend/src/main/kotlin/com/budgetbook/report/service/ReportService.kt` | **ReportService 쿼리 중복**: 동일 월 데이터를 여러 메서드에서 반복 조회(`sumByCategoryForCouple` 중복 호출). 캐싱 또는 단일 쿼리로 통합 필요. | Medium | BE | OPEN |
 | P-4 | `frontend/lib/features/statistics/presentation/bloc/statistics_bloc.dart` | ~~StatisticsBloc 순차 API 호출~~ | Medium | FE | ✅ FIXED - `Future.wait()` 병렬 호출로 교체 |
 | P-5 | `backend/src/main/kotlin/com/budgetbook/` (22개 서비스, 83곳) | **getActiveCouple() 중복 호출**: 22개 서비스 83곳에서 동일한 커플 조회 반복. RequestScope 캐싱 도입 필요. | Medium | BE | OPEN - 규모 증가 (9→22 서비스) |
-| P-6 | `frontend/web` (NotoSansKR-VF.ttf) | **한글 폰트 로딩 9초**: `NotoSansKR-VF.ttf` 가변 폰트 2.2MB가 압축·캐시 미적용으로 초기 진입 시 9초 소요. 2026-04-25 사용자 보고. nginx vhost `gzip on` 이미 적용되었으나 `.ttf` MIME 미포함 가능성, 또는 Cache-Control 미설정. `ops/nas-nginx/aiva-bb.conf`에 font MIME gzip + long-term cache 추가 필요. 또는 `fonts.google.com` → 로컬 번들화. | High | FE/DevOps | OPEN |
+| P-6 | `frontend/web` (NotoSansKR-VF.ttf) | **한글 폰트 로딩 9초**: 실제 파일 10MB (2.2MB 아님). 1차 fix(#153) 실패 — Flutter asset URL 은 /assets/assets/fonts/ (중복 /assets/) 인데 location prefix 를 /assets/fonts/ 로 작성해 매칭 실패, .ttf 가 application/octet-stream 서빙되어 gzip 미적용. 2차 fix: 확장자 정규식 location + MIME override 로 gzip + long-term cache 적용. 이후 근본 해결책으로 woff2 subset 또는 시스템 폰트 fallback 검토 필요 (첫 방문은 gzip 적용해도 3-4MB). | High | FE/DevOps | IN PROGRESS (2차 fix) |
 
 ---
 

--- a/ops/nas-nginx/aiva-bb.conf
+++ b/ops/nas-nginx/aiva-bb.conf
@@ -127,11 +127,22 @@ server {
         try_files /index.html =404;
     }
 
-    # ── Static fonts — long-term cache (Phase 25 post-Step6, P-6) ──
-    # NotoSansKR-VF.ttf 2.2MB — 초기 로딩 9초 보고 대응.
-    # Flutter 빌드 산출물의 fonts 디렉터리는 내용 변경 시 새 빌드 산출이므로
-    # immutable 캐시 안전. 폰트 교체 필요 시 파일명 변경 또는 재배포로 해결.
-    location ^~ /assets/fonts/ {
+    # ── Static fonts — long-term cache + MIME override (P-6 재시도) ──
+    # 1차 시도(PR #153) 실패 원인:
+    #   - Flutter web asset URL 이 /assets/assets/fonts/ (중복 /assets/) 인데
+    #     location prefix 를 /assets/fonts/ 로 작성 → 매칭 실패
+    #   - nginx 가 .ttf 를 application/octet-stream 으로 서빙 → gzip_types
+    #     매칭 실패 → gzip 미적용 (10MB 원본 그대로 전송)
+    #
+    # 해결: 확장자 정규식으로 경로 독립 매칭 + MIME 강제 override 로 gzip 적용.
+    # immutable 캐시는 빌드 산출물이 변경 시 새 URL 이라 안전.
+    location ~* \.(ttf|otf|woff|woff2)$ {
+        types {
+            font/ttf ttf;
+            font/otf otf;
+            font/woff woff;
+            font/woff2 woff2;
+        }
         add_header Cache-Control "public, max-age=31536000, immutable" always;
         access_log off;
         try_files $uri =404;


### PR DESCRIPTION
## Summary
PR #153 §C 폰트 최적화 실패. 실제 curl 결과로 원인 확인 후 수정.

## 원인 (§5.4 실패 처리 §1 원인 분석)
curl 로 실측한 응답:
```
content-type: application/octet-stream
content-length: 10415244  (10MB — 추정 2.2MB 아님)
cache-control: (없음)
content-encoding: (없음, gzip 미적용)
```

두 가지 실패:
1. **location 매칭 실패**: Flutter web asset URL 은 `/assets/assets/fonts/` (중복 /assets/), 내가 `^~ /assets/fonts/` 로 썼기에 매칭 자체가 안 됨 → Cache-Control 적용 실패
2. **gzip 미적용**: .ttf 를 nginx 기본 types 가 `application/octet-stream` 으로 서빙. gzip_types 에 `font/ttf` 는 있으나 실제 MIME 가 달라 매칭 실패

## 수정
- `location ^~ /assets/fonts/` 제거
- `location ~* \.(ttf|otf|woff|woff2)$` 확장자 정규식 매칭 (경로 독립)
- 내부 `types {}` 블록으로 Content-Type 강제 override → gzip_types 매칭 → gzip 적용
- Cache-Control / immutable 적용

## 재발 방지 (§2)
- 하네스 lessons-learned 인시던트 등록 (classification: `nginx_config`)
- `audit-patterns.json` 에 `nginx_config` 태그 신규 추가 — 앞으로 nginx 변경 시 curl 응답 헤더 검증 체크리스트 포함
- `docs/project-audit.md` P-6 상태 업데이트

## 플로우 개선 (§3)
CLAUDE.md 다음 개정 시 추가 예정:
- 배포 절차에 "curl -sI -H 'Accept-Encoding: gzip' <url>" 응답 헤더 검증 단계 의무화 (nginx/정적 자원 변경 시)

## 검증 기대값 (PR merge + 배포 후)
```
content-type: font/ttf
content-encoding: gzip
cache-control: public, max-age=31536000, immutable
content-length: ~3-4MB (gzip 적용)
```

## 한계 (follow-up 예정)
원본 10MB 폰트 자체가 큼. gzip 적용해도 **첫 방문은 3-4MB** 로 여전히 체감 느림 가능.
근본 해결: Noto Sans KR woff2 subset (한글 + 기본 라틴만, ~1-2MB) 또는 시스템 폰트 fallback.
사용자 결정 필요하므로 별도 이슈로 등록.

## Refs
- Regression of #153 §C
- P-6 in docs/project-audit.md