### PR TITLE
fix(statistics): 분석 탭의 통계 sub-tab 빈 화면 + sub-tab 아이콘

### DIFF
--- a/frontend/lib/features/statistics/presentation/pages/statistics_page.dart
+++ b/frontend/lib/features/statistics/presentation/pages/statistics_page.dart
@@ -22,45 +22,34 @@ class StatisticsPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // 5개 sub-tab. icon + text 형태로 통일. 순서는 기존 TabBarView children 과 맞춤
+    // (요약 → 카테고리 → 추이 → 전년비교 → 결제수단)
+    const tabs = [
+      Tab(icon: Icon(Icons.dashboard_outlined), text: '요약'),
+      Tab(icon: Icon(Icons.pie_chart_outline), text: '카테고리별'),
+      Tab(icon: Icon(Icons.show_chart), text: '추이'),
+      Tab(icon: Icon(Icons.compare_arrows), text: '전년 비교'),
+      Tab(icon: Icon(Icons.credit_card), text: '결제수단별'),
+    ];
     return DefaultTabController(
       length: 5,
       child: Scaffold(
-        appBar: !showAppBar
-            ? PreferredSize(
-                preferredSize: const Size.fromHeight(kTextTabBarHeight),
-                child: AppBar(
-                  toolbarHeight: 0,
-                  bottom: const TabBar(
-                    isScrollable: true,
-                    tabs: [
-                      Tab(text: '요약'),
-                      Tab(text: '카테고리별'),
-                      Tab(text: '월별 추이'),
-                      Tab(text: '결제수단'),
-                      Tab(text: '전년 비교'),
-                    ],
+        // showAppBar=false (분석 탭 wrapper) 시에도 PreferredSize 안 쓰고
+        // 단일 AppBar 의 toolbarHeight 만 0 으로 — nested TabController 충돌 회피.
+        appBar: AppBar(
+          toolbarHeight: showAppBar ? kToolbarHeight : 0,
+          automaticallyImplyLeading: showAppBar,
+          title: showAppBar ? const Text('통계') : null,
+          actions: showAppBar
+              ? [
+                  IconButton(
+                    icon: const Icon(Icons.analytics_outlined),
+                    tooltip: '기간별 상세 분석',
+                    onPressed: () => context.push('/period-summary'),
                   ),
-                ),
-              )
-            : AppBar(
-          title: const Text('통계'),
-          actions: [
-            IconButton(
-              icon: const Icon(Icons.analytics_outlined),
-              tooltip: '기간별 상세 분석',
-              onPressed: () => context.push('/period-summary'),
-            ),
-          ],
-          bottom: const TabBar(
-            isScrollable: true,
-            tabs: [
-              Tab(text: '요약'),
-              Tab(text: '카테고리별'),
-              Tab(text: '추이'),
-              Tab(text: '전년 비교'),
-              Tab(text: '결제수단별'),
-            ],
-          ),
+                ]
+              : null,
+          bottom: const TabBar(isScrollable: true, tabs: tabs),
         ),
         body: BlocBuilder<StatisticsBloc, StatisticsState>(
           builder: (context, state) {


### PR DESCRIPTION
## 사용자 보고
"분석은 이모티콘이 없다. 또한 분석에서 통계를 가면 아무것도 안 보인다."

## 원인
PR #164 의 `showAppBar=false` 분기가 `PreferredSize(AppBar(toolbarHeight:0, bottom:TabBar))` 패턴 사용. 분석 탭의 outer `DefaultTabController(length:2)` 와 `StatisticsPage` 의 inner `DefaultTabController(length:5)` 가 nested 되며 layout 또는 controller 컨텍스트 충돌로 body 영역이 안 그려진 것으로 보임.

## 수정
- `PreferredSize` 제거
- 단일 `AppBar` 의 `toolbarHeight` 만 conditional (`showAppBar ? kToolbarHeight : 0`) → AppBar 가 항상 inner DefaultTabController(length:5) 의 자식 위치 유지 → TabController 일관 + body 정상 렌더
- sub-tab 5개에 icon + text (요약/카테고리별/추이/전년비교/결제수단별) → 분석 탭의 [예산][통계] icon+text 패턴과 시각적 통일
- TabBarView children 순서는 그대로 유지 (회귀 회피)

## 검증
- ✅ flutter analyze — 0 error
- ✅ flutter test — 703 passed

## 라이브 검증 (PR merge 후)
- [ ] 분석 탭 → 통계 sub-tab 진입 → **5개 sub-tab(요약/카테고리별/추이/전년비교/결제수단별) 모두 icon+text 표시** + body 정상 렌더
- [ ] /statistics deep link → 분석 탭으로 redirect (Step 13/14) → 통계 sub-tab 정상

## Refs
- Regression of #164 Step 11
- Phase 25 Step 11 (분석 탭 wrapper)