### PR TITLE
feat: 거래 탭 잔액 요약 제거 + Phase 25 Step 13/14 — 4탭 최종 도달

### DIFF
--- a/frontend/lib/core/router/app_router.dart
+++ b/frontend/lib/core/router/app_router.dart
@@ -24,11 +24,7 @@ import 'package:budget_book/features/transaction/presentation/pages/transaction_
 import 'package:budget_book/features/transaction/presentation/pages/transaction_detail_page.dart';
 import 'package:budget_book/features/budget/presentation/bloc/budget_bloc.dart';
 import 'package:budget_book/features/budget/presentation/bloc/budget_event.dart';
-import 'package:budget_book/features/budget/presentation/pages/budget_list_page.dart';
 import 'package:budget_book/features/budget/presentation/pages/budget_form_page.dart';
-import 'package:budget_book/features/statistics/presentation/bloc/statistics_bloc.dart';
-import 'package:budget_book/features/statistics/presentation/bloc/statistics_event.dart';
-import 'package:budget_book/features/statistics/presentation/pages/statistics_page.dart';
 import 'package:budget_book/features/analysis/presentation/pages/analysis_page.dart';
 import 'package:budget_book/features/statistics/presentation/bloc/period_summary_bloc.dart';
 import 'package:budget_book/features/statistics/presentation/bloc/period_summary_event.dart';
@@ -295,41 +291,9 @@ GoRouter createAppRouter(AuthBloc authBloc) => GoRouter(
             ),
           ],
         ),
