### PR TITLE
fix(category): 카테고리 추가 dialog type 동기화 + 그룹 selector type 필터

### DIFF
--- a/frontend/lib/features/category/presentation/widgets/category_form_sheet.dart
+++ b/frontend/lib/features/category/presentation/widgets/category_form_sheet.dart
@@ -10,12 +10,16 @@ import 'package:budget_book/core/widgets/color_picker.dart';
 
 class CategoryFormSheet extends StatefulWidget {
   final Category? category;
+  /// Phase 25 후속 — 신규 추가 시 초기 type (EXPENSE/INCOME).
+  /// 자산 탭 [수입] 토글 상태에서 FAB 누르면 'INCOME' 전달.
+  final String initialType;
   final void Function(String name, String type, String? icon, String? color, String? groupId)
       onSubmit;
 
   const CategoryFormSheet({
     super.key,
     this.category,
+    this.initialType = 'EXPENSE',
     required this.onSubmit,
   });
 
@@ -38,7 +42,7 @@ class _CategoryFormSheetState extends State<CategoryFormSheet> {
   void initState() {
     super.initState();
     _nameController = TextEditingController(text: widget.category?.name ?? '');
-    _selectedType = widget.category?.type ?? 'EXPENSE';
+    _selectedType = widget.category?.type ?? widget.initialType;
     _selectedIcon = widget.category?.icon;
     _selectedColor = widget.category?.color;
     _selectedGroupId = widget.category?.groupId;
@@ -143,7 +147,22 @@ class _CategoryFormSheetState extends State<CategoryFormSheet> {
                   selected: {_selectedType},
                   onSelectionChanged: (value) {
                     setState(() {
-                      _selectedType = value.first;
+                      final newType = value.first;
+                      _selectedType = newType;
+                      // type 변경 시 현재 선택된 그룹이 새 type 의 그룹이 아니라면
+                      // 자동 해제 (잘못된 type 매핑 방지).
+                      if (_selectedGroupId != null) {
+                        final groupBloc = getIt<CategoryGroupBloc>();
+                        final state = groupBloc.state;
+                        if (state is CategoryGroupLoaded) {
+                          final group = state.groups
+                              .where((g) => g.id == _selectedGroupId)
+                              .firstOrNull;
+                          if (group != null && group.categoryType != newType) {
+                            _selectedGroupId = null;
+                          }
+                        }
+                      }
                     });
                   },
                 ),
@@ -251,7 +270,10 @@ class _CategoryFormSheetState extends State<CategoryFormSheet> {
           if (state is! CategoryGroupLoaded) {
             return const LinearProgressIndicator();
           }
-          final groups = state.groups;
+          // Phase 25 후속 — 현재 선택된 type 의 그룹만 노출.
+          final groups = state.groups
+              .where((g) => g.categoryType == _selectedType)
+              .toList();
           return DropdownButtonFormField<String?>(
             initialValue: _selectedGroupId,
             decoration: const InputDecoration(

--- a/frontend/lib/features/settings/presentation/pages/asset_management_page.dart
+++ b/frontend/lib/features/settings/presentation/pages/asset_management_page.dart
@@ -30,6 +30,11 @@ import 'package:budget_book/core/widgets/balance_adjustment_sheet.dart';
 import 'package:budget_book/core/widgets/month_navigator.dart';
 import 'package:budget_book/features/payment_method/domain/entities/card_settlement_summary.dart';
 
+/// Phase 25 후속 — 자산 탭의 [지출/수입] 토글과 카테고리 추가 dialog 사이 공유 state.
+/// _CategoryTab 이 토글 변경 시 갱신하고, FAB 의 _showAddCategory 가 읽어
+/// CategoryFormSheet.initialType 으로 전달한다.
+String _lastSelectedCategoryType = 'EXPENSE';
+
 class AssetManagementPage extends StatelessWidget {
   final int? initialYear;
   final int? initialMonth;
@@ -104,6 +109,7 @@ class AssetManagementPage extends StatelessWidget {
       context: context,
       isScrollControlled: true,
       builder: (_) => CategoryFormSheet(
+        initialType: _lastSelectedCategoryType,
         onSubmit: (name, type, icon, color, groupId) {
           bloc.add(CreateCategory(
             name: name,
@@ -173,7 +179,9 @@ class _CategoryTab extends StatefulWidget {
 
 class _CategoryTabState extends State<_CategoryTab> {
   // Phase 25 후속 E-3 — 카테고리 그룹 EXPENSE/INCOME 분리. 페이지 내 토글로 전환.
-  String _selectedType = 'EXPENSE';
+  // 마지막 선택을 top-level state(`_lastSelectedCategoryType`) 에 동기화하여
+  // FAB → 카테고리 추가 시 같은 type 의 dialog 노출.
+  String _selectedType = _lastSelectedCategoryType;
 
   @override
   Widget build(BuildContext context) {
@@ -230,8 +238,10 @@ class _CategoryTabState extends State<_CategoryTab> {
                         ButtonSegment(value: 'INCOME', label: Text('수입'), icon: Icon(Icons.trending_up, size: 16)),
                       ],
                       selected: {_selectedType},
-                      onSelectionChanged: (s) =>
-                          setState(() => _selectedType = s.first),
+                      onSelectionChanged: (s) {
+                        setState(() => _selectedType = s.first);
+                        _lastSelectedCategoryType = s.first;
+                      },
                     ),
                   ),
                   if (allTypeFiltered.isEmpty)


### PR DESCRIPTION
## 사용자 보고
1. "카테고리 추가 > 수입에서 추가했는데 지출 카테고리 기준으로 나옴"
2. "그룹 항목 선택 시 거래 등록에서는 수입만 나오는데 여기에선 지출 그룹처럼 나옴"

## 원인 분석
- `CategoryFormSheet` 의 default type = `'EXPENSE'`. 자산 탭 [수입] 토글 상태와 무관하게 시작
- `_buildGroupSelector` 가 모든 그룹 노출 (categoryType 필터 없음). 거래 폼의 `CategoryGroupSelectorSheet` 는 PR #170 에서 이미 type 필터링했지만 카테고리 추가 dialog 의 group dropdown 은 누락됨

## 수정
### CategoryFormSheet
- `initialType` 파라미터 (default `'EXPENSE'`) — 신규 추가 시 초기 type 지정
- `_buildGroupSelector`: `state.groups` 를 `categoryType == _selectedType` 로 필터링
- type 토글 변경 시 현재 선택된 그룹이 새 type 의 그룹이 아니면 자동 해제

### AssetManagementPage
- top-level `_lastSelectedCategoryType` 변수로 `_CategoryTab` 토글과 FAB 사이 type 공유
- `_CategoryTab` 의 type 변경 시 `_lastSelectedCategoryType` 갱신
- `_showAddCategory` 가 `_lastSelectedCategoryType` 을 `CategoryFormSheet.initialType` 으로 전달

→ 자산 탭 [수입] 토글 상태에서 FAB → 카테고리 추가 시 default `INCOME` + 그룹 selector 도 `INCOME` 그룹만.

## 검증
- ✅ flutter analyze — 0 error
- ✅ flutter test — 700 passed
- ✅ flutter build web --release — success

## 라이브 검증 (PR merge 후)
- [ ] 자산 탭 → 카테고리 → [수입] 토글 → FAB → 카테고리 추가 dialog
- [ ] dialog 진입 시 type=수입 default
- [ ] 그룹 dropdown 에 INCOME 그룹("수입") 만 표시 (지출 그룹 안 보임)
- [ ] dialog 안에서 type=지출 토글로 변경 → 그룹 dropdown 이 EXPENSE 그룹으로 갱신, 기존 INCOME 그룹 선택은 자동 해제

## 후속 (별 PR)
- C-1/C-2: 월간 예산 기간 처리 (V57 row_kind 활용, 큰 작업)