### PR TITLE
feat(budget): C-2.6 — applyToFuture 시 같은 scope 의 활성 TEMPLATE 자동 종료

### DIFF
--- a/backend/src/main/kotlin/com/budgetbook/budget/repository/MonthlyBudgetRepository.kt
+++ b/backend/src/main/kotlin/com/budgetbook/budget/repository/MonthlyBudgetRepository.kt
@@ -55,6 +55,30 @@ interface MonthlyBudgetRepository : JpaRepository<MonthlyBudget, UUID> {
 
     fun findByIdAndCoupleId(id: UUID, coupleId: UUID): MonthlyBudget?
 
+    /**
+     * Phase 25 후속 C-2.6 — 같은 scope (couple, category, group) 의 활성 TEMPLATE 1건 조회.
+     * V57 partial unique 보장으로 결과는 0~1건. categoryId/groupId 가 null 이면 미할당 scope.
+     * "활성" = `yearMonth <= :targetYearMonth AND (endYearMonth IS NULL OR endYearMonth >= :targetYearMonth)`.
+     * `:excludeId` 는 자기 자신 제외용 (currentRow 가 이미 TEMPLATE 인 케이스 등).
+     */
+    @Query("""
+        SELECT b FROM MonthlyBudget b
+        WHERE b.couple.id = :coupleId
+        AND b.rowKind = com.budgetbook.budget.domain.BudgetRowKind.TEMPLATE
+        AND ((:categoryId IS NULL AND b.category IS NULL) OR b.category.id = :categoryId)
+        AND ((:groupId IS NULL AND b.group IS NULL) OR b.group.id = :groupId)
+        AND b.yearMonth <= :targetYearMonth
+        AND (b.endYearMonth IS NULL OR b.endYearMonth >= :targetYearMonth)
+        AND (:excludeId IS NULL OR b.id <> :excludeId)
+    """)
+    fun findActiveTemplateInScope(
+        @Param("coupleId") coupleId: UUID,
+        @Param("categoryId") categoryId: UUID?,
+        @Param("groupId") groupId: UUID?,
+        @Param("targetYearMonth") targetYearMonth: String,
+        @Param("excludeId") excludeId: UUID?
+    ): MonthlyBudget?
+
     @Query("""
         SELECT CASE WHEN COUNT(b) > 0 THEN true ELSE false END
         FROM MonthlyBudget b

--- a/backend/src/main/kotlin/com/budgetbook/budget/service/BudgetService.kt
+++ b/backend/src/main/kotlin/com/budgetbook/budget/service/BudgetService.kt
@@ -280,7 +280,10 @@ class BudgetService(
         // Phase 25 후속 C-2 — applyToFuture=true 시 이 행을 TEMPLATE 으로 승격하고
         // endYearMonth=null (무기한) 으로 설정. 이후 같은 scope 의 OVERRIDE 가
         // 추가되면 우선순위에 따라 그 월만 덮어쓴다.
+        // C-2.6: 승격 전, 같은 scope 의 다른 활성 TEMPLATE 이 있으면 자동 종료
+        // (V57 partial unique 충돌 방지 + 사용자 의도 보존).
         if (request.applyToFuture) {
+            terminateConflictingTemplate(budget)
             budget.rowKind = BudgetRowKind.TEMPLATE
             budget.endYearMonth = null
         }
@@ -308,16 +311,19 @@ class BudgetService(
         // Phase 25 후속 C-2 — applyToFuture=true + TEMPLATE 인 경우, 행 삭제 대신
         // endYearMonth=(yearMonth-1) 로 종료. 이전 월들은 그대로 유효 처리.
         // - yearMonth == startYM 이면 시작월에서 종료가 불가능 → 행 삭제.
-        // - OVERRIDE 는 단일월이므로 applyToFuture 와 무관하게 그대로 삭제.
+        // - OVERRIDE + applyToFuture: C-2.6 — 같은 scope 의 활성 TEMPLATE 도 종료 (사용자가
+        //   "이 월 OVERRIDE + 미래 TEMPLATE 모두 종료" 의도로 누른 것으로 해석).
         if (applyToFuture && budget.rowKind == BudgetRowKind.TEMPLATE) {
             val prev = previousYearMonth(budget.yearMonth)
             if (prev >= budget.yearMonth) {
-                // 시작월보다 앞 월이 없는 비정상 상태 — 그냥 삭제
                 budgetRepository.delete(budget)
             } else {
                 budget.endYearMonth = prev
                 budgetRepository.save(budget)
             }
+        } else if (applyToFuture && budget.rowKind == BudgetRowKind.OVERRIDE) {
+            terminateConflictingTemplate(budget)
+            budgetRepository.delete(budget)
         } else {
             budgetRepository.delete(budget)
         }
@@ -335,6 +341,31 @@ class BudgetService(
     private fun previousYearMonth(yearMonth: String): String {
         val ym = YearMonth.parse(yearMonth)
         return ym.minusMonths(1).toString()
+    }
+
+    /**
+     * Phase 25 후속 C-2.6 — 주어진 budget 과 같은 scope (couple, category, group) 의
+     * 활성 TEMPLATE 을 (target.yearMonth - 1) 로 종료. 자기 자신은 제외.
+     *
+     * - 활성 TEMPLATE 이 없으면 no-op.
+     * - 종료 시점이 시작월보다 이르면 (TEMPLATE 시작월 == budget.yearMonth) 행 삭제.
+     * - V57 partial unique 보장으로 결과는 0~1건만 고려.
+     */
+    private fun terminateConflictingTemplate(budget: MonthlyBudget) {
+        val existing = budgetRepository.findActiveTemplateInScope(
+            coupleId = budget.couple.id,
+            categoryId = budget.category?.id,
+            groupId = budget.group?.id,
+            targetYearMonth = budget.yearMonth,
+            excludeId = budget.id
+        ) ?: return
+        val prev = previousYearMonth(budget.yearMonth)
+        if (prev < existing.yearMonth) {
+            budgetRepository.delete(existing)
+        } else {
+            existing.endYearMonth = prev
+            budgetRepository.save(existing)
+        }
     }
 
     @Transactional(readOnly = true)

--- a/backend/src/test/kotlin/com/budgetbook/budget/service/BudgetServiceApplyToFutureTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/budget/service/BudgetServiceApplyToFutureTest.kt
@@ -1,0 +1,204 @@
+package com.budgetbook.budget.service
+
+import com.budgetbook.auth.domain.AuthProvider
+import com.budgetbook.auth.domain.User
+import com.budgetbook.budget.domain.BudgetRowKind
+import com.budgetbook.budget.domain.MonthlyBudget
+import com.budgetbook.budget.dto.BudgetUpdateRequest
+import com.budgetbook.budget.repository.MonthlyBudgetRepository
+import com.budgetbook.category.domain.Category
+import com.budgetbook.category.domain.CategoryType
+import com.budgetbook.category.repository.CategoryGroupRepository
+import com.budgetbook.category.repository.CategoryRepository
+import com.budgetbook.couple.domain.Couple
+import com.budgetbook.couple.domain.CoupleStatus
+import com.budgetbook.couple.service.CoupleResolver
+import com.budgetbook.pocket.repository.MoneyPocketRepository
+import com.budgetbook.spendingplan.repository.SpendingPlanRepository
+import com.budgetbook.sync.SyncEventPublisher
+import com.budgetbook.transaction.repository.TransactionRepository
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import java.util.Optional
+
+/**
+ * Phase 25 후속 C-2.6 — applyToFuture 시 같은 scope 의 활성 TEMPLATE 자동 종료.
+ * V57 partial unique 충돌 회피 + 사용자 의도("이 월부터 미래 모두 새 값") 보존.
+ */
+class BudgetServiceApplyToFutureTest : BehaviorSpec({
+
+    isolationMode = IsolationMode.InstancePerLeaf
+
+    val budgetRepository = mockk<MonthlyBudgetRepository>()
+    val coupleResolver = mockk<CoupleResolver>()
+    val categoryRepository = mockk<CategoryRepository>()
+    val categoryGroupRepository = mockk<CategoryGroupRepository>()
+    val transactionRepository = mockk<TransactionRepository>()
+    val syncEventPublisher = mockk<SyncEventPublisher>(relaxed = true)
+    val moneyPocketRepository = mockk<MoneyPocketRepository>()
+    val userRepository = mockk<com.budgetbook.auth.repository.UserRepository>()
+    val spendingPlanRepository = mockk<SpendingPlanRepository>()
+    val service = BudgetService(
+        budgetRepository, coupleResolver, categoryRepository, categoryGroupRepository,
+        transactionRepository, syncEventPublisher, moneyPocketRepository, userRepository,
+        spendingPlanRepository
+    )
+
+    val u1 = User(email = "u1@t.com", nickname = "U1", provider = AuthProvider.GOOGLE, providerId = "g1")
+    val u2 = User(email = "u2@t.com", nickname = "U2", provider = AuthProvider.KAKAO, providerId = "k1")
+    val couple = Couple(user1 = u1, user2 = u2, status = CoupleStatus.ACTIVE)
+    val foodCat = Category(couple = couple, name = "식비", type = CategoryType.EXPENSE, icon = "f", color = "#1", isDefault = true)
+
+    every { coupleResolver.getActiveCouple(u1.id) } returns couple
+
+    Given("OVERRIDE 행에 applyToFuture=true 로 update — 같은 scope 에 활성 TEMPLATE 이 있을 때") {
+        val template = MonthlyBudget(
+            couple = couple, category = foodCat,
+            yearMonth = "2026-01", endYearMonth = null,
+            rowKind = BudgetRowKind.TEMPLATE, amount = 250_000L
+        )
+        val override = MonthlyBudget(
+            couple = couple, category = foodCat,
+            yearMonth = "2026-04", endYearMonth = "2026-04",
+            rowKind = BudgetRowKind.OVERRIDE, amount = 300_000L
+        )
+        every { budgetRepository.findById(override.id) } returns Optional.of(override)
+        every { budgetRepository.findActiveTemplateInScope(
+            couple.id, foodCat.id, null, "2026-04", override.id
+        ) } returns template
+        every { budgetRepository.save(template) } returns template
+        every { budgetRepository.save(override) } returns override
+
+        When("update(applyToFuture=true)") {
+            service.updateBudget(u1.id, override.id, BudgetUpdateRequest(amount = 350_000L, applyToFuture = true))
+
+            Then("기존 TEMPLATE 은 endYearMonth=2026-03 으로 종료") {
+                template.endYearMonth shouldBe "2026-03"
+                verify { budgetRepository.save(template) }
+            }
+            Then("override 행은 TEMPLATE 으로 승격 + endYearMonth=null + 새 금액") {
+                override.rowKind shouldBe BudgetRowKind.TEMPLATE
+                override.endYearMonth shouldBe null
+                override.amount shouldBe 350_000L
+            }
+        }
+    }
+
+    Given("OVERRIDE 가 TEMPLATE 시작월과 같은 월 — 종료 시 음수 범위") {
+        // 1월 시작 TEMPLATE 에 대해 1월 OVERRIDE 의 applyToFuture=true 가 들어오면
+        // endYearMonth=2025-12 가 startYM(2026-01)보다 앞 → TEMPLATE 행 자체 삭제.
+        val template = MonthlyBudget(
+            couple = couple, category = foodCat,
+            yearMonth = "2026-01", endYearMonth = null,
+            rowKind = BudgetRowKind.TEMPLATE, amount = 250_000L
+        )
+        val override = MonthlyBudget(
+            couple = couple, category = foodCat,
+            yearMonth = "2026-01", endYearMonth = "2026-01",
+            rowKind = BudgetRowKind.OVERRIDE, amount = 300_000L
+        )
+        every { budgetRepository.findById(override.id) } returns Optional.of(override)
+        every { budgetRepository.findActiveTemplateInScope(
+            couple.id, foodCat.id, null, "2026-01", override.id
+        ) } returns template
+        every { budgetRepository.delete(template) } returns Unit
+        every { budgetRepository.save(override) } returns override
+
+        When("update(applyToFuture=true)") {
+            service.updateBudget(u1.id, override.id, BudgetUpdateRequest(amount = 350_000L, applyToFuture = true))
+
+            Then("기존 TEMPLATE 은 행 삭제") {
+                verify { budgetRepository.delete(template) }
+            }
+            Then("override 는 TEMPLATE 승격") {
+                override.rowKind shouldBe BudgetRowKind.TEMPLATE
+                override.endYearMonth shouldBe null
+            }
+        }
+    }
+
+    Given("OVERRIDE 행에 applyToFuture=true 로 update — 같은 scope 에 활성 TEMPLATE 없음") {
+        val override = MonthlyBudget(
+            couple = couple, category = foodCat,
+            yearMonth = "2026-04", endYearMonth = "2026-04",
+            rowKind = BudgetRowKind.OVERRIDE, amount = 300_000L
+        )
+        every { budgetRepository.findById(override.id) } returns Optional.of(override)
+        every { budgetRepository.findActiveTemplateInScope(
+            couple.id, foodCat.id, null, "2026-04", override.id
+        ) } returns null
+        every { budgetRepository.save(override) } returns override
+
+        When("update(applyToFuture=true)") {
+            service.updateBudget(u1.id, override.id, BudgetUpdateRequest(amount = 350_000L, applyToFuture = true))
+
+            Then("종료 대상 없으므로 save(template) 호출 안 함") {
+                verify(exactly = 0) { budgetRepository.delete(any<MonthlyBudget>()) }
+            }
+            Then("override 만 TEMPLATE 으로 승격") {
+                override.rowKind shouldBe BudgetRowKind.TEMPLATE
+                override.endYearMonth shouldBe null
+                override.amount shouldBe 350_000L
+            }
+        }
+    }
+
+    Given("OVERRIDE 행에 applyToFuture=true 로 delete — 같은 scope 에 활성 TEMPLATE 있을 때") {
+        val template = MonthlyBudget(
+            couple = couple, category = foodCat,
+            yearMonth = "2026-01", endYearMonth = null,
+            rowKind = BudgetRowKind.TEMPLATE, amount = 250_000L
+        )
+        val override = MonthlyBudget(
+            couple = couple, category = foodCat,
+            yearMonth = "2026-04", endYearMonth = "2026-04",
+            rowKind = BudgetRowKind.OVERRIDE, amount = 300_000L
+        )
+        every { budgetRepository.findById(override.id) } returns Optional.of(override)
+        every { budgetRepository.findActiveTemplateInScope(
+            couple.id, foodCat.id, null, "2026-04", override.id
+        ) } returns template
+        every { budgetRepository.save(template) } returns template
+        every { budgetRepository.delete(override) } returns Unit
+
+        When("delete(applyToFuture=true)") {
+            service.deleteBudget(u1.id, override.id, applyToFuture = true)
+
+            Then("OVERRIDE 행은 삭제") {
+                verify { budgetRepository.delete(override) }
+            }
+            Then("기존 TEMPLATE 은 endYearMonth=2026-03 으로 종료") {
+                template.endYearMonth shouldBe "2026-03"
+                verify { budgetRepository.save(template) }
+            }
+        }
+    }
+
+    Given("기존 TEMPLATE 행에 applyToFuture=true 로 delete — C-2 기존 동작 유지") {
+        // C-2: TEMPLATE delete(applyToFuture) → endYearMonth=(yearMonth-1) 처리.
+        // findActiveTemplateInScope 는 호출되지 않아야 함 (TEMPLATE 분기).
+        val templateAtApril = MonthlyBudget(
+            couple = couple, category = foodCat,
+            yearMonth = "2026-04", endYearMonth = null,
+            rowKind = BudgetRowKind.TEMPLATE, amount = 250_000L
+        )
+        every { budgetRepository.findById(templateAtApril.id) } returns Optional.of(templateAtApril)
+        every { budgetRepository.save(templateAtApril) } returns templateAtApril
+
+        When("delete(applyToFuture=true)") {
+            service.deleteBudget(u1.id, templateAtApril.id, applyToFuture = true)
+
+            Then("endYearMonth=2026-03 으로 종료 (C-2 기존 동작)") {
+                templateAtApril.endYearMonth shouldBe "2026-03"
+                verify { budgetRepository.save(templateAtApril) }
+            }
+            Then("findActiveTemplateInScope 호출 안 함 (TEMPLATE 분기)") {
+                verify(exactly = 0) { budgetRepository.findActiveTemplateInScope(any(), any(), any(), any(), any()) }
+            }
+        }
+    }
+})

--- a/docs/sessions/2026-04-26_3_plan.md
+++ b/docs/sessions/2026-04-26_3_plan.md
@@ -1,0 +1,99 @@
+# C-2.6 — applyToFuture 시 같은 scope 의 활성 TEMPLATE 자동 종료
+> 날짜: 2026-04-26 | 회차: 3 | 상태: 기획
+
+## 요청 내용
+이전 세션 `2026-04-26_1_flow_analysis.md` §B/§C 두 항목 — V57 의 partial unique
+`uk_monthly_budgets_template (couple, category, group) WHERE row_kind=TEMPLATE`
+에 의해 한 scope 당 TEMPLATE 은 1개만 존재 가능. 그러나 현재 코드:
+- `updateBudget(OVERRIDE, applyToFuture=true)`: OVERRIDE 행을 TEMPLATE 으로 승격 →
+  같은 scope 에 이미 TEMPLATE 이 있으면 unique 충돌로 500.
+- `deleteBudget(OVERRIDE, applyToFuture=true)`: OVERRIDE 만 삭제 →
+  사용자 의도("이번 달 OVERRIDE + 미래 모든 TEMPLATE 까지 종료") 와 어긋남.
+
+본 PR 에서 처리:
+1. `updateBudget(applyToFuture=true)`: 승격 전, 같은 scope 의 다른 활성 TEMPLATE 을
+   `endYearMonth = (current.yearMonth - 1)` 로 종료. 시작월보다 앞이면 행 삭제.
+2. `deleteBudget(OVERRIDE, applyToFuture=true)`: 같은 scope 의 활성 TEMPLATE 도
+   동일 규칙으로 종료. OVERRIDE 자체는 삭제.
+3. 단위 테스트 4건 추가.
+
+## 영향 범위 분석
+
+### 변경 파일
+| 파일 | 유형 | 변경 |
+|------|------|------|
+| `backend/.../budget/repository/MonthlyBudgetRepository.kt` | 수정 | `findActiveTemplateInScope(...)` 신규 |
+| `backend/.../budget/service/BudgetService.kt` | 수정 | `updateBudget`/`deleteBudget` 에 충돌 해소 로직 |
+| `backend/src/test/.../budget/service/BudgetServiceTest.kt` | 수정 | C-2.6 시나리오 4건 추가 |
+
+### 관련 기존 코드
+- V57 partial unique: 같은 scope 에 TEMPLATE 1건만.
+- `BudgetService.previousYearMonth(...)` 헬퍼 — 재사용.
+
+### 기술적 제약사항
+- "scope" = (couple, category, group). category 와 group 이 둘 다 null 인 미할당 row 도 별도 scope.
+- 활성 TEMPLATE = `rowKind=TEMPLATE AND yearMonth <= currentMonth AND (endYearMonth IS NULL OR endYearMonth >= currentMonth)`.
+- 종료 계산: `previousMonth = (currentBudget.yearMonth - 1)`. previousMonth < template.yearMonth 면 → 행 삭제 (의미상 시작도 못함).
+
+## 작업 계획
+| # | 작업 | 담당 | 파일 | 난이도 |
+|---|------|------|------|--------|
+| 1 | `findActiveTemplateInScope` 쿼리 추가 | BE | MonthlyBudgetRepository.kt | M |
+| 2 | `updateBudget(applyToFuture)` 충돌 해소 | BE | BudgetService.kt | M |
+| 3 | `deleteBudget(OVERRIDE, applyToFuture)` TEMPLATE 종료 | BE | BudgetService.kt | S |
+| 4 | 단위 테스트 4건 추가 | BE | test/.../BudgetServiceTest.kt | M |
+
+## 성능 설계 (원칙 1.4)
+- **데이터 접근**: 추가 쿼리 1번/요청 (충돌 검사). 결과 ≤1 row (V57 unique 보장).
+- **예상 규모**: O(1) — partial unique 가 정확히 1건만 보장.
+- **연산 복잡도**: O(1).
+- **리소스 제약**: 무시 가능.
+- **트랜잭션**: 기존 `@Transactional` 안에서 모두 처리. 종료 + 승격이 같은 트랜잭션 → unique 충돌 race condition 없음 (PostgreSQL row-level locking).
+
+## 하네스 Scope Audit 결과 (Step 1.5)
+- **실행 명령**: `pre-change-audit.sh . "template_override_resolution"`
+- **분류 태그**: `template_override_resolution`
+- **Recurrence Check**: ✅ OK — 같은 시리즈 후속.
+- **Gate**: OPEN.
+- **재발 방지 조치**: 알려진 pitfall #4 ("TEMPLATE 시작월보다 앞 월 → 음수 범위") 케이스 테스트 포함.
+
+## 자동 검증 계획
+- [x] BE 테스트 통과 (`./gradlew test`)
+- [x] FE 분석 (FE 미변경)
+- [x] V57 partial unique 와 일관 (수정 후 같은 scope 에 TEMPLATE 1건 보장)
+
+## 배포 절차
+| # | 단계 | 주체 | 확인 |
+|---|------|------|------|
+| 1 | feature 브랜치 / commit / push | AI | git status |
+| 2 | PR / CI | AI | gh pr checks |
+| 3 | squash merge | AI | gh pr merge |
+| 4 | deploy-nas.yml watch | AI | gh run watch |
+| 5 | 사용자 라이브 검증 | 사용자 | F12 새로고침 |
+
+## 사용자 검증 시나리오
+
+### A. updateBudget(applyToFuture) — TEMPLATE 충돌 해소
+| # | 경로 | 조작 | 기대 |
+|---|------|------|------|
+| A1 | 예산 탭 | TEMPLATE (식비, 25만, 1월~무기한) 등록 후, 4월에 OVERRIDE (식비, 30만) 추가 | 둘 다 DB 존재 |
+| A2 | 4월 OVERRIDE 편집 → applyToFuture=true (35만) | 기존 TEMPLATE → endYearMonth=2026-03 종료 / OVERRIDE → TEMPLATE 승격 (4월~무기한, 35만) |
+| A3 | 5월 이동 | 35만 TEMPLATE 만 보임 |
+| A4 | 3월 이동 | 25만 TEMPLATE (1월~3월 활성) 만 보임 |
+
+### B. deleteBudget(OVERRIDE, applyToFuture) — TEMPLATE 종료
+| # | 경로 | 조작 | 기대 |
+|---|------|------|------|
+| B1 | A1 상태 (TEMPLATE 25만 + 4월 OVERRIDE 30만) | 4월 OVERRIDE → applyToFuture=true 로 삭제 | OVERRIDE 행 삭제 + TEMPLATE.endYearMonth=2026-03 |
+| B2 | 5월 이동 | 식비 예산 안 보임 |
+| B3 | 3월 이동 | 25만 TEMPLATE 보임 |
+
+### C. 회귀 없음
+| # | 확인 | 기대 |
+|---|------|------|
+| C1 | TEMPLATE 만 있는 상태에서 update(applyToFuture) | 기존 동작 유지 (자기 자신은 충돌 검사 제외) |
+| C2 | OVERRIDE 만 있는 상태에서 update(applyToFuture) | TEMPLATE 승격 + 충돌 없음 (기존 TEMPLATE 부재) |
+| C3 | TEMPLATE delete(applyToFuture) | C-2 기존 동작 유지 |
+
+## 사용자 승인
+- [ ] 승인 / 수정 요청: ___


### PR DESCRIPTION
## Summary
Phase 25 후속 C 시리즈 — V57 partial unique 충돌 회피 + 사용자 의도 보존.

V57 의 `uk_monthly_budgets_template (couple, category, group) WHERE row_kind=TEMPLATE` 가 한 scope 당 활성 TEMPLATE 1건만 허용. 그러나 C-2 의 update/delete(applyToFuture=true) 가 OVERRIDE 행에 작용할 때:
- update: OVERRIDE → TEMPLATE 승격이 unique 충돌로 실패 가능
- delete: OVERRIDE 만 삭제되어 사용자 의도("이 월부터 미래 모두 종료") 와 어긋남

해결 대상: `docs/sessions/2026-04-26_1_flow_analysis.md` §B/§C.

### 변경
- **MonthlyBudgetRepository**: `findActiveTemplateInScope(...)` — 같은 scope 의 활성 TEMPLATE 1건 조회 (자기 자신 `excludeId` 로 제외).
- **BudgetService**:
  - `terminateConflictingTemplate(budget)` 헬퍼 — 활성 TEMPLATE 을 `endYearMonth=(budget.yearMonth - 1)` 로 종료. 시작월보다 앞이면 행 삭제.
  - `updateBudget(applyToFuture=true)`: 승격 전 충돌 해소.
  - `deleteBudget(OVERRIDE, applyToFuture=true)`: 같은 scope 의 활성 TEMPLATE 도 종료.
- **테스트**: `BudgetServiceApplyToFutureTest` 5건 신규.

### 의존
PR #177 (C-2.5) 머지된 main 위에서 빌드. base = main.

## Test plan
- [x] `./gradlew test` 통과
- [x] flutter analyze (FE 미변경 — 변화 없음)
- [ ] 사용자 라이브 검증 (`docs/sessions/2026-04-26_3_plan.md` §사용자 검증 시나리오 A1~C3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)