### PR TITLE
docs: 2026-04-26 C 시리즈 결과 + 실패 분석

### DIFF
--- a/docs/sessions/2026-04-26_2_result.md
+++ b/docs/sessions/2026-04-26_2_result.md
@@ -1,0 +1,97 @@
+# Phase 25 후속 C 시리즈 (C-2.5/C-2.6/C-3) — 결과
+> 날짜: 2026-04-26 | 회차: 2/3/4 통합 | 상태: **부분 실패 + 재시도 진행**
+
+본 결과는 동일 시리즈 3 PR (`_2_plan.md`, `_3_plan.md`, `_4_plan.md`) 의 라이브 검증 결과를 통합 기록.
+
+## 변경 사항 (PR 별)
+
+### PR #177 (C-2.5)
+| 파일 | 유형 | 설명 |
+|------|------|------|
+| `MonthlyBudgetRepository.kt` | 수정 | 두 쿼리 V57 모델 (TEMPLATE 범위 + OVERRIDE 단일월) |
+| `MonthlyBudgetResolver.kt` | 신규 | OVERRIDE 우선순위 dedup 헬퍼 |
+| BudgetService 외 7개 service | 수정 | Resolver 적용 |
+| `MonthlyBudgetResolverTest.kt` | 신규 | 5건 |
+
+### PR #178 (C-2.6)
+| 파일 | 유형 | 설명 |
+|------|------|------|
+| `MonthlyBudgetRepository.kt` | 수정 | `findActiveTemplateInScope` 추가 |
+| `BudgetService.kt` | 수정 | `terminateConflictingTemplate` 헬퍼 + update/delete 충돌 해소 |
+| `BudgetServiceApplyToFutureTest.kt` | 신규 | 5건 |
+
+### PR #179 (C-3)
+| 파일 | 유형 | 설명 |
+|------|------|------|
+| FE 5 layer | 수정 | applyToFuture 체인 (interface→impl→datasource→bloc→event) |
+| `budget_form_page.dart` | 수정 | 편집 체크박스 + 삭제 dialog 체크박스 |
+| `budget_bloc_test.dart` | 수정 | 시나리오 2건 추가 |
+
+## 커밋 / PR 이력
+- PR #177 (squash `cb5a1ff`) — C-2.5
+- PR #178 (squash `dd96c50`) — C-2.6
+- PR #179 (squash `21cafb8`) — C-3
+- deploy-nas.yml runs: 24951607318 / 24951782013 / 24951864516 모두 success
+
+## 자동 검증 결과
+| 항목 | 결과 | 비고 |
+|------|------|------|
+| BE 테스트 | PASS | Kotest 전체 |
+| FE analyze | PASS | info 3건 무관 |
+| FE test | PASS | 702건 |
+| CI (3 PR) | PASS | backend+frontend 둘 다 |
+| 배포 (3 PR) | SUCCESS | NAS deploy success |
+
+## 사용자 라이브 검증 결과
+
+| 시나리오 | 결과 | 비고 |
+|---------|------|------|
+| A (TEMPLATE 조회) | **FAIL** | 5월 행 편집 시 체크박스 미체크여도 6월·7월 변경 |
+| B (충돌 해소) | 미실행 | A 실패로 중단 |
+| C (FE UI) | 부분 PASS | 월간 OK / **주간예산 체크박스 부재** |
+| D (회귀) | 미실행 | |
+
+## 실패 발생
+
+### 원인 분석
+**현상**: 사용자가 5월에 (기간 미지정 = OVERRIDE) 200,000원 신규 등록 후 그 5월 예산을 변경했는데, 체크박스 미체크임에도 6월·7월에도 변경됨.
+
+**가정 vs 실제**:
+- 기획 가정: "applyToFuture=false 면 단일 행만 변경" → 행이 OVERRIDE 면 OK, **TEMPLATE 면 활성 범위 전체 영향**
+- 실제: 사용자가 본 5월 행이 (이전 step 에서 만든) TEMPLATE 이었거나, 다른 경로로 TEMPLATE 으로 승격된 행을 편집한 결과.
+- 핵심: 사용자 멘탈 모델 = "월 단위 의도", 시스템 = "행 단위 변경". TEMPLATE/OVERRIDE 구분이 FE 에 노출되지 않으므로 사용자는 자기가 편집하는 게 어떤 행인지 모름.
+
+**기획 누락**: C-2 의 applyToFuture 가 OVERRIDE→TEMPLATE 승격만 다룸. **TEMPLATE 의 single-month split 케이스**(편집 대상이 이미 TEMPLATE 일 때 currentMonth 만 OVERRIDE 로 분리) 가 빠짐.
+
+**부수 누락**:
+- C-3 FE 작업이 `budget_form_page.dart` (월간) 만 — 주간예산 별도 페이지(`weekly_budget_*`) 에 동일 처리 누락
+- 그룹 예산 더보기 메뉴에 "거래 보기" 없음 — 카테고리/그룹/총 행 컴포넌트가 분기되며 일관성 깨짐
+
+### 재발 방지 장치
+- [x] 하네스 인시던트 등록: `~/.claude/harness/data/incidents/2026-04-26_template_split_semantic.json`
+- [x] `~/.claude/harness/lessons-learned.jsonl` 3건 추가 (split semantic / weekly miss / 더보기 통일)
+- [x] `~/.claude/harness/audit-patterns.json` v1.2.0:
+  - `template_override_resolution.known_pitfalls` 3건 추가
+  - `ux_temporal_intent_split` 신규 패턴 추가
+- [ ] 회귀 방지 자동 테스트 — C-2.7 PR 에서 추가 예정
+
+### 플로우 개선
+- 차기 기획서부터 §사용자 검증 시나리오 에 "TEMPLATE 행 편집 — applyToFuture=false 시 currentMonth 만 변경되는지" 항목 의무화
+- 하네스 audit 태그 `ux_temporal_intent_split` 활용
+- FE 작업 시 monthly + weekly 페이지 grep 전수 (incident 에 명시)
+- 예산 행 컴포넌트 통일 — 클릭=편집, 더보기=거래 보기 (모든 행)
+
+### 처리 방식
+- [ ] **롤백 안 함** — 데이터 손실 없음, TEMPLATE 모델 자체는 정상 동작. 행 단위와 월 단위의 의도 차이 문제이므로 추가 PR 로 해결.
+- [x] **follow-up PR 후보**:
+  - **C-2.7**: BE TEMPLATE split semantic — applyToFuture=false + 편집 대상=TEMPLATE 시 currentMonth OVERRIDE 신규 생성 (TEMPLATE 보존) / applyToFuture=true + TEMPLATE 시작월<currentMonth 시 분리
+  - **C-3.1**: 주간예산 편집/삭제 화면에 동일 체크박스
+  - **U-1**: 예산 카드 클릭=편집 통일 + 더보기 메뉴 모든 예산 "거래 보기" 통일
+
+## 발견된 추가 이슈
+- 그룹 예산 더보기 메뉴에 "거래 보기" 없음 (카테고리에는 있음) — UX 불일치
+- 사용자 제안: 행 클릭=편집, 더보기=거래 보기 (모든 예산 통일)
+
+## 롤백 정보
+- 본 시리즈 롤백 시 (적용 안함): `git revert 21cafb8 dd96c50 cb5a1ff`
+- 영향 범위: 예산 모듈 전체 (BE 8 service + FE 5 layer)


