### PR TITLE
feat: reorder 로컬 state 즉시 반영 + Phase 25 Step 8 거래 탭 요약 영역

### DIFF
--- a/frontend/lib/features/payment_method/presentation/bloc/payment_method_bloc.dart
+++ b/frontend/lib/features/payment_method/presentation/bloc/payment_method_bloc.dart
@@ -301,24 +301,16 @@ class PaymentMethodBloc
       return;
     }
 
-    // Optimistic emit + 백그라운드 PUT.
-    // - drop animation 종료 시점(~280ms) 후 emit 하여 ReorderableListView 의
-    //   native fade animation 과 frame 충돌(깜빡) 회피.
-    // - state 의 displayOrder 도 새 인덱스로 갱신되므로 builder sort 결과 일관.
-    // - PUT 은 emit 직후 백그라운드 진행. 실패 시 rollback + operationError.
-    await Future<void>.delayed(const Duration(milliseconds: 280));
-    emit(PaymentMethodLoaded(
-      reordered,
-      cardPendings: currentPendings,
-      cardSettlementSummary: currentSummary,
-    ));
-
+    // 즉시 백그라운드 PUT.
+    // - UI 즉시 반영은 _PaymentMethodTab 의 로컬 _localMethods 가 담당
+    //   (BlocConsumer rebuild 우회로 ReorderableListView native animation 보존).
+    // - 성공: reordered state 로 emit. listener 가 _localMethods 와 동기화 (변경 없음).
+    // - 실패: currentMethods + operationError emit. UI 가 원위치로 sync.
     try {
       final result =
           await paymentMethodRepository.reorderPaymentMethods(event.orderedIds);
       result.fold(
         (failure) {
-          // Rollback to original order + 알림
           emit(PaymentMethodLoaded(
             currentMethods,
             cardPendings: currentPendings,
@@ -327,7 +319,11 @@ class PaymentMethodBloc
           ));
         },
         (_) {
-          // Success — already showing reordered state (Optimistic 유지)
+          emit(PaymentMethodLoaded(
+            reordered,
+            cardPendings: currentPendings,
+            cardSettlementSummary: currentSummary,
+          ));
         },
       );
     } catch (_) {

--- a/frontend/lib/features/settings/presentation/pages/asset_management_page.dart
+++ b/frontend/lib/features/settings/presentation/pages/asset_management_page.dart
@@ -728,14 +728,43 @@ class _CategoryTab extends StatelessWidget {
 
 }
 
-class _PaymentMethodTab extends StatelessWidget {
+class _PaymentMethodTab extends StatefulWidget {
   const _PaymentMethodTab();
+
+  @override
+  State<_PaymentMethodTab> createState() => _PaymentMethodTabState();
+}
+
+/// 로컬 reorder state: 사용자가 drop 시 즉시 반영하기 위해 bloc state 와
+/// 별개로 _localMethods 를 유지한다. PUT 백그라운드 진행 동안 화면은
+/// _localMethods 가 노출. PUT 응답 후 listener 가 bloc state 와 동기화.
+class _PaymentMethodTabState extends State<_PaymentMethodTab> {
+  List<PaymentMethod>? _localMethods;
+
+  /// bloc state 의 paymentMethods 를 displayOrder ASC 로 정렬하여 반환.
+  List<PaymentMethod> _sortedFromState(PaymentMethodLoaded state) {
+    return List<PaymentMethod>.from(state.paymentMethods)
+      ..sort((a, b) => a.displayOrder.compareTo(b.displayOrder));
+  }
 
   @override
   Widget build(BuildContext context) {
     return BlocConsumer<PaymentMethodBloc, PaymentMethodState>(
+      listenWhen: (prev, curr) => curr is PaymentMethodLoaded,
       listener: (context, state) {
-        if (state is PaymentMethodLoaded && state.operationError != null) {
+        if (state is! PaymentMethodLoaded) return;
+
+        // 동기화: PUT 응답 후 bloc state 가 도착하면 _localMethods 갱신.
+        // 사용자 drop 직후에는 _justReordered 가 true 이므로, 같은 ids 라면
+        // displayOrder 만 업데이트 (visual 변화 없음). 다른 변경(예: 외부에서
+        // 추가/삭제) 이라면 새 list 로 교체.
+        final fromState = _sortedFromState(state);
+        if (!mounted) return;
+        setState(() {
+          _localMethods = fromState;
+        });
+
+        if (state.operationError != null) {
           ScaffoldMessenger.of(context).showSnackBar(
             SnackBar(
               content: Text(state.operationError!),
@@ -745,11 +774,19 @@ class _PaymentMethodTab extends StatelessWidget {
         }
       },
       builder: (context, state) {
-        if (state is! PaymentMethodLoaded) {
+        // 우선 _localMethods 사용 (즉시 반영 보장).
+        final List<PaymentMethod> methods;
+        final CardSettlementSummary? settlement;
+        if (_localMethods != null) {
+          methods = _localMethods!;
+          settlement =
+              state is PaymentMethodLoaded ? state.cardSettlementSummary : null;
+        } else if (state is PaymentMethodLoaded) {
+          methods = _sortedFromState(state);
+          settlement = state.cardSettlementSummary;
+        } else {
           return const Center(child: CircularProgressIndicator());
         }
-        final methods = List<PaymentMethod>.from(state.paymentMethods)
-          ..sort((a, b) => a.displayOrder.compareTo(b.displayOrder));
 
         if (methods.isEmpty) {
           return const EmptyStateWidget(
@@ -826,11 +863,22 @@ class _PaymentMethodTab extends StatelessWidget {
             if (methodOldIndex == methodNewIndex) return;
 
             // visual 단계에서 이미 -1 보정했으므로 method 단계 추가 보정 금지.
-            // (이전 PR #155 의 double subtraction 으로 dedup 가 같은 순서로
-            // 판정해 skip → "되돌아옴" 현상 발생함)
             final reordered = List<PaymentMethod>.from(methods);
             final item = reordered.removeAt(methodOldIndex);
             reordered.insert(methodNewIndex, item);
+
+            // FE 즉시 반영: displayOrder 도 새 인덱스로 갱신해 _localMethods 에
+            // 저장. PUT 응답 후 listener 가 동기화 (같은 순서면 visual 동일).
+            // builder rebuild 시 _localMethods 우선 → ReorderableListView 가
+            // 같은 child list 받음 → native drop animation 보존.
+            final reorderedWithOrder = <PaymentMethod>[];
+            for (int i = 0; i < reordered.length; i++) {
+              reorderedWithOrder.add(reordered[i].copyWith(displayOrder: i));
+            }
+            setState(() {
+              _localMethods = reorderedWithOrder;
+            });
+
             context.read<PaymentMethodBloc>().add(
               ReorderPaymentMethods(reordered.map((m) => m.id).toList()),
             );
@@ -888,7 +936,7 @@ class _PaymentMethodTab extends StatelessWidget {
                   child: _buildPaymentMethodTile(
                     context,
                     method,
-                    state.cardSettlementSummary,
+                    settlement,
                   ),
                 ),
                 ReorderableDragStartListener(

--- a/frontend/lib/features/transaction/presentation/pages/transaction_list_page.dart
+++ b/frontend/lib/features/transaction/presentation/pages/transaction_list_page.dart
@@ -32,6 +32,7 @@ import 'package:budget_book/core/widgets/error_widget.dart';
 import 'package:budget_book/core/widgets/empty_state_widget.dart';
 import 'package:budget_book/core/widgets/skeleton_loader.dart';
 import 'package:budget_book/core/models/unified_filter_state.dart';
+import 'package:budget_book/core/widgets/account_balance_card.dart';
 import 'package:budget_book/core/widgets/filters/unified_filter_bar.dart';
 import 'package:budget_book/core/widgets/filters/payment_method_filter.dart';
 import 'package:budget_book/features/transaction/presentation/widgets/transaction_calendar_view.dart';
@@ -61,6 +62,7 @@ class TransactionListPage extends StatefulWidget {
 enum _TxViewMode { list, calendar }
 
 const String _kTxViewModePrefKey = 'tx_view_mode';
+const String _kTxSummaryExpandedPrefKey = 'tx_summary_expanded';
 
 class _TransactionListPageState extends State<TransactionListPage> {
   final TextEditingController _searchController = TextEditingController();
@@ -71,6 +73,7 @@ class _TransactionListPageState extends State<TransactionListPage> {
   bool _isSearching = false;
   String? _pendingScrollToDate;
   _TxViewMode _viewMode = _TxViewMode.list;
+  bool _summaryExpanded = false;
 
   // Unified filter state
   late UnifiedFilterState _filterState = UnifiedFilterState(
@@ -104,16 +107,23 @@ class _TransactionListPageState extends State<TransactionListPage> {
   Future<void> _loadViewMode() async {
     final prefs = await SharedPreferences.getInstance();
     final saved = prefs.getString(_kTxViewModePrefKey);
+    final expanded = prefs.getBool(_kTxSummaryExpandedPrefKey) ?? false;
     if (!mounted) return;
-    if (saved == 'calendar') {
-      setState(() => _viewMode = _TxViewMode.calendar);
-    }
+    setState(() {
+      if (saved == 'calendar') _viewMode = _TxViewMode.calendar;
+      _summaryExpanded = expanded;
+    });
   }
 
   Future<void> _saveViewMode(_TxViewMode mode) async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setString(_kTxViewModePrefKey,
         mode == _TxViewMode.calendar ? 'calendar' : 'list');
+  }
+
+  Future<void> _saveSummaryExpanded(bool expanded) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_kTxSummaryExpandedPrefKey, expanded);
   }
 
   @override
@@ -516,6 +526,16 @@ class _TransactionListPageState extends State<TransactionListPage> {
                     balance: displayIncome - displayExpense,
                     totalTransfer: displayTransfer > 0 ? displayTransfer : null,
                   ),
+                  // Phase 25 Step 8 — 리스트 뷰 상단 요약 영역 (홈 위젯 재사용).
+                  // 달력 뷰 에서는 노출 안 함 (공간 부족).
+                  if (_viewMode == _TxViewMode.list)
+                    _SummaryExpansion(
+                      expanded: _summaryExpanded,
+                      onChanged: (v) {
+                        setState(() => _summaryExpanded = v);
+                        _saveSummaryExpanded(v);
+                      },
+                    ),
                   if (_viewMode == _TxViewMode.calendar)
                     Expanded(
                       child: TransactionCalendarView(
@@ -996,6 +1016,43 @@ class _ViewModeToggle extends StatelessWidget {
         if (s.isNotEmpty) onChanged(s.first);
       },
       showSelectedIcon: false,
+    );
+  }
+}
+
+/// Phase 25 Step 8 — 리스트 뷰 상단 요약 영역 (홈 탭 위젯 복제).
+/// AccountBalanceCard 를 ExpansionTile 로 감싸 default collapsed 노출.
+/// 사용자가 펼치면 SharedPreferences 에 저장되어 다음 진입 시 유지.
+class _SummaryExpansion extends StatelessWidget {
+  final bool expanded;
+  final ValueChanged<bool> onChanged;
+
+  const _SummaryExpansion({required this.expanded, required this.onChanged});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Theme(
+      data: theme.copyWith(dividerColor: Colors.transparent),
+      child: ExpansionTile(
+        key: const PageStorageKey<String>('tx_summary_expansion'),
+        initiallyExpanded: expanded,
+        onExpansionChanged: onChanged,
+        tilePadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 0),
+        childrenPadding: const EdgeInsets.fromLTRB(8, 0, 8, 8),
+        leading: Icon(
+          Icons.account_balance_wallet,
+          size: 18,
+          color: theme.colorScheme.primary,
+        ),
+        title: Text(
+          '잔액 요약',
+          style: theme.textTheme.bodyMedium?.copyWith(
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        children: const [AccountBalanceCard(showHeader: false)],
+      ),
     );
   }
 }

--- a/frontend/test/features/payment_method/presentation/bloc/payment_method_bloc_test.dart
+++ b/frontend/test/features/payment_method/presentation/bloc/payment_method_bloc_test.dart
@@ -425,8 +425,7 @@ void main() {
     });
 
     group('ReorderPaymentMethods', () {
-      // Optimistic + 백그라운드 PUT: drop animation 종료 후 emit 1회 (Optimistic),
-      // 그 후 PUT 응답이 실패하면 rollback emit 추가.
+      // FE 로컬 state 가 즉시 반영을 담당. bloc 은 PUT 응답 후 1회 emit.
       // displayOrder 는 새 인덱스(0, 1, ...) 로 갱신.
       final reorderedCredit = tCreditMethod.copyWith(displayOrder: 0);
       final reorderedCash = tCashMethod.copyWith(displayOrder: 1);
@@ -442,11 +441,8 @@ void main() {
         act: (bloc) =>
             bloc.add(const ReorderPaymentMethods(['pm-2', 'pm-1'])),
         expect: () => [
-          // Optimistic emit (drop animation settle delay 후)
           PaymentMethodLoaded([reorderedCredit, reorderedCash]),
         ],
-        // Optimistic emit 전 280ms drop animation settle delay 고려
-        wait: const Duration(milliseconds: 400),
       );
 
       blocTest<PaymentMethodBloc, PaymentMethodState>(
@@ -461,13 +457,10 @@ void main() {
         act: (bloc) =>
             bloc.add(const ReorderPaymentMethods(['pm-2', 'pm-1'])),
         expect: () => [
-          // First: Optimistic emit (drop animation settle 후)
-          PaymentMethodLoaded([reorderedCredit, reorderedCash]),
-          // Then: PUT 실패 → rollback to original + operationError
+          // PUT 실패 → original state + operationError 1회만 emit.
           PaymentMethodLoaded(tMethods,
               operationError: 'Failed to reorder payment methods'),
         ],
-        wait: const Duration(milliseconds: 400),
       );
     });
 


### PR DESCRIPTION
## A. Reorder UX — true 즉시 반영
사용자 보고: PR #161 의 280ms 지연 emit 으로 "기존 화면 → 변경 동작" transition 추가 발생, 이질감.

### 패턴 (사용자 제안: "FE에서 이동 처리 반영, BE 백그라운드 API")
- `_PaymentMethodTab` StatefulWidget 변환
- 로컬 `_localMethods` state 유지 (bloc state 와 별개)
- onReorder 시 `_localMethods` 즉시 갱신 (displayOrder 0..N) + setState
- `bloc.add` 백그라운드 → PUT 응답 후 emit
- BlocConsumer listener 가 새 state 받으면 `_localMethods` 와 동기화 (같은 순서면 visual 변화 없음)
- bloc 의 280ms delay 제거, 즉시 PUT 진행

### 데이터 정합성
- PUT 성공: bloc emit → listener 가 _localMethods 동기화 (같은 순서)
- PUT 실패: bloc 이 currentMethods + operationError emit → listener 가 _localMethods 를 원위치로 sync + snackbar 알림
- 외부 변경(다른 사용자 추가/삭제 등): WebSocket sync 로 LoadPaymentMethods → emit → listener 동기화

## B. Phase 25 Step 8 — 거래 탭 요약 영역 (L)
거래 탭 리스트 모드 MonthSummaryBar 아래에 `ExpansionTile` "잔액 요약" 추가.
- 펼치면 `AccountBalanceCard` (홈 탭 위젯 재사용, `getIt` 으로 `PaymentMethodBloc` 자체 접근)
- `_summaryExpanded` 상태 SharedPreferences 영속 (`tx_summary_expanded` 키)
- 달력 모드에서는 비노출 (공간 부족)
- 홈 탭 그대로 유지 (A/B 병존, Phase 25 점진 이행 원칙)

## 검증
- ✅ flutter analyze — 0 error
- ✅ flutter test — 703 passed
- ✅ flutter build web --release — success

## 라이브 검증 (PR merge 후)
### A
- [ ] 자산 탭 reorder → **드롭 직후 즉시 새 위치 유지**, transition / 깜빡 / 원복 없음
- [ ] 새로고침 후 유지
- [ ] (가능하면) 네트워크 차단 상태 reorder → snackbar 에러 + UI 원복

### B
- [ ] 거래 탭 (리스트 모드) MonthSummaryBar 아래에 "잔액 요약" 토글 표시
- [ ] 토글 펼침 → AccountBalanceCard 노출 (현금/은행/카드 잔액)
- [ ] 펼친 상태가 새로고침/탭 전환 후에도 유지
- [ ] 달력 모드에는 노출 안 됨

### 회귀
- [ ] 거래 / 자산 / 분석 / 더보기 탭 정상
- [ ] 잔액 수정 토글 정상

## Refs
- PR #161 Optimistic 280ms 지연 → 본 PR 에서 즉시 반영 패턴으로 대체