### PR TITLE
fix(statistics): visibility reload + 카테고리 ungrouped drill-down + 전수 검사

### DIFF
--- a/frontend/lib/features/statistics/presentation/bloc/statistics_bloc.dart
+++ b/frontend/lib/features/statistics/presentation/bloc/statistics_bloc.dart
@@ -43,7 +43,11 @@ class StatisticsBloc extends Bloc<StatisticsEvent, StatisticsState> {
     Emitter<StatisticsState> emit,
   ) {
     emit(state.copyWith(visibilityFilter: event.visibility));
+    // 모든 sub-tab 의 데이터를 visibility 변경에 맞게 reload.
+    // (이전: LoadAllStatistics 만 호출 → 결제수단/연간비교 stale 회귀)
     add(LoadAllStatistics(year: state.year, month: state.month));
+    add(LoadPaymentMethodStats(year: state.year, month: state.month));
+    add(LoadYearComparison(year: state.year, month: state.month));
   }
 
   Future<void> _onLoadAll(
@@ -216,8 +220,10 @@ class StatisticsBloc extends Bloc<StatisticsEvent, StatisticsState> {
     ));
 
     try {
-      final result =
-          await statisticsRepository.getMonthlyTrend(months: event.months);
+      final result = await statisticsRepository.getMonthlyTrend(
+        months: event.months,
+        visibility: state.visibilityFilter,
+      );
       result.fold(
         (failure) => emit(state.copyWith(
           trendLoading: false,
@@ -246,11 +252,14 @@ class StatisticsBloc extends Bloc<StatisticsEvent, StatisticsState> {
     ));
 
     try {
-      // Load current year and previous year summary in parallel
+      // Load current year and previous year summary in parallel.
+      // visibility 필터 반영 — 변경 시 ChangeVisibilityFilter 가 fire 함.
+      final vis = state.visibilityFilter;
       final results = await Future.wait([
-        statisticsRepository.getSummary(year: event.year, month: event.month),
         statisticsRepository.getSummary(
-            year: event.year - 1, month: event.month),
+            year: event.year, month: event.month, visibility: vis),
+        statisticsRepository.getSummary(
+            year: event.year - 1, month: event.month, visibility: vis),
       ]);
 
       StatisticsSummary? currentSummary;
@@ -303,6 +312,7 @@ class StatisticsBloc extends Bloc<StatisticsEvent, StatisticsState> {
       final result = await statisticsRepository.getPaymentMethodStats(
         year: event.year,
         month: event.month,
+        visibility: state.visibilityFilter,
       );
       result.fold(
         (failure) => emit(state.copyWith(

--- a/frontend/lib/features/statistics/presentation/widgets/category_breakdown_tab.dart
+++ b/frontend/lib/features/statistics/presentation/widgets/category_breakdown_tab.dart
@@ -168,7 +168,7 @@ class _CategoryBreakdownTabState extends State<CategoryBreakdownTab> {
     final groupMap = <String, _GroupData>{};
     for (final stat in widget.categoryStats) {
       final gId = stat.category.groupId ?? 'ungrouped';
-      final gName = stat.category.groupName ?? '미분류';
+      final gName = stat.category.groupName ?? '(그룹 미할당)';
       groupMap.putIfAbsent(gId, () => _GroupData(id: gId, name: gName));
       groupMap[gId]!.amount += stat.amount;
       groupMap[gId]!.count += stat.transactionCount;
@@ -216,12 +216,11 @@ class _CategoryBreakdownTabState extends State<CategoryBreakdownTab> {
               amount: g.amount,
               percentage: g.percentage,
               count: g.count,
-              onTap: g.id != 'ungrouped'
-                  ? () => setState(() {
-                        _selectedGroupId = g.id;
-                        _selectedGroupName = g.name;
-                      })
-                  : null,
+              // ungrouped 도 drill-down 가능 (sub-view 에서 미할당 카테고리 표시).
+              onTap: () => setState(() {
+                _selectedGroupId = g.id;
+                _selectedGroupName = g.name;
+              }),
             );
           }),
         ],
@@ -231,8 +230,12 @@ class _CategoryBreakdownTabState extends State<CategoryBreakdownTab> {
 
   /// Subcategory view: categories within a selected group
   Widget _buildSubcategoryView(BuildContext context) {
+    // ungrouped 가상 그룹 ID 처리: 카테고리의 실제 groupId == null 매치.
+    final isUngrouped = _selectedGroupId == 'ungrouped';
     final filtered = widget.categoryStats
-        .where((s) => s.category.groupId == _selectedGroupId)
+        .where((s) => isUngrouped
+            ? s.category.groupId == null
+            : s.category.groupId == _selectedGroupId)
         .toList()
       ..sort((a, b) => b.amount.compareTo(a.amount));
 


### PR DESCRIPTION
## 사용자 보고
1. UI: 분석 탭과 통계 > 요약 아이콘 — 분석/통계 sub-tab 의 icon 은 코드상 표시되어 있음 (PR #166). 캐시/렌더 이슈일 수 있어 본 PR 에서 추가 확인 항목 포함.
2. **카테고리별 — 전체/수입/그룹별 선택 시 미분류로 나오고 전체 카테고리는 급여로 나옴**
3. **결제수단별 — 전체/공유/개인 변경해도 값들 안 바뀜**
4. **관련 전수 검사 필요**

## A. 결제수단별 + 전년비교 visibility 무동작 (Critical)
### 원인 (전수 검사 결과)
- `_onChangeVisibilityFilter` 가 `LoadAllStatistics` 만 fire → 결제수단별 / 연간비교 / 단독 monthly trend stale
- `_onLoadPaymentMethodStats` 가 visibility 파라미터 미전달 (Repository/DataSource 는 받음)
- `_onLoadYearComparison` 의 `getSummary` 호출 visibility 미전달
- `_onLoadMonthlyTrend` (단독 호출 시) visibility 미전달

### 수정
- `_onChangeVisibilityFilter`: `LoadAllStatistics` + `LoadPaymentMethodStats` + `LoadYearComparison` 모두 fire
- `_onLoadPaymentMethodStats`: `visibility = state.visibilityFilter` 전달
- `_onLoadYearComparison`: 두 getSummary 호출에 visibility 전달
- `_onLoadMonthlyTrend`: visibility 전달

## B. 카테고리별 그룹 미할당 drill-down
### 원인
수입 카테고리에 `groupId == null` (그룹 미할당) 인 경우 그룹별 모드는 'ungrouped' 합계만 표시하고 클릭 차단되어 안의 카테고리(예: 급여) 확인 불가. 데이터 자체는 정상이지만 UX 가 막힘.

### 수정
- 라벨 "미분류" → "(그룹 미할당)" 명확화
- ungrouped 그룹도 `onTap` 활성화 → drill-down 가능
- `_buildSubcategoryView` 가 `_selectedGroupId == 'ungrouped'` 일 때 `groupId == null` 매칭하여 미할당 카테고리(급여 등) 노출

## 검증
- ✅ flutter analyze — 0 error
- ✅ flutter test — 703 passed
- ✅ flutter build web --release — success

## 라이브 검증 (PR merge 후)
### A 결제수단별 / 연간비교
- [ ] 분석 탭 → 통계 → 결제수단별 → 전체/공유/개인 토글 → **값 변경됨**
- [ ] 전년 비교 sub-tab 도 visibility 반영

### B 카테고리별
- [ ] 수입 type 선택 → 그룹별 모드 → "(그룹 미할당)" 항목 클릭 → 미할당 카테고리(급여 등) drill-down 표시

### UI sub-tab icon
- [ ] 분석 탭 [예산][통계] sub-tab icon 표시
- [ ] 통계 5 sub-tab (요약/카테고리별/추이/전년비교/결제수단별) 모두 icon+text 표시