### PR TITLE
chore(deploy): E-2 — backend deploy 가속 (5-7분 → 1-2분 예상)

### DIFF
--- a/.github/workflows/deploy-nas.yml
+++ b/.github/workflows/deploy-nas.yml
@@ -36,74 +36,135 @@ jobs:
               - '.github/workflows/deploy-nas.yml'
 
   # ── Backend 배포 (변경 시에만) ──
+  # E-2 (2026-04-26): GitHub Actions runner 에서 gradle bootJar 실행 (cache 활용)
+  # → JAR + 경량 runtime Dockerfile 만 SSH 로 NAS 전송. NAS 는 image build 만 (jre + jar).
+  # 기존: NAS 컨테이너 안에서 매 빌드 fresh gradle (5m20s) → 7m12s 총.
+  # 신: Actions cache hit 시 gradle ~30s + scp ~10s + image build ~10s + health ~30s ≈ 1-2m.
   deploy-backend:
     needs: changes
     if: needs.changes.outputs.backend == 'true'
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
     steps:
-      - name: Deploy Backend to NAS
-        uses: appleboy/ssh-action@v1.0.3
+      - uses: actions/checkout@v4
+
+      - name: Setup JDK 21
+        uses: actions/setup-java@v4
         with:
-          host: ${{ secrets.NAS_HOST }}
-          username: ${{ secrets.NAS_USERNAME }}
-          key: ${{ secrets.NAS_SSH_KEY }}
-          port: ${{ secrets.NAS_SSH_PORT }}
-          command_timeout: 10m
-          script: |
-            set -e
-            export PATH=/usr/local/bin:$PATH
-            cd /volume1/docker/budget-book
+          distribution: temurin
+          java-version: '21'
 
-            git fetch origin main --depth=1
-            git reset --hard origin/main
+      - name: Setup Gradle (with cache)
+        uses: gradle/actions/setup-gradle@v3
 
-            cd backend
-            # NAS Docker 엔진에 buildx 미설치 → legacy builder 사용.
-            # 동일 태그 재사용으로 Docker 가 layer cache 자동 활용.
-            docker build -t bb-backend:latest .
+      - name: Build bootJar
+        run: ./gradlew bootJar --no-daemon
 
