### PR TITLE
fix(budget): E-4 — V60: TEMPLATE unique 완화 (multi-segment 허용)

### DIFF
--- a/backend/src/main/resources/db/migration/V60__drop_template_unique_for_multi_segment.sql
+++ b/backend/src/main/resources/db/migration/V60__drop_template_unique_for_multi_segment.sql
@@ -1,0 +1,16 @@
+-- Phase 25 후속 E-4 (2026-04-26)
+-- V57 의 `uk_monthly_budgets_template (couple, cat, group) WHERE row_kind=TEMPLATE` 는
+-- 한 scope 당 TEMPLATE 1건만 허용했으나, applyToFuture=true 시:
+--   1) 기존 TEMPLATE 의 endYearMonth = (대상월-1) 로 "종료"
+--   2) 새 TEMPLATE [대상월~∞] 저장
+-- 두 단계 사이 트랜잭션 안에서 같은 scope 의 TEMPLATE 두 행이 공존하여 partial unique 위반.
+--
+-- 다중 세그먼트(non-overlapping) TEMPLATE 허용으로 정책 변경:
+--   - 한 scope 의 TEMPLATE 행이 시간 범위로 N 개 가능 (e.g., [Jan~Apr], [May~∞]).
+--   - 비중첩 보장은 app 의 BudgetService.terminateConflictingTemplate 가 책임 (DB 차원
+--     비중첩 강제는 별도 trigger/range index 필요 — overhead 대비 효용 낮아 채택 보류).
+--   - 조회는 MonthlyBudgetRepository 의 `findByCoupleIdAndYearMonth*` 가 시간 범위 조건
+--     (yearMonth <= target AND (endYearMonth IS NULL OR endYearMonth >= target)) 으로
+--     active TEMPLATE 만 매칭. Resolver 의 OVERRIDE 우선순위 dedup 동작에는 영향 없음.
+
+DROP INDEX IF EXISTS uk_monthly_budgets_template;


### PR DESCRIPTION
## Summary
사용자 보고: applyToFuture=true update 시 \`CONSTRAINT_VIOLATION\` 에러.

### 원인
V57 의 \`uk_monthly_budgets_template (couple, cat, group) WHERE row_kind=TEMPLATE\` 가 한 scope 당 TEMPLATE 1건만 허용. applyToFuture=true 시 terminate-then-save 의 두 단계 사이 같은 scope 에 TEMPLATE 2개 공존 → unique 위반.

### 수정
- V60 migration 추가: \`DROP INDEX IF EXISTS uk_monthly_budgets_template\`
- 다중 세그먼트(non-overlapping) TEMPLATE 허용
- 비중첩 보장은 app 의 \`terminateConflictingTemplate\` 가 책임 (이미 endYearMonth=prev 로 자르고 새 TEMPLATE 시작하므로 시간상 비중첩)
- 조회는 yearMonth/endYearMonth 범위 조건이라 active TEMPLATE 만 매칭 — 영향 없음

### 영향
- C-2.6 (update applyToFuture + 충돌 해소) 정상 동작
- E-1 (create applyToFuture + 충돌 해소) 정상 동작
- 사용자가 보고한 시나리오 success 예상

## Test plan
- [x] BE 회귀 테스트 통과
- [ ] 라이브 검증: \`PUT /budgets/{id}\` 로 applyToFuture=true 업데이트 → 200 OK
- [ ] 미래 월에 새 amount 반영, 과거 월에 기존 TEMPLATE 의 endYearMonth 종료된 값 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)