### PR TITLE
chore(batch-1): follow-up + 보안 + report week fix (A-1, A-2, B-1, F-3)

### DIFF
--- a/.github/workflows/deploy-nas.yml
+++ b/.github/workflows/deploy-nas.yml
@@ -151,8 +151,10 @@ jobs:
                -p 8081:8080 \
                --env-file /tmp/bb_env \
                bb-backend:latest
-             # Health check — Flyway/Hibernate 마이그레이션 여유 (10회 × 6s)
-             for i in $(seq 1 10); do
+             # Health check — Flyway/Hibernate 마이그레이션 여유 (20회 × 6s = 120s)
+             # 배치 1 A-1 (2026-04-26): Spring Boot 가 60s 넘어 70~80s 시작하는 케이스
+             # (#182 deploy fail 원인) 대응. timeout 완화.
+             for i in $(seq 1 20); do
                sleep 6
                STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8081/actuator/health 2>/dev/null || echo "000")
                if [ "$STATUS" = "200" ]; then

--- a/backend/src/main/kotlin/com/budgetbook/auth/controller/AuthController.kt
+++ b/backend/src/main/kotlin/com/budgetbook/auth/controller/AuthController.kt
@@ -43,6 +43,7 @@ class AuthController(
         return ApiResponse.ok(userResponse)
     }
 
