### PR TITLE
feat(category): E-1 — CategoryGroup.categoryType + V58 + 통합 plan

### DIFF
--- a/backend/src/main/kotlin/com/budgetbook/category/domain/CategoryGroup.kt
+++ b/backend/src/main/kotlin/com/budgetbook/category/domain/CategoryGroup.kt
@@ -38,6 +38,14 @@ class CategoryGroup(
     @Column(name = "budget_type", nullable = false, length = 20)
     var budgetType: BudgetType = BudgetType.MONTHLY,
 
+    /**
+     * Phase 25 후속 — 그룹의 카테고리 종류(EXPENSE/INCOME).
+     * 한 그룹 안의 모든 Category.type 은 이 값과 일치해야 함 (Service 단 검증).
+     */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "category_type", nullable = false, length = 10)
+    var categoryType: CategoryType = CategoryType.EXPENSE,
+
     @Column(name = "display_order", nullable = false)
     var displayOrder: Int = 0,
 

--- a/backend/src/main/kotlin/com/budgetbook/category/dto/CategoryGroupDtos.kt
+++ b/backend/src/main/kotlin/com/budgetbook/category/dto/CategoryGroupDtos.kt
@@ -16,7 +16,9 @@ data class CategoryGroupResponse(
     val categories: List<CategoryResponse>,
     val visibility: String = "SHARED",
     val ownerId: UUID? = null,
-    val createdAt: Instant
+    val createdAt: Instant,
+    /** Phase 25 후속 — EXPENSE/INCOME. 기존 위치 인자 호환 위해 끝에 배치. */
+    val categoryType: String = "EXPENSE",
 )
 
 data class CreateCategoryGroupRequest(
@@ -26,6 +28,8 @@ data class CreateCategoryGroupRequest(
     val icon: String? = null,
     val color: String? = null,
     val budgetType: String = "MONTHLY",
+    /** EXPENSE/INCOME. 미지정 시 EXPENSE. */
+    val categoryType: String = "EXPENSE",
     val visibility: String? = "SHARED"
 )
 
@@ -35,6 +39,8 @@ data class UpdateCategoryGroupRequest(
     val icon: String? = null,
     val color: String? = null,
     val budgetType: String? = null,
+    /** Phase 25 후속 — 그룹 안 카테고리들과 type 일치 시에만 변경 허용 (서비스 단 검증). */
+    val categoryType: String? = null,
     val displayOrder: Int? = null,
     val visibility: String? = null
 )

--- a/backend/src/main/kotlin/com/budgetbook/category/service/CategoryGroupService.kt
+++ b/backend/src/main/kotlin/com/budgetbook/category/service/CategoryGroupService.kt
@@ -4,6 +4,7 @@ import com.budgetbook.auth.domain.User
 import com.budgetbook.auth.repository.UserRepository
 import com.budgetbook.category.domain.BudgetType
 import com.budgetbook.category.domain.CategoryGroup
+import com.budgetbook.category.domain.CategoryType
 import com.budgetbook.category.dto.CategoryGroupResponse
 import com.budgetbook.category.dto.CategoryResponse
 import com.budgetbook.category.dto.CreateCategoryGroupRequest
@@ -90,12 +91,19 @@ class CategoryGroupService(
                 .orElseThrow { NotFoundException("USER_NOT_FOUND", "User not found.") }
         } else null
 
+        val categoryType = try {
+            CategoryType.valueOf(request.categoryType)
+        } catch (e: IllegalArgumentException) {
+            throw BusinessException("VALIDATION_ERROR", "Invalid category type: ${request.categoryType}")
+        }
+
         val group = CategoryGroup(
             couple = couple,
             name = request.name,
             icon = request.icon,
             color = request.color,
             budgetType = budgetType,
+            categoryType = categoryType,
             displayOrder = 0,
             isDefault = false,
             visibility = visibility,
@@ -129,6 +137,25 @@ class CategoryGroupService(
                 BudgetType.valueOf(bt)
             } catch (e: IllegalArgumentException) {
                 throw BusinessException("VALIDATION_ERROR", "Invalid budget type: $bt")
+            }
+        }
+        request.categoryType?.let { ct ->
+            val newType = try {
+                CategoryType.valueOf(ct)
+            } catch (e: IllegalArgumentException) {
+                throw BusinessException("VALIDATION_ERROR", "Invalid category type: $ct")
+            }
+            // type 변경 시 그룹 안 모든 카테고리 type 과 일치해야 함.
+            if (newType != group.categoryType) {
+                val children = categoryRepository.findByCoupleIdAndGroupId(couple.id, group.id)
+                val mismatched = children.filter { it.type != newType }
+                if (mismatched.isNotEmpty()) {
+                    throw BusinessException(
+                        "CATEGORY_TYPE_MISMATCH",
+                        "그룹 안 ${mismatched.size}개 카테고리의 type 이 다릅니다. 먼저 카테고리를 이동하세요.",
+                    )
+                }
+                group.categoryType = newType
             }
         }
         request.displayOrder?.let { group.displayOrder = it }
@@ -331,6 +358,7 @@ class CategoryGroupService(
         icon = icon,
         color = color,
         budgetType = budgetType.name,
+        categoryType = categoryType.name,
         displayOrder = displayOrder,
         isDefault = isDefault,
         categories = categories,

--- a/backend/src/main/resources/db/migration/V58__add_category_type_to_groups.sql
+++ b/backend/src/main/resources/db/migration/V58__add_category_type_to_groups.sql
@@ -1,0 +1,46 @@
+-- Phase 25 후속 — 카테고리 그룹 지출/수입 분리
+--
+-- 사용자 보고: "카테고리 관리가 지출/수입 별로 별도로 되어야하는데 현재는
+-- 거의 같은 그룹을 가지는 문제가 존재한다. 두 개는 완전 다른 개념이기 때문에
+-- 각각 설정이 가능해야하며 서로 영향을 미치지 않는다."
+--
+-- category_groups 에 category_type (EXPENSE/INCOME) 컬럼 추가.
+-- 기존 row 백필 — 그룹 안 카테고리 type 의 majority. 동률 또는 카테고리 없는
+-- 그룹은 EXPENSE 기본값 (사용자 나중에 수정 가능).
+
+-- 1) 컬럼 추가 (멱등)
+ALTER TABLE category_groups ADD COLUMN IF NOT EXISTS category_type VARCHAR(10);
+
+-- 2) 백필: 그룹 안 카테고리 type 의 majority
+WITH group_type_stats AS (
+    SELECT
+        group_id,
+        COUNT(*) FILTER (WHERE type = 'EXPENSE') AS expense_count,
+        COUNT(*) FILTER (WHERE type = 'INCOME') AS income_count
+    FROM categories
+    WHERE group_id IS NOT NULL
+    GROUP BY group_id
+)
+UPDATE category_groups cg
+SET category_type = CASE
+    WHEN gts.income_count > gts.expense_count THEN 'INCOME'
+    ELSE 'EXPENSE'
+END
+FROM group_type_stats gts
+WHERE cg.id = gts.group_id
+  AND cg.category_type IS NULL;
+
+-- 3) 카테고리 없는 그룹 또는 백필 미적용 row 는 EXPENSE 기본
+UPDATE category_groups SET category_type = 'EXPENSE' WHERE category_type IS NULL;
+
+-- 4) NOT NULL constraint
+ALTER TABLE category_groups ALTER COLUMN category_type SET NOT NULL;
+
+-- 5) CHECK constraint (멱등)
+ALTER TABLE category_groups DROP CONSTRAINT IF EXISTS ck_category_groups_category_type;
+ALTER TABLE category_groups ADD CONSTRAINT ck_category_groups_category_type
+    CHECK (category_type IN ('EXPENSE', 'INCOME'));
+
+-- 6) 인덱스 — type 별 조회 빈번
+CREATE INDEX IF NOT EXISTS idx_category_groups_couple_type
+    ON category_groups (couple_id, category_type, display_order);

