### PR TITLE
fix(deploy): concurrency group 추가 — NAS deploy 직렬화

### DIFF
--- a/.github/workflows/deploy-nas.yml
+++ b/.github/workflows/deploy-nas.yml
@@ -7,6 +7,13 @@ on:
   push:
     branches: [main]
 
+# 2026-04-26 deploy fail 분석: 병렬 머지 시 동일 NAS 의 /tmp/bb-deploy 폴더 충돌.
+# concurrency group 으로 NAS deploy 를 직렬화. 새 push 시 진행 중인 run 취소 안 함
+# (cancel-in-progress=false) — 모두 차례로 완료.
+concurrency:
+  group: deploy-nas
+  cancel-in-progress: false
+
 permissions:
   contents: read
   issues: write


### PR DESCRIPTION
## Issue
2026-04-26 batch-1/2/3 (#187/188/189) 머지 후 deploy-nas.yml 이 3개 동시에 시작. 동일 NAS 의 `/tmp/bb-deploy` 폴더 공유 → 한 deploy 의 `rm -rf /tmp/bb-deploy` 가 다른 deploy 의 파일 삭제. #189 가 `scp: /tmp/bb-deploy/Dockerfile: No such file` 로 실패.

## Fix
workflow 에 `concurrency: group: deploy-nas` 추가. 동시 실행 차단, FIFO 직렬화. `cancel-in-progress=false` — 진행 중인 deploy 끝까지 기다림.

## Test plan
- [x] yaml 문법 OK
- [ ] 머지 후 다음 deploy run 이 직렬화 되는지 확인 (동시 푸시 시 queued 상태)

🤖 Generated with [Claude Code](https://claude.com/claude-code)