### PR TITLE
feat(nav): Phase 25 Step 10 — 홈 탭 제거 (6→5탭)

### DIFF
--- a/frontend/lib/core/router/app_router.dart
+++ b/frontend/lib/core/router/app_router.dart
@@ -5,7 +5,6 @@ import 'package:go_router/go_router.dart';
 import 'package:budget_book/core/di/injection.dart';
 import 'package:budget_book/core/widgets/main_shell_page.dart';
 import 'package:budget_book/core/websocket/websocket_bloc.dart';
-import 'package:budget_book/features/home/presentation/bloc/dashboard_state.dart';
 import 'package:budget_book/features/auth/presentation/bloc/auth_bloc.dart';
 import 'package:budget_book/features/auth/presentation/bloc/auth_state.dart';
 import 'package:budget_book/features/auth/presentation/pages/login_page.dart';
@@ -52,9 +51,6 @@ import 'package:budget_book/features/recurring/presentation/bloc/recurring_bloc.
 import 'package:budget_book/features/recurring/presentation/bloc/recurring_event.dart';
 import 'package:budget_book/features/recurring/presentation/pages/recurring_list_page.dart';
 import 'package:budget_book/features/recurring/presentation/pages/recurring_form_page.dart';
-import 'package:budget_book/features/home/presentation/bloc/dashboard_bloc.dart';
-import 'package:budget_book/features/home/presentation/bloc/dashboard_event.dart';
-import 'package:budget_book/features/home/presentation/pages/dashboard_page.dart';
 import 'package:budget_book/features/settings/presentation/pages/settings_page.dart';
 import 'package:budget_book/features/settings/presentation/pages/profile_edit_page.dart';
 import 'package:budget_book/features/settings/presentation/pages/app_info_page.dart';
@@ -161,7 +157,7 @@ GoRouter createAppRouter(AuthBloc authBloc) => GoRouter(
         markOnboardingCompleted();
       }
       if (!_onboardingCompleted) return '/onboarding';
