### PR TITLE
feat: Phase 25 Step 7 거래 탭 리스트/달력 toggle + reorder 깜빡 fix

### DIFF
--- a/docs/sessions/2026-04-25_2_plan.md
+++ b/docs/sessions/2026-04-25_2_plan.md
@@ -1,0 +1,110 @@
+# Phase 25 Step 7 + Reorder 깜빡 fix
+> 날짜: 2026-04-25 | 회차: 2 | 상태: 검증완료 / auto mode (사용자 명시 요청)
+
+## 요청
+1. 결제수단 재정렬 시 UI 깜빡거림 문제 해결
+2. Phase 25 Step 7 — 거래 탭 리스트/달력 toggle 진행
+
+## A. Reorder 깜빡 원인 분석 + Fix
+### 코드 추적 결과
+- onReorder fire → `bloc.add(ReorderPaymentMethods)` → handler 가 즉시 Optimistic emit
+- BlocConsumer rebuild → 새 list 위젯 트리 즉시 그려짐
+- 동시에 Flutter ReorderableListView 자체 drop fade-in animation 진행
+- 두 효과가 같은 frame 에 겹치며 위치 점프 → "깜빡"
+
+### Fix
+**Optimistic emit 제거**. PUT 응답 후만 emit.
+- PUT latency (~100-200ms) 동안 ReorderableListView 의 native drop animation 만 노출
+- 응답 success → displayOrder 갱신된 정식 state 로 1회 emit
+- 응답 failure → emit 자체 없음 (또는 operationError emit). builder 가 옛 state 의 stale displayOrder 로 sort → 자동 원복 (의도된 fail 표시)
+
+### 트레이드오프
+- Optimistic 의 "즉시 반영" UX 약화. 단 PUT 빠르므로(~100ms) 체감 차이 미미.
+- 깜빡 제거가 더 큰 UX 이득.
+
+## B. Phase 25 Step 7 — 거래 탭 리스트/달력 toggle (M)
+### 변경 (Phase 25 plan 따름)
+- `UnifiedFilterBar` 우측 slot 에 `[리스트] [달력]` SegmentedButton 노출
+- ViewMode 는 `SharedPreferences` 에 저장 (`tx_view_mode`: `list` | `calendar`)
+- 달력 view: `table_calendar` 패키지 사용, 일별 수입/지출 마커, 일 탭 시 바텀시트 (해당 일자 거래 리스트)
+- 리스트 view = 기존 그대로 (Zero regression)
+- 홈 탭 그대로
+
+### pubspec
+- `table_calendar: ^3.1.2` 추가
+
+### 구현 구조
+- `UnifiedFilterBar` 에 `trailing` 위젯 슬롯 추가 (옵셔널, 다른 페이지 영향 없음)
+- 신규 `transaction_calendar_view.dart` — 달력 모드 위젯
+- `transaction_list_page._buildLoaded` 에서 viewMode 별 분기:
+  - `list`: 기존 `_buildGroupedList` 그대로
+  - `calendar`: 신규 `TransactionCalendarView`
+
+### 회귀 위험
+- list 모드는 기존과 100% 동일 (default)
+- 달력 모드 추가만 — 사용자가 toggle 안 누르면 기존 동작
+- UnifiedFilterBar 의 다른 호출처 (분석/자산 등) 영향 없음 (trailing 옵셔널)
+
+## 영향 범위
+| 파일 | 변경 |
+|---|---|
+| `frontend/lib/features/payment_method/presentation/bloc/payment_method_bloc.dart` | reorder Optimistic 제거 |
+| `frontend/test/features/payment_method/.../payment_method_bloc_test.dart` | 테스트 갱신 |
+| `frontend/pubspec.yaml` | `table_calendar` 추가 |
+| `frontend/lib/core/widgets/filters/unified_filter_bar.dart` | `trailing` 슬롯 추가 |
+| `frontend/lib/features/transaction/presentation/widgets/transaction_calendar_view.dart` | 신규 |
+| `frontend/lib/features/transaction/presentation/pages/transaction_list_page.dart` | viewMode toggle + 분기 |
+
+## 성능 설계
+- A: Optimistic 제거. emit 1회 감소. 추가 API 호출 없음
+- B: 달력 view 는 기존 `state.filteredTransactions` 재사용 (추가 API 없음). 일별 그룹핑은 in-memory O(N).
+- ViewMode SharedPreferences 읽기/쓰기 — 빈번하지 않음 (toggle 시 1회)
+
+## 하네스 Scope Audit
+- `pre-change-audit.sh . "ui_pattern,navigation_state,optimistic_state_invariant"` → ✅ OK
+- 신규 등록한 `optimistic_state_invariant` 인시던트 검출됨 → Optimistic emit 제거로 회피
+
+## 배포 절차
+| # | 단계 | 주체 | 확인 |
+|---|---|---|---|
+| 1 | PR 생성 | AI | gh pr create |
+| 2 | CI | 자동 | gh pr checks |
+| 3 | squash merge | AI | gh pr merge --squash |
+| 4 | deploy-nas watch | AI | gh run list --workflow=deploy-nas.yml |
+| 5 | playwright 라이브 검증 | **AI** (이번엔 의무) | 실제 브라우저 자동화 |
+| 6 | F12 cache disable + 사용자 검증 | 사용자 | 깜빡 + toggle 동작 확인 |
+
+## 사용자 검증 시나리오
+
+### A. 깜빡 제거
+- [ ] **A1** 자산 탭 → 결제수단 → 같은 type 내 reorder → **깜빡 없이 부드럽게 위치 변경**
+- [ ] **A2** 새로고침 후 변경된 순서 유지
+
+### B. 거래 탭 리스트/달력 toggle
+- [ ] **B1** 거래 탭 진입 → UnifiedFilterBar 우측에 `[리스트] [달력]` toggle 표시
+- [ ] **B2** 기본값 = 리스트 (기존 동작)
+- [ ] **B3** "달력" 클릭 → table_calendar 표시, 일별 수입/지출 마커
+- [ ] **B4** 달력의 임의 일자 탭 → 바텀시트로 해당 일 거래 리스트
+- [ ] **B5** "리스트" 클릭 → 기존 리스트 뷰
+- [ ] **B6** 새로고침 / 탭 전환 후에도 마지막 viewMode 유지 (SharedPreferences)
+- [ ] **B7** 회귀: 검색 / 필터 / MonthNavigator / FAB 정상
+
+### C. 회귀
+- [ ] 다른 탭 (자산/분석/더보기) 정상
+- [ ] 잔액 수정 토글 정상
+- [ ] 폰트 1.2MB 정상
+
+## playwright 라이브 검증 의무화 (메타)
+이전 PR #155, #157, #158 에서 시뮬만 하고 라이브 미검증 → 같은 영역 4회 회귀.
+이번엔 PR merge + 배포 후 **playwright MCP 로 실제 브라우저 자동화 검증**:
+- aiva-bb.duckdns.org 접속 (테스트 계정 로그인 필요 시 사용자에게 한 번 요청)
+- 자산 탭 진입 → reorder 확인
+- 거래 탭 진입 → toggle 동작 확인
+- 결과를 PR 로 보고
+
+## 실패 시 처리 (§5.4)
+모든 fail → 즉시 §5.4 절차 (원인 분석 + 재발 방지 장치 + 플로우 개선) 후 follow-up PR
+
+## 롤백 정보
+- A: bloc 변경 1개 → revert 단순
+- B: 추가만 (기존 list view 유지) → 잘못되면 toggle 만 숨기고 default list 로

