### PR TITLE
fix(payment_method): 재정렬 중복 PUT 요청 방지 (idempotent dedup)

### DIFF
--- a/frontend/lib/features/payment_method/presentation/bloc/payment_method_bloc.dart
+++ b/frontend/lib/features/payment_method/presentation/bloc/payment_method_bloc.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart' show listEquals;
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:budget_book/features/payment_method/domain/entities/payment_method.dart';
 import 'package:budget_book/features/payment_method/domain/repositories/payment_method_repository.dart';
@@ -273,16 +274,27 @@ class PaymentMethodBloc
         ? (state as PaymentMethodLoaded).cardSettlementSummary
         : null;
 
-    // Optimistic update: reorder locally first
+    // Compute desired ordering (event ids first, then any unspecified at end).
     final reordered = <PaymentMethod>[];
     for (final id in event.orderedIds) {
       final pm = currentMethods.where((m) => m.id == id).firstOrNull;
       if (pm != null) reordered.add(pm);
     }
-    // Add any methods not in the reorder list
     for (final pm in currentMethods) {
       if (!event.orderedIds.contains(pm.id)) reordered.add(pm);
     }
+
+    // Idempotent dedup: 현재 순서와 동일하면 no-op.
+    // - Flutter ReorderableListView 가 동일 drop 에 대해 onReorder 를 두 번
+    //   fire 하는 케이스 방지 (Optimistic emit 으로 인한 rebuild 와 충돌)
+    // - 동일 페이로드 재호출 (다른 경로/refresh) 시 BE 부하 절감
+    final currentOrder = currentMethods.map((m) => m.id).toList();
+    final desiredOrder = reordered.map((m) => m.id).toList();
+    if (listEquals(currentOrder, desiredOrder)) {
+      return;
+    }
+
+    // Optimistic update
     emit(PaymentMethodLoaded(
       reordered,
       cardPendings: currentPendings,


### PR DESCRIPTION
## 사용자 보고
> https://aiva-bb.duckdns.org/api/v1/payment-methods/reorder
> {orderedIds: [...]}  ← 같은 페이로드 2번 요청됨

## 원인
PR #155 머지 후 재정렬 자체는 동작하지만 **동일 페이로드 PUT 이 2번 발사**.

추정: Flutter `ReorderableListView` 가 동일 drop event 에 대해 onReorder 를
두 번 fire 하는 케이스. Optimistic emit 으로 BlocConsumer 가 즉시 rebuild
되며 진행 중 gesture 가 새 위젯에 재처리됨.

두 요청 페이로드가 **identical** = 같은 초기 상태 기준 컴퓨트 → 두 번째는 BE 가 같은 결과를 다시 저장하는 낭비.

## 수정
`PaymentMethodBloc._onReorderPaymentMethods` 에 idempotent dedup:
- 현재 state 의 paymentMethods 순서가 desired 순서와 같으면 즉시 return (no-op)
- Optimistic emit + BE PUT 모두 skip
- 첫 호출 → state 가 desired 로 변경 → 두 번째 호출 시 currentOrder == desiredOrder → skip

이 fix 는 다음 모두 보호:
1. Flutter framework 의 onReorder 더블 fire
2. 다른 경로에서 동일 페이로드 dispatch
3. WebSocket sync 후 stale event 재발

## 검증
- ✅ flutter analyze — 0 error
- ✅ flutter test — 703 passed

## 라이브 검증 (PR merge 후)
- [ ] DevTools Network 탭에서 재정렬 시 PUT /reorder 가 **1번만** 호출
- [ ] 순서 변경 자체는 정상 (PR #155 회귀 없음)

## Refs
- 보고: 2026-04-25
- Regression after #155