### PR TITLE
chore(batch-3): DevOps — Kover 커버리지 + 롤백 스크립트

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -64,11 +64,23 @@ jobs:
       # 무관하고, runtime @Value/@ConfigurationProperties 검증은 deploy health check 에서 수행됨.
       - name: Build and Test
         if: steps.filter.outputs.backend == 'true'
-        run: ./gradlew build
+        run: ./gradlew build koverXmlReport koverHtmlReport
         env:
           SPRING_DATASOURCE_URL: jdbc:postgresql://localhost:5432/budgetbook_test
           SPRING_DATASOURCE_USERNAME: budgetbook
           SPRING_DATASOURCE_PASSWORD: budgetbook
+
+      # 배치 3 G-4 (2026-04-26) — Kover XML/HTML 리포트 artifact 업로드
+      - name: Upload coverage report
+        if: steps.filter.outputs.backend == 'true' && always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-coverage
+          path: |
+            backend/build/reports/kover/report.xml
+            backend/build/reports/kover/html/
+          if-no-files-found: ignore
+          retention-days: 7
 
       - name: Skipped (no backend changes)
         if: steps.filter.outputs.backend != 'true'

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -4,6 +4,28 @@ plugins {
     alias(libs.plugins.kotlin.jpa)
     alias(libs.plugins.spring.boot)
     alias(libs.plugins.spring.dependency.management)
+    // 배치 3 G-4 (2026-04-26) — 코드 커버리지. `./gradlew koverHtmlReport` / `koverXmlReport`.
+    alias(libs.plugins.kover)
+}
+
+// Kover 설정 — XML/HTML 리포트만 활성, 임계치는 별도 enforcement 없음 (단계적 도입).
+kover {
+    reports {
+        verify {
+            // 향후 임계치 필요 시 활성화. 현재는 측정만.
+            // rule { bound { minValue = 60 } }
+        }
+        filters {
+            excludes {
+                classes(
+                    "com.budgetbook.BudgetBookApplicationKt",
+                    "com.budgetbook.config.*",
+                    "com.budgetbook.*.dto.*",
+                    "com.budgetbook.*.domain.*"
+                )
+            }
+        }
+    }
 }
 
 group = "com.budgetbook"

--- a/backend/gradle/libs.versions.toml
+++ b/backend/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ flyway = "10.15.0"
 jjwt = "0.12.6"
 sentry = "7.14.0"
 micrometer-prometheus = "1.12.5"
+kover = "0.8.0"
 
 [libraries]
 # Spring Boot
@@ -60,3 +61,4 @@ kotlin-spring = { id = "org.jetbrains.kotlin.plugin.spring", version.ref = "kotl
 kotlin-jpa = { id = "org.jetbrains.kotlin.plugin.jpa", version.ref = "kotlin" }
 spring-boot = { id = "org.springframework.boot", version.ref = "spring-boot" }
 spring-dependency-management = { id = "io.spring.dependency-management", version.ref = "spring-dependency-management" }
+kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }

--- a/ops/rollback.sh
+++ b/ops/rollback.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# 배치 3 C-2 (2026-04-26) — 롤백 헬퍼 스크립트
+#
+# Usage:
+#   ./ops/rollback.sh <target-sha>
+#   ./ops/rollback.sh HEAD~1
+#
+# 동작:
+#   1) 현재 HEAD 와 target sha 사이의 PR 목록을 출력
+#   2) 사용자 확인 후 git revert (single revert commit, 다중 커밋 가능)
+#   3) push origin main → deploy-nas.yml 자동 트리거 → 배포 watch 안내
+#
+# Safety:
+#   - main 브랜치에서만 실행
+#   - 변경 없는 working tree 강제
+#   - 사용자 확인 없으면 진행 안 함
+
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "Usage: $0 <target-sha>"
+  echo "  target-sha 까지 롤백 (target sha 까지의 모든 커밋을 revert)"
+  exit 1
+fi
+
+TARGET="$1"
+CURRENT=$(git rev-parse HEAD)
+
+# 안전장치
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [ "$BRANCH" != "main" ]; then
+  echo "ERROR: rollback 은 main 브랜치에서만 실행. 현재: $BRANCH"
+  exit 1
+fi
+
+if ! git diff-index --quiet HEAD --; then
+  echo "ERROR: working tree 가 dirty. commit/stash 후 재시도."
+  exit 1
+fi
+
+# 대상 SHA resolve
+TARGET_SHA=$(git rev-parse "$TARGET")
+if [ "$TARGET_SHA" == "$CURRENT" ]; then
+  echo "ERROR: target sha == current HEAD. 롤백할 커밋 없음."
+  exit 1
+fi
+
+# revert 대상 커밋 미리보기
+echo ""
+echo "다음 커밋들을 revert 합니다 (최신순):"
+echo ""
+git log --oneline "$TARGET_SHA..HEAD"
+echo ""
+COUNT=$(git rev-list --count "$TARGET_SHA..HEAD")
+echo "총 $COUNT 개 커밋 revert."
+echo ""
+read -p "계속하시겠습니까? (yes/no): " CONFIRM
+
+if [ "$CONFIRM" != "yes" ]; then
+  echo "취소됨."
+  exit 0
+fi
+
+# revert 진행 (single revert commit; 충돌 시 사용자 처리)
+git revert --no-edit "$TARGET_SHA..HEAD"
+
+echo ""
+echo "✅ revert 완료. 'git push origin main' 실행 시 deploy-nas.yml 자동 트리거."
+echo "확인 후:"
+echo "  git log --oneline -10"
+echo "  git push origin main"
+echo "  GH_CONFIG_DIR=~/.config/gh-personal gh run watch <run-id>"


### PR DESCRIPTION
## Summary
audit 의 DevOps 항목들 일괄 처리. 다수는 이미 적용된 상태였으나 다음 두 가지만 보강:

### G-4: Kover 코드 커버리지
- `libs.versions.toml` + `build.gradle.kts` 에 `kover 0.8.0` 플러그인
- excludes: ApplicationKt, config.*, dto.*, domain.* (자동 코드/엔티티)
- `ci-backend.yml` 의 build 단계에 `koverXmlReport` + `koverHtmlReport` 추가
- artifact 'backend-coverage' 업로드 (7일 보존)
- 임계치 enforcement 는 단계적 도입 — 본 PR 은 측정만

### C-2: 롤백 스크립트 `ops/rollback.sh`
- main 브랜치 + clean tree 안전장치
- target sha 까지 revert (사용자 확인 후)
- push → deploy-nas.yml 자동 트리거 안내

### Skipped (이미 적용됨 — audit outdated)
- **C-1 Sentry**: BE `sentry-spring-boot-starter` 7.14.0 + FE `error_reporter.dart` 적용됨
- **G-1 CI 중복 실행**: paths-filter 로 conditional 처리됨
- **G-2 feature/* CI**: 정책상 PR 에서만 검증 — 직접 push 시 미실행은 의도
- **G-3 구조화 로깅**: `logback-spring.xml` prod profile 에 JSON_CONSOLE + correlationId MDC

## Test plan
- [x] `./gradlew build` (Kover 포함) 성공
- [ ] CI 머지 후 PR 의 backend-coverage artifact 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)