--- a/frontend/lib/core/widgets/filters/unified_filter_bar.dart
+++ b/frontend/lib/core/widgets/filters/unified_filter_bar.dart
@@ -27,12 +27,18 @@ class UnifiedFilterBar extends StatelessWidget {
   /// Optional: category type for category filter ('EXPENSE', 'INCOME')
   final String categoryType;
 
+  /// 필터 행 우측에 추가로 노출할 위젯 (옵션). Phase 25 Step 7 — 거래 탭에서
+  /// 리스트/달력 toggle 을 같은 행에 배치하기 위해 도입. 다른 페이지에서는
+  /// 미전달 시 영향 없음.
+  final Widget? trailing;
+
   const UnifiedFilterBar({
     super.key,
     required this.enabledFilters,
     required this.state,
     required this.onFilterChanged,
     this.categoryType = 'EXPENSE',
+    this.trailing,
   });
 
   int get _activeFilterCount {
@@ -121,7 +127,17 @@ class UnifiedFilterBar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    if (!_hasAdvancedFilters) return const SizedBox.shrink();
+    if (!_hasAdvancedFilters) {
+      // trailing 만 있는 경우(필터 disabled) 도 trailing 은 노출.
+      if (trailing == null) return const SizedBox.shrink();
+      return Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.end,
+          children: [trailing!],
+        ),
+      );
+    }
 
     final chips = _allChips;
     const maxVisible = 3;
