### PR TITLE
feat: 카테고리 그룹 라벨 + Phase 25 Step 11 분석 탭 신규

### DIFF
--- a/frontend/lib/core/router/app_router.dart
+++ b/frontend/lib/core/router/app_router.dart
@@ -29,6 +29,7 @@ import 'package:budget_book/features/budget/presentation/pages/budget_form_page.
 import 'package:budget_book/features/statistics/presentation/bloc/statistics_bloc.dart';
 import 'package:budget_book/features/statistics/presentation/bloc/statistics_event.dart';
 import 'package:budget_book/features/statistics/presentation/pages/statistics_page.dart';
+import 'package:budget_book/features/analysis/presentation/pages/analysis_page.dart';
 import 'package:budget_book/features/statistics/presentation/bloc/period_summary_bloc.dart';
 import 'package:budget_book/features/statistics/presentation/bloc/period_summary_event.dart';
 import 'package:budget_book/features/statistics/presentation/pages/period_summary_page.dart';
@@ -282,6 +283,15 @@ GoRouter createAppRouter(AuthBloc authBloc) => GoRouter(
                   ),
                 );
               },
+            ),
+          ],
+        ),
+        // Tab 1: Analysis (Phase 25 Step 11 — 분석 탭 신규, A/B 병존)
+        StatefulShellBranch(
+          routes: [
+            GoRoute(
+              path: '/analysis',
+              builder: (context, state) => const AnalysisPage(),
             ),
           ],
         ),

