### PR TITLE
fix(budget): E-3 — TEMPLATE split 충돌 체크가 OVERRIDE 만 보도록

### DIFF
--- a/backend/src/main/kotlin/com/budgetbook/budget/repository/MonthlyBudgetRepository.kt
+++ b/backend/src/main/kotlin/com/budgetbook/budget/repository/MonthlyBudgetRepository.kt
@@ -106,4 +106,27 @@ interface MonthlyBudgetRepository : JpaRepository<MonthlyBudget, UUID> {
         @Param("groupId") groupId: UUID?,
         @Param("yearMonth") yearMonth: String
     ): Boolean
+
+    /**
+     * Phase 25 후속 E-3 — OVERRIDE 행 충돌 전용 검사.
+     * V57 partial unique `uk_monthly_budgets_override_month` 가 OVERRIDE-only 이므로,
+     * split semantic 에서 OVERRIDE 신규 가능 여부 체크 시 TEMPLATE 행을 제외해야 한다.
+     * 기존 `existsByCoupleIdAndCategoryGroupAndYearMonth` 는 rowKind 무관하게 매칭하여
+     * TEMPLATE 자체를 false-positive 로 잡는 버그가 있었다.
+     */
+    @Query("""
+        SELECT CASE WHEN COUNT(b) > 0 THEN true ELSE false END
+        FROM MonthlyBudget b
+        WHERE b.couple.id = :coupleId
+        AND b.rowKind = com.budgetbook.budget.domain.BudgetRowKind.OVERRIDE
+        AND b.yearMonth = :yearMonth
+        AND ((:categoryId IS NULL AND b.category IS NULL) OR b.category.id = :categoryId)
+        AND ((:groupId IS NULL AND b.group IS NULL) OR b.group.id = :groupId)
+    """)
+    fun existsOverrideByCoupleIdAndCategoryGroupAndYearMonth(
+        @Param("coupleId") coupleId: UUID,
+        @Param("categoryId") categoryId: UUID?,
+        @Param("groupId") groupId: UUID?,
+        @Param("yearMonth") yearMonth: String
+    ): Boolean
 }

--- a/backend/src/main/kotlin/com/budgetbook/budget/service/BudgetService.kt
+++ b/backend/src/main/kotlin/com/budgetbook/budget/service/BudgetService.kt
@@ -429,10 +429,13 @@ class BudgetService(
             request.weeklyAmount ?: (request.amount / calculateNumberOfWeeks(viewingMonth))
         } else null
 
-        // V57 OVERRIDE partial unique 충돌 체크
+        // V57 OVERRIDE partial unique 충돌 체크 (E-3 fix: rowKind=OVERRIDE 만 검사 —
+        // 기존 existsByCoupleIdAndCategoryGroupAndYearMonth 는 TEMPLATE 행도 포함하여
+        // viewingMonth == template.yearMonth 케이스에서 자기 자신을 false-positive 로
+        // 매칭하던 버그 해결).
         val categoryIdForCheck = resolvedCategory?.id
         val groupIdForCheck = resolvedGroup?.id
