### PR TITLE
feat(budget): C-3 — FE 예산 편집 sheet '이후 모든 일정에 반영' 체크박스

### DIFF
--- a/docs/sessions/2026-04-26_4_plan.md
+++ b/docs/sessions/2026-04-26_4_plan.md
@@ -1,0 +1,69 @@
+# C-3 — FE 예산 편집 sheet '이후 모든 일정에 반영' 체크박스
+> 날짜: 2026-04-26 | 회차: 4 | 상태: 기획
+
+## 요청 내용
+이전 세션 §A/§B/§C 의 마무리. BE 가 V57 + applyToFuture (C-1/C-2/C-2.5/C-2.6) 를
+모두 갖춘 상태에서 FE 가 `applyToFuture` 체크박스를 노출 + 전송하도록.
+
+## 영향 범위 분석
+
+### 변경 파일
+| 파일 | 유형 | 변경 |
+|------|------|------|
+| `frontend/lib/features/budget/domain/repositories/budget_repository.dart` | 수정 | `updateBudget`/`deleteBudget` 시그니처에 `applyToFuture: bool = false` |
+| `frontend/lib/features/budget/data/repositories/budget_repository_impl.dart` | 수정 | `applyToFuture` 전송 |
+| `frontend/lib/features/budget/data/datasources/budget_remote_datasource.dart` | 수정 | `deleteBudget` query param + body 전송 |
+| `frontend/lib/features/budget/presentation/bloc/budget_event.dart` | 수정 | `UpdateBudget`/`DeleteBudget` 에 `applyToFuture` |
+| `frontend/lib/features/budget/presentation/bloc/budget_bloc.dart` | 수정 | 전달 |
+| `frontend/lib/features/budget/presentation/pages/budget_form_page.dart` | 수정 | 편집 모드 체크박스 + 삭제 dialog 체크박스 |
+| `frontend/test/features/budget/presentation/bloc/budget_bloc_test.dart` | 수정 | applyToFuture 시나리오 추가 |
+
+### 기술적 제약사항
+- BE API 계약:
+  - `PUT /budgets/{id}` body 에 `applyToFuture: bool` (BudgetUpdateRequest)
+  - `DELETE /budgets/{id}?applyToFuture=true|false` (RequestParam)
+- FE 데이터소스에서 두 곳 처리 분리 필요 (PUT body vs DELETE query).
+
+## 작업 계획
+| # | 작업 | 담당 | 파일 | 난이도 |
+|---|------|------|------|--------|
+| 1 | Repository 인터페이스 시그니처 확장 | FE | budget_repository.dart | S |
+| 2 | RemoteDataSource: PUT body + DELETE query 전송 | FE | budget_remote_datasource.dart | S |
+| 3 | RepositoryImpl: 인자 전달 | FE | budget_repository_impl.dart | S |
+| 4 | Bloc event/handler 확장 | FE | budget_event.dart, budget_bloc.dart | S |
+| 5 | UI 체크박스 (편집 + 삭제 dialog) | FE | budget_form_page.dart | M |
+| 6 | bloc 테스트 시나리오 추가 | FE | budget_bloc_test.dart | M |
+
+## 성능 설계 (원칙 1.4)
+- FE 만 변경. 추가 네트워크 호출 없음.
+- 체크박스 1 bool 추가 — 무시 가능.
+
+## 하네스 Scope Audit 결과
+- `template_override_resolution`, `filter_propagation`: ✅ OK, gate OPEN.
+- 체인 전수: Event → Bloc → Repository → DataSource → API 모두 적용.
+
+## 자동 검증
+- [x] flutter analyze
+- [x] flutter test
+- [ ] 사용자 라이브 검증
+
+## 사용자 검증 시나리오
+
+### A. 편집 + applyToFuture
+| # | 경로 | 조작 | 기대 |
+|---|------|------|------|
+| A1 | 예산 → 편집 | 체크박스 미체크, 금액 변경 | 그 월만 변경 (OVERRIDE) |
+| A2 | 예산 → 편집 | 체크박스 체크, 금액 변경 | 행 → TEMPLATE 승격, 미래 월에도 적용 (BE C-2.6 충돌 자동 해소) |
+
+### B. 삭제 + applyToFuture
+| # | 경로 | 조작 | 기대 |
+|---|------|------|------|
+| B1 | 예산 → 삭제 dialog | 체크박스 미체크 | 단일 row 삭제 |
+| B2 | 예산 → 삭제 dialog | 체크박스 체크 | TEMPLATE 종료 또는 OVERRIDE 삭제+TEMPLATE 종료 |
+
+### C. 회귀 없음
+- C1: 신규 등록 흐름 변화 없음
+- C2: 기존 편집/삭제 (체크박스 미체크) 동작 동일
+
+## 사용자 승인
+- [ ] 승인 / 수정: ___

