### PR TITLE
feat(budget): C-1 — MonthlyBudget 도메인에 V57 컬럼 매핑 (template+override)

### DIFF
--- a/backend/src/main/kotlin/com/budgetbook/budget/domain/MonthlyBudget.kt
+++ b/backend/src/main/kotlin/com/budgetbook/budget/domain/MonthlyBudget.kt
@@ -40,6 +40,19 @@ class MonthlyBudget(
     @Column(name = "year_month", nullable = false, length = 7)
     val yearMonth: String,
 
+    /**
+     * Phase 25 후속 C-1 — 템플릿+오버라이드 모델 (V57 컬럼 매핑 시작).
+     * - TEMPLATE: 시작월=yearMonth, 종료월=endYearMonth (null=무기한)
+     * - OVERRIDE: 단일월 — yearMonth == endYearMonth
+     * 기존 데이터는 V57 백필로 모두 OVERRIDE + endYearMonth=yearMonth.
+     */
+    @Column(name = "end_year_month", length = 7)
+    var endYearMonth: String? = null,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "row_kind", nullable = false, length = 10)
+    var rowKind: BudgetRowKind = BudgetRowKind.OVERRIDE,
+
     @Column(nullable = false)
     var amount: Long,
 
@@ -76,3 +89,10 @@ class MonthlyBudget(
 enum class BudgetPeriod { WEEKLY, MONTHLY }
 
 enum class PeriodType { NONE, DAILY, WEEKLY, MONTHLY }
+
+/**
+ * Phase 25 후속 C-1 — V57 모델.
+ * - TEMPLATE: 범위 안 모든 월에 effective 예산 제공
+ * - OVERRIDE: 단일월 덮어쓰기. 같은 월에 TEMPLATE 이 있어도 OVERRIDE 우선.
+ */
+enum class BudgetRowKind { TEMPLATE, OVERRIDE }


### PR DESCRIPTION
## Phase 25 후속 C-1 (BE 도메인 only, 호환 유지)
사용자: "기간 없는 예산 = 전체 일정 동일, 4월 수정 시 4월만, 이후 모든 일정에 반영 체크 시 이후 모두 제거"

큰 작업 단계 분할 1번째. V57 마이그레이션(Phase 23 PR-X4)은 이미 적용되어 `monthly_budgets` 에 `end_year_month` + `row_kind` 컬럼이 있고 기존 데이터는 모두 `OVERRIDE` 백필. BE 코드는 #144 에서 롤백되어 매핑 안 되어 있던 상태.

## 변경 (호환 유지)
### MonthlyBudget 도메인
- `endYearMonth` (nullable, OVERRIDE 시 yearMonth 와 동일)
- `rowKind: enum BudgetRowKind { TEMPLATE, OVERRIDE }` (default OVERRIDE)

### enum BudgetRowKind 신규
- `TEMPLATE`: 범위(yearMonth ~ endYearMonth, null=무기한) 안 모든 월에 effective 예산
- `OVERRIDE`: 단일월 덮어쓰기. 같은 월에 TEMPLATE 이 있어도 OVERRIDE 우선

## 기존 동작 보존 (회귀 0)
- 모든 기존 row 가 OVERRIDE + `endYearMonth=yearMonth` (V57 백필)
- 기존 Service/Repository 로직은 `yearMonth` 매칭 그대로 → 결과 동일
- API 응답 변화 없음
- 신규 컬럼은 default 값으로 호환

## 후속 PR (단계별)
- **C-2**: BE Service merge 로직 (TEMPLATE+OVERRIDE 우선순위) + `applyToFuture` 옵션 API
- **C-3**: FE 예산 수정 sheet "이후 모든 일정에 반영" 체크박스

## 검증
- ✅ BE compileKotlin — success
- ✅ BE gradle test — BUILD SUCCESSFUL (기존 테스트 모두 통과)

## 라이브 검증 (PR merge 후)
- [ ] 기존 예산 페이지 진입 정상 (회귀 없음)
- [ ] 예산 추가/수정/삭제 기존 동작 유지
- [ ] BE health 200