@@ -160,6 +176,10 @@ class UnifiedFilterBar extends StatelessWidget {
                 padding: EdgeInsets.zero,
               ),
             ),
+          if (trailing != null) ...[
+            const Spacer(),
+            trailing!,
+          ],
         ],
       ),
     );

--- a/frontend/lib/features/payment_method/presentation/bloc/payment_method_bloc.dart
+++ b/frontend/lib/features/payment_method/presentation/bloc/payment_method_bloc.dart
@@ -295,8 +295,6 @@ class PaymentMethodBloc
     }
 
     // Idempotent dedup: 현재 순서와 동일하면 no-op.
-    // - Flutter ReorderableListView 가 동일 drop 에 대해 onReorder 를 두 번
-    //   fire 하는 케이스 방지 (Optimistic emit 으로 인한 rebuild 와 충돌)
     // - 동일 페이로드 재호출 (다른 경로/refresh) 시 BE 부하 절감
     final currentOrder = currentMethods.map((m) => m.id).toList();
     final desiredOrder = reordered.map((m) => m.id).toList();
@@ -304,19 +302,19 @@ class PaymentMethodBloc
       return;
     }
 
-    // Optimistic update — reordered list + 갱신된 displayOrder
-    emit(PaymentMethodLoaded(
-      reordered,
-      cardPendings: currentPendings,
-      cardSettlementSummary: currentSummary,
-    ));
-
+    // Non-optimistic: PUT 응답 후만 emit.
+    // - Optimistic emit 시 BlocConsumer rebuild 가 ReorderableListView 의
+    //   native drop animation 과 같은 frame 에 겹쳐 깜빡 발생.
+    // - PUT latency 동안에는 ReorderableListView 자체 drop animation 으로 위치 표시.
+    // - 응답 success → reordered (displayOrder 갱신) emit 1회.
+    // - 응답 failure → emit 안 함. builder 가 stale displayOrder 로 sort 하여
+    //   자동 원복 (의도된 fail 표시).
     try {
       final result =
           await paymentMethodRepository.reorderPaymentMethods(event.orderedIds);
       result.fold(
         (failure) {
-          // Rollback on failure
+          // 실패 알림만 표시. paymentMethods 는 currentMethods 그대로 (자동 원복).
           emit(PaymentMethodLoaded(
             currentMethods,
             cardPendings: currentPendings,
@@ -325,11 +323,15 @@ class PaymentMethodBloc
           ));
         },
         (_) {
-          // Already showing reordered state
+          // Success — reordered (displayOrder 갱신) state 로 1회 emit
+          emit(PaymentMethodLoaded(
+            reordered,
+            cardPendings: currentPendings,
+            cardSettlementSummary: currentSummary,
+          ));
         },
       );
     } catch (_) {
-      // Rollback on unexpected error
       emit(PaymentMethodLoaded(
         currentMethods,
         cardPendings: currentPendings,

--- a/frontend/lib/features/transaction/presentation/pages/transaction_list_page.dart
+++ b/frontend/lib/features/transaction/presentation/pages/transaction_list_page.dart
@@ -34,6 +34,8 @@ import 'package:budget_book/core/widgets/skeleton_loader.dart';
 import 'package:budget_book/core/models/unified_filter_state.dart';
 import 'package:budget_book/core/widgets/filters/unified_filter_bar.dart';
 import 'package:budget_book/core/widgets/filters/payment_method_filter.dart';
+import 'package:budget_book/features/transaction/presentation/widgets/transaction_calendar_view.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:budget_book/features/payment_method/presentation/bloc/payment_method_bloc.dart';
 import 'package:budget_book/features/payment_method/presentation/bloc/payment_method_state.dart';
 
@@ -55,6 +57,11 @@ class TransactionListPage extends StatefulWidget {
   State<TransactionListPage> createState() => _TransactionListPageState();
 }
 
+/// Phase 25 Step 7 — 거래 탭 view mode (리스트 / 달력).
+enum _TxViewMode { list, calendar }
+
+const String _kTxViewModePrefKey = 'tx_view_mode';
+
 class _TransactionListPageState extends State<TransactionListPage> {
   final TextEditingController _searchController = TextEditingController();
   final ScrollController _scrollController = ScrollController();
@@ -63,6 +70,7 @@ class _TransactionListPageState extends State<TransactionListPage> {
   Timer? _debounceTimer;
   bool _isSearching = false;
   String? _pendingScrollToDate;
+  _TxViewMode _viewMode = _TxViewMode.list;
 
   // Unified filter state
   late UnifiedFilterState _filterState = UnifiedFilterState(
@@ -90,6 +98,22 @@ class _TransactionListPageState extends State<TransactionListPage> {
         });
       }
     }
+    _loadViewMode();
+  }
+
+  Future<void> _loadViewMode() async {
+    final prefs = await SharedPreferences.getInstance();
+    final saved = prefs.getString(_kTxViewModePrefKey);
+    if (!mounted) return;
+    if (saved == 'calendar') {
+      setState(() => _viewMode = _TxViewMode.calendar);
+    }
+  }
+
+  Future<void> _saveViewMode(_TxViewMode mode) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_kTxViewModePrefKey,
+        mode == _TxViewMode.calendar ? 'calendar' : 'list');
   }
 
   @override