-      return '/home';
+      return '/transactions';
     }
 
     if (authState is AuthAuthenticated) {
@@ -173,7 +169,7 @@ GoRouter createAppRouter(AuthBloc authBloc) => GoRouter(
 
       // Admin guard: redirect non-admin users away from admin pages
       if (isOnAdminPage && authState.user.role != 'ADMIN') {
-        return '/home';
+        return '/transactions';
       }
 
       // Allow onboarding page to pass through
@@ -233,27 +229,8 @@ GoRouter createAppRouter(AuthBloc authBloc) => GoRouter(
         );
       },
       branches: [
-        // Tab 0: Home/Dashboard
-        StatefulShellBranch(
-          routes: [
-            GoRoute(
-              path: '/home',
-              builder: (context, state) {
-                // Only load on first visit; preserve month when returning from sub-pages
-                final bloc = getIt<DashboardBloc>();
-                if (bloc.state is DashboardInitial) {
-                  final now = DateTime.now();
-                  bloc.add(LoadDashboard(year: now.year, month: now.month));
-                }
-                return BlocProvider<DashboardBloc>.value(
-                  value: bloc,
-                  child: const DashboardPage(),
-                );
-              },
-            ),
-          ],
-        ),
-        // Tab 1: Transactions
+        // Phase 25 Step 10 — 홈 탭 제거. /home 은 root-level redirect 으로 처리.
+        // Tab 0: Transactions (기존 Tab 1)
         StatefulShellBranch(
           routes: [
             GoRoute(
@@ -390,6 +367,19 @@ GoRouter createAppRouter(AuthBloc authBloc) => GoRouter(
     // Sub-pages (pushed on top of shell, no bottom nav)
     // IMPORTANT: Use BlocProvider.value() for singleton BLoCs to avoid
     // auto-close on pop which would permanently kill the singleton.
+
+    // Phase 25 Step 10 — 홈 탭 제거 후 redirect.
+    // / 와 /home 진입 시 거래 탭으로 이동.
+    GoRoute(
+      path: '/',
+      parentNavigatorKey: _rootNavigatorKey,
+      redirect: (context, state) => '/transactions',
+    ),
+    GoRoute(
+      path: '/home',
+      parentNavigatorKey: _rootNavigatorKey,
+      redirect: (context, state) => '/transactions',
+    ),
     GoRoute(
       path: '/categories',
       parentNavigatorKey: _rootNavigatorKey,

--- a/frontend/lib/core/widgets/main_shell_page.dart
+++ b/frontend/lib/core/widgets/main_shell_page.dart
@@ -13,8 +13,6 @@ import 'package:budget_book/core/widgets/offline_banner.dart';
 import 'package:budget_book/core/services/connectivity_service.dart';
 import 'package:budget_book/features/auth/presentation/bloc/auth_bloc.dart';
 import 'package:budget_book/features/auth/presentation/bloc/auth_state.dart';
-import 'package:budget_book/features/home/presentation/bloc/dashboard_bloc.dart';
-import 'package:budget_book/features/home/presentation/bloc/dashboard_event.dart';
 import 'package:budget_book/features/transaction/presentation/bloc/transaction_bloc.dart';
 import 'package:budget_book/features/transaction/presentation/bloc/transaction_event.dart';
 import 'package:budget_book/features/budget/presentation/bloc/budget_bloc.dart';
@@ -74,26 +72,25 @@ class _MainShellPageState extends State<MainShellPage> {
     final previousIndex = _previousIndex;
     _previousIndex = index;
 
+    // Phase 25 Step 10 — 홈 탭 제거 후 인덱스 매핑:
+    // 0: 거래, 1: 예산, 2: 통계, 3: 자산, 4: 더보기
     // Refresh data when switching to a different tab
     if (index != previousIndex) {
       final now = DateTime.now();
       switch (index) {
         case 0:
-          getIt<DashboardBloc>()
-              .add(LoadDashboard(year: now.year, month: now.month));
-        case 1:
           getIt<TransactionBloc>()
               .add(LoadTransactions(year: now.year, month: now.month));
-        case 2:
+        case 1:
           getIt<BudgetBloc>()
               .add(LoadBudgets(year: now.year, month: now.month));
-        // Tab 3 (Statistics) uses factory, loaded fresh by its builder
-        case 4:
-          // Tab 4 (Assets) — refresh payment method data + card settlement summary
+        // Tab 2 (Statistics) uses factory, loaded fresh by its builder
+        case 3:
+          // Tab 3 (Assets) — refresh payment method data + card settlement summary
           getIt<PaymentMethodBloc>().add(const LoadPaymentMethods());
           getIt<PaymentMethodBloc>().add(
               LoadCardSettlementSummary(year: now.year, month: now.month));
-        // Tab 5 (Settings) needs no refresh
+        // Tab 4 (Settings) needs no refresh
       }
     }
 
@@ -132,12 +129,8 @@ class _MainShellPageState extends State<MainShellPage> {
       bottomNavigationBar: NavigationBar(
         selectedIndex: widget.navigationShell.currentIndex,
         onDestinationSelected: _onDestinationSelected,
+        // Phase 25 Step 10 — 홈 탭 제거. 5탭 구조 (거래/예산/통계/자산/더보기).
         destinations: const [
-          NavigationDestination(
-            icon: Icon(Icons.home_outlined),
-            selectedIcon: Icon(Icons.home),
-            label: '홈',
-          ),
           NavigationDestination(
             icon: Icon(Icons.receipt_long_outlined),
             selectedIcon: Icon(Icons.receipt_long),


### PR DESCRIPTION
## Step 9 검증 게이트 통과
사용자 확인: 거래 탭 잔액 요약(#162 Step 8) 도입 후 홈 탭 기능 거래 탭에서 충분히 접근 가능. 홈 탭 제거 가능.

## 변경
### main_shell_page
- 홈 destination 삭제
- switch case 인덱스 재매핑:
  - 기존: 0=홈, 1=거래, 2=예산, 3=통계, 4=자산, 5=더보기
  - 신규: 0=거래, 1=예산, 2=통계, 3=자산, 4=더보기

### app_router
- 홈 `StatefulShellBranch` (`/home` route) 제거
- `/` → `/transactions` redirect 추가 (root 진입)
- `/home` → `/transactions` redirect 추가 (deep link 호환)
- 기존 auth/admin redirect 의 `/home` 타깃도 `/transactions` 로 변경
- unused imports (DashboardBloc/DashboardEvent/DashboardPage/DashboardState) 정리

### 보존
- `DashboardPage` 파일 보존 — Step 11 분석 탭 도입 시 위젯 일부 재사용 예정
- `DashboardBloc` 자체는 다른 곳 (AccountBalanceCard 등) 에서 직접 호출 가능성 있어 di 등록 유지

## Phase 25 진행 상황
| 단계 | 상태 |
|---|---|
| Step 1 (라벨 rename) | ✅ #145 |
| Step 0/0.6 (NAS nginx) | ✅ #146, #148 |
| Step 2-5 (자산 탭 + 3카드 + 잔액 + MonthNav) | ✅ #147 |
| Step 6 (총자산 미니카드) | ✅ #149 → #153 에서 제거 |
| Step 7 (리스트/달력 toggle) | ✅ #160 |
| Step 8 (거래 탭 잔액 요약) | ✅ #162 |
| Step 9 (검증 게이트) | ✅ 사용자 확인 |
| **Step 10 (홈 탭 제거)** | ⬅ 본 PR |
| Step 11 (분석 탭 신규) | 다음 |
| Step 13/14 (예산/통계 제거) | 후속 |

## 검증
- ✅ flutter analyze — 0 error
- ✅ flutter test — 703 passed
- ✅ flutter build web --release — success

## 라이브 검증 (PR merge 후)
- [ ] 하단 네비게이션이 5탭 [거래][예산][통계][자산][더보기]
- [ ] 앱 진입 시 거래 탭이 default
- [ ] 기존 deep link `/home` 진입 시 거래 탭으로 redirect
- [ ] 잔액 요약 / 거래 / 자산 / 분석 탭 정상