### PR TITLE
feat(category): E-2 — INCOME 기본 그룹 자동 시드 (V59 + service)

### DIFF
--- a/backend/src/main/kotlin/com/budgetbook/category/service/CategoryGroupService.kt
+++ b/backend/src/main/kotlin/com/budgetbook/category/service/CategoryGroupService.kt
@@ -271,10 +271,16 @@ class CategoryGroupService(
 
     @Transactional
     fun seedDefaultCategoryGroups(couple: Couple) {
+        // Phase 25 후속 — 신규 사용자에게 EXPENSE 3개 + INCOME 1개 기본 그룹.
         val defaults = listOf(
-            DefaultGroup("생활비", "account_balance_wallet", "#4CAF50", BudgetType.WEEKLY, 1),
-            DefaultGroup("고정지출", "receipt_long", "#2196F3", BudgetType.MONTHLY, 2),
-            DefaultGroup("기타", "more_horiz", "#9E9E9E", BudgetType.NONE, 3)
+            DefaultGroup("생활비", "account_balance_wallet", "#4CAF50",
+                BudgetType.WEEKLY, CategoryType.EXPENSE, 1),
+            DefaultGroup("고정지출", "receipt_long", "#2196F3",
+                BudgetType.MONTHLY, CategoryType.EXPENSE, 2),
+            DefaultGroup("기타", "more_horiz", "#9E9E9E",
+                BudgetType.NONE, CategoryType.EXPENSE, 3),
+            DefaultGroup("수입", "attach_money", "#4CAF50",
+                BudgetType.NONE, CategoryType.INCOME, 100),
         )
 
         val groups = defaults.map { d ->
@@ -284,6 +290,7 @@ class CategoryGroupService(
                 icon = d.icon,
                 color = d.color,
                 budgetType = d.budgetType,
+                categoryType = d.categoryType,
                 displayOrder = d.displayOrder,
                 isDefault = true
             )
@@ -295,9 +302,11 @@ class CategoryGroupService(
 
         val livingGroup = groupMap["생활비"]
         val etcGroup = groupMap["기타"]
+        val incomeGroup = groupMap["수입"]
 
         val livingCategoryNames = listOf("식비", "교통비", "쇼핑")
         val etcCategoryNames = listOf("기타", "의료/건강", "문화/여가")
+        val incomeCategoryNames = listOf("급여", "부업/용돈")
 
         if (livingGroup != null) {
             val livingCategories = categoryRepository.findByCoupleIdAndNameIn(couple.id, livingCategoryNames)
@@ -309,6 +318,12 @@ class CategoryGroupService(
             val etcCategories = categoryRepository.findByCoupleIdAndNameIn(couple.id, etcCategoryNames)
             etcCategories.forEach { it.group = etcGroup }
             categoryRepository.saveAll(etcCategories)
+        }
+
+        if (incomeGroup != null) {
+            val incomeCategories = categoryRepository.findByCoupleIdAndNameIn(couple.id, incomeCategoryNames)
+            incomeCategories.forEach { it.group = incomeGroup }
+            categoryRepository.saveAll(incomeCategories)
         }
     }
 
@@ -378,6 +393,7 @@ class CategoryGroupService(
         val icon: String,
         val color: String,
         val budgetType: BudgetType,
+        val categoryType: CategoryType,
         val displayOrder: Int
     )
 }

--- a/backend/src/main/resources/db/migration/V59__seed_default_income_group.sql
+++ b/backend/src/main/resources/db/migration/V59__seed_default_income_group.sql
@@ -1,0 +1,44 @@
+-- Phase 25 후속 — 기존 사용자에게 INCOME 기본 그룹 자동 시드
+--
+-- 사용자 보고: "수입에 대한 그룹 카테고리도 별도로 생겨야하는데 제대로
+-- 분석이 안된 것 같다"
+--
+-- V58 백필은 "수입 카테고리가 들어 있는 그룹" 만 INCOME 으로 분류함.
+-- 사용자 데이터에서 수입 카테고리("급여" 등) 가 group_id NULL 인 경우
+-- INCOME 그룹이 없게 됨. → 이 마이그레이션으로 각 couple 에 INCOME 기본
+-- 그룹 1개 생성하고 미할당 수입 카테고리들을 자동 할당.
+
+-- 1) INCOME 그룹이 없는 couple 에 기본 "수입" 그룹 생성
+INSERT INTO category_groups (
+    id, couple_id, name, icon, color,
+    budget_type, category_type, display_order, is_default,
+    visibility, created_at, updated_at
+)
+SELECT
+    gen_random_uuid(),
+    c.id,
+    '수입',
+    'attach_money',
+    '#4CAF50',
+    'NONE',
+    'INCOME',
+    100,           -- 기존 EXPENSE 그룹 (1, 2, 3) 뒤에
+    TRUE,
+    'SHARED',
+    NOW(),
+    NOW()
+FROM couples c
+WHERE NOT EXISTS (
+    SELECT 1 FROM category_groups cg
+    WHERE cg.couple_id = c.id AND cg.category_type = 'INCOME'
+);
+
+-- 2) 그룹 미할당 INCOME 카테고리들을 새 그룹에 자동 할당
+UPDATE categories cat
+SET group_id = cg.id
+FROM category_groups cg
+WHERE cat.couple_id = cg.couple_id
+  AND cg.category_type = 'INCOME'
+  AND cg.is_default = TRUE
+  AND cat.type = 'INCOME'
+  AND cat.group_id IS NULL;

--- a/backend/src/test/kotlin/com/budgetbook/category/service/CategoryGroupServiceTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/category/service/CategoryGroupServiceTest.kt
@@ -338,18 +338,21 @@ class CategoryGroupServiceTest : BehaviorSpec({
         val category4 = Category(couple = couple, name = "기타", type = CategoryType.EXPENSE, isDefault = true)
         val category5 = Category(couple = couple, name = "의료/건강", type = CategoryType.EXPENSE, isDefault = true)
         val category6 = Category(couple = couple, name = "문화/여가", type = CategoryType.EXPENSE, isDefault = true)
+        val incomeCategory1 = Category(couple = couple, name = "급여", type = CategoryType.INCOME, isDefault = true)
+        val incomeCategory2 = Category(couple = couple, name = "부업/용돈", type = CategoryType.INCOME, isDefault = true)
 
         every { categoryRepository.findByCoupleIdAndNameIn(couple.id, listOf("식비", "교통비", "쇼핑")) } returns listOf(category1, category2, category3)
         every { categoryRepository.findByCoupleIdAndNameIn(couple.id, listOf("기타", "의료/건강", "문화/여가")) } returns listOf(category4, category5, category6)
+        every { categoryRepository.findByCoupleIdAndNameIn(couple.id, listOf("급여", "부업/용돈")) } returns listOf(incomeCategory1, incomeCategory2)
 
         every { categoryRepository.saveAll(any<List<Category>>()) } answers { firstArg() }
 
         When("seedDefaultCategoryGroups is called") {
             categoryGroupService.seedDefaultCategoryGroups(couple)
 
-            Then("creates 3 default groups") {
-                savedGroupsList shouldHaveSize 3
-                savedGroupsList.map { it.name } shouldBe listOf("생활비", "고정지출", "기타")
+            Then("creates 4 default groups (3 EXPENSE + 1 INCOME)") {
+                savedGroupsList shouldHaveSize 4
+                savedGroupsList.map { it.name } shouldBe listOf("생활비", "고정지출", "기타", "수입")
                 savedGroupsList.all { it.isDefault } shouldBe true
                 savedGroupsList.all { it.couple == couple } shouldBe true
             }
@@ -361,6 +364,8 @@ class CategoryGroupServiceTest : BehaviorSpec({
                 category4.group?.name shouldBe "기타"
                 category5.group?.name shouldBe "기타"
                 category6.group?.name shouldBe "기타"
+                incomeCategory1.group?.name shouldBe "수입"
+                incomeCategory2.group?.name shouldBe "수입"
             }
         }
     }


### PR DESCRIPTION
## 사용자 보고
"수입에 대한 그룹 카테고리도 별도로 생겨야하는데 제대로 분석이 안된 것 같다"

## 원인
V58 (PR #169) 백필 알고리즘: "그룹 안 카테고리 type 의 majority". 사용자 데이터의 수입 카테고리("급여" 등)가 `group_id` NULL 이라 어떤 그룹도 INCOME 으로 분류되지 않음. → 자산 탭 → 카테고리 → "수입" 토글이 빈 상태.

## 수정
### Flyway V59 (기존 사용자)
- 각 couple 에 INCOME 그룹이 없으면 기본 "수입" 그룹 자동 생성 (멱등: `NOT EXISTS` 체크)
- 그룹 미할당 INCOME 카테고리 (`type='INCOME' AND group_id IS NULL`) 들을 새 그룹에 자동 할당

### CategoryGroupService.seedDefaultCategoryGroups (신규 사용자)
- 기본 그룹: 생활비/고정지출/기타 (EXPENSE) + **"수입" (INCOME)** 추가
- `DefaultGroup` data class 에 `categoryType` 필드 추가
- 시드 후 `categoryRepository.findByCoupleIdAndNameIn(["급여", "부업/용돈"])` 로 INCOME 카테고리 자동 할당

## 검증
- ✅ BE compileKotlin — success
- ✅ BE test — BUILD SUCCESSFUL
- ✅ 테스트 갱신: `seedDefaultCategoryGroups` 가 4 그룹 생성 + 수입 카테고리 할당 검증

## 라이브 검증 (PR merge 후)
- [ ] 자산 탭 → 카테고리 → **"수입" 토글** → "수입" 그룹 표시
- [ ] 수입 그룹 안에 "급여", "부업/용돈" 카테고리
- [ ] 분석 탭 → 통계 → 카테고리별 → 수입 → 그룹별 → "수입" 그룹 노출 (이전엔 "(그룹 미할당)")
- [ ] 거래 추가 → type=수입 → 카테고리 선택 → "수입" 그룹 노출

## 후속
- **C-1/C-2** (별 PR, 큰 작업): 월간 예산 기간 처리 (V57 row_kind 활용)

## Refs
- E-1 PR #169 (BE V58 + 도메인)
- E-3+E-4 PR #170 (FE 분리)