-        val overrideExists = budgetRepository.existsByCoupleIdAndCategoryGroupAndYearMonth(
+        val overrideExists = budgetRepository.existsOverrideByCoupleIdAndCategoryGroupAndYearMonth(
             couple.id, categoryIdForCheck, groupIdForCheck, viewingMonth
         )
         if (overrideExists) {

--- a/backend/src/test/kotlin/com/budgetbook/budget/service/BudgetServiceTemplateSplitTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/budget/service/BudgetServiceTemplateSplitTest.kt
@@ -65,7 +65,7 @@ class BudgetServiceTemplateSplitTest : BehaviorSpec({
             rowKind = BudgetRowKind.TEMPLATE, amount = 250_000L
         )
         every { budgetRepository.findById(template.id) } returns Optional.of(template)
-        every { budgetRepository.existsByCoupleIdAndCategoryGroupAndYearMonth(
+        every { budgetRepository.existsOverrideByCoupleIdAndCategoryGroupAndYearMonth(
             couple.id, foodCat.id, null, "2026-05"
         ) } returns false
         val savedSlot = slot<MonthlyBudget>()
@@ -103,7 +103,7 @@ class BudgetServiceTemplateSplitTest : BehaviorSpec({
             rowKind = BudgetRowKind.TEMPLATE, amount = 250_000L
         )
         every { budgetRepository.findById(template.id) } returns Optional.of(template)
-        every { budgetRepository.existsByCoupleIdAndCategoryGroupAndYearMonth(
+        every { budgetRepository.existsOverrideByCoupleIdAndCategoryGroupAndYearMonth(
             couple.id, foodCat.id, null, "2026-05"
         ) } returns true
 
@@ -114,6 +114,39 @@ class BudgetServiceTemplateSplitTest : BehaviorSpec({
                         BudgetUpdateRequest(amount = 300_000L, yearMonth = "2026-05", applyToFuture = false))
                 }
                 ex.code shouldBe "BUDGET_ALREADY_EXISTS"
+            }
+        }
+    }
+
+    // E-3 회귀 방지: viewingMonth == TEMPLATE.yearMonth 케이스 — 자기 자신을
+    // false-positive 매칭하던 버그 (이전 existsByCoupleIdAndCategoryGroupAndYearMonth
+    // 가 rowKind 무관하게 매칭) 검증.
+    Given("TEMPLATE 시작월 == viewingMonth (예: 5월에 신규 등록한 TEMPLATE 을 5월 편집)") {
+        val template = MonthlyBudget(
+            couple = couple, category = foodCat,
+            yearMonth = "2026-05", endYearMonth = null,
+            rowKind = BudgetRowKind.TEMPLATE, amount = 250_000L
+        )
+        every { budgetRepository.findById(template.id) } returns Optional.of(template)
+        // OVERRIDE 만 검사하므로 false (TEMPLATE 자체는 매칭 안됨)
+        every { budgetRepository.existsOverrideByCoupleIdAndCategoryGroupAndYearMonth(
+            couple.id, foodCat.id, null, "2026-05"
+        ) } returns false
+        val savedSlot = slot<MonthlyBudget>()
+        every { budgetRepository.save(capture(savedSlot)) } answers { savedSlot.captured }
+
+        When("amount=300000, yearMonth=2026-05, applyToFuture=false 로 update") {
+            val result = service.updateBudget(u1.id, template.id,
+                BudgetUpdateRequest(amount = 300_000L, yearMonth = "2026-05", applyToFuture = false))
+
+            Then("ConflictException 안 던지고 split 정상 동작 — TEMPLATE 보존 + OVERRIDE 신규") {
+                template.amount shouldBe 250_000L
+                template.rowKind shouldBe BudgetRowKind.TEMPLATE
+                val saved = savedSlot.captured
+                saved.rowKind shouldBe BudgetRowKind.OVERRIDE
+                saved.yearMonth shouldBe "2026-05"
+                saved.amount shouldBe 300_000L
+                result.amount shouldBe 300_000L
             }
         }
     }


### PR DESCRIPTION
## Summary
사용자 보고 (2026-04-26): "5월 예산만 변경하려니 'On override' 에러로 동작 안됨".

### 원인
\`performTemplateSplit\` (E-2.7) 의 충돌 체크 \`existsByCoupleIdAndCategoryGroupAndYearMonth\` 가 rowKind 무관하게 yearMonth 만 매칭. \`viewingMonth == template.yearMonth\` 케이스 (예: 5월에 신규 등록한 TEMPLATE 을 5월에서 편집) 에서 TEMPLATE 자기 자신을 false-positive 로 잡아 ConflictException throw.

### 변경
- \`MonthlyBudgetRepository\`: \`existsOverrideByCoupleIdAndCategoryGroupAndYearMonth\` 신규 (rowKind=OVERRIDE 필터).
- \`BudgetService.performTemplateSplit\`: 신규 메서드 사용.
- 회귀 테스트 추가: viewingMonth == TEMPLATE.yearMonth 케이스 정상 split.

## Test plan
- [x] 신규 회귀 테스트 통과
- [x] 전체 BE 테스트 회귀 없음
- [ ] 라이브 검증: 5월 단일 TEMPLATE → 5월 편집 (체크 안 함) → ConflictException 없이 OVERRIDE 신규 생성 + TEMPLATE 보존

🤖 Generated with [Claude Code](https://claude.com/claude-code)