### PR TITLE
feat(budget): E-1 — 신규 예산 등록 시 '이후 모든 일정에 반영' 체크박스

### DIFF
--- a/backend/src/main/kotlin/com/budgetbook/budget/dto/BudgetDtos.kt
+++ b/backend/src/main/kotlin/com/budgetbook/budget/dto/BudgetDtos.kt
@@ -42,7 +42,15 @@ data class BudgetRequest(
 
     val pocketId: UUID? = null,
 
-    val visibility: String? = "SHARED"
+    val visibility: String? = "SHARED",
+
+    /**
+     * Phase 25 후속 E-1 — 신규 등록 시 사용자가 "이후 모든 일정에 반영" 체크.
+     * - false (default): 단일월 OVERRIDE (기존 동작)
+     * - true: TEMPLATE (yearMonth ~ 무기한). 같은 scope 의 기존 TEMPLATE 자동 종료 (V57 unique 충돌 회피).
+     * endYearMonth 가 명시적으로 주어진 경우 그 값이 우선.
+     */
+    val applyToFuture: Boolean = false
 )
 
 data class BudgetUpdateRequest(

--- a/backend/src/main/kotlin/com/budgetbook/budget/service/BudgetService.kt
+++ b/backend/src/main/kotlin/com/budgetbook/budget/service/BudgetService.kt
@@ -133,12 +133,18 @@ class BudgetService(
                 .orElseThrow { NotFoundException("USER_NOT_FOUND", "User not found.") }
         } else null
 
-        // Phase 25 후속 C-2 — endYearMonth 와 rowKind 결정.
-        // - request.endYearMonth == null → 단일월 OVERRIDE (endYearMonth=yearMonth)
-        // - endYearMonth != yearMonth → TEMPLATE (yearMonth ~ endYearMonth, endYearMonth=null 도 무기한 TEMPLATE)
+        // Phase 25 후속 C-2 / E-1 — endYearMonth 와 rowKind 결정.
+        // 우선순위:
+        //   1) request.applyToFuture=true → TEMPLATE (yearMonth ~ 무기한)
+        //   2) request.endYearMonth == null → 단일월 OVERRIDE
+        //   3) request.endYearMonth == yearMonth → 단일월 OVERRIDE
+        //   4) 그 외 → TEMPLATE (yearMonth ~ request.endYearMonth)
         val rowKind: BudgetRowKind
         val effectiveEndYearMonth: String?
-        if (request.endYearMonth == null) {
+        if (request.applyToFuture) {
+            rowKind = BudgetRowKind.TEMPLATE
+            effectiveEndYearMonth = null
+        } else if (request.endYearMonth == null) {
             rowKind = BudgetRowKind.OVERRIDE
             effectiveEndYearMonth = request.yearMonth
         } else if (request.endYearMonth == request.yearMonth) {
@@ -166,6 +172,12 @@ class BudgetService(
             visibility = visibility,
             owner = owner
         )
+
+        // E-1: TEMPLATE 신규 등록 시 같은 scope 의 기존 TEMPLATE 자동 종료
+        // (V57 partial unique 충돌 회피 + 사용자 의도 보존).
+        if (rowKind == BudgetRowKind.TEMPLATE) {
+            terminateConflictingTemplate(budget)
+        }
 
         val saved = budgetRepository.save(budget)
         syncEventPublisher.publish(SyncEvent(

--- a/frontend/lib/features/budget/data/repositories/budget_repository_impl.dart
+++ b/frontend/lib/features/budget/data/repositories/budget_repository_impl.dart
@@ -23,6 +23,7 @@ class BudgetRepositoryImpl implements BudgetRepository {
     String periodType = 'MONTHLY',
     DateTime? startDate,
     DateTime? endDate,
+    bool applyToFuture = false,
   }) async {
     try {
       final data = <String, dynamic>{
@@ -36,6 +37,7 @@ class BudgetRepositoryImpl implements BudgetRepository {
         if (pocketId != null) 'pocketId': pocketId,
         if (startDate != null) 'startDate': startDate.toIso8601String().split('T')[0],
         if (endDate != null) 'endDate': endDate.toIso8601String().split('T')[0],
+        if (applyToFuture) 'applyToFuture': true,
       };
       final result = await remoteDataSource.createBudget(data);
       return Right(result);

--- a/frontend/lib/features/budget/domain/repositories/budget_repository.dart
+++ b/frontend/lib/features/budget/domain/repositories/budget_repository.dart
@@ -14,6 +14,7 @@ abstract class BudgetRepository {
     String periodType = 'MONTHLY',
     DateTime? startDate,
     DateTime? endDate,
+    bool applyToFuture = false,
   });
 
   Future<Either<Failure, List<Budget>>> getBudgets({

--- a/frontend/lib/features/budget/presentation/bloc/budget_bloc.dart
+++ b/frontend/lib/features/budget/presentation/bloc/budget_bloc.dart
@@ -124,6 +124,7 @@ class BudgetBloc extends Bloc<BudgetEvent, BudgetState> {
         periodType: event.periodType,
         startDate: event.startDate,
         endDate: event.endDate,
+        applyToFuture: event.applyToFuture,
       );
       result.fold(
         (failure) {

--- a/frontend/lib/features/budget/presentation/bloc/budget_event.dart
+++ b/frontend/lib/features/budget/presentation/bloc/budget_event.dart
@@ -38,6 +38,7 @@ class CreateBudget extends BudgetEvent {
   final String periodType;
   final DateTime? startDate;
   final DateTime? endDate;
+  final bool applyToFuture;
 
   const CreateBudget({
     this.categoryId,
@@ -50,6 +51,7 @@ class CreateBudget extends BudgetEvent {
     this.periodType = 'MONTHLY',
     this.startDate,
     this.endDate,
+    this.applyToFuture = false,
   });
 
   @override
@@ -64,6 +66,7 @@ class CreateBudget extends BudgetEvent {
         periodType,
         startDate,
         endDate,
+        applyToFuture,
       ];
 }
 

--- a/frontend/lib/features/budget/presentation/pages/budget_form_page.dart
+++ b/frontend/lib/features/budget/presentation/pages/budget_form_page.dart
@@ -321,21 +321,21 @@ class _BudgetFormPageState extends State<BudgetFormPage> {
                   return null;
                 },
               ),
-            if (isEditing) ...[
-              const SizedBox(height: 8),
-              CheckboxListTile(
-                contentPadding: EdgeInsets.zero,
-                controlAffinity: ListTileControlAffinity.leading,
-                dense: true,
-                title: const Text('이후 모든 일정에 반영'),
-                subtitle: const Text(
-                  '체크 안 함: 이번 달만 변경 (미래 일정 보존)\n체크 함: 이번 달부터 미래 모든 달에 적용',
-                  style: TextStyle(fontSize: 12),
-                ),
-                value: _applyToFuture,
-                onChanged: (v) => setState(() => _applyToFuture = v ?? false),
+            const SizedBox(height: 8),
+            CheckboxListTile(
+              contentPadding: EdgeInsets.zero,
+              controlAffinity: ListTileControlAffinity.leading,
+              dense: true,
+              title: const Text('이후 모든 일정에 반영'),
+              subtitle: Text(
+                isEditing
+                    ? '체크 안 함: 이번 달만 변경 (미래 일정 보존)\n체크 함: 이번 달부터 미래 모든 달에 적용'
+                    : '체크 안 함: 이번 달만 적용\n체크 함: 이번 달부터 미래 모든 달 자동 적용',
+                style: const TextStyle(fontSize: 12),
               ),
-            ],
+              value: _applyToFuture,
+              onChanged: (v) => setState(() => _applyToFuture = v ?? false),
+            ),
             const SizedBox(height: 32),
             // Submit button
             FilledButton(
@@ -701,6 +701,7 @@ class _BudgetFormPageState extends State<BudgetFormPage> {
           periodType: periodType,
           startDate: _periodSelection.startDate,
           endDate: _periodSelection.endDate,
+          applyToFuture: _applyToFuture,
         ));
       }
     }

--- a/frontend/test/features/budget/presentation/bloc/budget_bloc_test.dart
+++ b/frontend/test/features/budget/presentation/bloc/budget_bloc_test.dart
@@ -55,6 +55,7 @@ class MockBudgetRepository extends Mock implements BudgetRepository {
     String periodType = 'MONTHLY',
     DateTime? startDate,
     DateTime? endDate,
+    bool applyToFuture = false,
   }) =>
       super.noSuchMethod(
         Invocation.method(#createBudget, [], {
@@ -68,6 +69,7 @@ class MockBudgetRepository extends Mock implements BudgetRepository {
           #periodType: periodType,
           #startDate: startDate,
           #endDate: endDate,
+          #applyToFuture: applyToFuture,
         }),
         returnValue: Future.value(
           Right<Failure, Budget>(_dummyBudget),


### PR DESCRIPTION
## Summary
사용자 보고 (2026-04-26): \"예산 추가 → 기간 없음 선택 → 체크박스 없음\". 편집 전용이던 applyToFuture 체크박스를 신규 등록 모드에도 추가.

### BE
- \`BudgetRequest.applyToFuture\` 필드 (default false) 추가.
- \`createBudget\` rowKind 결정 보강: \`applyToFuture=true\` → TEMPLATE 무기한.
- TEMPLATE 신규 시 V57 partial unique 충돌 방지: 같은 scope 의 기존 TEMPLATE 자동 종료 (\`terminateConflictingTemplate\`).

### FE
- CreateBudget event / Repository / RepositoryImpl 에 \`applyToFuture\` 체인.
- \`budget_form_page\`: \`isEditing\` 게이트 제거 → 항상 표시. 안내 카피 분기 (등록/편집).
- \`budget_bloc_test\` mock 시그니처 동기화.

## Test plan
- [x] BE Kotest 통과
- [x] FE \`flutter analyze\` clean, \`flutter test\` 702건 통과
- [ ] 라이브 검증:
  - 신규 등록 화면 → 체크박스 보임 + 등록용 안내 ('이번 달만 적용 / 이번 달부터 미래 모든 달 자동 적용')
  - 체크 안 함: 단일월 OVERRIDE
  - 체크 함: TEMPLATE 무기한, 미래 월에 자동 적용
🤖 Generated with [Claude Code](https://claude.com/claude-code)