+    @RateLimit(maxRequests = 30, windowSeconds = 60)
     @PatchMapping("/me")
     fun updateProfile(
         @AuthUser userId: UUID,
@@ -52,6 +53,7 @@ class AuthController(
         return ApiResponse.ok(userResponse)
     }
 
+    @RateLimit(maxRequests = 5, windowSeconds = 60)
     @PostMapping("/me/profile-image")
     fun uploadProfileImage(
         @AuthUser userId: UUID,
@@ -61,12 +63,14 @@ class AuthController(
         return ApiResponse.ok(userResponse)
     }
 
+    @RateLimit(maxRequests = 10, windowSeconds = 60)
     @DeleteMapping("/me/profile-image")
     fun removeProfileImage(@AuthUser userId: UUID): ApiResponse<UserResponse> {
         val userResponse = authService.removeProfileImage(userId)
         return ApiResponse.ok(userResponse)
     }
 
+    @RateLimit(maxRequests = 30, windowSeconds = 60)
     @PostMapping("/logout")
     fun logout(
         @AuthUser userId: UUID,

--- a/backend/src/main/kotlin/com/budgetbook/budget/service/BudgetService.kt
+++ b/backend/src/main/kotlin/com/budgetbook/budget/service/BudgetService.kt
@@ -208,19 +208,29 @@ class BudgetService(
         validatePrivateOwner(budget, userId)
 
         // Phase 25 후속 C-2.7 — TEMPLATE 행 편집 split semantic.
-        // 사용자 의도는 "viewingMonth (= request.yearMonth) 만 변경" 인데, TEMPLATE 행을
+        // 사용자 의도는 "viewingMonth (= request.yearMonth) 만/부터 변경" 인데, TEMPLATE 행을
         // 그대로 update 하면 활성 범위 [yearMonth, endYearMonth] 전체에 영향. 따라서:
         //   - applyToFuture=false + 편집 대상 = TEMPLATE + viewingMonth 가 활성 범위 내
         //     → split: 원본 TEMPLATE 보존 + viewingMonth 단일 OVERRIDE 신규.
-        // applyToFuture=true 케이스는 기존 C-2 동작 유지 (전체 TEMPLATE 범위 적용).
+        //   - applyToFuture=true + 편집 대상 = TEMPLATE + viewingMonth > 시작월 (배치 1 A-2)
+        //     → late-split: 원본 endYearMonth=(viewing-1) 로 종료, viewingMonth~∞ 새 TEMPLATE.
+        //       (V60 으로 multi-segment TEMPLATE 허용된 후 가능)
         val viewingMonth = request.yearMonth
-        val needsSplit = !request.applyToFuture
-            && budget.rowKind == BudgetRowKind.TEMPLATE
-            && viewingMonth != null
+        val viewingInActiveRange = viewingMonth != null
             && viewingMonth >= budget.yearMonth
             && (budget.endYearMonth == null || viewingMonth <= budget.endYearMonth!!)
+        val needsSplit = !request.applyToFuture
+            && budget.rowKind == BudgetRowKind.TEMPLATE
+            && viewingInActiveRange
         if (needsSplit) {
             return performTemplateSplit(userId, couple, budget, request, viewingMonth!!)
+        }
+        val needsLateSplit = request.applyToFuture
+            && budget.rowKind == BudgetRowKind.TEMPLATE
+            && viewingMonth != null
+            && viewingMonth > budget.yearMonth
+        if (needsLateSplit) {
+            return performLateTemplateSplit(userId, couple, budget, request, viewingMonth!!)
         }
 
         // Update category if provided
@@ -474,12 +484,108 @@ class BudgetService(
     }
 
     /**
+     * Phase 25 후속 배치 1 A-2 — TEMPLATE 행에 applyToFuture=true 적용 시
+     * viewingMonth > budget.yearMonth 케이스 split.
+     *
+     * 효과:
+     *  - 원본 TEMPLATE 의 endYearMonth = (viewingMonth - 1) 로 종료, amount/category/etc. 보존
+     *  - 새 TEMPLATE [viewingMonth, ∞] 생성 — request 의 새 값 반영
+     *  - V60 으로 multi-segment TEMPLATE 허용된 후 동작 가능
+     *
+     * 비중첩 보장: 원본 endYearMonth=viewing-1, 새 yearMonth=viewing → 시간 범위 비중첩.
+     */
+    private fun performLateTemplateSplit(
+        userId: UUID,
+        couple: Couple,
+        original: MonthlyBudget,
+        request: BudgetUpdateRequest,
+        viewingMonth: String
+    ): BudgetResponse {
+        // category/group 결정 (request 우선, 없으면 원본)
+        val resolvedCategory = request.categoryId?.let { catId ->
+            val cat = categoryRepository.findById(catId)
+                .orElseThrow { NotFoundException("CATEGORY_NOT_FOUND", "Specified category does not exist.") }
+            OwnershipValidator.validateOwnership(cat.couple.id, couple, "Category")
+            cat
+        } ?: if (request.groupId != null) null else original.category
+
+        val resolvedGroup = request.groupId?.let { gId ->
+            categoryGroupRepository.findByIdAndCoupleId(gId, couple.id)
+                ?: throw NotFoundException("GROUP_NOT_FOUND", "Specified category group does not exist.")
+        } ?: if (request.categoryId != null) null else original.group
+
+        val resolvedPocket = request.pocketId?.let {
+            val p = moneyPocketRepository.findById(it).orElseThrow {
+                NotFoundException("POCKET_NOT_FOUND", "Pocket not found.")
+            }
+            OwnershipValidator.validateOwnership(p.couple.id, couple, "Pocket")
+            p
+        } ?: original.pocket
+
+        val resolvedBudgetPeriod = request.budgetPeriod?.let { BudgetPeriod.valueOf(it) }
+            ?: original.budgetPeriod
+        val resolvedPeriodType = request.periodType?.let { PeriodType.valueOf(it) }
+            ?: original.periodType
+        val (sd, ed) = resolveStartEndDates(resolvedPeriodType, viewingMonth, request.startDate, request.endDate)
+
+        val visibility = when {
+            resolvedCategory != null -> resolvedCategory.visibility
+            resolvedGroup != null -> resolvedGroup.visibility
+            else -> Visibility.SHARED
+        }
+        val owner = if (visibility == Visibility.PRIVATE) {
+            userRepository.findById(userId)
+                .orElseThrow { NotFoundException("USER_NOT_FOUND", "User not found.") }
+        } else null
+
+        val weeklyAmount = if (resolvedBudgetPeriod == BudgetPeriod.WEEKLY) {
+            request.weeklyAmount ?: (request.amount / calculateNumberOfWeeks(viewingMonth))
+        } else null
+
+        // 1) 원본 TEMPLATE 종료
+        val prev = previousYearMonth(viewingMonth)
+        original.endYearMonth = prev
+        budgetRepository.save(original)
+
+        // 2) 새 TEMPLATE 생성 [viewingMonth, ∞]
+        val newTemplate = MonthlyBudget(
+            couple = couple,
+            category = resolvedCategory,
+            group = resolvedGroup,
+            yearMonth = viewingMonth,
+            endYearMonth = null,
+            rowKind = BudgetRowKind.TEMPLATE,
+            amount = request.amount,
+            budgetPeriod = resolvedBudgetPeriod,
+            weeklyAmount = weeklyAmount,
+            periodType = resolvedPeriodType,
+            startDate = sd,
+            endDate = ed,
+            pocket = resolvedPocket,
+            visibility = visibility,
+            owner = owner
+        )
+        // 같은 scope 의 다른 TEMPLATE (원본 제외) 충돌 방지 — V60 후에도 비중첩 보장 책임은 app
+        terminateConflictingTemplate(newTemplate)
+        val saved = budgetRepository.save(newTemplate)
+
+        syncEventPublisher.publish(SyncEvent(
+            type = "BUDGET_UPDATED",
+            entityType = "BUDGET",
+            entityId = saved.id,
+            coupleId = couple.id,
+            authorId = userId
+        ))
+        return saved.toResponse()
+    }
+
+    /**
      * Phase 25 후속 C-2.6 — 주어진 budget 과 같은 scope (couple, category, group) 의
      * 활성 TEMPLATE 을 (target.yearMonth - 1) 로 종료. 자기 자신은 제외.
      *
      * - 활성 TEMPLATE 이 없으면 no-op.
      * - 종료 시점이 시작월보다 이르면 (TEMPLATE 시작월 == budget.yearMonth) 행 삭제.
-     * - V57 partial unique 보장으로 결과는 0~1건만 고려.
+     * - V60 후 multi-segment TEMPLATE 허용 — 비중첩 보장은 본 헬퍼가 책임.
      */
     private fun terminateConflictingTemplate(budget: MonthlyBudget) {
         val existing = budgetRepository.findActiveTemplateInScope(

--- a/backend/src/test/kotlin/com/budgetbook/budget/service/BudgetServiceTemplateSplitTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/budget/service/BudgetServiceTemplateSplitTest.kt
@@ -195,7 +195,7 @@ class BudgetServiceTemplateSplitTest : BehaviorSpec({
         }
     }
 
-    Given("TEMPLATE 행 + applyToFuture=true (split 미적용, 기존 C-2 동작 유지)") {
+    Given("TEMPLATE 행 + applyToFuture=true + viewingMonth == 시작월 (split 미적용)") {
         val template = MonthlyBudget(
             couple = couple, category = foodCat,
             yearMonth = "2026-01", endYearMonth = null,
@@ -205,14 +205,47 @@ class BudgetServiceTemplateSplitTest : BehaviorSpec({
         every { budgetRepository.findActiveTemplateInScope(any(), any(), any(), any(), any()) } returns null
         every { budgetRepository.save(template) } returns template
 
-        When("amount=350000, yearMonth=2026-05, applyToFuture=true 로 update") {
+        When("amount=350000, yearMonth=2026-01, applyToFuture=true 로 update") {
             service.updateBudget(u1.id, template.id,
-                BudgetUpdateRequest(amount = 350_000L, yearMonth = "2026-05", applyToFuture = true))
+                BudgetUpdateRequest(amount = 350_000L, yearMonth = "2026-01", applyToFuture = true))
 
-            Then("기존 TEMPLATE 의 amount 만 변경 (split 안 함, endYearMonth=null 유지)") {
+            Then("기존 TEMPLATE 의 amount 만 변경 (이미 시작월에 있어서 late-split 미적용)") {
                 template.amount shouldBe 350_000L
                 template.rowKind shouldBe BudgetRowKind.TEMPLATE
                 template.endYearMonth shouldBe null
+            }
+        }
+    }
+
+    // 배치 1 A-2 — applyToFuture=true + viewingMonth > 시작월 → late-split
+    Given("TEMPLATE 행 + applyToFuture=true + viewingMonth > 시작월 (late-split)") {
+        val template = MonthlyBudget(
+            couple = couple, category = foodCat,
+            yearMonth = "2026-01", endYearMonth = null,
+            rowKind = BudgetRowKind.TEMPLATE, amount = 250_000L
+        )
+        every { budgetRepository.findById(template.id) } returns Optional.of(template)
+        every { budgetRepository.findActiveTemplateInScope(any(), any(), any(), any(), any()) } returns null
+        val savedSlot = slot<MonthlyBudget>()
+        every { budgetRepository.save(capture(savedSlot)) } answers { savedSlot.captured }
+
+        When("amount=350000, yearMonth=2026-05, applyToFuture=true 로 update") {
+            val result = service.updateBudget(u1.id, template.id,
+                BudgetUpdateRequest(amount = 350_000L, yearMonth = "2026-05", applyToFuture = true))
+
+            Then("원본 TEMPLATE 종료 (endYearMonth=2026-04, amount 보존)") {
+                template.endYearMonth shouldBe "2026-04"
+                template.amount shouldBe 250_000L
+                template.rowKind shouldBe BudgetRowKind.TEMPLATE
+            }
+            Then("새 TEMPLATE 생성 [2026-05, ∞] amount=35만") {
+                val saved = savedSlot.captured
+                saved.rowKind shouldBe BudgetRowKind.TEMPLATE
+                saved.yearMonth shouldBe "2026-05"
+                saved.endYearMonth shouldBe null
+                saved.amount shouldBe 350_000L
+                result.amount shouldBe 350_000L
+                result.yearMonth shouldBe "2026-05"
             }
         }
     }

--- a/frontend/lib/features/report/presentation/pages/report_page.dart
+++ b/frontend/lib/features/report/presentation/pages/report_page.dart
@@ -49,12 +49,19 @@ class _ReportPageState extends State<ReportPage> {
     });
     // MonthCubit 동기화 — MonthSyncHandler가 ReportBloc.LoadMonthlyReport + AiInsightBloc 자동 처리
     context.read<MonthCubit>().changeMonth(year, month);
-    // LoadWeeklyReport은 week 파라미터가 필요하므로 페이지 자체에서 dispatch
+    // LoadWeeklyReport은 week 파라미터가 필요하므로 페이지 자체에서 dispatch.
+    // 배치 1 F-3 (2026-04-26): 과거 월에 week=1 하드코딩되어 있던 것을
+    // 해당 월의 마지막 주(현실적으로 사용자가 가장 보고 싶은 주)로 변경.
     final now = DateTime.now();
     final week = (year == now.year && month == now.month)
         ? _currentWeekOfMonth(now)
-        : 1;
+        : _lastWeekOfMonth(year, month);
     context.read<ReportBloc>().add(LoadWeeklyReport(year: year, month: month, week: week));
+  }
+
+  static int _lastWeekOfMonth(int year, int month) {
+    final lastDay = DateTime(year, month + 1, 0); // 다음달 0일 = 이번달 마지막 일
+    return _currentWeekOfMonth(lastDay);
   }
 
   @override


### PR DESCRIPTION
## Summary

### A-1: deploy-nas health check 60s → 120s
#182 deploy fail 원인 (Spring Boot 가끔 70~80s 시작) 대응. 20회 × 6s.

### A-2: applyToFuture=true + TEMPLATE 시작월 < viewing → late-split
V60 multi-segment 허용 후 가능해진 케이스.
- performLateTemplateSplit: 원본 endYearMonth=viewing-1 종료 (amount/기타 보존) + 새 TEMPLATE [viewing, ∞]
- 사용자 의도: '5월에 "이후 모두" 체크 시 1~4월=기존, 5월~=새 amount'
- 테스트 갱신 (시작월 == viewing 단순 update / 시작월 < viewing late-split)

### B-1: 보안 RateLimit 확장 (AuthController)
- PATCH /auth/me 30/분
- POST /auth/me/profile-image 5/분
- DELETE /auth/me/profile-image 10/분
- POST /auth/logout 30/분

### F-3: report page week=1 하드코딩 → 마지막 주차
과거 월 진입 시 week=1 으로 강제 → 의미 없음. 마지막 주차로 변경.

## Test plan
- [x] BE 전체 테스트 통과
- [x] FE analyze + report 테스트 통과
- [ ] 라이브: 1월~ 식비 25만 TEMPLATE → 5월에서 35만 + applyToFuture 체크 → 1~4월=25만, 5월~=35만 분리

🤖 Generated with [Claude Code](https://claude.com/claude-code)