--- a/frontend/lib/core/widgets/filters/unified_filter_bar.dart
+++ b/frontend/lib/core/widgets/filters/unified_filter_bar.dart
@@ -507,7 +507,27 @@ String buildCategoryDisplayLabel(
   Set<String> categoryGroupIds, {
   String? fallbackName,
 }) {
-  final total = categoryIds.length + categoryGroupIds.length;
+  // 그룹 선택 시 cascade 로 자식 categoryIds 도 함께 채워지므로, 라벨 계산
+  // 시점에는 "그룹에 흡수된" 자식 categoryIds 를 제외하고 visible count 산정.
+  // → 그룹 1개(자식 N개 cascade) 선택 시 "X 그룹 전체" 로 표시.
+  Set<String> visibleCategoryIds = categoryIds;
+  if (categoryGroupIds.isNotEmpty) {
+    final gState = _safeBlocState<CategoryGroupBloc>();
+    if (gState is CategoryGroupLoaded) {
+      final absorbed = <String>{};
+      for (final gid in categoryGroupIds) {
+        final group = gState.groups.where((g) => g.id == gid).firstOrNull;
+        if (group != null) {
+          for (final cat in group.categories) {
+            if (categoryIds.contains(cat.id)) absorbed.add(cat.id);
+          }
+        }
+      }
+      visibleCategoryIds = categoryIds.difference(absorbed);
+    }
+  }
+
+  final total = visibleCategoryIds.length + categoryGroupIds.length;
   if (total == 0) return '전체';
   String? firstName;
   bool fromGroup = false;
@@ -524,14 +544,14 @@ String buildCategoryDisplayLabel(
     final cState = _safeBlocState<CategoryBloc>();
     if (cState is CategoryLoaded) {
       final all = [...cState.expenseCategories, ...cState.incomeCategories];
-      final c = all.where((c) => c.id == categoryIds.first).firstOrNull;
+      final c = all.where((c) => c.id == visibleCategoryIds.first).firstOrNull;
       firstName = c?.name;
     }
   }
   firstName ??= fallbackName;
   if (total == 1) {
     if (firstName == null) return '선택됨';
-    return fromGroup ? '$firstName 그룹' : firstName;
+    return fromGroup ? '$firstName 그룹 전체' : firstName;
   }
   final base = firstName != null
       ? (fromGroup ? '$firstName 그룹' : firstName)

--- a/frontend/lib/core/widgets/main_shell_page.dart
+++ b/frontend/lib/core/widgets/main_shell_page.dart
@@ -72,8 +72,9 @@ class _MainShellPageState extends State<MainShellPage> {
     final previousIndex = _previousIndex;
     _previousIndex = index;
 
-    // Phase 25 Step 10 — 홈 탭 제거 후 인덱스 매핑:
-    // 0: 거래, 1: 예산, 2: 통계, 3: 자산, 4: 더보기
+    // Phase 25 Step 10/11 — 홈 제거 + 분석 추가. 6탭 인덱스 매핑:
+    // 0:거래, 1:분석, 2:예산, 3:통계, 4:자산, 5:더보기
+    // (Step 13/14 에서 예산/통계 제거 → 4탭 [거래][분석][자산][더보기] 도달)
     // Refresh data when switching to a different tab
     if (index != previousIndex) {
       final now = DateTime.now();
@@ -81,16 +82,17 @@ class _MainShellPageState extends State<MainShellPage> {
         case 0:
           getIt<TransactionBloc>()
               .add(LoadTransactions(year: now.year, month: now.month));
-        case 1:
+        // Tab 1 (Analysis) — wrapper 가 자체 BudgetBloc/StatisticsBloc 처리
+        case 2:
           getIt<BudgetBloc>()
               .add(LoadBudgets(year: now.year, month: now.month));
-        // Tab 2 (Statistics) uses factory, loaded fresh by its builder
-        case 3:
-          // Tab 3 (Assets) — refresh payment method data + card settlement summary
+        // Tab 3 (Statistics) uses factory, loaded fresh by its builder
+        case 4:
+          // Tab 4 (Assets) — refresh payment method data + card settlement summary
           getIt<PaymentMethodBloc>().add(const LoadPaymentMethods());
           getIt<PaymentMethodBloc>().add(
               LoadCardSettlementSummary(year: now.year, month: now.month));
-        // Tab 4 (Settings) needs no refresh
+        // Tab 5 (Settings) needs no refresh
       }
     }
 
@@ -129,12 +131,18 @@ class _MainShellPageState extends State<MainShellPage> {
       bottomNavigationBar: NavigationBar(
         selectedIndex: widget.navigationShell.currentIndex,
         onDestinationSelected: _onDestinationSelected,
-        // Phase 25 Step 10 — 홈 탭 제거. 5탭 구조 (거래/예산/통계/자산/더보기).
+        // Phase 25 Step 10/11 — 홈 제거 + 분석 추가. 6탭 (A/B 병존 단계).
+        // 다음 단계(13/14) 에서 예산/통계 제거 → 4탭 [거래][분석][자산][더보기].
         destinations: const [
           NavigationDestination(
             icon: Icon(Icons.receipt_long_outlined),
             selectedIcon: Icon(Icons.receipt_long),
             label: '거래',
+          ),
+          NavigationDestination(
+            icon: Icon(Icons.insights_outlined),
+            selectedIcon: Icon(Icons.insights),
+            label: '분석',
           ),
           NavigationDestination(
             icon: Icon(Icons.account_balance_wallet_outlined),

--- a/frontend/lib/features/analysis/presentation/pages/analysis_page.dart
+++ b/frontend/lib/features/analysis/presentation/pages/analysis_page.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import 'package:budget_book/core/di/injection.dart';
+import 'package:budget_book/features/budget/presentation/bloc/budget_bloc.dart';
+import 'package:budget_book/features/budget/presentation/bloc/budget_event.dart';
+import 'package:budget_book/features/budget/presentation/pages/budget_list_page.dart';
+import 'package:budget_book/features/statistics/presentation/bloc/statistics_bloc.dart';
+import 'package:budget_book/features/statistics/presentation/bloc/statistics_event.dart';
+import 'package:budget_book/features/statistics/presentation/pages/statistics_page.dart';
+
+/// Phase 25 Step 11 — 분석 탭 신규.
+///
+/// **현재 단계**: v1.0 의 BudgetListPage + StatisticsPage 를 TabBar 로 묶어
+/// 단일 진입점으로 노출 (A/B 병존). 기존 [예산][통계] 탭은 그대로 유지.
+///
+/// **다음 단계 (후속 PR)**: 두 페이지의 핵심 섹션을 단일 페이지로 통합 예정
+/// (BudgetSummaryCard, 카테고리 지출, 월별 추이, 결제수단 도넛, 전년 비교 등).
+class AnalysisPage extends StatelessWidget {
+  const AnalysisPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return DefaultTabController(
+      length: 2,
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('분석'),
+          bottom: const TabBar(
+            tabs: [
+              Tab(icon: Icon(Icons.account_balance_wallet_outlined), text: '예산'),
+              Tab(icon: Icon(Icons.bar_chart_outlined), text: '통계'),
+            ],
+          ),
+        ),
+        body: const TabBarView(
+          children: [
+            _BudgetTabWrapper(),
+            _StatisticsTabWrapper(),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// 예산 탭 wrapper — BudgetListPage 를 자체 AppBar 없이 노출.
+class _BudgetTabWrapper extends StatelessWidget {
+  const _BudgetTabWrapper();
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider<BudgetBloc>.value(
+      value: getIt<BudgetBloc>()
+        ..add(LoadBudgets(
+          year: DateTime.now().year,
+          month: DateTime.now().month,
+        )),
+      child: const BudgetListPage(showAppBar: false),
+    );
+  }
+}
+
+/// 통계 탭 wrapper — StatisticsPage 를 자체 AppBar 없이 노출.
+class _StatisticsTabWrapper extends StatelessWidget {
+  const _StatisticsTabWrapper();
+
+  @override
+  Widget build(BuildContext context) {
+    final now = DateTime.now();
+    return BlocProvider<StatisticsBloc>(
+      create: (_) => getIt<StatisticsBloc>()
+        ..add(LoadAllStatistics(year: now.year, month: now.month))
+        ..add(LoadPaymentMethodStats(year: now.year, month: now.month)),
+      child: const StatisticsPage(showAppBar: false),
+    );
+  }
+}

--- a/frontend/lib/features/budget/presentation/pages/budget_list_page.dart
+++ b/frontend/lib/features/budget/presentation/pages/budget_list_page.dart
@@ -27,7 +27,10 @@ import 'package:budget_book/features/weekly_budget/presentation/widgets/week_sum
 import 'package:budget_book/features/weekly_budget/domain/entities/current_week_summary.dart';
 
 class BudgetListPage extends StatefulWidget {
-  const BudgetListPage({super.key});
+  /// Phase 25 Step 11 — 분석 탭 wrapper 에서는 false. 자체 진입(/budgets) 시 true.
+  final bool showAppBar;
+
+  const BudgetListPage({super.key, this.showAppBar = true});
 
   @override
   State<BudgetListPage> createState() => _BudgetListPageState();
@@ -39,7 +42,7 @@ class _BudgetListPageState extends State<BudgetListPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
+      appBar: !widget.showAppBar ? null : AppBar(
         title: Text(_isWeeklyView ? '주간 예산' : '예산 관리'),
         actions: _isWeeklyView
             ? null

--- a/frontend/lib/features/statistics/presentation/pages/statistics_page.dart
+++ b/frontend/lib/features/statistics/presentation/pages/statistics_page.dart
@@ -15,14 +15,34 @@ import 'package:budget_book/features/statistics/presentation/widgets/payment_met
 import 'package:budget_book/core/utils/couple_mode.dart';
 
 class StatisticsPage extends StatelessWidget {
-  const StatisticsPage({super.key});
+  /// Phase 25 Step 11 — 분석 탭 wrapper 에서는 false. 자체 진입(/statistics) 시 true.
+  final bool showAppBar;
+
+  const StatisticsPage({super.key, this.showAppBar = true});
 
   @override
   Widget build(BuildContext context) {
     return DefaultTabController(
       length: 5,
       child: Scaffold(
-        appBar: AppBar(
+        appBar: !showAppBar
+            ? PreferredSize(
+                preferredSize: const Size.fromHeight(kTextTabBarHeight),
+                child: AppBar(
+                  toolbarHeight: 0,
+                  bottom: const TabBar(
+                    isScrollable: true,
+                    tabs: [
+                      Tab(text: '요약'),
+                      Tab(text: '카테고리별'),
+                      Tab(text: '월별 추이'),
+                      Tab(text: '결제수단'),
+                      Tab(text: '전년 비교'),
+                    ],
+                  ),
+                ),
+              )
+            : AppBar(
           title: const Text('통계'),
           actions: [
             IconButton(


### PR DESCRIPTION
## A. 카테고리 그룹 라벨 단순화
사용자 보고: "필터에서 상위 그룹 선택하면 하위 N개 항목 선택으로 나오는데 그룹 전체 형태가 좋겠다"

### 원인
그룹 선택 시 cascade 로 자식 `categoryIds` 도 함께 채워짐 → `buildCategoryDisplayLabel` 의 total 이 `1+N` → "X 그룹 외 N개" 표시.

### 수정
그룹의 자식 `categoryIds` 가 모두 cascade 로 포함되었으면 라벨 계산 시점에 **흡수 처리**:
- 1개 그룹 단독 (자식 모두 포함) → **"X 그룹 전체"**
- 혼합 (그룹 + 다른 단독 카테고리) → "X 그룹 외 K개"

cascade 자체는 BE 호환성 유지 위해 그대로 (categoryIds 에 자식들 포함됨).

## B. Phase 25 Step 11 — 분석 탭 신규 (A/B 병존)
### 변경
- `analysis_page.dart` 신규 — `DefaultTabController` 로 [예산][통계] TabBar wrapping
- `BudgetListPage` / `StatisticsPage` 에 `showAppBar` 매개변수 추가 (default true). 분석 탭 wrapper 가 false 로 호출해 nested AppBar 회피
- `/analysis` 라우트 + main_shell 분석 destination 추가 (5→6탭)
- 순서: `[거래][분석][예산][통계][자산][더보기]`

### Zero regression
- 기존 `/budgets`, `/statistics` 그대로 유지
- 사용자가 분석 탭 안 누르면 변화 없음
- 기존 BudgetListPage/StatisticsPage 호출처 (deep link, 분석 페이지 외) 는 default true → 기존 AppBar 노출

### 다음 단계
- 후속 PR: 분석 페이지를 단일 페이지로 통합 (BudgetSummaryCard, 카테고리 지출, 월별 추이, 결제수단 도넛, 전년 비교)
- Step 13/14: 예산/통계 탭 제거 → 4탭 [거래][분석][자산][더보기] 최종

## 검증
- ✅ flutter analyze — 0 error
- ✅ flutter test — 703 passed
- ✅ flutter build web --release — success

## 라이브 검증 (PR merge 후)
### A
- [ ] 거래 탭 필터 → 카테고리 → 그룹 1개 선택 → 칩 "X 그룹 전체" 표시 (NOT "X 외 N개")
- [ ] 그룹 + 다른 카테고리 혼합 → "X 그룹 외 K개"
- [ ] 그룹 일부 자식만 선택 → 기존대로 단순 카테고리 라벨

### B
- [ ] 하단 네비 6탭 [거래][분석][예산][통계][자산][더보기]
- [ ] 분석 탭 진입 → [예산][통계] TabBar 표시
- [ ] 예산 탭 / 통계 탭 정상 (기존 `/budgets`, `/statistics`)
- [ ] 분석 탭 안에서 예산/통계 정상 동작

### 회귀
- [ ] 거래 / 자산 / 더보기 탭 정상
- [ ] 잔액 요약, 잔액 수정 토글 정상