-        // Tab 2: Budget
-        StatefulShellBranch(
-          routes: [
-            GoRoute(
-              path: '/budgets',
-              builder: (context, state) {
-                final now = DateTime.now();
-                getIt<BudgetBloc>()
-                    .add(LoadBudgets(year: now.year, month: now.month));
-                return BlocProvider<BudgetBloc>.value(
-                  value: getIt<BudgetBloc>(),
-                  child: const BudgetListPage(),
-                );
-              },
-            ),
-          ],
-        ),
-        // Tab 3: Statistics
-        StatefulShellBranch(
-          routes: [
-            GoRoute(
-              path: '/statistics',
-              builder: (context, state) {
-                final now = DateTime.now();
-                return BlocProvider<StatisticsBloc>(
-                  create: (_) => getIt<StatisticsBloc>()
-                    ..add(LoadAllStatistics(year: now.year, month: now.month))
-                    ..add(LoadPaymentMethodStats(year: now.year, month: now.month)),
-                  child: const StatisticsPage(),
-                );
-              },
-            ),
-          ],
-        ),
-        // Tab 4: Assets (Phase 25 Step 2 — 5→6탭, /asset-management 라우트 그대로 유지)
+        // Phase 25 Step 13/14 — 예산/통계 탭 제거. 분석 탭 안에 통합됨.
+        // /budgets, /statistics 진입은 root-level redirect → /analysis 로 이동.
+        // Tab 2: Assets (Phase 25 Step 2 — /asset-management 라우트 그대로 유지)
         StatefulShellBranch(
           routes: [
             GoRoute(
@@ -389,6 +353,18 @@ GoRouter createAppRouter(AuthBloc authBloc) => GoRouter(
       path: '/home',
       parentNavigatorKey: _rootNavigatorKey,
       redirect: (context, state) => '/transactions',
+    ),
+    // Phase 25 Step 13/14 — 예산/통계 탭 제거. 분석 탭으로 통합 redirect.
+    // 기존 deep link / 북마크 호환 유지.
+    GoRoute(
+      path: '/budgets',
+      parentNavigatorKey: _rootNavigatorKey,
+      redirect: (context, state) => '/analysis',
+    ),
+    GoRoute(
+      path: '/statistics',
+      parentNavigatorKey: _rootNavigatorKey,
+      redirect: (context, state) => '/analysis',
     ),
     GoRoute(
       path: '/categories',

--- a/frontend/lib/core/widgets/main_shell_page.dart
+++ b/frontend/lib/core/widgets/main_shell_page.dart
@@ -15,8 +15,6 @@ import 'package:budget_book/features/auth/presentation/bloc/auth_bloc.dart';
 import 'package:budget_book/features/auth/presentation/bloc/auth_state.dart';
 import 'package:budget_book/features/transaction/presentation/bloc/transaction_bloc.dart';
 import 'package:budget_book/features/transaction/presentation/bloc/transaction_event.dart';
-import 'package:budget_book/features/budget/presentation/bloc/budget_bloc.dart';
-import 'package:budget_book/features/budget/presentation/bloc/budget_event.dart';
 import 'package:budget_book/features/category_group/presentation/bloc/category_group_bloc.dart';
 import 'package:budget_book/features/category_group/presentation/bloc/category_group_event.dart';
 import 'package:budget_book/features/payment_method/presentation/bloc/payment_method_bloc.dart';
@@ -72,10 +70,8 @@ class _MainShellPageState extends State<MainShellPage> {
     final previousIndex = _previousIndex;
     _previousIndex = index;
 
-    // Phase 25 Step 10/11 — 홈 제거 + 분석 추가. 6탭 인덱스 매핑:
-    // 0:거래, 1:분석, 2:예산, 3:통계, 4:자산, 5:더보기
-    // (Step 13/14 에서 예산/통계 제거 → 4탭 [거래][분석][자산][더보기] 도달)
-    // Refresh data when switching to a different tab
+    // Phase 25 Step 13/14 — 예산/통계 탭 제거. 4탭 최종 인덱스 매핑:
+    // 0:거래, 1:분석, 2:자산, 3:더보기
     if (index != previousIndex) {
       final now = DateTime.now();
       switch (index) {
@@ -84,15 +80,11 @@ class _MainShellPageState extends State<MainShellPage> {
               .add(LoadTransactions(year: now.year, month: now.month));
         // Tab 1 (Analysis) — wrapper 가 자체 BudgetBloc/StatisticsBloc 처리
         case 2:
-          getIt<BudgetBloc>()
-              .add(LoadBudgets(year: now.year, month: now.month));
-        // Tab 3 (Statistics) uses factory, loaded fresh by its builder
-        case 4:
-          // Tab 4 (Assets) — refresh payment method data + card settlement summary
+          // Tab 2 (Assets) — refresh payment method data + card settlement summary
           getIt<PaymentMethodBloc>().add(const LoadPaymentMethods());
           getIt<PaymentMethodBloc>().add(
               LoadCardSettlementSummary(year: now.year, month: now.month));
-        // Tab 5 (Settings) needs no refresh
+        // Tab 3 (Settings) needs no refresh
       }
     }
 
@@ -131,8 +123,8 @@ class _MainShellPageState extends State<MainShellPage> {
       bottomNavigationBar: NavigationBar(
         selectedIndex: widget.navigationShell.currentIndex,
         onDestinationSelected: _onDestinationSelected,
-        // Phase 25 Step 10/11 — 홈 제거 + 분석 추가. 6탭 (A/B 병존 단계).
-        // 다음 단계(13/14) 에서 예산/통계 제거 → 4탭 [거래][분석][자산][더보기].
+        // Phase 25 Step 13/14 — 4탭 최종: [거래][분석][자산][더보기].
+        // 예산/통계는 분석 탭 안의 [예산][통계] sub-tab 으로 통합됨.
         destinations: const [
           NavigationDestination(
             icon: Icon(Icons.receipt_long_outlined),
@@ -143,16 +135,6 @@ class _MainShellPageState extends State<MainShellPage> {
             icon: Icon(Icons.insights_outlined),
             selectedIcon: Icon(Icons.insights),
             label: '분석',
-          ),
-          NavigationDestination(
-            icon: Icon(Icons.account_balance_wallet_outlined),
-            selectedIcon: Icon(Icons.account_balance_wallet),
-            label: '예산',
-          ),
-          NavigationDestination(
-            icon: Icon(Icons.bar_chart_outlined),
-            selectedIcon: Icon(Icons.bar_chart),
-            label: '통계',
           ),
           NavigationDestination(
             icon: Icon(Icons.savings_outlined),

--- a/frontend/lib/features/transaction/presentation/pages/transaction_list_page.dart
+++ b/frontend/lib/features/transaction/presentation/pages/transaction_list_page.dart
@@ -32,7 +32,6 @@ import 'package:budget_book/core/widgets/error_widget.dart';
 import 'package:budget_book/core/widgets/empty_state_widget.dart';
 import 'package:budget_book/core/widgets/skeleton_loader.dart';
 import 'package:budget_book/core/models/unified_filter_state.dart';
-import 'package:budget_book/core/widgets/account_balance_card.dart';
 import 'package:budget_book/core/widgets/filters/unified_filter_bar.dart';
 import 'package:budget_book/core/widgets/filters/payment_method_filter.dart';
 import 'package:budget_book/features/transaction/presentation/widgets/transaction_calendar_view.dart';
@@ -62,7 +61,6 @@ class TransactionListPage extends StatefulWidget {
 enum _TxViewMode { list, calendar }
 
 const String _kTxViewModePrefKey = 'tx_view_mode';
-const String _kTxSummaryExpandedPrefKey = 'tx_summary_expanded';
 
 class _TransactionListPageState extends State<TransactionListPage> {
   final TextEditingController _searchController = TextEditingController();
@@ -73,7 +71,6 @@ class _TransactionListPageState extends State<TransactionListPage> {
   bool _isSearching = false;
   String? _pendingScrollToDate;
   _TxViewMode _viewMode = _TxViewMode.list;
-  bool _summaryExpanded = false;
 
   // Unified filter state
   late UnifiedFilterState _filterState = UnifiedFilterState(
@@ -107,23 +104,16 @@ class _TransactionListPageState extends State<TransactionListPage> {
   Future<void> _loadViewMode() async {
     final prefs = await SharedPreferences.getInstance();
     final saved = prefs.getString(_kTxViewModePrefKey);
-    final expanded = prefs.getBool(_kTxSummaryExpandedPrefKey) ?? false;
     if (!mounted) return;
-    setState(() {
-      if (saved == 'calendar') _viewMode = _TxViewMode.calendar;
-      _summaryExpanded = expanded;
-    });
+    if (saved == 'calendar') {
+      setState(() => _viewMode = _TxViewMode.calendar);
+    }
   }
 
   Future<void> _saveViewMode(_TxViewMode mode) async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setString(_kTxViewModePrefKey,
         mode == _TxViewMode.calendar ? 'calendar' : 'list');
-  }
-
-  Future<void> _saveSummaryExpanded(bool expanded) async {
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.setBool(_kTxSummaryExpandedPrefKey, expanded);
   }
 
   @override
@@ -526,16 +516,6 @@ class _TransactionListPageState extends State<TransactionListPage> {
                     balance: displayIncome - displayExpense,
                     totalTransfer: displayTransfer > 0 ? displayTransfer : null,
                   ),
-                  // Phase 25 Step 8 — 리스트 뷰 상단 요약 영역 (홈 위젯 재사용).
-                  // 달력 뷰 에서는 노출 안 함 (공간 부족).
-                  if (_viewMode == _TxViewMode.list)
-                    _SummaryExpansion(
-                      expanded: _summaryExpanded,
-                      onChanged: (v) {
-                        setState(() => _summaryExpanded = v);
-                        _saveSummaryExpanded(v);
-                      },
-                    ),
                   if (_viewMode == _TxViewMode.calendar)
                     Expanded(
                       child: TransactionCalendarView(
@@ -1020,39 +1000,3 @@ class _ViewModeToggle extends StatelessWidget {
   }
 }
 
-/// Phase 25 Step 8 — 리스트 뷰 상단 요약 영역 (홈 탭 위젯 복제).
-/// AccountBalanceCard 를 ExpansionTile 로 감싸 default collapsed 노출.
-/// 사용자가 펼치면 SharedPreferences 에 저장되어 다음 진입 시 유지.
-class _SummaryExpansion extends StatelessWidget {
-  final bool expanded;
-  final ValueChanged<bool> onChanged;
-
-  const _SummaryExpansion({required this.expanded, required this.onChanged});
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    return Theme(
-      data: theme.copyWith(dividerColor: Colors.transparent),
-      child: ExpansionTile(
-        key: const PageStorageKey<String>('tx_summary_expansion'),
-        initiallyExpanded: expanded,
-        onExpansionChanged: onChanged,
-        tilePadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 0),
-        childrenPadding: const EdgeInsets.fromLTRB(8, 0, 8, 8),
-        leading: Icon(
-          Icons.account_balance_wallet,
-          size: 18,
-          color: theme.colorScheme.primary,
-        ),
-        title: Text(
-          '잔액 요약',
-          style: theme.textTheme.bodyMedium?.copyWith(
-            fontWeight: FontWeight.w600,
-          ),
-        ),
-        children: const [AccountBalanceCard(showHeader: false)],
-      ),
-    );
-  }
-}


### PR DESCRIPTION
## A. 거래 탭 잔액 요약 ExpansionTile 제거
사용자: "이전에 제거 요청했기에 이후에도 제거되는게 맞다 (다시 생기지 않게 잘 확인)"

### 회귀 분석
- PR #149: 거래 탭 상단 "총자산 미니카드" 추가 → 사용자 "불필요" → #153 에서 제거
- PR #162 (Phase 25 Step 8): 같은 거래 탭에 "잔액 요약" ExpansionTile 추가 (형태는 다르지만 의미 동일: 거래 탭 안에 잔액/자산 정보 노출) → 사용자 다시 거부
- 의도를 "특정 위젯 형태" 가 아닌 **"거래 탭 안에 잔액/자산 정보 노출"** 의미 단위로 기억하지 못함

### 수정
- `_SummaryExpansion` 클래스 제거
- `_summaryExpanded`, `_kTxSummaryExpandedPrefKey`, `_saveSummaryExpanded` 정리
- `AccountBalanceCard` import 제거

### 재발 방지
- 메모리 `feedback_user_rejected_ui_no_re_add.md` 등록 (글로벌, 모든 프로젝트)
- 하네스 `lessons-learned` 인시던트 등록 (`ux_intent_persistence`)
- `audit-patterns.json` 에 `ux_intent_persistence` 태그 신규 추가 — 앞으로 '복제/요약/재사용' 류 작업 시 거부 이력 검색 의무

## B. Phase 25 Step 13/14 — 4탭 최종 도달
### 변경
- `main_shell`: 예산/통계 destination 제거. 4탭 인덱스 (0:거래, 1:분석, 2:자산, 3:더보기). switch case 재매핑
- `app_router`: `/budgets`, `/statistics` StatefulShellBranch 제거. root-level redirect → `/analysis` (deep link 호환)
- 동일 기능은 분석 탭 안의 [예산][통계] sub-tab 유지

### Phase 25 점진 이행 진행 현황 (최종)
| 단계 | 상태 |
|---|---|
| 1~10 (홈 제거, 5탭) | ✅ |
| 11 (분석 탭 신규, 6탭) | ✅ |
| 12 (검증 게이트) | ✅ 사용자 통과 |
| **13/14 (예산/통계 제거, 4탭)** | ✅ **본 PR** |
| **최종 4탭 [거래][분석][자산][더보기]** | ✅ **달성** |

### 후속 (선택)
- 분석 탭 단일 페이지 통합 (현재는 wrapper, BudgetSummaryCard / 카테고리 지출 / 월별 추이 등 직접 이식)
- Step 15 (커플 visibility 통합), Step 16 (정리 PR)

## 검증
- ✅ flutter analyze — 0 error
- ✅ flutter test — 703 passed
- ✅ flutter build web --release — success

## 라이브 검증 (PR merge 후)
### A
- [ ] 거래 탭 상단에 "잔액 요약" 안 보임 (제거 확인)
- [ ] MonthSummaryBar 와 거래 리스트만 표시

### B
- [ ] 하단 네비 4탭 [거래][분석][자산][더보기]
- [ ] 분석 탭 진입 → [예산][통계] sub-tab 동작
- [ ] 기존 `/budgets`, `/statistics` deep link → 분석 탭으로 redirect
- [ ] 회귀: 거래/자산/더보기 탭 정상