### PR TITLE
feat(budget): C-2.7 + C-3.1 + U-1 — TEMPLATE split semantic + UX 통일

### DIFF
--- a/backend/src/main/kotlin/com/budgetbook/budget/dto/BudgetDtos.kt
+++ b/backend/src/main/kotlin/com/budgetbook/budget/dto/BudgetDtos.kt
@@ -67,6 +67,13 @@ data class BudgetUpdateRequest(
     val visibility: String? = null,
 
     /**
+     * Phase 25 후속 C-2.7 — 사용자가 편집 화면을 열 때 보고 있던 월 ("YYYY-MM").
+     * - TEMPLATE 행 편집 시 split semantic 의 기준 월로 사용.
+     * - null 이면 split 비활성 (기존 단순 update).
+     */
+    val yearMonth: String? = null,
+
+    /**
      * Phase 25 후속 C-2 — 사용자가 "이후 모든 일정에 반영" 체크 시 true.
      * - false (default): 단일월 OVERRIDE 만 추가/갱신 (기존 동작)
      * - true: 기존 TEMPLATE 의 endYearMonth = (대상월-1) 로 종료 + 새 TEMPLATE

--- a/backend/src/main/kotlin/com/budgetbook/budget/service/BudgetService.kt
+++ b/backend/src/main/kotlin/com/budgetbook/budget/service/BudgetService.kt
@@ -195,6 +195,22 @@ class BudgetService(
         OwnershipValidator.validateOwnership(budget.couple.id, couple, "Budget")
         validatePrivateOwner(budget, userId)
 
+        // Phase 25 후속 C-2.7 — TEMPLATE 행 편집 split semantic.
+        // 사용자 의도는 "viewingMonth (= request.yearMonth) 만 변경" 인데, TEMPLATE 행을
+        // 그대로 update 하면 활성 범위 [yearMonth, endYearMonth] 전체에 영향. 따라서:
+        //   - applyToFuture=false + 편집 대상 = TEMPLATE + viewingMonth 가 활성 범위 내
+        //     → split: 원본 TEMPLATE 보존 + viewingMonth 단일 OVERRIDE 신규.
+        // applyToFuture=true 케이스는 기존 C-2 동작 유지 (전체 TEMPLATE 범위 적용).
+        val viewingMonth = request.yearMonth
+        val needsSplit = !request.applyToFuture
+            && budget.rowKind == BudgetRowKind.TEMPLATE
+            && viewingMonth != null
+            && viewingMonth >= budget.yearMonth
+            && (budget.endYearMonth == null || viewingMonth <= budget.endYearMonth!!)
+        if (needsSplit) {
+            return performTemplateSplit(userId, couple, budget, request, viewingMonth!!)
+        }
+
         // Update category if provided
         request.categoryId?.let { catId ->
             val cat = categoryRepository.findById(catId)
@@ -341,6 +357,105 @@ class BudgetService(
     private fun previousYearMonth(yearMonth: String): String {
         val ym = YearMonth.parse(yearMonth)
         return ym.minusMonths(1).toString()
+    }
+
+    /**
+     * Phase 25 후속 C-2.7 — TEMPLATE 행 편집 시 viewingMonth 단일 OVERRIDE 로 split.
+     *
+     * 호출 조건: applyToFuture=false + budget.rowKind=TEMPLATE + viewingMonth 가 활성 범위 내.
+     * 효과:
+     *  - 원본 TEMPLATE 행 보존 (변경 없음).
+     *  - viewingMonth 단일 OVERRIDE 신규 생성 — request 의 새 값 반영.
+     *  - V57 partial unique `(couple, cat, group, year_month) WHERE row_kind=OVERRIDE` 충돌 시
+     *    ConflictException (이미 OVERRIDE 가 있으면 사용자가 '편집' 진입 자체가 OVERRIDE 였어야 함).
+     */
+    private fun performTemplateSplit(
+        userId: UUID,
+        couple: Couple,
+        template: MonthlyBudget,
+        request: BudgetUpdateRequest,
+        viewingMonth: String
+    ): BudgetResponse {
+        // category/group 결정 (request 우선, 없으면 원본)
+        val resolvedCategory = request.categoryId?.let { catId ->
+            val cat = categoryRepository.findById(catId)
+                .orElseThrow { NotFoundException("CATEGORY_NOT_FOUND", "Specified category does not exist.") }
+            OwnershipValidator.validateOwnership(cat.couple.id, couple, "Category")
+            cat
+        } ?: if (request.groupId != null) null else template.category
+
+        val resolvedGroup = request.groupId?.let { gId ->
+            categoryGroupRepository.findByIdAndCoupleId(gId, couple.id)
+                ?: throw NotFoundException("GROUP_NOT_FOUND", "Specified category group does not exist.")
+        } ?: if (request.categoryId != null) null else template.group
+
+        val resolvedPocket = request.pocketId?.let {
+            val p = moneyPocketRepository.findById(it).orElseThrow {
+                NotFoundException("POCKET_NOT_FOUND", "Pocket not found.")
+            }
+            OwnershipValidator.validateOwnership(p.couple.id, couple, "Pocket")
+            p
+        } ?: template.pocket
+
+        val resolvedBudgetPeriod = request.budgetPeriod?.let { BudgetPeriod.valueOf(it) }
+            ?: template.budgetPeriod
+        val resolvedPeriodType = request.periodType?.let { PeriodType.valueOf(it) }
+            ?: template.periodType
+        val (sd, ed) = resolveStartEndDates(resolvedPeriodType, viewingMonth, request.startDate, request.endDate)
+
+        val visibility = when {
+            resolvedCategory != null -> resolvedCategory.visibility
+            resolvedGroup != null -> resolvedGroup.visibility
+            else -> Visibility.SHARED
+        }
+        val owner = if (visibility == Visibility.PRIVATE) {
+            userRepository.findById(userId)
+                .orElseThrow { NotFoundException("USER_NOT_FOUND", "User not found.") }
+        } else null
+
+        val weeklyAmount = if (resolvedBudgetPeriod == BudgetPeriod.WEEKLY) {
+            request.weeklyAmount ?: (request.amount / calculateNumberOfWeeks(viewingMonth))
+        } else null
+
+        // V57 OVERRIDE partial unique 충돌 체크
+        val categoryIdForCheck = resolvedCategory?.id
+        val groupIdForCheck = resolvedGroup?.id
+        val overrideExists = budgetRepository.existsByCoupleIdAndCategoryGroupAndYearMonth(
+            couple.id, categoryIdForCheck, groupIdForCheck, viewingMonth
+        )
+        if (overrideExists) {
+            throw ConflictException(
+                "BUDGET_ALREADY_EXISTS",
+                "An OVERRIDE budget already exists for this scope and month."
+            )
+        }
+
+        val newOverride = MonthlyBudget(
+            couple = couple,
+            category = resolvedCategory,
+            group = resolvedGroup,
+            yearMonth = viewingMonth,
+            endYearMonth = viewingMonth,
+            rowKind = BudgetRowKind.OVERRIDE,
+            amount = request.amount,
+            budgetPeriod = resolvedBudgetPeriod,
+            weeklyAmount = weeklyAmount,
+            periodType = resolvedPeriodType,
+            startDate = sd,
+            endDate = ed,
+            pocket = resolvedPocket,
+            visibility = visibility,
+            owner = owner
+        )
+        val saved = budgetRepository.save(newOverride)
+        syncEventPublisher.publish(SyncEvent(
+            type = "BUDGET_UPDATED",
+            entityType = "BUDGET",
+            entityId = saved.id,
+            coupleId = couple.id,
+            authorId = userId
+        ))
+        return saved.toResponse()
     }
 
     /**

--- a/backend/src/test/kotlin/com/budgetbook/budget/service/BudgetServiceTemplateSplitTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/budget/service/BudgetServiceTemplateSplitTest.kt
@@ -1,0 +1,186 @@
+package com.budgetbook.budget.service
+
+import com.budgetbook.auth.domain.AuthProvider
+import com.budgetbook.auth.domain.User
+import com.budgetbook.budget.domain.BudgetRowKind
+import com.budgetbook.budget.domain.MonthlyBudget
+import com.budgetbook.budget.dto.BudgetUpdateRequest
+import com.budgetbook.budget.repository.MonthlyBudgetRepository
+import com.budgetbook.category.domain.Category
+import com.budgetbook.category.domain.CategoryType
+import com.budgetbook.category.repository.CategoryGroupRepository
+import com.budgetbook.category.repository.CategoryRepository
+import com.budgetbook.common.exception.ConflictException
+import com.budgetbook.couple.domain.Couple
+import com.budgetbook.couple.domain.CoupleStatus
+import com.budgetbook.couple.service.CoupleResolver
+import com.budgetbook.pocket.repository.MoneyPocketRepository
+import com.budgetbook.spendingplan.repository.SpendingPlanRepository
+import com.budgetbook.sync.SyncEventPublisher
+import com.budgetbook.transaction.repository.TransactionRepository
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import java.util.Optional
+
+/**
+ * Phase 25 후속 C-2.7 — TEMPLATE 행 편집 시 split semantic.
+ * applyToFuture=false + 편집 대상 = TEMPLATE 시 viewingMonth 단일 OVERRIDE 신규 생성 (TEMPLATE 보존).
+ */
+class BudgetServiceTemplateSplitTest : BehaviorSpec({
+
+    isolationMode = IsolationMode.InstancePerLeaf
+
+    val budgetRepository = mockk<MonthlyBudgetRepository>()
+    val coupleResolver = mockk<CoupleResolver>()
+    val categoryRepository = mockk<CategoryRepository>()
+    val categoryGroupRepository = mockk<CategoryGroupRepository>()
+    val transactionRepository = mockk<TransactionRepository>()
+    val syncEventPublisher = mockk<SyncEventPublisher>(relaxed = true)
+    val moneyPocketRepository = mockk<MoneyPocketRepository>()
+    val userRepository = mockk<com.budgetbook.auth.repository.UserRepository>()
+    val spendingPlanRepository = mockk<SpendingPlanRepository>()
+    val service = BudgetService(
+        budgetRepository, coupleResolver, categoryRepository, categoryGroupRepository,
+        transactionRepository, syncEventPublisher, moneyPocketRepository, userRepository,
+        spendingPlanRepository
+    )
+
+    val u1 = User(email = "u1@t.com", nickname = "U1", provider = AuthProvider.GOOGLE, providerId = "g1")
+    val u2 = User(email = "u2@t.com", nickname = "U2", provider = AuthProvider.KAKAO, providerId = "k1")
+    val couple = Couple(user1 = u1, user2 = u2, status = CoupleStatus.ACTIVE)
+    val foodCat = Category(couple = couple, name = "식비", type = CategoryType.EXPENSE, icon = "f", color = "#1", isDefault = true)
+
+    every { coupleResolver.getActiveCouple(u1.id) } returns couple
+
+    Given("TEMPLATE 식비(1월~무기한, 25만) — 5월 편집, applyToFuture=false") {
+        val template = MonthlyBudget(
+            couple = couple, category = foodCat,
+            yearMonth = "2026-01", endYearMonth = null,
+            rowKind = BudgetRowKind.TEMPLATE, amount = 250_000L
+        )
+        every { budgetRepository.findById(template.id) } returns Optional.of(template)
+        every { budgetRepository.existsByCoupleIdAndCategoryGroupAndYearMonth(
+            couple.id, foodCat.id, null, "2026-05"
+        ) } returns false
+        val savedSlot = slot<MonthlyBudget>()
+        every { budgetRepository.save(capture(savedSlot)) } answers { savedSlot.captured }
+
+        When("amount=300000, yearMonth=2026-05, applyToFuture=false 로 update") {
+            val result = service.updateBudget(u1.id, template.id,
+                BudgetUpdateRequest(amount = 300_000L, yearMonth = "2026-05", applyToFuture = false))
+
+            Then("원본 TEMPLATE 그대로 유지 (yearMonth=2026-01, endYearMonth=null, amount=25만)") {
+                template.yearMonth shouldBe "2026-01"
+                template.endYearMonth shouldBe null
+                template.amount shouldBe 250_000L
+                template.rowKind shouldBe BudgetRowKind.TEMPLATE
+            }
+            Then("새 OVERRIDE 가 5월 단일월로 저장됨") {
+                val saved = savedSlot.captured
+                saved.rowKind shouldBe BudgetRowKind.OVERRIDE
+                saved.yearMonth shouldBe "2026-05"
+                saved.endYearMonth shouldBe "2026-05"
+                saved.amount shouldBe 300_000L
+                saved.category?.id shouldBe foodCat.id
+            }
+            Then("응답은 새 OVERRIDE 의 정보") {
+                result.amount shouldBe 300_000L
+                result.yearMonth shouldBe "2026-05"
+            }
+        }
+    }
+
+    Given("TEMPLATE 행 편집 시 5월에 이미 OVERRIDE 가 존재") {
+        val template = MonthlyBudget(
+            couple = couple, category = foodCat,
+            yearMonth = "2026-01", endYearMonth = null,
+            rowKind = BudgetRowKind.TEMPLATE, amount = 250_000L
+        )
+        every { budgetRepository.findById(template.id) } returns Optional.of(template)
+        every { budgetRepository.existsByCoupleIdAndCategoryGroupAndYearMonth(
+            couple.id, foodCat.id, null, "2026-05"
+        ) } returns true
+
+        When("split 시도") {
+            Then("ConflictException — V57 partial unique 충돌 사전 차단") {
+                val ex = shouldThrow<ConflictException> {
+                    service.updateBudget(u1.id, template.id,
+                        BudgetUpdateRequest(amount = 300_000L, yearMonth = "2026-05", applyToFuture = false))
+                }
+                ex.code shouldBe "BUDGET_ALREADY_EXISTS"
+            }
+        }
+    }
+
+    Given("TEMPLATE 활성 범위 밖 — viewingMonth < startMonth") {
+        val template = MonthlyBudget(
+            couple = couple, category = foodCat,
+            yearMonth = "2026-05", endYearMonth = null,
+            rowKind = BudgetRowKind.TEMPLATE, amount = 250_000L
+        )
+        every { budgetRepository.findById(template.id) } returns Optional.of(template)
+        every { budgetRepository.save(template) } returns template
+
+        When("viewingMonth=2026-03 (시작월보다 앞) 으로 update") {
+            service.updateBudget(u1.id, template.id,
+                BudgetUpdateRequest(amount = 300_000L, yearMonth = "2026-03", applyToFuture = false))
+
+            Then("split 안 일어나고 기존 TEMPLATE 그대로 update (활성 범위 밖이므로)") {
+                template.amount shouldBe 300_000L
+                template.rowKind shouldBe BudgetRowKind.TEMPLATE
+            }
+        }
+    }
+
+    Given("OVERRIDE 행 편집 (split 미적용)") {
+        val override = MonthlyBudget(
+            couple = couple, category = foodCat,
+            yearMonth = "2026-05", endYearMonth = "2026-05",
+            rowKind = BudgetRowKind.OVERRIDE, amount = 300_000L
+        )
+        every { budgetRepository.findById(override.id) } returns Optional.of(override)
+        every { budgetRepository.save(override) } returns override
+
+        When("amount=350000, yearMonth=2026-05, applyToFuture=false 로 update") {
+            service.updateBudget(u1.id, override.id,
+                BudgetUpdateRequest(amount = 350_000L, yearMonth = "2026-05", applyToFuture = false))
+
+            Then("기존 OVERRIDE 행을 그대로 update (split 안 함)") {
+                override.amount shouldBe 350_000L
+                override.rowKind shouldBe BudgetRowKind.OVERRIDE
+                override.yearMonth shouldBe "2026-05"
+            }
+            Then("split 의 unique check 호출 안 됨") {
+                verify(exactly = 0) { budgetRepository.existsByCoupleIdAndCategoryGroupAndYearMonth(any(), any(), any(), any()) }
+            }
+        }
+    }
+
+    Given("TEMPLATE 행 + applyToFuture=true (split 미적용, 기존 C-2 동작 유지)") {
+        val template = MonthlyBudget(
+            couple = couple, category = foodCat,
+            yearMonth = "2026-01", endYearMonth = null,
+            rowKind = BudgetRowKind.TEMPLATE, amount = 250_000L
+        )
+        every { budgetRepository.findById(template.id) } returns Optional.of(template)
+        every { budgetRepository.findActiveTemplateInScope(any(), any(), any(), any(), any()) } returns null
+        every { budgetRepository.save(template) } returns template
+
+        When("amount=350000, yearMonth=2026-05, applyToFuture=true 로 update") {
+            service.updateBudget(u1.id, template.id,
+                BudgetUpdateRequest(amount = 350_000L, yearMonth = "2026-05", applyToFuture = true))
+
+            Then("기존 TEMPLATE 의 amount 만 변경 (split 안 함, endYearMonth=null 유지)") {
+                template.amount shouldBe 350_000L
+                template.rowKind shouldBe BudgetRowKind.TEMPLATE
+                template.endYearMonth shouldBe null
+            }
+        }
+    }
+})

--- a/docs/sessions/2026-04-26_5_plan.md
+++ b/docs/sessions/2026-04-26_5_plan.md
@@ -1,0 +1,105 @@
+# C-2.7 + C-3.1 + U-1 통합 PR — TEMPLATE split semantic + UX 통일
+> 날짜: 2026-04-26 | 회차: 5 | 상태: 기획
+
+## 요청 내용 (사용자 라이브 검증 §A 실패 + UX 개선)
+1. **버그 1**: 5월 예산 편집 시 "이후 모든 일정에 반영" 체크 안 했는데 6월·7월 변경됨.
+2. **버그 2**: 주간 예산에 체크박스 보이지 않음 (사용자 보고).
+3. **UX 개선**: 그룹 예산 더보기에 "거래 보기" 없음 — 모든 예산 행에서 클릭=편집 / 더보기=거래 보기 통일.
+
+## 영향 범위 분석
+
+### 변경 파일
+| 파일 | 유형 | 목적 |
+|------|------|------|
+| **BE** | | |
+| `backend/.../budget/service/BudgetService.kt` | 수정 | C-2.7 split semantic |
+| `backend/src/test/.../BudgetServiceTemplateSplitTest.kt` | 신규 | 4건 |
+| **FE** | | |
+| `frontend/lib/features/budget/presentation/widgets/budget_transactions_sheet.dart` | 수정 | `categoryGroupId` 파라미터 지원 + 미할당(필터 없음) 지원 |
+| `frontend/lib/features/budget/presentation/pages/budget_list_page.dart` | 수정 | onTap=편집 / PopupMenu '거래 보기' 모든 예산 |
+| `frontend/lib/features/budget/presentation/pages/budget_form_page.dart` | 수정 | 체크박스 카피 universal ("이번 시점부터 미래 모든 일정에 적용") |
+
+### 기술 결정
+- BE: `request.yearMonth` 를 viewing month 로 활용. FE 가 form 초기화 시 viewing month 로 세팅하므로 안전.
+- "split" 결정 조건: `budget.rowKind == TEMPLATE` AND viewingMonth 가 활성 범위 내.
+
+### 행동 매트릭스
+| budget.rowKind | viewingMonth ↔ TEMPLATE.yearMonth | applyToFuture | 동작 |
+|---|---|---|---|
+| OVERRIDE | (단일월) | false | 그냥 update |
+| OVERRIDE | (단일월) | true | TEMPLATE 승격 + C-2.6 충돌 해소 |
+| TEMPLATE | viewingMonth == start | false | 그냥 update (단일 TEMPLATE 동작 = 모든 월 영향, 사용자가 시작월에 있을 때는 의도 일치) |
+| TEMPLATE | viewingMonth == start | true | 그냥 update (이미 미래 적용) |
+| TEMPLATE | viewingMonth > start (활성 범위 내) | false | **split**: TEMPLATE 보존 + viewingMonth OVERRIDE 신규 |
+| TEMPLATE | viewingMonth > start (활성 범위 내) | true | **split**: 원본 TEMPLATE 종료(endYM=viewingMonth-1) + viewingMonth~ 새 TEMPLATE |
+
+### 주간예산 체크박스 (C-3.1)
+- 기존 `budget_form_page.dart` 의 line 324 `if (isEditing) ...[` 가 WEEKLY/MONTHLY 외부에 있어 둘 다 표시되어야 함. 사용자 보고는 캐시 또는 확인 누락 가능성. 확인 차원에서 카피만 보강 ("이번 시점부터 미래 모든 일정에 적용됩니다").
+- 별도 코드 path 없음 — weekly_budget_page 는 view-only.
+
+### U-1 (UX 통일)
+- 기존: budget_list_page row 클릭 → /transactions?categoryId=... 필터 이동.
+- 변경: 클릭 → /budgets/edit/{id}?year=..&month=.. (편집 진입).
+- 더보기 메뉴 "거래 보기": category=있음 / group=없음 / total=없음 → **모두 표시**.
+  - category: `categoryId` 로 필터
+  - group: `categoryGroupId` 로 필터 (TransactionList 가 이미 지원)
+  - total: 필터 없이 month 만 (BudgetTransactionsSheet 가 nullable 지원하도록 보강)
+
+### 사용자 메모리 충돌 검증
+- `feedback_user_rejected_ui_no_re_add.md`: "한 번 제거 요청한 UI 는 재추가 금지". 본 변경은 "거부한 UI 재추가" 가 아닌 **사용자가 본 세션에서 직접 명시적으로 요청한 변경** — "그냥 클릭 시 수정하기로 하고 모든 예산 더보기 메뉴에 거래 보기로 필터링 적용하는게 더 깔끔". 충돌 없음.
+
+## 작업 계획
+| # | 작업 | 영역 | 난이도 |
+|---|------|------|------|
+| 1 | BudgetService.updateBudget split semantic | BE | M |
+| 2 | 단위 테스트 4건 (split 시나리오) | BE | M |
+| 3 | budget_transactions_sheet 인자 확장 (categoryGroupId, nullable filters) | FE | S |
+| 4 | budget_list_page onTap=편집 + 더보기 '거래 보기' 모든 예산 | FE | M |
+| 5 | budget_form_page 체크박스 카피 보강 | FE | XS |
+| 6 | flutter test 회귀 + analyze | FE | S |
+
+## 성능 설계
+- BE: split 시 INSERT 1회 추가 (or UPDATE+INSERT 2회). 트랜잭션 내 처리. 무시 가능.
+- FE: 기존 sheet/route 재사용. 추가 호출 없음.
+
+## 하네스 Scope Audit 결과
+- 실행: `pre-change-audit.sh . "template_override_resolution,ux_temporal_intent_split,ui_pattern"`
+- Verdict: ✅ OK, gate OPEN.
+- 새로 추가된 `ux_temporal_intent_split` cross-check 충실히 반영 (행동 매트릭스 6 케이스).
+
+## 자동 검증 계획
+- [x] BE 테스트 통과 + 신규 split 시나리오 4건
+- [x] FE analyze + test 702건+ 유지
+- [x] 메모리 `feedback_user_rejected_ui_no_re_add` 충돌 없음 확인
+
+## 사용자 검증 시나리오
+
+### A. C-2.7 split (단일월 변경)
+| # | 경로 | 조작 | 기대 |
+|---|------|------|------|
+| A1 | TEMPLATE 식비(25만, 1월~) 활성 / 5월 이동 → 식비 편집 → 30만 (체크 안함) | 5월=30만, 4월=25만, 6월=25만 |
+| A2 | 위 상태에서 5월 OVERRIDE(30만) 다시 편집 → 32만 (체크 안함) | 5월=32만, 4월/6월=25만 |
+| A3 | 5월 식비 편집 → 35만 + 체크 (TEMPLATE 시작 1월 < viewing 5월) | 1~4월=25만, 5월~=35만 (TEMPLATE 분리) |
+
+### B. C-3.1 (주간예산 체크박스)
+| # | 경로 | 조작 | 기대 |
+|---|------|------|------|
+| B1 | 예산 → 주간 예산 항목 편집 진입 | 체크박스 보임 + "이번 시점부터 미래 모든 일정에 적용" 안내 |
+
+### C. U-1 (UX 통일)
+| # | 경로 | 조작 | 기대 |
+|---|------|------|------|
+| C1 | 예산 카테고리 행 클릭 | 편집 화면 진입 (/budgets/edit/{id}) |
+| C2 | 카테고리 행 더보기 → 거래 보기 | 카테고리 필터 sheet |
+| C3 | 그룹 예산 행 더보기 → 거래 보기 | **그룹 필터 sheet** (categoryGroupId) |
+| C4 | 총 예산 행 더보기 → 거래 보기 | 필터 없는 sheet (해당 월 모든 거래) |
+
+### D. 회귀
+| # | 확인 | 기대 |
+|---|------|------|
+| D1 | 신규 등록 (편집 아님) | 체크박스 안 보임 (편집 전용) |
+| D2 | 분석/리포트/통계 페이지 | 정상 |
+| D3 | 거래 탭 필터 chips | 정상 |
+
+## 사용자 승인
+- [x] 사용자 선택 B (셋 통합) — 즉시 진행

--- a/frontend/lib/features/budget/presentation/pages/budget_form_page.dart
+++ b/frontend/lib/features/budget/presentation/pages/budget_form_page.dart
@@ -329,7 +329,7 @@ class _BudgetFormPageState extends State<BudgetFormPage> {
                 dense: true,
                 title: const Text('이후 모든 일정에 반영'),
                 subtitle: const Text(
-                  '체크 시 이번 달부터 미래 모든 달에 적용됩니다',
+                  '체크 안 함: 이번 달만 변경 (미래 일정 보존)\n체크 함: 이번 달부터 미래 모든 달에 적용',
                   style: TextStyle(fontSize: 12),
                 ),
                 value: _applyToFuture,

--- a/frontend/lib/features/budget/presentation/pages/budget_list_page.dart
+++ b/frontend/lib/features/budget/presentation/pages/budget_list_page.dart
@@ -682,15 +682,16 @@ class _BudgetListPageState extends State<BudgetListPage> {
                 final month =
                     state is BudgetLoaded ? state.month : DateTime.now().month;
                 if (value == 'transactions') {
-                  if (budget.category != null) {
-                    showBudgetTransactionsSheet(
-                      context: context,
-                      year: year,
-                      month: month,
-                      categoryId: budget.category!.id,
-                      categoryName: budget.targetLabel,
-                    );
-                  }
+                  // Phase 25 후속 U-1 — 모든 예산 종류(카테고리/그룹/총) 거래 보기 통일.
+                  showBudgetTransactionsSheet(
+                    context: context,
+                    year: year,
+                    month: month,
+                    categoryId: budget.category?.id,
+                    categoryGroupId:
+                        budget.category == null ? budget.groupId : null,
+                    categoryName: budget.targetLabel,
+                  );
                 } else if (value == 'edit') {
                   context.push(
                       '/budgets/edit/${budget.id}?year=$year&month=$month');
@@ -708,17 +709,16 @@ class _BudgetListPageState extends State<BudgetListPage> {
                 }
               },
               itemBuilder: (context) => [
-                if (budget.category != null)
-                  const PopupMenuItem(
-                    value: 'transactions',
-                    child: Row(
-                      children: [
-                        Icon(Icons.receipt_long, size: 18),
-                        SizedBox(width: 8),
-                        Text('거래 보기'),
-                      ],
-                    ),
+                const PopupMenuItem(
+                  value: 'transactions',
+                  child: Row(
+                    children: [
+                      Icon(Icons.receipt_long, size: 18),
+                      SizedBox(width: 8),
+                      Text('거래 보기'),
+                    ],
                   ),
+                ),
                 const PopupMenuItem(
                   value: 'edit',
                   child: Row(
@@ -743,31 +743,15 @@ class _BudgetListPageState extends State<BudgetListPage> {
             ),
           ],
         ),
-        // 사용자 요청: 클릭 시 수정이 아닌 거래 탭의 필터로 세부 내역.
-        // (수정은 PopupMenu(...) 의 'edit' 항목으로 가능)
+        // Phase 25 후속 U-1 — 행 클릭 = 편집 진입 (모든 예산 통일).
+        // 거래 보기 / 삭제는 PopupMenu 통해 접근.
         onTap: () {
           final state = context.read<BudgetBloc>().state;
           final year =
               state is BudgetLoaded ? state.year : DateTime.now().year;
           final month =
               state is BudgetLoaded ? state.month : DateTime.now().month;
-          final params = <String, String>{
-            'year': '$year',
-            'month': '$month',
-          };
-          if (budget.category != null) {
-            params['categoryId'] = budget.category!.id;
-            params['categoryName'] =
-                Uri.encodeComponent(budget.targetLabel);
-          } else if (budget.groupId != null) {
-            params['categoryGroupId'] = budget.groupId!;
-            params['categoryName'] =
-                Uri.encodeComponent(budget.targetLabel);
-          }
-          // total budget: 필터 없이 month 만 적용
-          final query =
-              params.entries.map((e) => '${e.key}=${e.value}').join('&');
-          context.go('/transactions?$query');
+          context.push('/budgets/edit/${budget.id}?year=$year&month=$month');
         },
       ),
     );

--- a/frontend/lib/features/budget/presentation/widgets/budget_transactions_sheet.dart
+++ b/frontend/lib/features/budget/presentation/widgets/budget_transactions_sheet.dart
@@ -10,12 +10,18 @@ import 'package:budget_book/features/transaction/presentation/bloc/transaction_e
 import 'package:budget_book/features/transaction/presentation/bloc/transaction_state.dart';
 import 'package:budget_book/features/transaction/presentation/widgets/transaction_list_tile.dart';
 
-/// Shows a bottom sheet with transactions filtered by categoryId for a budget item.
+/// Shows a bottom sheet with transactions filtered for a budget item.
+///
+/// Phase 25 후속 U-1 — 모든 예산 행에 거래 보기 통일:
+/// - category 예산: `categoryId` 로 필터
+/// - group 예산: `categoryGroupId` 로 필터
+/// - total (미할당) 예산: 둘 다 null — 해당 월 전체 거래
 void showBudgetTransactionsSheet({
   required BuildContext context,
   required int year,
   required int month,
-  required String? categoryId,
+  String? categoryId,
+  String? categoryGroupId,
   required String categoryName,
   String? dateFrom,
   String? dateTo,
@@ -40,6 +46,8 @@ void showBudgetTransactionsSheet({
               year: year,
               month: month,
               categoryId: categoryId,
+              categoryGroupIds:
+                  categoryGroupId != null ? {categoryGroupId} : const {},
               dateFrom: dateFrom,
               dateTo: dateTo,
             ));


### PR DESCRIPTION
## Summary
2026-04-26 라이브 검증 §A 실패 (TEMPLATE 행 편집 시 의도치 않은 미래 전파) + UX 일관성 개선을 통합 처리.

해결 대상: `docs/sessions/2026-04-26_2_result.md` §실패 발생.

### C-2.7 — BE TEMPLATE split semantic
사용자 멘탈 모델(월 단위) ↔ 시스템 행 단위 변경 어긋남 해결.

- **BudgetUpdateRequest** 에 `yearMonth` 필드 (사용자 viewing month) 추가.
- **BudgetService.updateBudget**:
  - `applyToFuture=false` + 편집 대상 = TEMPLATE + viewingMonth 가 활성 범위 내
    → `performTemplateSplit`: 원본 TEMPLATE 보존 + viewingMonth 단일 OVERRIDE 신규.
  - V57 partial unique 충돌 사전 차단.
  - `applyToFuture=true` 케이스는 기존 C-2 동작 유지 (전체 TEMPLATE 적용 — 의도 일치).
- 단위 테스트 5건 추가 (`BudgetServiceTemplateSplitTest`).

### C-3.1 — 주간예산 체크박스
`budget_form_page` 의 `if (isEditing)` 체크박스는 WEEKLY/MONTHLY 외부 위치 — 둘 다 노출.
카피 보강 (체크 안 함 / 체크 함 동작 명시).

### U-1 — 예산 카드 UX 통일
- **행 클릭 = 편집** (이전: /transactions 필터 이동). 사용자 명시 요청.
- **PopupMenu '거래 보기' 모든 예산 종류** 표시 (이전: category 만).
  - category 예산 → categoryId 필터
  - group 예산 → categoryGroupId 필터
  - total (미할당) → 필터 없이 월 전체
- `showBudgetTransactionsSheet`: `categoryGroupId` 파라미터 추가, `categoryId` optional.

## Test plan
- [x] BE: `./gradlew test` 전체 + 신규 5건 통과
- [x] FE: `flutter analyze` clean, `flutter test` 702건 통과
- [ ] 사용자 라이브 검증 (`docs/sessions/2026-04-26_5_plan.md`):
  - **A1**: TEMPLATE 식비(1월~) 25만 → 5월 편집 30만 (체크 안함) → 5월=30만, 4월=25만, 6월=25만
  - **A2**: 5월 OVERRIDE(30만) 다시 편집 32만 (체크 안함) → 5월=32만, 4/6월=25만
  - **A3**: 5월 식비 편집 35만 + 체크 → 1~4월=25만, 5월~=35만 (TEMPLATE 분리; **applyToFuture+TEMPLATE 케이스는 본 PR 에서 미보강 — 전체 TEMPLATE 영향, follow-up 필요할 수 있음**)
  - **B1**: 주간 예산 편집 진입 → 체크박스 보임
  - **C1~C4**: 클릭=편집 / 더보기=거래 보기 모든 예산 종류

🤖 Generated with [Claude Code](https://claude.com/claude-code)