--- a/frontend/lib/features/budget/data/datasources/budget_remote_datasource.dart
+++ b/frontend/lib/features/budget/data/datasources/budget_remote_datasource.dart
@@ -6,7 +6,7 @@ abstract class BudgetRemoteDataSource {
   Future<BudgetModel> createBudget(Map<String, dynamic> data);
   Future<List<BudgetModel>> getBudgets({required int year, required int month});
   Future<BudgetModel> updateBudget(String id, Map<String, dynamic> data);
-  Future<void> deleteBudget(String id);
+  Future<void> deleteBudget(String id, {bool applyToFuture = false});
   Future<BudgetSummaryModel> getBudgetSummary({
     required int year,
     required int month,
@@ -61,8 +61,11 @@ class BudgetRemoteDataSourceImpl implements BudgetRemoteDataSource {
   }
 
   @override
-  Future<void> deleteBudget(String id) async {
-    await apiClient.dio.delete('${ApiEndpoints.budgets}/$id');
+  Future<void> deleteBudget(String id, {bool applyToFuture = false}) async {
+    await apiClient.dio.delete(
+      '${ApiEndpoints.budgets}/$id',
+      queryParameters: applyToFuture ? {'applyToFuture': 'true'} : null,
+    );
   }
 
   @override

--- a/frontend/lib/features/budget/data/repositories/budget_repository_impl.dart
+++ b/frontend/lib/features/budget/data/repositories/budget_repository_impl.dart
@@ -75,6 +75,7 @@ class BudgetRepositoryImpl implements BudgetRepository {
     String? categoryId,
     String? groupId,
     String? yearMonth,
+    bool applyToFuture = false,
   }) async {
     try {
       final data = <String, dynamic>{
@@ -88,6 +89,7 @@ class BudgetRepositoryImpl implements BudgetRepository {
         if (categoryId != null) 'categoryId': categoryId,
         if (groupId != null) 'groupId': groupId,
         if (yearMonth != null) 'yearMonth': yearMonth,
+        if (applyToFuture) 'applyToFuture': true,
       };
       final result = await remoteDataSource.updateBudget(id, data);
       return Right(result);
@@ -99,9 +101,12 @@ class BudgetRepositoryImpl implements BudgetRepository {
   }
 
   @override
-  Future<Either<Failure, void>> deleteBudget(String id) async {
+  Future<Either<Failure, void>> deleteBudget(
+    String id, {
+    bool applyToFuture = false,
+  }) async {
     try {
-      await remoteDataSource.deleteBudget(id);
+      await remoteDataSource.deleteBudget(id, applyToFuture: applyToFuture);
       return const Right(null);
     } on DioException catch (e) {
       return Left(mapDioError(e, '예산을 삭제하지 못했습니다'));

--- a/frontend/lib/features/budget/domain/repositories/budget_repository.dart
+++ b/frontend/lib/features/budget/domain/repositories/budget_repository.dart
@@ -33,9 +33,13 @@ abstract class BudgetRepository {
     String? categoryId,
     String? groupId,
     String? yearMonth,
+    bool applyToFuture = false,
   });
 
-  Future<Either<Failure, void>> deleteBudget(String id);
+  Future<Either<Failure, void>> deleteBudget(
+    String id, {
+    bool applyToFuture = false,
+  });
 
   Future<Either<Failure, BudgetSummary>> getBudgetSummary({
     required int year,

--- a/frontend/lib/features/budget/presentation/bloc/budget_bloc.dart
+++ b/frontend/lib/features/budget/presentation/bloc/budget_bloc.dart
@@ -175,6 +175,7 @@ class BudgetBloc extends Bloc<BudgetEvent, BudgetState> {
         categoryId: event.categoryId,
         groupId: event.groupId,
         yearMonth: event.yearMonth,
+        applyToFuture: event.applyToFuture,
       );
       result.fold(
         (failure) {
@@ -215,7 +216,10 @@ class BudgetBloc extends Bloc<BudgetEvent, BudgetState> {
   ) async {
     try {
       final currentState = state;
-      final result = await budgetRepository.deleteBudget(event.id);
+      final result = await budgetRepository.deleteBudget(
+        event.id,
+        applyToFuture: event.applyToFuture,
+      );
       result.fold(
         (failure) {
           if (currentState is BudgetLoaded) {

--- a/frontend/lib/features/budget/presentation/bloc/budget_event.dart
+++ b/frontend/lib/features/budget/presentation/bloc/budget_event.dart
@@ -79,6 +79,7 @@ class UpdateBudget extends BudgetEvent {
   final String? categoryId;
   final String? groupId;
   final String? yearMonth;
+  final bool applyToFuture;
 
   const UpdateBudget({
     required this.id,
@@ -92,6 +93,7 @@ class UpdateBudget extends BudgetEvent {
     this.categoryId,
     this.groupId,
     this.yearMonth,
+    this.applyToFuture = false,
   });
 
   @override
@@ -107,16 +109,18 @@ class UpdateBudget extends BudgetEvent {
         categoryId,
         groupId,
         yearMonth,
+        applyToFuture,
       ];
 }
 
 class DeleteBudget extends BudgetEvent {
   final String id;
+  final bool applyToFuture;
 
-  const DeleteBudget(this.id);
+  const DeleteBudget(this.id, {this.applyToFuture = false});
 
   @override
-  List<Object?> get props => [id];
+  List<Object?> get props => [id, applyToFuture];
 }
 
 class CopyPreviousMonthBudgets extends BudgetEvent {

--- a/frontend/lib/features/budget/presentation/pages/budget_form_page.dart
+++ b/frontend/lib/features/budget/presentation/pages/budget_form_page.dart
@@ -62,6 +62,7 @@ class _BudgetFormPageState extends State<BudgetFormPage> {
   bool _initialized = false;
   bool _isSubmitting = false;
   bool _isDeleting = false;
+  bool _applyToFuture = false;
 
   bool get isEditing => widget.budgetId != null;
 
@@ -320,6 +321,21 @@ class _BudgetFormPageState extends State<BudgetFormPage> {
                   return null;
                 },
               ),
+            if (isEditing) ...[
+              const SizedBox(height: 8),
+              CheckboxListTile(
+                contentPadding: EdgeInsets.zero,
+                controlAffinity: ListTileControlAffinity.leading,
+                dense: true,
+                title: const Text('이후 모든 일정에 반영'),
+                subtitle: const Text(
+                  '체크 시 이번 달부터 미래 모든 달에 적용됩니다',
+                  style: TextStyle(fontSize: 12),
+                ),
+                value: _applyToFuture,
+                onChanged: (v) => setState(() => _applyToFuture = v ?? false),
+              ),
+            ],
             const SizedBox(height: 32),
             // Submit button
             FilledButton(
@@ -572,26 +588,47 @@ class _BudgetFormPageState extends State<BudgetFormPage> {
   }
 
   void _confirmDelete(BuildContext context) {
+    bool applyToFutureInDialog = false;
     showDialog(
       context: context,
-      builder: (ctx) => AlertDialog(
-        title: const Text('삭제'),
-        content: const Text('이 예산을 삭제하시겠습니까?'),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(ctx),
-            child: const Text('취소'),
+      builder: (ctx) => StatefulBuilder(
+        builder: (ctx, setStateDialog) => AlertDialog(
+          title: const Text('삭제'),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const Text('이 예산을 삭제하시겠습니까?'),
+              const SizedBox(height: 8),
+              CheckboxListTile(
+                contentPadding: EdgeInsets.zero,
+                controlAffinity: ListTileControlAffinity.leading,
+                dense: true,
+                title: const Text('이후 모든 일정에 반영'),
+                value: applyToFutureInDialog,
+                onChanged: (v) => setStateDialog(() => applyToFutureInDialog = v ?? false),
+              ),
+            ],
           ),
-          TextButton(
-            onPressed: () {
-              Navigator.pop(ctx);
-              setState(() => _isDeleting = true);
-              this.context.read<BudgetBloc>().add(DeleteBudget(widget.budgetId!));
-            },
-            style: TextButton.styleFrom(foregroundColor: Theme.of(context).colorScheme.error),
-            child: const Text('삭제'),
-          ),
-        ],
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(ctx),
+              child: const Text('취소'),
+            ),
+            TextButton(
+              onPressed: () {
+                Navigator.pop(ctx);
+                setState(() => _isDeleting = true);
+                this.context.read<BudgetBloc>().add(
+                      DeleteBudget(widget.budgetId!,
+                          applyToFuture: applyToFutureInDialog),
+                    );
+              },
+              style: TextButton.styleFrom(foregroundColor: Theme.of(context).colorScheme.error),
+              child: const Text('삭제'),
+            ),
+          ],
+        ),
       ),
     );
   }
@@ -650,6 +687,7 @@ class _BudgetFormPageState extends State<BudgetFormPage> {
           categoryId: _selectedCategoryId,
           groupId: _selectedGroupId,
           yearMonth: yearMonth,
+          applyToFuture: _applyToFuture,
         ));
       } else {
         bloc.add(CreateBudget(

--- a/frontend/test/features/budget/presentation/bloc/budget_bloc_test.dart
+++ b/frontend/test/features/budget/presentation/bloc/budget_bloc_test.dart
@@ -87,6 +87,7 @@ class MockBudgetRepository extends Mock implements BudgetRepository {
     String? categoryId,
     String? groupId,
     String? yearMonth,
+    bool applyToFuture = false,
   }) =>
       super.noSuchMethod(
         Invocation.method(#updateBudget, [], {
@@ -101,6 +102,7 @@ class MockBudgetRepository extends Mock implements BudgetRepository {
           #categoryId: categoryId,
           #groupId: groupId,
           #yearMonth: yearMonth,
+          #applyToFuture: applyToFuture,
         }),
         returnValue: Future.value(
           Right<Failure, Budget>(_dummyBudget),
@@ -108,9 +110,14 @@ class MockBudgetRepository extends Mock implements BudgetRepository {
       ) as Future<Either<Failure, Budget>>;
 
   @override
-  Future<Either<Failure, void>> deleteBudget(String id) =>
+  Future<Either<Failure, void>> deleteBudget(
+    String? id, {
+    bool applyToFuture = false,
+  }) =>
       super.noSuchMethod(
-        Invocation.method(#deleteBudget, [id]),
+        Invocation.method(#deleteBudget, [id], {
+          #applyToFuture: applyToFuture,
+        }),
         returnValue: Future.value(const Right<Failure, void>(null)),
       ) as Future<Either<Failure, void>>;
 
@@ -435,6 +442,84 @@ void main() {
             operationError: 'Failed to delete budget',
           ),
         ],
+      );
+
+      // Phase 25 후속 C-3 — applyToFuture 가 repository 까지 전달되는지 검증
+      blocTest<BudgetBloc, BudgetState>(
+        'forwards applyToFuture=true to repository.deleteBudget',
+        build: () {
+          when(mockRepository.deleteBudget('budget-1',
+                  applyToFuture: true))
+              .thenAnswer((_) async => const Right(null));
+          when(mockRepository.getBudgets(year: 2026, month: 3))
+              .thenAnswer((_) async => Right([tBudget2]));
+          when(mockRepository.getBudgetSummary(year: 2026, month: 3))
+              .thenAnswer((_) async => const Right(tSummary));
+          return budgetBloc;
+        },
+        seed: () => BudgetLoaded(
+          budgets: tBudgets,
+          summary: tSummary,
+          year: 2026,
+          month: 3,
+        ),
+        act: (bloc) => bloc.add(
+          const DeleteBudget('budget-1', applyToFuture: true),
+        ),
+        verify: (_) {
+          verify(mockRepository.deleteBudget('budget-1',
+                  applyToFuture: true))
+              .called(1);
+        },
+      );
+    });
+
+    // Phase 25 후속 C-3 — UpdateBudget 에 applyToFuture 가 repository 까지 전달
+    group('UpdateBudget with applyToFuture', () {
+      blocTest<BudgetBloc, BudgetState>(
+        'forwards applyToFuture=true to repository.updateBudget',
+        build: () {
+          when(mockRepository.updateBudget(
+            id: 'budget-1',
+            amount: 200000,
+            budgetPeriod: null,
+            weeklyAmount: null,
+            pocketId: null,
+            periodType: null,
+            startDate: null,
+            endDate: null,
+            applyToFuture: true,
+          )).thenAnswer((_) async => Right(tBudget1));
+          when(mockRepository.getBudgets(year: 2026, month: 3))
+              .thenAnswer((_) async => Right(tBudgets));
+          when(mockRepository.getBudgetSummary(year: 2026, month: 3))
+              .thenAnswer((_) async => const Right(tSummary));
+          return budgetBloc;
+        },
+        seed: () => BudgetLoaded(
+          budgets: tBudgets,
+          summary: tSummary,
+          year: 2026,
+          month: 3,
+        ),
+        act: (bloc) => bloc.add(const UpdateBudget(
+          id: 'budget-1',
+          amount: 200000,
+          applyToFuture: true,
+        )),
+        verify: (_) {
+          verify(mockRepository.updateBudget(
+            id: 'budget-1',
+            amount: 200000,
+            budgetPeriod: null,
+            weeklyAmount: null,
+            pocketId: null,
+            periodType: null,
+            startDate: null,
+            endDate: null,
+            applyToFuture: true,
+          )).called(1);
+        },
       );
     });
 


### PR DESCRIPTION
## Summary
Phase 25 후속 C 시리즈 마무리 (C-1 도메인 / C-2 create+update+delete / C-2.5 조회 / C-2.6 충돌 해소 / **C-3 FE UI**).

전체 체인에 `applyToFuture` 추가:
- domain/repositories: 인터페이스 시그니처 확장
- data/repositories: PUT body
- data/datasources: DELETE query param `applyToFuture=true`
- presentation/bloc: event/handler 전달
- presentation/pages/budget_form_page.dart:
  - **편집 모드**: 체크박스 "이후 모든 일정에 반영" (subtitle 안내 포함)
  - **삭제 dialog**: 동일 체크박스 (StatefulBuilder)

### 테스트
- bloc 테스트 시나리오 2건 추가 + 기존 mocks 시그니처 동기화
- 전체 FE 702건 통과
- flutter analyze clean

### 의존
PR #177 (C-2.5), PR #178 (C-2.6) 머지된 main.

## Test plan
- [x] flutter analyze
- [x] flutter test (702건 통과)
- [ ] 사용자 라이브 검증 (`docs/sessions/2026-04-26_4_plan.md` §사용자 검증 시나리오):
  - A1/A2: 편집 + applyToFuture
  - B1/B2: 삭제 dialog + applyToFuture
  - C1/C2: 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)