### PR TITLE
fix(payment_method): Optimistic 시 displayOrder 도 갱신 — 재정렬 화면 원복 진짜 원인

### DIFF
--- a/frontend/lib/features/payment_method/domain/entities/payment_method.dart
+++ b/frontend/lib/features/payment_method/domain/entities/payment_method.dart
@@ -34,6 +34,36 @@ class PaymentMethod extends Equatable {
   bool get isCredit => type == 'CREDIT';
   bool get isBank => type == 'BANK';
 
+  PaymentMethod copyWith({
+    String? id,
+    String? name,
+    String? type,
+    int? settlementDay,
+    int? closingDay,
+    bool? isActive,
+    bool? isDefault,
+    int? displayOrder,
+    int? balance,
+    String? linkedBankId,
+    String? linkedBankName,
+    DateTime? createdAt,
+  }) {
+    return PaymentMethod(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      type: type ?? this.type,
+      settlementDay: settlementDay ?? this.settlementDay,
+      closingDay: closingDay ?? this.closingDay,
+      isActive: isActive ?? this.isActive,
+      isDefault: isDefault ?? this.isDefault,
+      displayOrder: displayOrder ?? this.displayOrder,
+      balance: balance ?? this.balance,
+      linkedBankId: linkedBankId ?? this.linkedBankId,
+      linkedBankName: linkedBankName ?? this.linkedBankName,
+      createdAt: createdAt ?? this.createdAt,
+    );
+  }
+
   @override
   List<Object?> get props => [
         id,

--- a/frontend/lib/features/payment_method/presentation/bloc/payment_method_bloc.dart
+++ b/frontend/lib/features/payment_method/presentation/bloc/payment_method_bloc.dart
@@ -275,13 +275,23 @@ class PaymentMethodBloc
         : null;
 
     // Compute desired ordering (event ids first, then any unspecified at end).
+    // CRITICAL: 각 entity 의 displayOrder 도 새 인덱스로 갱신해야 함.
+    // 이를 누락하면 builder 가 sort by displayOrder 시 원래 순서로 복귀하여
+    // "Optimistic update 가 즉시 되돌아가는" 회귀 발생 (#155~#158 의 진짜 원인).
+    final orderedPool = <String, PaymentMethod>{
+      for (final pm in currentMethods) pm.id: pm,
+    };
     final reordered = <PaymentMethod>[];
     for (final id in event.orderedIds) {
-      final pm = currentMethods.where((m) => m.id == id).firstOrNull;
-      if (pm != null) reordered.add(pm);
+      final pm = orderedPool[id];
+      if (pm != null) {
+        reordered.add(pm.copyWith(displayOrder: reordered.length));
+      }
     }
     for (final pm in currentMethods) {
-      if (!event.orderedIds.contains(pm.id)) reordered.add(pm);
+      if (!event.orderedIds.contains(pm.id)) {
+        reordered.add(pm.copyWith(displayOrder: reordered.length));
+      }
     }
 
     // Idempotent dedup: 현재 순서와 동일하면 no-op.
@@ -294,7 +304,7 @@ class PaymentMethodBloc
       return;
     }
 
-    // Optimistic update
+    // Optimistic update — reordered list + 갱신된 displayOrder
     emit(PaymentMethodLoaded(
       reordered,
       cardPendings: currentPendings,

--- a/frontend/test/features/payment_method/presentation/bloc/payment_method_bloc_test.dart
+++ b/frontend/test/features/payment_method/presentation/bloc/payment_method_bloc_test.dart
@@ -425,6 +425,11 @@ void main() {
     });
 
     group('ReorderPaymentMethods', () {
+      // Optimistic emit 시 entity 의 displayOrder 도 새 인덱스로 갱신됨.
+      // (builder 가 sort by displayOrder 하므로 갱신 누락 시 화면 원복 회귀)
+      final reorderedCredit = tCreditMethod.copyWith(displayOrder: 0);
+      final reorderedCash = tCashMethod.copyWith(displayOrder: 1);
+
       blocTest<PaymentMethodBloc, PaymentMethodState>(
         'emits [PaymentMethodLoaded] with reordered methods on success',
         build: () {
@@ -436,7 +441,7 @@ void main() {
         act: (bloc) =>
             bloc.add(const ReorderPaymentMethods(['pm-2', 'pm-1'])),
         expect: () => [
-          PaymentMethodLoaded([tCreditMethod, tCashMethod]),
+          PaymentMethodLoaded([reorderedCredit, reorderedCash]),
         ],
       );
 
@@ -452,9 +457,9 @@ void main() {
         act: (bloc) =>
             bloc.add(const ReorderPaymentMethods(['pm-2', 'pm-1'])),
         expect: () => [
-          // First: optimistic update
-          PaymentMethodLoaded([tCreditMethod, tCashMethod]),
-          // Then: rollback
+          // First: optimistic update with displayOrder updated
+          PaymentMethodLoaded([reorderedCredit, reorderedCash]),
+          // Then: rollback to original
           PaymentMethodLoaded(tMethods,
               operationError: 'Failed to reorder payment methods'),
         ],


### PR DESCRIPTION
## 사용자 보고 (4번째)
> 재정렬 하면 화면에서는 이전으로 다시 돌아갔다가 새로고침해야 반영되는 버그
> 4~5번째 동일 요청을 진행 중인데 정확한 분석도 안 되고 반복 요청 중

비판 정당함. 메타 문제 인정.

## 진짜 원인 (PR #155, #157, #158 모두 놓침)
`_PaymentMethodTab` builder 는 매 rebuild 마다:
```dart
final methods = List<PaymentMethod>.from(state.paymentMethods)
  ..sort((a, b) => a.displayOrder.compareTo(b.displayOrder));
```

`PaymentMethodBloc._onReorderPaymentMethods` 의 Optimistic emit 은 **list 순서만** 바꾸고 각 entity 의 `displayOrder` 필드는 stale 그대로 둠. 

→ emit → BlocConsumer rebuild → builder 가 다시 sort by displayOrder → **즉시 원래 순서로 복원**됨.
→ BE 는 정상 저장. 다음 `LoadPaymentMethods` 가 새 displayOrder 반환할 때(새로고침/탭전환) 비로소 화면 반영.

이전 가설(onReorder double-fire, double subtraction, dedup)은 부수적 요인. 진짜 결정타를 놓쳤음.

## 수정
1. `PaymentMethod` 엔티티에 `copyWith` 추가
2. `_onReorderPaymentMethods` 에서 reordered list 의 각 entity 에 새 `displayOrder` (0, 1, 2, ...) 를 `copyWith` 로 적용
3. 테스트 갱신: 새 동작 반영

## 재발 방지 (생략 안 함)
- 하네스 `lessons-learned.jsonl` 에 인시던트 등록 (`optimistic_state_invariant`, `sort_key_stale`, `ui_pattern`)
- `audit-patterns.json` 에 `optimistic_state_invariant` 태그 신규 등록
  - 앞으로 ReorderableListView / displayOrder / sort key 변경 시 해당 태그 audit 로 동일 실수 차단

## 메타 학습 (사용자 비판 반영)
- 라이브 검증 없이 시뮬만 보고 PR 생성 → §1.1 위반 반복
- builder 의 sort/filter 흐름을 추적 안 함 → 결정적 원인 누락
- 앞으로 Optimistic emit 수정 시 **builder 의 sort/filter 키 stale 여부 필수 점검**

## 검증
- ✅ `flutter analyze` — 0 error
- ✅ `flutter test` — 703 passed

## 라이브 검증 (PR merge 후)
- [ ] 자산 탭 결제수단 같은 type 내 순서 변경 → **즉시 새 순서로 표시 (되돌아오지 않음)**
- [ ] 새로고침 후에도 유지

## Refs
- #149, #150, #153, #155, #157, #158 fix attempts