### PR TITLE
fix: reorder 즉시 반영(Optimistic+백그라운드) + 달력 금액 단순 표기

### DIFF
--- a/frontend/lib/features/payment_method/presentation/bloc/payment_method_bloc.dart
+++ b/frontend/lib/features/payment_method/presentation/bloc/payment_method_bloc.dart
@@ -295,26 +295,30 @@ class PaymentMethodBloc
     }
 
     // Idempotent dedup: 현재 순서와 동일하면 no-op.
-    // - 동일 페이로드 재호출 (다른 경로/refresh) 시 BE 부하 절감
     final currentOrder = currentMethods.map((m) => m.id).toList();
     final desiredOrder = reordered.map((m) => m.id).toList();
     if (listEquals(currentOrder, desiredOrder)) {
       return;
     }
 
-    // Non-optimistic: PUT 응답 후만 emit.
-    // - Optimistic emit 시 BlocConsumer rebuild 가 ReorderableListView 의
-    //   native drop animation 과 같은 frame 에 겹쳐 깜빡 발생.
-    // - PUT latency 동안에는 ReorderableListView 자체 drop animation 으로 위치 표시.
-    // - 응답 success → reordered (displayOrder 갱신) emit 1회.
-    // - 응답 failure → emit 안 함. builder 가 stale displayOrder 로 sort 하여
-    //   자동 원복 (의도된 fail 표시).
+    // Optimistic emit + 백그라운드 PUT.
+    // - drop animation 종료 시점(~280ms) 후 emit 하여 ReorderableListView 의
+    //   native fade animation 과 frame 충돌(깜빡) 회피.
+    // - state 의 displayOrder 도 새 인덱스로 갱신되므로 builder sort 결과 일관.
+    // - PUT 은 emit 직후 백그라운드 진행. 실패 시 rollback + operationError.
+    await Future<void>.delayed(const Duration(milliseconds: 280));
+    emit(PaymentMethodLoaded(
+      reordered,
+      cardPendings: currentPendings,
+      cardSettlementSummary: currentSummary,
+    ));
+
     try {
       final result =
           await paymentMethodRepository.reorderPaymentMethods(event.orderedIds);
       result.fold(
         (failure) {
-          // 실패 알림만 표시. paymentMethods 는 currentMethods 그대로 (자동 원복).
+          // Rollback to original order + 알림
           emit(PaymentMethodLoaded(
             currentMethods,
             cardPendings: currentPendings,
@@ -323,12 +327,7 @@ class PaymentMethodBloc
           ));
         },
         (_) {
-          // Success — reordered (displayOrder 갱신) state 로 1회 emit
-          emit(PaymentMethodLoaded(
-            reordered,
-            cardPendings: currentPendings,
-            cardSettlementSummary: currentSummary,
-          ));
+          // Success — already showing reordered state (Optimistic 유지)
         },
       );
     } catch (_) {

--- a/frontend/lib/features/transaction/presentation/widgets/transaction_calendar_view.dart
+++ b/frontend/lib/features/transaction/presentation/widgets/transaction_calendar_view.dart
@@ -126,7 +126,7 @@ class _TransactionCalendarViewState extends State<TransactionCalendarView> {
                     children: [
                       if (summary.income > 0)
                         Text(
-                          '+${CurrencyFormatter.toKoreanUnit(summary.income)}',
+                          '+${CurrencyFormatter.format(summary.income)}',
                           style: TextStyle(
                             fontSize: 9,
                             color: Colors.blue.shade700,
@@ -137,7 +137,7 @@ class _TransactionCalendarViewState extends State<TransactionCalendarView> {
                         ),
                       if (summary.expense > 0)
                         Text(
-                          '-${CurrencyFormatter.toKoreanUnit(summary.expense)}',
+                          '-${CurrencyFormatter.format(summary.expense)}',
                           style: TextStyle(
                             fontSize: 9,
                             color: Colors.red.shade700,

--- a/frontend/test/features/payment_method/presentation/bloc/payment_method_bloc_test.dart
+++ b/frontend/test/features/payment_method/presentation/bloc/payment_method_bloc_test.dart
@@ -425,7 +425,8 @@ void main() {
     });
 
     group('ReorderPaymentMethods', () {
-      // Non-optimistic: PUT 응답 후 emit (성공/실패 모두 1회만).
+      // Optimistic + 백그라운드 PUT: drop animation 종료 후 emit 1회 (Optimistic),
+      // 그 후 PUT 응답이 실패하면 rollback emit 추가.
       // displayOrder 는 새 인덱스(0, 1, ...) 로 갱신.
       final reorderedCredit = tCreditMethod.copyWith(displayOrder: 0);
       final reorderedCash = tCashMethod.copyWith(displayOrder: 1);
@@ -441,12 +442,15 @@ void main() {
         act: (bloc) =>
             bloc.add(const ReorderPaymentMethods(['pm-2', 'pm-1'])),
         expect: () => [
+          // Optimistic emit (drop animation settle delay 후)
           PaymentMethodLoaded([reorderedCredit, reorderedCash]),
         ],
+        // Optimistic emit 전 280ms drop animation settle delay 고려
+        wait: const Duration(milliseconds: 400),
       );
 
       blocTest<PaymentMethodBloc, PaymentMethodState>(
-        'emits operationError without optimistic update on failure',
+        'rolls back on failure',
         build: () {
           when(mockRepository.reorderPaymentMethods(['pm-2', 'pm-1']))
               .thenAnswer((_) async => const Left(
@@ -457,10 +461,13 @@ void main() {
         act: (bloc) =>
             bloc.add(const ReorderPaymentMethods(['pm-2', 'pm-1'])),
         expect: () => [
-          // 실패 시 paymentMethods 는 원본 그대로 + operationError 만 추가.
+          // First: Optimistic emit (drop animation settle 후)
+          PaymentMethodLoaded([reorderedCredit, reorderedCash]),
+          // Then: PUT 실패 → rollback to original + operationError
           PaymentMethodLoaded(tMethods,
               operationError: 'Failed to reorder payment methods'),
         ],
+        wait: const Duration(milliseconds: 400),
       );
     });
 


### PR DESCRIPTION
## A. Reorder 즉시 반영 (사용자 보고: 반영 느림)
### 원인
PR #160 의 PUT-응답-후 emit 패턴은 깜빡 제거에는 성공했으나 PUT latency(~100-200ms) 동안 state 변경 없음. 다른 rebuild trigger 시 builder 가 stale displayOrder 로 sort → 잠깐 원위치 보임 → "느림".

### 수정 (사용자 제안 패턴)
bloc handler 가 **drop animation settle delay (280ms) 후 Optimistic emit** + **백그라운드 PUT**:
- 사용자 눈엔 즉시 반영 (드롭 후 native fade 종료 시점에 state 업데이트)
- ReorderableListView native fade animation 과 frame 충돌 회피
- PUT 응답:
  - 성공 → 이미 showing reordered (Optimistic 유지, 추가 emit 없음)
  - 실패 → rollback to original + operationError snackbar
- 데이터 정합성: 사용자 PUT 1회 실패 시 즉시 rollback. (offline retry queue 는 과한 설계)

## B. 달력 금액 표기 단순화 (사용자 제안)
"10만 1,760원" 한글 단위 변환 → "101,760" 천단위 콤마만.
- 달력 마커는 일별 금액 빠른 비교가 목적 → 단위 변환은 인지 부하만 증가
- `TransactionCalendarView` markerBuilder: `toKoreanUnit` → `format`

## 검증
- ✅ flutter analyze — 0 error
- ✅ flutter test — 703 passed (reorder 테스트 wait 보정)

## 라이브 검증 (PR merge 후)
- [ ] 자산 탭 reorder → 깜빡 없이 **즉시 새 순서 유지** (PUT latency 동안 원복 없음)
- [ ] 달력 마커 금액이 "+101,760" / "-50,000" 형식
- [ ] 회귀 없음

## Refs
- PR #160 (깜빡 fix, 반영 느림 회귀)
- 사용자 보고: 2026-04-25