@@ -392,6 +416,7 @@ class _TransactionListPageState extends State<TransactionListPage> {
           ),
         ),
         // Unified filter bar (category, payment, pocket, amount, date range)
+        // Phase 25 Step 7 — 우측 trailing 에 [리스트][달력] toggle.
         UnifiedFilterBar(
           enabledFilters: const {
             FilterType.dateRange,
@@ -404,6 +429,13 @@ class _TransactionListPageState extends State<TransactionListPage> {
           },
           state: _filterState,
           onFilterChanged: _onFilterChanged,
+          trailing: _ViewModeToggle(
+            mode: _viewMode,
+            onChanged: (m) {
+              setState(() => _viewMode = m);
+              _saveViewMode(m);
+            },
+          ),
         ),
         // Summary bar + Transaction list (both need transfers)
         Expanded(
@@ -484,7 +516,20 @@ class _TransactionListPageState extends State<TransactionListPage> {
                     balance: displayIncome - displayExpense,
                     totalTransfer: displayTransfer > 0 ? displayTransfer : null,
                   ),
-                  if (state.filteredTransactions.isEmpty && listTransfers.isEmpty)
+                  if (_viewMode == _TxViewMode.calendar)
+                    Expanded(
+                      child: TransactionCalendarView(
+                        year: state.year,
+                        month: state.month,
+                        transactions: state.filteredTransactions,
+                        transfers: searchedTransfers,
+                        onTransactionTap: (tx) =>
+                            context.push('/transactions/${tx.id}'),
+                        onTransferTap: (tr) =>
+                            context.push('/transfers/${tr.id}'),
+                      ),
+                    )
+                  else if (state.filteredTransactions.isEmpty && listTransfers.isEmpty)
                     Expanded(child: _buildEmpty(context))
                   else
                     Expanded(child: _buildGroupedList(context, state, listTransfers)),
@@ -916,3 +961,41 @@ class _DateHeader extends StatelessWidget {
   }
 }
 
+
+/// Phase 25 Step 7 — 리스트/달력 toggle.
+class _ViewModeToggle extends StatelessWidget {
+  final _TxViewMode mode;
+  final ValueChanged<_TxViewMode> onChanged;
+
+  const _ViewModeToggle({required this.mode, required this.onChanged});
+
+  @override
+  Widget build(BuildContext context) {
+    return SegmentedButton<_TxViewMode>(
+      style: const ButtonStyle(
+        visualDensity: VisualDensity.compact,
+        tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+        padding: WidgetStatePropertyAll(
+          EdgeInsets.symmetric(horizontal: 6, vertical: 0),
+        ),
+      ),
+      segments: const [
+        ButtonSegment(
+          value: _TxViewMode.list,
+          icon: Icon(Icons.list, size: 16),
+          tooltip: '리스트',
+        ),
+        ButtonSegment(
+          value: _TxViewMode.calendar,
+          icon: Icon(Icons.calendar_month, size: 16),
+          tooltip: '달력',
+        ),
+      ],
+      selected: {mode},
+      onSelectionChanged: (s) {
+        if (s.isNotEmpty) onChanged(s.first);
+      },
+      showSelectedIcon: false,
+    );
+  }
+}

--- a/frontend/lib/features/transaction/presentation/widgets/transaction_calendar_view.dart
+++ b/frontend/lib/features/transaction/presentation/widgets/transaction_calendar_view.dart
@@ -1,0 +1,289 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:table_calendar/table_calendar.dart';
+
+import 'package:budget_book/core/utils/currency_formatter.dart';
+import 'package:budget_book/features/transaction/domain/entities/transaction.dart';
+import 'package:budget_book/features/transaction/presentation/widgets/transaction_list_tile.dart';
+import 'package:budget_book/features/transaction/presentation/widgets/transfer_list_tile.dart';
+import 'package:budget_book/features/transfer/domain/entities/transfer.dart';
+
+/// Phase 25 Step 7 — 거래 탭 달력 뷰.
+///
+/// 일별 수입/지출 마커 표시. 일자 탭 시 바텀시트로 해당 일자의
+/// 거래/이체 목록을 노출.
+class TransactionCalendarView extends StatefulWidget {
+  final int year;
+  final int month;
+  final List<Transaction> transactions;
+  final List<Transfer> transfers;
+  final void Function(Transaction)? onTransactionTap;
+  final void Function(Transfer)? onTransferTap;
+
+  const TransactionCalendarView({
+    super.key,
+    required this.year,
+    required this.month,
+    required this.transactions,
+    required this.transfers,
+    this.onTransactionTap,
+    this.onTransferTap,
+  });
+
+  @override
+  State<TransactionCalendarView> createState() =>
+      _TransactionCalendarViewState();
+}
+
+class _TransactionCalendarViewState extends State<TransactionCalendarView> {
+  late DateTime _focusedDay = DateTime(widget.year, widget.month, 1);
+
+  /// 일자별 거래 그룹핑 (transactionDate 기준, "yyyy-MM-dd" 형식).
+  Map<DateTime, _DaySummary> _groupByDay() {
+    final map = <DateTime, _DaySummary>{};
+    for (final tx in widget.transactions) {
+      final key = _parseDateKey(tx.transactionDate);
+      final entry = map.putIfAbsent(key, () => _DaySummary());
+      if (tx.type == 'INCOME') {
+        entry.income += tx.amount;
+      } else if (tx.type == 'EXPENSE') {
+        entry.expense += tx.amount;
+      }
+      entry.transactions.add(tx);
+    }
+    for (final tr in widget.transfers) {
+      final key = _parseDateKey(tr.transferDate);
+      final entry = map.putIfAbsent(key, () => _DaySummary());
+      entry.transfers.add(tr);
+    }
+    return map;
+  }
+
+  static DateTime _parseDateKey(String yyyymmdd) {
+    final parts = yyyymmdd.split('-');
+    return DateTime(
+      int.parse(parts[0]),
+      int.parse(parts[1]),
+      int.parse(parts[2]),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final byDay = _groupByDay();
+    final firstOfMonth = DateTime(widget.year, widget.month, 1);
+    final lastOfMonth = DateTime(widget.year, widget.month + 1, 0);
+
+    return SingleChildScrollView(
+      child: Column(
+        children: [
+          TableCalendar<_DaySummary>(
+            firstDay: firstOfMonth.subtract(const Duration(days: 365)),
+            lastDay: lastOfMonth.add(const Duration(days: 365)),
+            focusedDay: _focusedDay,
+            currentDay: DateTime.now(),
+            availableCalendarFormats: const {CalendarFormat.month: 'Month'},
+            headerVisible: false,
+            startingDayOfWeek: StartingDayOfWeek.sunday,
+            daysOfWeekHeight: 24,
+            rowHeight: 64,
+            calendarStyle: CalendarStyle(
+              outsideDaysVisible: true,
+              cellMargin: const EdgeInsets.all(2),
+              todayDecoration: BoxDecoration(
+                color: theme.colorScheme.primary.withValues(alpha: 0.15),
+                shape: BoxShape.circle,
+              ),
+              todayTextStyle: TextStyle(
+                color: theme.colorScheme.primary,
+                fontWeight: FontWeight.w600,
+              ),
+              defaultTextStyle: const TextStyle(fontSize: 13),
+              weekendTextStyle: TextStyle(
+                fontSize: 13,
+                color: Colors.red.shade600,
+              ),
+              outsideTextStyle: TextStyle(
+                fontSize: 13,
+                color: theme.colorScheme.onSurface.withValues(alpha: 0.3),
+              ),
+            ),
+            eventLoader: (day) {
+              final key = DateTime(day.year, day.month, day.day);
+              final summary = byDay[key];
+              return summary == null ? const [] : [summary];
+            },
+            calendarBuilders: CalendarBuilders<_DaySummary>(
+              markerBuilder: (context, day, events) {
+                if (events.isEmpty) return const SizedBox.shrink();
+                final summary = events.first;
+                return Padding(
+                  padding: const EdgeInsets.only(top: 28),
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.center,
+                    children: [
+                      if (summary.income > 0)
+                        Text(
+                          '+${CurrencyFormatter.toKoreanUnit(summary.income)}',
+                          style: TextStyle(
+                            fontSize: 9,
+                            color: Colors.blue.shade700,
+                            fontWeight: FontWeight.w600,
+                          ),
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      if (summary.expense > 0)
+                        Text(
+                          '-${CurrencyFormatter.toKoreanUnit(summary.expense)}',
+                          style: TextStyle(
+                            fontSize: 9,
+                            color: Colors.red.shade700,
+                            fontWeight: FontWeight.w600,
+                          ),
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                    ],
+                  ),
+                );
+              },
+            ),
+            onDaySelected: (selected, focused) {
+              setState(() => _focusedDay = focused);
+              final key = DateTime(selected.year, selected.month, selected.day);
+              final summary = byDay[key];
+              _showDayBottomSheet(context, selected, summary);
+            },
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _showDayBottomSheet(
+    BuildContext context,
+    DateTime day,
+    _DaySummary? summary,
+  ) {
+    final theme = Theme.of(context);
+    final dateLabel = DateFormat('M월 d일 (E)', 'ko_KR').format(day);
+    final hasItems = summary != null &&
+        (summary.transactions.isNotEmpty || summary.transfers.isNotEmpty);
+
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+      ),
+      builder: (ctx) {
+        return DraggableScrollableSheet(
+          initialChildSize: 0.5,
+          minChildSize: 0.3,
+          maxChildSize: 0.9,
+          expand: false,
+          builder: (_, scrollController) {
+            return Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                const SizedBox(height: 8),
+                Center(
+                  child: Container(
+                    width: 36,
+                    height: 4,
+                    decoration: BoxDecoration(
+                      color:
+                          theme.colorScheme.onSurface.withValues(alpha: 0.2),
+                      borderRadius: BorderRadius.circular(2),
+                    ),
+                  ),
+                ),
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(16, 12, 16, 8),
+                  child: Row(
+                    children: [
+                      Text(
+                        dateLabel,
+                        style: theme.textTheme.titleMedium?.copyWith(
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                      const Spacer(),
+                      if (summary != null && summary.income > 0)
+                        Padding(
+                          padding: const EdgeInsets.only(right: 8),
+                          child: Text(
+                            '+${CurrencyFormatter.format(summary.income)}',
+                            style: TextStyle(
+                              color: Colors.blue.shade700,
+                              fontWeight: FontWeight.w600,
+                            ),
+                          ),
+                        ),
+                      if (summary != null && summary.expense > 0)
+                        Text(
+                          '-${CurrencyFormatter.format(summary.expense)}',
+                          style: TextStyle(
+                            color: Colors.red.shade700,
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                    ],
+                  ),
+                ),
+                const Divider(height: 1),
+                Expanded(
+                  child: !hasItems
+                      ? Center(
+                          child: Text(
+                            '거래 없음',
+                            style: TextStyle(
+                              color: theme.colorScheme.onSurface
+                                  .withValues(alpha: 0.5),
+                            ),
+                          ),
+                        )
+                      : ListView(
+                          controller: scrollController,
+                          padding: const EdgeInsets.only(bottom: 16),
+                          children: [
+                            ...summary.transactions.map((tx) =>
+                                TransactionListTile(
+                                  transaction: tx,
+                                  onTap: widget.onTransactionTap == null
+                                      ? null
+                                      : () {
+                                          Navigator.of(ctx).pop();
+                                          widget.onTransactionTap!(tx);
+                                        },
+                                )),
+                            ...summary.transfers.map((tr) => TransferListTile(
+                                  transfer: tr,
+                                  onTap: widget.onTransferTap == null
+                                      ? null
+                                      : () {
+                                          Navigator.of(ctx).pop();
+                                          widget.onTransferTap!(tr);
+                                        },
+                                )),
+                          ],
+                        ),
+                ),
+              ],
+            );
+          },
+        );
+      },
+    );
+  }
+}
+
+class _DaySummary {
+  int income = 0;
+  int expense = 0;
+  final List<Transaction> transactions = [];
+  final List<Transfer> transfers = [];
+}

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -36,6 +36,9 @@ dependencies:
   # Charts
   fl_chart: ^0.69.0
 
+  # Calendar (Phase 25 Step 7 — 거래 탭 달력 뷰)
+  table_calendar: ^3.1.2
+
   # UI
   shimmer: ^3.0.0
   cached_network_image: ^3.4.1

--- a/frontend/test/features/payment_method/presentation/bloc/payment_method_bloc_test.dart
+++ b/frontend/test/features/payment_method/presentation/bloc/payment_method_bloc_test.dart
@@ -425,8 +425,8 @@ void main() {
     });
 
     group('ReorderPaymentMethods', () {
-      // Optimistic emit 시 entity 의 displayOrder 도 새 인덱스로 갱신됨.
-      // (builder 가 sort by displayOrder 하므로 갱신 누락 시 화면 원복 회귀)
+      // Non-optimistic: PUT 응답 후 emit (성공/실패 모두 1회만).
+      // displayOrder 는 새 인덱스(0, 1, ...) 로 갱신.
       final reorderedCredit = tCreditMethod.copyWith(displayOrder: 0);
       final reorderedCash = tCashMethod.copyWith(displayOrder: 1);
 
@@ -446,7 +446,7 @@ void main() {
       );
 
       blocTest<PaymentMethodBloc, PaymentMethodState>(
-        'rolls back on failure',
+        'emits operationError without optimistic update on failure',
         build: () {
           when(mockRepository.reorderPaymentMethods(['pm-2', 'pm-1']))
               .thenAnswer((_) async => const Left(
@@ -457,9 +457,7 @@ void main() {
         act: (bloc) =>
             bloc.add(const ReorderPaymentMethods(['pm-2', 'pm-1'])),
         expect: () => [
-          // First: optimistic update with displayOrder updated
-          PaymentMethodLoaded([reorderedCredit, reorderedCash]),
-          // Then: rollback to original
+          // 실패 시 paymentMethods 는 원본 그대로 + operationError 만 추가.
           PaymentMethodLoaded(tMethods,
               operationError: 'Failed to reorder payment methods'),
         ],


### PR DESCRIPTION
## A. Reorder 깜빡 fix
### 원인
- onReorder fire → bloc.add → 즉시 Optimistic emit
- BlocConsumer rebuild → 새 list 위젯 트리 즉시 그려짐
- 동시에 Flutter ReorderableListView 자체 drop fade-in animation 진행
- 같은 frame 에 겹치며 위치 점프 → 깜빡

### 수정
PaymentMethodBloc 의 Optimistic emit 제거. PUT 응답 후만 emit.
- 성공: reordered (displayOrder 갱신) emit 1회
- 실패: operationError emit, paymentMethods 는 currentMethods 그대로 → builder 가 stale displayOrder 로 sort 하여 자동 원복
- PUT latency (~100-200ms) 동안 ReorderableListView native drop animation 만 노출

## B. Phase 25 Step 7 — 거래 탭 리스트/달력 toggle (M)
### 변경
- `pubspec.yaml`: `table_calendar: ^3.1.2` 추가
- `UnifiedFilterBar` 에 `trailing` 위젯 슬롯 추가 (옵셔널, 다른 페이지 영향 없음)
- `transaction_list_page`:
  - `_TxViewMode` enum (list/calendar) + SharedPreferences 영속 (`tx_view_mode`)
  - filter bar 우측에 `[리스트][달력]` SegmentedButton
  - viewMode 별 분기: `list` = 기존 그대로 / `calendar` = `TransactionCalendarView`
- `transaction_calendar_view.dart` 신규
  - `table_calendar` 일별 마커 (수입/지출 한국어 단위 변환 — 만/억)
  - 일자 탭 시 DraggableScrollableSheet 바텀시트
  - 거래/이체 리스트 + tap → 상세 페이지

### Zero regression
- list 모드 = 기존 100% 동일 (default)
- 사용자가 toggle 안 누르면 변경 없음
- UnifiedFilterBar trailing 옵셔널 — 다른 호출처(분석/자산/...) 영향 없음

## 검증
- ✅ flutter analyze — 0 error (신규)
- ✅ flutter test — 703 passed (reorder 테스트 갱신)
- ✅ flutter build web --release — success
- ✅ 하네스 audit (ui_pattern, navigation_state, optimistic_state_invariant) — OK

## 라이브 검증 (PR merge 후)
### A. 깜빡 제거
- [ ] 자산 탭 → 결제수단 → 같은 type 내 reorder → 깜빡 없이 부드러운 위치 변경
- [ ] 새로고침 후 변경된 순서 유지

### B. 리스트/달력 toggle
- [ ] 거래 탭 진입 → filter bar 우측 `[리스트][달력]` 표시
- [ ] 기본값 = 리스트 (기존 동작)
- [ ] 달력 → 일별 수입/지출 마커, 일자 탭 시 바텀시트 (해당 일 거래 리스트)
- [ ] 리스트 ↔ 달력 toggle 시 SharedPreferences 저장, 새로고침 후 마지막 모드 유지
- [ ] 검색 / 필터 / FAB / MonthNavigator 정상

## 기획서
docs/sessions/2026-04-25_2_plan.md