--- a/docs/sessions/2026-04-25_3_plan.md
+++ b/docs/sessions/2026-04-25_3_plan.md
@@ -1,0 +1,118 @@
+# Phase 25 후속 — 3 건 통합 plan
+> 날짜: 2026-04-25 | 회차: 3 | 상태: 검증완료 / auto mode
+
+## 작업 범위
+사용자 보고 3 건 통합 plan. 각 항목 큰 작업이라 별 PR 로 분리.
+
+| # | 작업 | 사이즈 | 우선순위 |
+|---|---|---|---|
+| C | 월간 예산 기간 처리 (template + override) | XL | 중 |
+| E | 카테고리 지출/수입 분리 | L | 높 (사용자 카테고리 미분류 fix 의 후속) |
+| D | 하네스 작업 자동 등록 | S | 즉시 (별 repo) |
+
+## D. 하네스 자동 등록 (즉시 적용 — budget-book 외 작업)
+### 원인
+`~/.claude/harness/scripts/auto-register-request.py` 가 cwd 기반 프로젝트 매칭만 사용. Claude Code 시작 cwd 가 `/Users/kdh/.claude` (메타 디렉토리) 라 budget-book(`/Users/kdh/kdh/github/AIVA-SaaS/budget-book`) 매칭 실패. 4월 20일 마지막 등록 후 모든 작업 미등록.
+
+### Fix (이미 적용됨)
+auto-register-request.py 에 fallback 2 단계 추가:
+1. **2차**: 사용자 프롬프트에 프로젝트 root path 또는 name 언급 시 매칭
+2. **3차**: 최근 30분 내 git activity (`.git/HEAD` mtime) 가 있는 active 프로젝트로 매칭
+
+검증: `req-1777112154454-001` 새로 생성 확인.
+
+### 후속 (선택)
+- harness server 의 GitHub webhook 연동 → PR 머지 시 자동 step 진행
+- claude session-end hook → 작업 완료 시 step='done' 자동 처리
+
+---
+
+## E. 카테고리 지출/수입 분리 (현재 plan 의 핵심)
+
+### 사용자 의도
+> 카테고리 관리가 지출/수입 별로 별도로 되어야하는데 현재는 거의 같은 그룹을 가지는 문제. 두 개는 완전 다른 개념이라 각각 설정 + 기본값 + 테이블 분리도 OK.
+
+### 현재 모델 분석
+- `Category`: `type` (EXPENSE/INCOME), `groupId` (CategoryGroup FK)
+- `CategoryGroup`: type 무관 (`budgetType` 은 WEEKLY/MONTHLY/NONE 의 다른 개념)
+- 결과: 한 그룹 안에 EXPENSE + INCOME 카테고리 혼재 가능. 사용자 혼란.
+
+### 해결 방향 (테이블 분리 vs 컬럼 추가)
+**컬럼 추가 채택** — 마이그레이션 부담 최소화. 사용자 OK 한 옵션.
+
+#### 변경
+1. **BE V58 migration**: `category_groups` 에 `category_type` (EXPENSE/INCOME NOT NULL) 컬럼 추가. 기존 row 백필 — 그룹 안 카테고리 type 의 majority 또는 EXPENSE 기본값.
+2. **Domain**: `CategoryGroup.categoryType` enum 추가
+3. **DTO/Service**:
+   - 그룹 생성 시 `categoryType` 필수
+   - 카테고리 생성/이동 시 type 일치 검증 (다른 type 그룹에 못 넣음)
+   - 기본 그룹 시드 — EXPENSE 그룹 (식비/주거/교통/...) + INCOME 그룹 (월급/부수입/금융수익/...)
+4. **API**: `GET /api/category-groups?type=EXPENSE` 같은 type 필터
+5. **FE**:
+   - CategoryGroupBloc: type 별 state 분리 (`expenseGroups`, `incomeGroups`)
+   - 카테고리 관리 페이지: type 별 탭 또는 토글
+   - 카테고리 선택 sheet: 거래 type 에 맞는 그룹만 노출
+
+### PR 분할
+- **E-1 PR**: BE 마이그레이션 + 도메인 + DTO + 검증 (FE 변경 없음, 호환)
+- **E-2 PR**: BE 시드 데이터 + 신규 사용자 기본값 분리
+- **E-3 PR**: FE CategoryGroupBloc + 카테고리 관리 페이지 type 분리
+- **E-4 PR**: FE 카테고리 선택 sheet + 거래 폼 등 사용처 일관성
+
+### 회귀 위험
+- 기존 그룹 타입 백필 알고리즘이 잘못되면 카테고리/그룹 미스매치 — 검증 쿼리 + dry-run 필수
+- API 호환성: `categoryType` 미전달 시 default EXPENSE 처리
+
+### 하네스 audit
+- `db_schema`, `ui_pattern` 태그 + `category_type_separation` (신규 등록 예정)
+
+---
+
+## C. 월간 예산 기간 처리 (가장 큰 작업)
+
+### 사용자 의도
+> 기간 없을 경우 전체 일정에 동일 예산이 보이지만, 각 달마다 예산을 수정하거나 삭제하면 해당 월에만 반영되어야한다. 이후 모든 일정에 반영 같은 체크 표시하면 이후 일정은 모두 제거되게 하는 기능이 필요하다.
+
+### 발견 사항
+**V57 (`budget_template_override.sql`) 이미 적용 완료**. Phase 23 PR-X4 의 마이그레이션. 그러나 BE 코드는 #144 (Phase 23 전면 롤백) 시 함께 롤백 가능성 — 실제 활용 여부 확인 필요.
+
+### 모델 (V57 정의)
+- `monthly_budgets` 컬럼:
+  - `row_kind` (TEMPLATE | OVERRIDE)
+  - `year_month` (시작월), `end_year_month` (종료월, null=무기한)
+- TEMPLATE: 범위 안 모든 월에 기본 예산 제공
+- OVERRIDE: 특정 단일 월만 덮어쓰기 (TEMPLATE 우선)
+
+### 작업
+1. **BE 확인**: V57 활용하는 service/repo 코드 현재 상태 (#144 롤백 후 잔존?)
+2. 부재 시: BE 재구현 (Phase 23 PR-X4 코드 참고)
+   - `getMonthlyBudgets(year, month)`: TEMPLATE + OVERRIDE merge → 월별 effective 예산
+   - `createBudget(category, amount, startMonth, endMonth?)`: TEMPLATE row 생성
+   - `updateBudgetForMonth(category, month, amount, applyToFuture: bool)`:
+     - applyToFuture=false: 단일 OVERRIDE 추가
+     - applyToFuture=true: 기존 TEMPLATE end_year_month = month-1 로 종료 + 새 TEMPLATE (month, ...) 생성
+   - `deleteBudgetForMonth(category, month, applyToFuture: bool)`:
+     - applyToFuture=false: OVERRIDE 추가 (amount=0)
+     - applyToFuture=true: TEMPLATE end_year_month = month-1 로 종료
+3. **FE**: 예산 수정 sheet 에 "이후 모든 일정에 반영" 체크박스. 삭제 시도 시도.
+
+### PR 분할
+- **C-1**: BE V57 활용 코드 복구/재구현
+- **C-2**: FE 예산 수정 UX 개선
+
+### 회귀 위험 (큼)
+- 기존 데이터 백필 — 모든 row 가 OVERRIDE 인 상태. TEMPLATE 도입 시 기존 행과 충돌 없는지 dry-run.
+- 월별 effective amount 계산 로직 정확도 — 단위 테스트 필수.
+
+---
+
+## 진행 순서 추천
+1. ✅ **D 적용 완료** (이미 적용)
+2. **E-1 진행 (이번 PR)** — BE 마이그레이션 + 도메인 + DTO. FE 호환 유지
+3. 사용자 검증 → E-2, E-3, E-4 순차
+4. 분리 마무리 후 **C-1** 진행
+
+## 검증 (E-1)
+- BE 빌드 + Kotest 통과
+- Flyway V58 적용 후 `category_type` 컬럼 NOT NULL 백필 확인
+- DTO 호환 — 기존 FE 호출 영향 없음 (categoryType 응답에만 추가)


### PR DESCRIPTION
## 통합 plan (3건)
**docs/sessions/2026-04-25_3_plan.md** — C/E/D 작업 plan.

### D 하네스 동기화 (이미 적용)
사용자 보고: "21건 대기, 3건 진행 중" 화면에 우리 작업 안 보임.

원인: `~/.claude/harness/scripts/auto-register-request.py` 가 cwd 매칭만. Claude Code 시작 cwd=`~/.claude` (메타) → budget-book root 매칭 실패.

Fix: fallback 2단계 추가 — (2) 프롬프트에 프로젝트 root/name 언급 매칭, (3) 최근 30분 내 git activity (`.git/HEAD` mtime). 검증: `req-1777112154454-001` 새로 생성.

### E-1 (본 PR) — BE V58 + 도메인 + DTO
사용자: "카테고리 관리가 지출/수입 별로 별도로 되어야하는데 현재는 거의 같은 그룹을 가지는 문제. 두 개는 완전 다른 개념이라 각각 설정 + 기본값 + 테이블 분리 OK."

#### Flyway V58
- `category_groups.category_type` (EXPENSE/INCOME NOT NULL) 추가
- 백필: 그룹 안 카테고리 type 의 **majority**. 동률/카테고리 없는 그룹은 EXPENSE 기본
- CHECK constraint + `(couple_id, category_type, display_order)` 인덱스

#### 도메인 / DTO / Service
- `CategoryGroup.categoryType` 필드. 기존 enum `CategoryType { INCOME, EXPENSE }` (Category.kt:60) 재사용 (이름 충돌 회피)
- `CategoryGroupResponse.categoryType` — 기존 위치 인자 호환 위해 끝에 배치 (테스트 깨지지 않음)
- 그룹 생성/수정 시 categoryType 검증
- 그룹 type 변경 시 그룹 안 카테고리의 type 일치해야 통과 (mismatch → `CATEGORY_TYPE_MISMATCH` 에러)

### 후속 PR (별 진행)
- **E-2**: BE 시드 데이터 — EXPENSE/INCOME 그룹 분리 기본값
- **E-3**: FE CategoryGroupBloc + 카테고리 관리 페이지 type 분리
- **E-4**: FE 카테고리 선택 sheet 일관성
- **C-1/C-2**: 월간 예산 기간 처리 (V57 row_kind/end_year_month 활용)

## 검증
- ✅ BE `compileKotlin` — success
- ✅ BE `gradle test` — BUILD SUCCESSFUL
- ✅ FE analyze — 0 error
- ✅ FE test — 700 passed

## API 호환성
- `categoryType` 응답 필드 추가만 (default "EXPENSE")
- 기존 FE 호출 (categoryType 미전달) 도 default 적용으로 정상 동작
- 기존 카테고리/그룹 백필 자동 적용

## 라이브 검증 (PR merge 후)
- [ ] BE 헬스 정상
- [ ] V58 마이그레이션 적용 후 기존 그룹 동작 정상 (회귀 없음)
- [ ] `GET /api/category-groups` 응답에 `categoryType` 필드 포함

## 다음 단계 후보
1. E-2 (시드 데이터 분리)
2. E-3 (FE 카테고리 관리 페이지 type 분리) — 사용자 체감 큰 변경