### PR DESCRIPTION
## Summary
PR #177/#178/#179 (C-2.5/C-2.6/C-3) 라이브 검증 결과 통합 기록.

### 검증 결과
- 자동 검증 (BE/FE/CI/배포): 모두 PASS
- 사용자 라이브 검증: **시나리오 A 실패** — TEMPLATE 행 편집 시 체크박스 미체크여도 미래 월 변경됨

### 원인
C-2 의 applyToFuture 가 OVERRIDE→TEMPLATE 승격만 다룸. **TEMPLATE 행 편집 시 currentMonth 만 변경하는 split semantic 누락**.

### 재발 방지
- 하네스 인시던트 등록 (~/.claude/harness/data/incidents/2026-04-26_template_split_semantic.json)
- lessons-learned.jsonl 3건 추가
- audit-patterns.json v1.2.0:
  - template_override_resolution.known_pitfalls 3건 추가
  - **ux_temporal_intent_split** 신규 패턴 추가

### Follow-up PR 후보
- **C-2.7**: BE TEMPLATE split semantic
- **C-3.1**: 주간예산 동일 체크박스
- **U-1**: 예산 카드 클릭=편집 통일 + 더보기 메뉴 모든 예산 거래 보기

## Test plan
- [x] 결과 문서화만 — 코드 변경 없음
🤖 Generated with [Claude Code](https://claude.com/claude-code)