### PR TITLE
fix: 통계 회색화면 (singleton+create 회귀) + 요약 sub-tab 제거

### DIFF
--- a/frontend/lib/core/router/app_router.dart
+++ b/frontend/lib/core/router/app_router.dart
@@ -211,9 +211,8 @@ GoRouter createAppRouter(AuthBloc authBloc) => GoRouter(
     ),
     GoRoute(
       path: '/couple',
-      builder: (context, state) => BlocProvider<CoupleBloc>(
-        create: (context) =>
-            getIt<CoupleBloc>()..add(const LoadCouple()),
+      builder: (context, state) => BlocProvider<CoupleBloc>.value(
+        value: getIt<CoupleBloc>()..add(const LoadCouple()),
         child: const CouplePage(),
       ),
     ),
@@ -555,8 +554,8 @@ GoRouter createAppRouter(AuthBloc authBloc) => GoRouter(
       parentNavigatorKey: _rootNavigatorKey,
       builder: (context, state) {
         final now = DateTime.now();
-        return BlocProvider<WeeklyBudgetBloc>(
-          create: (_) => getIt<WeeklyBudgetBloc>()
+        return BlocProvider<WeeklyBudgetBloc>.value(
+          value: getIt<WeeklyBudgetBloc>()
             ..add(LoadWeeklyOverview(year: now.year, month: now.month))
             ..add(const LoadCurrentWeek()),
           child: const WeeklyBudgetPage(),
@@ -568,8 +567,8 @@ GoRouter createAppRouter(AuthBloc authBloc) => GoRouter(
       parentNavigatorKey: _rootNavigatorKey,
       builder: (context, state) {
         final now = DateTime.now();
-        return BlocProvider<WeeklySettlementBloc>(
-          create: (_) => getIt<WeeklySettlementBloc>()
+        return BlocProvider<WeeklySettlementBloc>.value(
+          value: getIt<WeeklySettlementBloc>()
             ..add(LoadSettlements(year: now.year, month: now.month)),
           child: const WeeklySettlementPage(),
         );
@@ -580,8 +579,8 @@ GoRouter createAppRouter(AuthBloc authBloc) => GoRouter(
       parentNavigatorKey: _rootNavigatorKey,
       builder: (context, state) {
         final now = DateTime.now();
-        return BlocProvider<ReportBloc>(
-          create: (_) => getIt<ReportBloc>()
+        return BlocProvider<ReportBloc>.value(
+          value: getIt<ReportBloc>()
             ..add(LoadMonthlyReport(year: now.year, month: now.month))
             ..add(LoadWeeklyReport(
                 year: now.year, month: now.month, week: 1)),
@@ -599,8 +598,8 @@ GoRouter createAppRouter(AuthBloc authBloc) => GoRouter(
         final lastDay = DateTime(now.year, now.month + 1, 0).day;
         final dateTo =
             '${now.year}-${now.month.toString().padLeft(2, '0')}-${lastDay.toString().padLeft(2, '0')}';
-        return BlocProvider<PeriodSummaryBloc>(
-          create: (_) => getIt<PeriodSummaryBloc>()
+        return BlocProvider<PeriodSummaryBloc>.value(
+          value: getIt<PeriodSummaryBloc>()
             ..add(LoadPeriodSummary(dateFrom: dateFrom, dateTo: dateTo)),
           child: const PeriodSummaryPage(),
         );
@@ -609,9 +608,8 @@ GoRouter createAppRouter(AuthBloc authBloc) => GoRouter(
     GoRoute(
       path: '/recurring',
       parentNavigatorKey: _rootNavigatorKey,
-      builder: (context, state) => BlocProvider<RecurringBloc>(
-        create: (_) =>
-            getIt<RecurringBloc>()..add(const LoadRecurringTransactions()),
+      builder: (context, state) => BlocProvider<RecurringBloc>.value(
+        value: getIt<RecurringBloc>()..add(const LoadRecurringTransactions()),
         child: const RecurringListPage(),
       ),
     ),
@@ -623,8 +621,8 @@ GoRouter createAppRouter(AuthBloc authBloc) => GoRouter(
         getIt<PaymentMethodBloc>().add(const LoadPaymentMethods());
         return MultiBlocProvider(
           providers: [
-            BlocProvider<RecurringBloc>(
-              create: (_) => getIt<RecurringBloc>()
+            BlocProvider<RecurringBloc>.value(
+              value: getIt<RecurringBloc>()
                 ..add(const LoadRecurringTransactions()),
             ),
             BlocProvider<CategoryBloc>.value(
@@ -647,8 +645,8 @@ GoRouter createAppRouter(AuthBloc authBloc) => GoRouter(
         getIt<PaymentMethodBloc>().add(const LoadPaymentMethods());
         return MultiBlocProvider(
           providers: [
-            BlocProvider<RecurringBloc>(
-              create: (_) => getIt<RecurringBloc>()
+            BlocProvider<RecurringBloc>.value(
+              value: getIt<RecurringBloc>()
                 ..add(const LoadRecurringTransactions()),
             ),
             BlocProvider<CategoryBloc>.value(

--- a/frontend/lib/features/analysis/presentation/pages/analysis_page.dart
+++ b/frontend/lib/features/analysis/presentation/pages/analysis_page.dart
@@ -68,8 +68,10 @@ class _StatisticsTabWrapper extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final now = DateTime.now();
-    return BlocProvider<StatisticsBloc>(
-      create: (_) => getIt<StatisticsBloc>()
+    // singleton bloc 은 BlocProvider.value 사용. (create 패턴은 dispose 시
+    // close() 호출되어 singleton 이 dead 상태로 다음 진입 시 회색화면 회귀)
+    return BlocProvider<StatisticsBloc>.value(
+      value: getIt<StatisticsBloc>()
         ..add(LoadAllStatistics(year: now.year, month: now.month))
         ..add(LoadPaymentMethodStats(year: now.year, month: now.month)),
       child: const StatisticsPage(showAppBar: false),

--- a/frontend/lib/features/statistics/presentation/pages/statistics_page.dart
+++ b/frontend/lib/features/statistics/presentation/pages/statistics_page.dart
@@ -7,7 +7,6 @@ import 'package:budget_book/core/widgets/filters/date_range_filter.dart';
 import 'package:budget_book/features/statistics/presentation/bloc/statistics_bloc.dart';
 import 'package:budget_book/features/statistics/presentation/bloc/statistics_event.dart';
 import 'package:budget_book/features/statistics/presentation/bloc/statistics_state.dart';
-import 'package:budget_book/features/statistics/presentation/widgets/summary_tab.dart';
 import 'package:budget_book/features/statistics/presentation/widgets/category_breakdown_tab.dart';
 import 'package:budget_book/features/statistics/presentation/widgets/monthly_trend_tab.dart';
 import 'package:budget_book/features/statistics/presentation/widgets/year_comparison_tab.dart';
@@ -22,17 +21,16 @@ class StatisticsPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // 5개 sub-tab. icon + text 형태로 통일. 순서는 기존 TabBarView children 과 맞춤
-    // (요약 → 카테고리 → 추이 → 전년비교 → 결제수단)
+    // 4개 sub-tab. 요약은 다른 항목들과 중복되어 제거 (사용자 요청).
+    // 순서는 기존 TabBarView children 과 맞춤 (카테고리 → 추이 → 전년비교 → 결제수단).
     const tabs = [
-      Tab(icon: Icon(Icons.dashboard_outlined), text: '요약'),
       Tab(icon: Icon(Icons.pie_chart_outline), text: '카테고리별'),
       Tab(icon: Icon(Icons.show_chart), text: '추이'),
       Tab(icon: Icon(Icons.compare_arrows), text: '전년 비교'),
       Tab(icon: Icon(Icons.credit_card), text: '결제수단별'),
     ];
     return DefaultTabController(
-      length: 5,
+      length: 4,
       child: Scaffold(
         // showAppBar=false (분석 탭 wrapper) 시에도 PreferredSize 안 쓰고
         // 단일 AppBar 의 toolbarHeight 만 0 으로 — nested TabController 충돌 회피.
@@ -126,11 +124,6 @@ class StatisticsPage extends StatelessWidget {
                 Expanded(
                   child: TabBarView(
                     children: [
-                      SummaryTab(
-                        summary: state.summary,
-                        isLoading: state.summaryLoading,
-                        error: state.summaryError,
-                      ),
                       CategoryBreakdownTab(
                         categoryStats: state.categoryStats,
                         isLoading: state.categoryLoading,

--- a/frontend/test/features/statistics/statistics_page_test.dart
+++ b/frontend/test/features/statistics/statistics_page_test.dart
@@ -61,7 +61,7 @@ void main() {
   final now = DateTime.now();
 
   group('StatisticsPage', () {
-    testWidgets('shows tab bar with 3 tabs', (tester) async {
+    testWidgets('shows tab bar with 4 sub-tabs (요약 제거됨)', (tester) async {
       when(() => mockBloc.state).thenReturn(StatisticsState(
         year: now.year,
         month: now.month,
@@ -70,46 +70,12 @@ void main() {
       await tester.pumpWidget(createTestWidget());
 
       expect(find.text('통계'), findsOneWidget);
-      expect(find.text('요약'), findsOneWidget);
+      // 요약 sub-tab 은 사용자 요청으로 제거됨 (다른 항목과 중복)
+      expect(find.text('요약'), findsNothing);
       expect(find.text('카테고리별'), findsOneWidget);
       expect(find.text('추이'), findsOneWidget);
-    });
-
-    testWidgets('shows loading indicator when summary is loading',
-        (tester) async {
-      when(() => mockBloc.state).thenReturn(StatisticsState(
-        year: now.year,
-        month: now.month,
-        summaryLoading: true,
-      ));
-
-      await tester.pumpWidget(createTestWidget());
-
-      expect(find.byType(CircularProgressIndicator), findsOneWidget);
-    });
-
-    testWidgets('shows summary data when loaded', (tester) async {
-      when(() => mockBloc.state).thenReturn(StatisticsState(
-        year: now.year,
-        month: now.month,
-        summary: const StatisticsSummary(
-          yearMonth: '2026-03',
-          totalIncome: 5000000,
-          totalExpense: 3200000,
-          balance: 1800000,
-          transactionCount: 45,
-        ),
-      ));
-
-      await tester.pumpWidget(createTestWidget());
-
-      expect(find.text('수입'), findsOneWidget);
-      expect(find.text('지출'), findsOneWidget);
-      expect(find.text('잔액'), findsOneWidget);
-      expect(find.textContaining('5,000,000원'), findsOneWidget);
-      expect(find.textContaining('3,200,000원'), findsOneWidget);
-      expect(find.textContaining('1,800,000원'), findsOneWidget);
-      expect(find.text('총 45건의 거래'), findsOneWidget);
+      expect(find.text('전년 비교'), findsOneWidget);
+      expect(find.text('결제수단별'), findsOneWidget);
     });
 
     testWidgets('shows category breakdown tab when tapped', (tester) async {
@@ -171,19 +137,6 @@ void main() {
       // Legend items
       expect(find.text('수입'), findsWidgets);
       expect(find.text('지출'), findsWidgets);
-    });
-
-    testWidgets('shows error message when summary has error', (tester) async {
-      when(() => mockBloc.state).thenReturn(StatisticsState(
-        year: now.year,
-        month: now.month,
-        summaryError: '통계 요약을 불러오지 못했습니다',
-      ));
-
-      await tester.pumpWidget(createTestWidget());
-
-      expect(find.text('통계 요약을 불러오지 못했습니다'), findsOneWidget);
-      expect(find.byIcon(Icons.error_outline), findsOneWidget);
     });
 
     testWidgets('shows month navigator with MonthCubit current month',

--- a/frontend/test/features/statistics/statistics_page_test.dart
+++ b/frontend/test/features/statistics/statistics_page_test.dart
@@ -9,7 +9,6 @@ import 'package:budget_book/features/statistics/presentation/bloc/statistics_blo
 import 'package:budget_book/features/statistics/presentation/bloc/statistics_event.dart';
 import 'package:budget_book/features/statistics/presentation/bloc/statistics_state.dart';
 import 'package:budget_book/features/statistics/presentation/pages/statistics_page.dart';
-import 'package:budget_book/features/statistics/domain/entities/statistics_summary.dart';
 import 'package:budget_book/features/statistics/domain/entities/category_statistics.dart';
 import 'package:budget_book/features/statistics/domain/entities/monthly_trend.dart';
 import 'package:budget_book/features/transaction/domain/entities/transaction_category.dart';


### PR DESCRIPTION
## 사용자 보고
1. "예산 > 통계 > 예산 > 통계 가면 통계에서 회색화면 (이전에도 다른 곳에서 이런 동일 문제가 있었고 해결했는데 참고)"
2. "요약은 굳이 필요없을 것 같다 (다른 항목들과 모두 겹침)"

## 1. 회색화면 — Critical 회귀 (전수 fix)
### 원인
`BlocProvider<XBloc>(create: (_) => getIt<XBloc>())` 패턴이 위젯 dispose 시 `bloc.close()` 호출. `registerLazySingleton` 으로 등록된 singleton 이라 close 후 dead 상태 → 다음 진입 시 같은 dead 인스턴스 반환 → state stream 닫혀있어 builder 갱신 못 받고 회색.

PR #150 에서 transaction route 1곳 fix 했으나 **다른 9곳 잔존** (사용자 인용 "이전에도 동일 문제" 가 PR #150).

### Fix (전수 검사)
모든 singleton BLoC 의 `BlocProvider(create:)` → `BlocProvider.value`:
- analysis_page `_StatisticsTabWrapper` (StatisticsBloc)
- app_router `/couple`, `/weekly-budgets`, `/weekly-budgets/settlement`, `/reports`, `/period-summary`, `/recurring`, `/recurring/create`, `/recurring/edit/:id`

## 2. 통계 요약 sub-tab 제거
- `tabs` 5→4 (요약 제거)
- `TabBarView` children 5→4 (SummaryTab 제거)
- `summary_tab.dart` import 정리
- 테스트 갱신 (요약 관련 3개 정리, sub-tab 검증을 4개 기준으로)

## 재발 방지
- 메모리 `feedback_singleton_blocprovider.md` 글로벌 등록
- 하네스 인시던트 `bloc_provider_lifecycle` 등록
- audit-patterns.json `singleton_bloc_provider` 태그 신규 — 앞으로 `BlocProvider(create: getIt<>)` 패턴 자동 감지

## 검증
- ✅ flutter analyze — 0 error
- ✅ flutter test — 700 passed
- ✅ flutter build web --release — success

## 라이브 검증 (PR merge 후)
- [ ] 분석 → 통계 → 예산 → 통계 (왕복 여러번) → **회색화면 안 나옴**
- [ ] 분석 → 통계 sub-tab 4개 [카테고리별][추이][전년비교][결제수단별]
- [ ] 다른 페이지 (가계부 주간/주간 정산/리포트/기간 요약/반복 거래/커플 페이지) 도 같은 패턴 fix 됨 — 진입 후 다른 곳 갔다 돌아와도 정상

## 다음 세션 plan (사용자 요청 "함께 진행")
- C **월간 예산 기간 처리** — 기간 없는 예산 = 템플릿, 월별 override (BE/FE 큰 작업)
- E **카테고리 지출/수입 분리** — 둘은 완전 다른 개념, 각각 그룹 + 기본값 + 테이블 분리 가능 (BE/FE 큰 작업)
- D **하네스 동기화** — claude code 작업이 ~/.claude/harness/server task tracker 에 자동 등록 안 됨

3건 모두 큰 작업이라 다음 세션 plan 으로.