### PR TITLE
feat(category): E-3+E-4 — FE 카테고리 그룹 지출/수입 분리

### DIFF
--- a/frontend/lib/core/widgets/category_group_selector_sheet.dart
+++ b/frontend/lib/core/widgets/category_group_selector_sheet.dart
@@ -281,12 +281,17 @@ class _CategoryGroupSelectorSheetState
     }
 
     final coupled = isCoupleMode();
+    // Phase 25 후속 — 그룹 자체도 categoryType 으로 필터링.
+    // (선택 sheet 가 거래 type 에 맞는 그룹만 노출)
+    final typed = groups
+        .where((g) => g.categoryType == widget.categoryType)
+        .toList();
     final sharedGroups = coupled
-        ? (groups.where((g) => g.isShared).toList()
+        ? (typed.where((g) => g.isShared).toList()
           ..sort((a, b) => a.displayOrder.compareTo(b.displayOrder)))
-        : (groups.toList()..sort((a, b) => a.displayOrder.compareTo(b.displayOrder)));
+        : (typed.toList()..sort((a, b) => a.displayOrder.compareTo(b.displayOrder)));
     final privateGroups = coupled
-        ? (groups.where((g) => g.isPrivate).toList()
+        ? (typed.where((g) => g.isPrivate).toList()
           ..sort((a, b) => a.displayOrder.compareTo(b.displayOrder)))
         : <CategoryGroup>[];
 

--- a/frontend/lib/features/category_group/data/models/category_group_model.dart
+++ b/frontend/lib/features/category_group/data/models/category_group_model.dart
@@ -14,6 +14,7 @@ class CategoryGroupModel extends CategoryGroup {
     super.visibility,
     super.ownerId,
     required super.createdAt,
+    super.categoryType,
   });
 
   factory CategoryGroupModel.fromJson(Map<String, dynamic> json) {
@@ -24,6 +25,7 @@ class CategoryGroupModel extends CategoryGroup {
       icon: json['icon'] as String?,
       color: json['color'] as String?,
       budgetType: json['budgetType'] as String? ?? 'NONE',
+      categoryType: json['categoryType'] as String? ?? 'EXPENSE',
       displayOrder: json['displayOrder'] as int? ?? 0,
       isDefault: json['isDefault'] as bool? ?? false,
       categories: categoriesJson

--- a/frontend/lib/features/category_group/data/repositories/category_group_repository_impl.dart
+++ b/frontend/lib/features/category_group/data/repositories/category_group_repository_impl.dart
@@ -30,11 +30,13 @@ class CategoryGroupRepositoryImpl implements CategoryGroupRepository {
     String? color,
     String? budgetType,
     String visibility = 'SHARED',
+    String categoryType = 'EXPENSE',
   }) async {
     try {
       final data = <String, dynamic>{
         'name': name,
         'visibility': visibility,
+        'categoryType': categoryType,
         if (icon != null) 'icon': icon,
         if (color != null) 'color': color,
         if (budgetType != null) 'budgetType': budgetType,

--- a/frontend/lib/features/category_group/domain/entities/category_group.dart
+++ b/frontend/lib/features/category_group/domain/entities/category_group.dart
@@ -13,6 +13,8 @@ class CategoryGroup extends Equatable {
   final String visibility;
   final String? ownerId;
   final DateTime createdAt;
+  /// Phase 25 후속 — EXPENSE/INCOME (그룹의 카테고리 종류).
+  final String categoryType;
 
   const CategoryGroup({
     required this.id,
@@ -26,12 +28,15 @@ class CategoryGroup extends Equatable {
     this.visibility = 'SHARED',
     this.ownerId,
     required this.createdAt,
+    this.categoryType = 'EXPENSE',
   });
 
   bool get isWeekly => budgetType == 'WEEKLY';
   bool get isMonthly => budgetType == 'MONTHLY';
   bool get isPrivate => visibility == 'PRIVATE';
   bool get isShared => visibility == 'SHARED';
+  bool get isExpense => categoryType == 'EXPENSE';
+  bool get isIncome => categoryType == 'INCOME';
 
   @override
   List<Object?> get props => [
@@ -46,5 +51,6 @@ class CategoryGroup extends Equatable {
         visibility,
         ownerId,
         createdAt,
+        categoryType,
       ];
 }

--- a/frontend/lib/features/category_group/domain/repositories/category_group_repository.dart
+++ b/frontend/lib/features/category_group/domain/repositories/category_group_repository.dart
@@ -10,6 +10,7 @@ abstract class CategoryGroupRepository {
     String? color,
     String? budgetType,
     String visibility = 'SHARED',
+    String categoryType = 'EXPENSE',
   });
   Future<Either<Failure, CategoryGroup>> updateCategoryGroup({
     required String id,

--- a/frontend/lib/features/category_group/presentation/bloc/category_group_bloc.dart
+++ b/frontend/lib/features/category_group/presentation/bloc/category_group_bloc.dart
@@ -48,6 +48,7 @@ class CategoryGroupBloc
         color: event.color,
         budgetType: event.budgetType,
         visibility: event.visibility,
+        categoryType: event.categoryType,
       );
       result.fold(
         (failure) => emit(CategoryGroupLoaded(currentGroups,

--- a/frontend/lib/features/category_group/presentation/bloc/category_group_event.dart
+++ b/frontend/lib/features/category_group/presentation/bloc/category_group_event.dart
@@ -17,6 +17,8 @@ class CreateCategoryGroup extends CategoryGroupEvent {
   final String? color;
   final String? budgetType;
   final String visibility;
+  /// Phase 25 후속 — EXPENSE/INCOME.
+  final String categoryType;
 
   const CreateCategoryGroup({
     required this.name,
@@ -24,10 +26,12 @@ class CreateCategoryGroup extends CategoryGroupEvent {
     this.color,
     this.budgetType,
     this.visibility = 'SHARED',
+    this.categoryType = 'EXPENSE',
   });
 
   @override
-  List<Object?> get props => [name, icon, color, budgetType, visibility];
+  List<Object?> get props =>
+      [name, icon, color, budgetType, visibility, categoryType];
 }
 
 class UpdateCategoryGroup extends CategoryGroupEvent {

--- a/frontend/lib/features/settings/presentation/pages/asset_management_page.dart
+++ b/frontend/lib/features/settings/presentation/pages/asset_management_page.dart
@@ -164,8 +164,16 @@ class AssetManagementPage extends StatelessWidget {
 
 const _virtualGroupId = '00000000-0000-0000-0000-000000000000';
 
-class _CategoryTab extends StatelessWidget {
+class _CategoryTab extends StatefulWidget {
   const _CategoryTab();
+
+  @override
+  State<_CategoryTab> createState() => _CategoryTabState();
+}
+
+class _CategoryTabState extends State<_CategoryTab> {
+  // Phase 25 후속 E-3 — 카테고리 그룹 EXPENSE/INCOME 분리. 페이지 내 토글로 전환.
+  String _selectedType = 'EXPENSE';
 
   @override
   Widget build(BuildContext context) {
@@ -187,23 +195,19 @@ class _CategoryTab extends StatelessWidget {
             return const Center(child: CircularProgressIndicator());
           }
           final coupled = isCoupleMode();
+          // type 별 필터링 — 사용자가 선택한 EXPENSE/INCOME 만 노출.
+          final allTypeFiltered = state.groups
+              .where((g) => g.categoryType == _selectedType)
+              .toList();
           final sharedGroups = coupled
-              ? (state.groups.where((g) => g.isShared).toList()
+              ? (allTypeFiltered.where((g) => g.isShared).toList()
                 ..sort((a, b) => a.displayOrder.compareTo(b.displayOrder)))
-              : (state.groups.toList()
+              : (allTypeFiltered.toList()
                 ..sort((a, b) => a.displayOrder.compareTo(b.displayOrder)));
           final privateGroups = coupled
-              ? (state.groups.where((g) => g.isPrivate).toList()
+              ? (allTypeFiltered.where((g) => g.isPrivate).toList()
                 ..sort((a, b) => a.displayOrder.compareTo(b.displayOrder)))
               : <CategoryGroup>[];
-
-          if (state.groups.isEmpty) {
-            return const EmptyStateWidget(
-              icon: Icons.category,
-              title: '카테고리가 없습니다',
-              subtitle: '+ 버튼을 눌러 카테고리를 추가하세요',
-            );
-          }
 
           return BlocListener<CategoryBloc, CategoryState>(
             listener: (context, catState) {
@@ -216,17 +220,47 @@ class _CategoryTab extends StatelessWidget {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  // Shared groups - reorderable
-                  _buildReorderableGroupSection(
-                    context,
-                    groups: sharedGroups,
+                  // EXPENSE / INCOME 토글
+                  Padding(
+                    padding: const EdgeInsets.symmetric(
+                        horizontal: 16, vertical: 8),
+                    child: SegmentedButton<String>(
+                      segments: const [
+                        ButtonSegment(value: 'EXPENSE', label: Text('지출'), icon: Icon(Icons.shopping_cart_outlined, size: 16)),
+                        ButtonSegment(value: 'INCOME', label: Text('수입'), icon: Icon(Icons.trending_up, size: 16)),
+                      ],
+                      selected: {_selectedType},
+                      onSelectionChanged: (s) =>
+                          setState(() => _selectedType = s.first),
+                    ),
                   ),
+                  if (allTypeFiltered.isEmpty)
+                    Padding(
+                      padding: const EdgeInsets.symmetric(vertical: 32),
+                      child: EmptyStateWidget(
+                        icon: Icons.category,
+                        title: _selectedType == 'EXPENSE'
+                            ? '지출 카테고리 그룹이 없습니다'
+                            : '수입 카테고리 그룹이 없습니다',
+                        subtitle: '+ 버튼을 눌러 추가하세요',
+                      ),
+                    )
+                  else ...[
+                    // Shared groups - reorderable
+                    _buildReorderableGroupSection(
+                      context,
+                      groups: sharedGroups,
+                    ),
+                  ],
                   // Add group button
                   _buildAddButton(
                     context,
                     icon: Icons.create_new_folder,
                     label: coupled ? '공유 그룹 추가' : '그룹 추가',
-                    onTap: () => _showAddGroupDialog(context),
+                    onTap: () => _showAddGroupDialog(
+                      context,
+                      categoryType: _selectedType,
+                    ),
                   ),
                   // Private section (couple mode only)
                   if (coupled) ...[
@@ -243,7 +277,11 @@ class _CategoryTab extends StatelessWidget {
                       icon: Icons.add,
                       label: '개인 그룹 추가',
                       color: Theme.of(context).colorScheme.onSurfaceVariant,
-                      onTap: () => _showAddGroupDialog(context, visibility: 'PRIVATE'),
+                      onTap: () => _showAddGroupDialog(
+                        context,
+                        visibility: 'PRIVATE',
+                        categoryType: _selectedType,
+                      ),
                     ),
                   ],
                   const SizedBox(height: 88),
@@ -553,12 +591,19 @@ class _CategoryTab extends StatelessWidget {
     );
   }
 
-  void _showAddGroupDialog(BuildContext context, {String visibility = 'SHARED'}) {
+  void _showAddGroupDialog(
+    BuildContext context, {
+    String visibility = 'SHARED',
+    String categoryType = 'EXPENSE',
+  }) {
     final controller = TextEditingController();
+    final typeLabel = categoryType == 'INCOME' ? '수입' : '지출';
     showDialog(
       context: context,
       builder: (dialogContext) => AlertDialog(
-        title: Text(visibility == 'PRIVATE' ? '개인 그룹 추가' : '그룹 추가'),
+        title: Text(
+          '$typeLabel ${visibility == 'PRIVATE' ? '개인 그룹' : '그룹'} 추가',
+        ),
         content: TextField(
           controller: controller,
           decoration: const InputDecoration(hintText: '그룹 이름'),
@@ -575,7 +620,11 @@ class _CategoryTab extends StatelessWidget {
               if (name.isNotEmpty) {
                 Navigator.of(dialogContext).pop();
                 getIt<CategoryGroupBloc>().add(
-                  CreateCategoryGroup(name: name, visibility: visibility),
+                  CreateCategoryGroup(
+                    name: name,
+                    visibility: visibility,
+                    categoryType: categoryType,
+                  ),
                 );
               }
             },

--- a/frontend/test/features/category_group/presentation/bloc/category_group_bloc_test.dart
+++ b/frontend/test/features/category_group/presentation/bloc/category_group_bloc_test.dart
@@ -28,6 +28,7 @@ class MockCategoryGroupRepository extends Mock
     String? color,
     String? budgetType,
     String visibility = 'SHARED',
+    String categoryType = 'EXPENSE',
   }) =>
       super.noSuchMethod(
         Invocation.method(#createCategoryGroup, [], {
@@ -36,6 +37,7 @@ class MockCategoryGroupRepository extends Mock
           #color: color,
           #budgetType: budgetType,
           #visibility: visibility,
+          #categoryType: categoryType,
         }),
         returnValue: Future.value(
           Right<Failure, CategoryGroup>(CategoryGroup(


### PR DESCRIPTION
## 사용자 보고
"카테고리 항목에 대해선 아직 지출/수입으로 분류되진 않는 것 같다. 다음 단계 진행하면서 최종 잘 반영되도록 확인"

## E-3 자산 탭 카테고리 섹션 type 분리
- `_CategoryTab` StatelessWidget → StatefulWidget
- 상단 `[지출][수입]` SegmentedButton (icon+text)
- 선택된 type 의 그룹만 노출 (categoryType 필터)
- 빈 상태 안내 ("지출/수입 카테고리 그룹이 없습니다")
- 그룹 추가 dialog 가 type 명시 ("지출 그룹 추가" / "수입 그룹 추가")

## E-4 CategoryGroupSelectorSheet (거래 폼 등) type 필터
- 그룹 자체도 categoryType 으로 필터링
- 거래 type=EXPENSE 폼 → EXPENSE 그룹만 / INCOME 폼 → INCOME 그룹만
- 카테고리 0개인 그룹도 type 안 맞으면 안 보임

## 모델 / Bloc / Repository
- `CategoryGroup` 엔티티: `categoryType` 필드 + `isExpense`/`isIncome` 게터
- `CategoryGroupModel.fromJson`: `categoryType` 파싱 (default 'EXPENSE')
- `CreateCategoryGroup` event: `categoryType` 파라미터
- Repository / domain interface 시그니처에 `categoryType` 추가
- 테스트 mock 갱신 (`createCategoryGroup` 시그니처 변경 반영)

## 검증
- ✅ flutter analyze — 0 error
- ✅ flutter test — 700 passed
- ✅ flutter build web --release — success
- BE V58 (PR #169) 적용 후 정상 응답 → FE 가 categoryType 정상 활용

## 라이브 검증 (PR merge 후)
- [ ] 자산 탭 → 카테고리 → `[지출][수입]` 토글 표시
- [ ] 지출 토글 → EXPENSE 그룹만 / 수입 토글 → INCOME 그룹만
- [ ] 그룹 추가 시 현재 토글의 type 으로 생성됨
- [ ] 거래 추가 → type=지출 → 카테고리 선택 sheet 가 EXPENSE 그룹만 / 수입 → INCOME 그룹만
- [ ] 분석 탭 → 통계 → 카테고리별 → 지출/수입 토글 시 해당 type 그룹만

## 후속
- **E-2** (별 PR): BE 시드 데이터 — 신규 사용자 EXPENSE/INCOME 그룹 분리 기본값
- **C-1/C-2** (별 PR): 월간 예산 기간 처리

## Refs
- E-1 PR #169 (BE V58 + 도메인)