-            cat > /tmp/bb_env << 'ENVEOF'
-            SPRING_PROFILES_ACTIVE=prod
-            SPRING_DATASOURCE_URL=jdbc:postgresql://host.docker.internal:5433/budgetbook?sslmode=disable
-            DB_HOST=host.docker.internal
-            DB_PORT=5433
-            DB_NAME=budgetbook
-            DB_USERNAME=budgetbook
-            DB_PASSWORD=${{ secrets.NAS_DB_PASSWORD }}
-            JWT_SECRET=${{ secrets.NAS_JWT_SECRET }}
-            FRONTEND_URL=https://aiva-bb.duckdns.org
-            GOOGLE_CLIENT_ID=${{ secrets.GOOGLE_CLIENT_ID }}
-            GOOGLE_CLIENT_SECRET=${{ secrets.GOOGLE_CLIENT_SECRET }}
-            REDIS_URL=redis://host.docker.internal:6380
-            FLYWAY_ENABLED=true
-            SERVER_FORWARD_HEADERS_STRATEGY=framework
-            SERVER_TOMCAT_REMOTEIP_PROTOCOL_HEADER=X-Forwarded-Proto
-            ENVEOF
-            sed -i 's/^            //' /tmp/bb_env
+      - name: Locate JAR
+        id: jar
+        run: |
+          JAR=$(ls build/libs/*-SNAPSHOT.jar 2>/dev/null | head -1)
+          if [ -z "$JAR" ]; then JAR=$(ls build/libs/*.jar | grep -v plain | head -1); fi
+          if [ -z "$JAR" ]; then echo "ERR: no jar" >&2; exit 1; fi
+          echo "path=$JAR" >> "$GITHUB_OUTPUT"
+          echo "Built: $JAR ($(du -h "$JAR" | cut -f1))"
 
-            docker stop bb_app 2>/dev/null || true
-            docker rm bb_app 2>/dev/null || true
-            docker run -d \
-              --name bb_app \
-              --restart unless-stopped \
-              --add-host=host.docker.internal:host-gateway \
-              -p 8081:8080 \
-              --env-file /tmp/bb_env \
-              bb-backend:latest
+      - name: Setup SSH key
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.NAS_SSH_KEY }}" > ~/.ssh/nas_key
+          chmod 600 ~/.ssh/nas_key
+          ssh-keyscan -p ${{ secrets.NAS_SSH_PORT }} ${{ secrets.NAS_HOST }} >> ~/.ssh/known_hosts 2>/dev/null
 
-            # Health check — V54 같은 무거운 마이그레이션/Hibernate 스키마 검증
-            # 여유 확보 (10회 × 6s = 60s). 실제 장애 시에만 fail.
-            for i in $(seq 1 10); do
-              sleep 6
-              STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8081/actuator/health 2>/dev/null || echo "000")
-              if [ "$STATUS" = "200" ]; then
-                echo "Backend UP (attempt $i)"
-                exit 0
-              fi
-            done
-            echo "FAILED: Backend did not start"
-            docker logs --tail 60 bb_app
-            exit 1
+      - name: Generate runtime Dockerfile
+        run: |
+          cat > /tmp/Dockerfile.runtime << 'EOF'
+          FROM eclipse-temurin:21-jre-alpine
+          RUN addgroup -S app && adduser -S app -G app
+          WORKDIR /app
+          COPY app.jar app.jar
+          USER app
+          EXPOSE 8080
+          ENTRYPOINT ["java", \
+            "-Xms128m", "-Xmx384m", \
+            "-XX:+UseSerialGC", \
+            "-XX:+TieredCompilation", "-XX:TieredStopAtLevel=1", \
+            "-Dspring.jmx.enabled=false", \
+            "-jar", "app.jar"]
+          EOF
+
+      - name: Transfer JAR + Dockerfile to NAS
+        run: |
+          ssh -i ~/.ssh/nas_key -p ${{ secrets.NAS_SSH_PORT }} \
+            ${{ secrets.NAS_USERNAME }}@${{ secrets.NAS_HOST }} \
+            'rm -rf /tmp/bb-deploy && mkdir -p /tmp/bb-deploy'
+          scp -O -i ~/.ssh/nas_key -P ${{ secrets.NAS_SSH_PORT }} \
+            "${{ steps.jar.outputs.path }}" \
+            ${{ secrets.NAS_USERNAME }}@${{ secrets.NAS_HOST }}:/tmp/bb-deploy/app.jar
+          scp -O -i ~/.ssh/nas_key -P ${{ secrets.NAS_SSH_PORT }} \
+            /tmp/Dockerfile.runtime \
+            ${{ secrets.NAS_USERNAME }}@${{ secrets.NAS_HOST }}:/tmp/bb-deploy/Dockerfile
+
+      - name: Build image + restart container on NAS
+        env:
+          NAS_DB_PASSWORD: ${{ secrets.NAS_DB_PASSWORD }}
+          NAS_JWT_SECRET: ${{ secrets.NAS_JWT_SECRET }}
+          GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
+          GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
+        run: |
+          # env 파일을 SSH 경유로 NAS 에 작성 (secrets 노출 최소화: stdin heredoc).
+          ssh -i ~/.ssh/nas_key -p ${{ secrets.NAS_SSH_PORT }} \
+            ${{ secrets.NAS_USERNAME }}@${{ secrets.NAS_HOST }} \
+            "cat > /tmp/bb_env" << ENVEOF
+          SPRING_PROFILES_ACTIVE=prod
+          SPRING_DATASOURCE_URL=jdbc:postgresql://host.docker.internal:5433/budgetbook?sslmode=disable
+          DB_HOST=host.docker.internal
+          DB_PORT=5433
+          DB_NAME=budgetbook
+          DB_USERNAME=budgetbook
+          DB_PASSWORD=${NAS_DB_PASSWORD}
+          JWT_SECRET=${NAS_JWT_SECRET}
+          FRONTEND_URL=https://aiva-bb.duckdns.org
+          GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID}
+          GOOGLE_CLIENT_SECRET=${GOOGLE_CLIENT_SECRET}
+          REDIS_URL=redis://host.docker.internal:6380
+          FLYWAY_ENABLED=true
+          SERVER_FORWARD_HEADERS_STRATEGY=framework
+          SERVER_TOMCAT_REMOTEIP_PROTOCOL_HEADER=X-Forwarded-Proto
+          ENVEOF
+
+          # 빌드 + 컨테이너 재기동 + health check
+          ssh -i ~/.ssh/nas_key -p ${{ secrets.NAS_SSH_PORT }} \
+            ${{ secrets.NAS_USERNAME }}@${{ secrets.NAS_HOST }} \
+            'set -e
+             export PATH=/usr/local/bin:$PATH
+             cd /tmp/bb-deploy
+             docker build -t bb-backend:latest .
+             docker stop bb_app 2>/dev/null || true
+             docker rm bb_app 2>/dev/null || true
+             docker run -d \
+               --name bb_app \
+               --restart unless-stopped \
+               --add-host=host.docker.internal:host-gateway \
+               -p 8081:8080 \
+               --env-file /tmp/bb_env \
+               bb-backend:latest
+             # Health check — Flyway/Hibernate 마이그레이션 여유 (10회 × 6s)
+             for i in $(seq 1 10); do
+               sleep 6
+               STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8081/actuator/health 2>/dev/null || echo "000")
+               if [ "$STATUS" = "200" ]; then
+                 echo "Backend UP (attempt $i)"
+                 # cleanup
+                 rm -rf /tmp/bb-deploy /tmp/bb_env
+                 exit 0
+               fi
+             done
+             echo "FAILED: Backend did not start"
+             docker logs --tail 60 bb_app
+             exit 1'
 
   # ── Frontend 배포 (변경 시에만) ──
   deploy-frontend:

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,3 +1,6 @@
+# 로컬 docker build 용 (배포는 .github/workflows/deploy-nas.yml 가 GitHub Actions
+# runner 에서 빌드한 JAR 만 NAS 로 전송 + 인라인 runtime Dockerfile 사용 — E-2 2026-04-26).
+# 본 Dockerfile 은 로컬 검증/대체 경로 호환을 위해 기존 multi-stage 형태 유지.
 FROM gradle:8.7-jdk21 AS build
 WORKDIR /app
 COPY build.gradle.kts settings.gradle.kts ./


### PR DESCRIPTION
## Summary
사용자 요구 (2026-04-26): \"배포가 7분이 너무 오래 걸린다, 간소화\".

### 분석
- BE 변경 PR 의 deploy 7m12s 의 병목 = NAS 컨테이너 안에서 매 빌드 fresh \`gradle bootJar\` (5m20s)
- 기존 Dockerfile multi-stage 는 src 변경 시 build layer 통째로 invalidate
- \`--no-daemon\` + NAS 외부 Gradle 캐시 마운트 없음

### 변경
- \`.github/workflows/deploy-nas.yml\` deploy-backend 재구성:
  - actions/checkout → setup-java 21 → gradle/actions/setup-gradle (cache) → \`./gradlew bootJar\`
  - JAR(약 50MB) + 경량 runtime Dockerfile 만 \`scp -O\` 로 NAS 로 전송
  - NAS 는 단일 stage image build (\`FROM jre + COPY jar\`) 만 — 수 초
  - secrets 는 stdin heredoc 로 env 파일 안전 작성
- \`backend/Dockerfile\` 주석 추가 (로컬 docker build 호환 유지)

### 효과 예상
| 단계 | 기존 (7m12s) | 신 (목표 1-2m) |
|------|-------------|---------------|
| changes 검사 | 4s | 4s |
| Actions checkout/JDK/Gradle setup | – | ~30s |
| **\`gradle bootJar\`** | NAS 컨테이너 5m20s | **Actions cache hit 시 30~60s** |
| Dockerfile 생성 + scp JAR | – | ~10s |
| NAS docker build (jre + COPY) | 25s | ~10s |
| 컨테이너 restart + health check | 50s | ~30-50s |

## Test plan
- [x] yaml syntax check (ruby YAML.load_file OK)
- [ ] 머지 후 첫 배포 시간 측정 — 1-2분대 확인
- [ ] 컨테이너 정상 기동 + actuator/health 200 확인
- [ ] secrets 파일이 NAS 에 정상 전달되는지 (ENV var 흐름)

## 롤백
\`git revert b566658\` — 기존 deploy-nas.yml 으로 복귀

🤖 Generated with [Claude Code](https://claude.com/claude-code)