### PR TITLE
fix(transaction): D-4 — 거래 복사 새로고침 유실 fix

### DIFF
--- a/frontend/lib/core/router/app_router.dart
+++ b/frontend/lib/core/router/app_router.dart
@@ -382,7 +382,9 @@ GoRouter createAppRouter(AuthBloc authBloc) => GoRouter(
       builder: (context, state) {
         final type = state.uri.queryParameters['type'];
         final tab = state.uri.queryParameters['tab'];
+        // 배치 4 D-4 (2026-04-26): state.extra 는 새로고침 유실 → copyFromId query param 권장
         final copyFrom = state.extra as Transaction?;
+        final copyFromId = state.uri.queryParameters['copyFromId'];
         final dateStr = state.uri.queryParameters['date'];
         final initialPaymentMethodId = state.uri.queryParameters['paymentMethodId'];
         DateTime? initialDate;
@@ -414,6 +416,7 @@ GoRouter createAppRouter(AuthBloc authBloc) => GoRouter(
             initialType: copyFrom?.type ?? type,
             initialTab: tab,
             copyFrom: copyFrom,
+            copyFromId: copyFromId,
             initialDate: initialDate,
             initialPaymentMethodId: initialPaymentMethodId,
           ),

--- a/frontend/lib/features/transaction/presentation/pages/transaction_detail_page.dart
+++ b/frontend/lib/features/transaction/presentation/pages/transaction_detail_page.dart
@@ -30,7 +30,9 @@ class TransactionDetailPage extends StatelessWidget {
               if (state is TransactionLoaded) {
                 final txn = _findTransaction(state);
                 if (txn != null) {
-                  context.push('/transactions/create', extra: txn);
+                  // 배치 4 D-4 (2026-04-26): state.extra 새로고침 유실 fix —
+                  // copyFromId query param 으로 전달, form page 가 fetch.
+                  context.push('/transactions/create?copyFromId=${txn.id}');
                 }
               }
             },

--- a/frontend/lib/features/transaction/presentation/pages/transaction_form_page.dart
+++ b/frontend/lib/features/transaction/presentation/pages/transaction_form_page.dart
@@ -57,7 +57,13 @@ class TransactionFormPage extends StatefulWidget {
 
   /// Pre-fill fields from an existing transaction (for copy).
   /// Date defaults to today; all other fields are copied.
+  /// 배치 4 D-4 (2026-04-26): state.extra 사용은 deprecated — 웹 새로고침 시 유실.
+  /// 신규 진입은 copyFromId (query param) 권장. 본 필드는 기존 호환을 위해 유지.
   final tx_entity.Transaction? copyFrom;
+
+  /// 배치 4 D-4: copy-from transaction 의 id (query param 으로 전달).
+  /// 새로고침 시에도 URL 에서 보존되어 prefill 가능.
+  final String? copyFromId;
 
   /// Optional initial date for the transaction.
   /// Used when navigating from a date header in the transaction list.
@@ -76,6 +82,7 @@ class TransactionFormPage extends StatefulWidget {
     this.transactionId,
     this.initialType,
     this.copyFrom,
+    this.copyFromId,
     this.initialDate,
     this.initialPaymentMethodId,
     this.initialTab,
@@ -190,23 +197,57 @@ class _TransactionFormPageState extends State<TransactionFormPage>
       _isLoadingTransaction = true;
       _loadTransaction();
     } else if (widget.copyFrom != null) {
-      // Pre-fill from copied transaction (date defaults to today)
-      final src = widget.copyFrom!;
-      _descriptionController.text = src.description;
-      _memoController.text = src.memo ?? '';
-      _selectedType = src.type;
-      _selectedCategoryId = src.category?.id;
-      _selectedCategoryDisplayName = src.category?.displayName;
-      _selectedPaymentMethodId = src.paymentMethodId;
-      _selectedPocketId = src.pocketId;
-      // Set amount after frame to ensure CurrencyInputFormatter doesn't strip commas
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (mounted) {
-          _amountController.text = CurrencyFormatter.format(src.amount);
-        }
-      });
+      _prefillFromTransaction(widget.copyFrom!);
+    } else if (widget.copyFromId != null) {
+      // 배치 4 D-4: query param 으로 전달된 copy-from id → API 로 fetch 후 prefill.
+      // 새로고침 시에도 URL 에서 보존되어 정상 동작.
+      _isLoadingTransaction = true;
+      _loadCopyFromTransaction(widget.copyFromId!);
     } else {
       _loadDefaultPaymentMethod();
+    }
+  }
+
+  void _prefillFromTransaction(tx_entity.Transaction src) {
+    _descriptionController.text = src.description;
+    _memoController.text = src.memo ?? '';
+    _selectedType = src.type;
+    _selectedCategoryId = src.category?.id;
+    _selectedCategoryDisplayName = src.category?.displayName;
+    _selectedPaymentMethodId = src.paymentMethodId;
+    _selectedPocketId = src.pocketId;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) {
+        _amountController.text = CurrencyFormatter.format(src.amount);
+      }
+    });
+  }
+
+  Future<void> _loadCopyFromTransaction(String id) async {
+    try {
+      final repo = context.read<TransactionBloc>().transactionRepository;
+      final result = await repo.getTransaction(id);
+      result.fold(
+        (failure) {
+          if (mounted) {
+            setState(() => _isLoadingTransaction = false);
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(
+                content: Text('복사할 거래를 불러올 수 없습니다: ${failure.message}'),
+                backgroundColor: Theme.of(context).colorScheme.error,
+              ),
+            );
+          }
+        },
+        (transaction) {
+          if (mounted) {
+            setState(() => _isLoadingTransaction = false);
+            _prefillFromTransaction(transaction);
+          }
+        },
+      );
+    } catch (_) {
+      if (mounted) setState(() => _isLoadingTransaction = false);
     }
   }
 

--- a/frontend/lib/features/transaction/presentation/pages/transaction_list_page.dart
+++ b/frontend/lib/features/transaction/presentation/pages/transaction_list_page.dart
@@ -778,7 +778,8 @@ class _TransactionListPageState extends State<TransactionListPage> {
               title: const Text('복사'),
               onTap: () {
                 Navigator.pop(ctx);
-                context.push('/transactions/create', extra: transaction);
+                // 배치 4 D-4 (2026-04-26): copyFromId query param — 새로고침 유실 fix
+                context.push('/transactions/create?copyFromId=${transaction.id}');
               },
             ),
             ListTile(


### PR DESCRIPTION
## Summary
audit 의 `state.extra 웹 새로고침 유실 (1곳 - 거래 복사)` 해결. 다른 batch-4 audit 항목들은 모두 이미 적용된 상태였다.

### 문제
`context.push('/transactions/create', extra: tx)` 의 `state.extra` 는 in-memory 만 보관. 새로고침 시 URL 은 보존되지만 prefill 정보 유실.

### 해결
`copyFromId` query param 으로 전달, form page 가 `getTransaction(id)` 호출하여 prefill.
- 새로고침해도 URL 에서 id 보존 → 정상 prefill 가능
- 기존 `extra: Transaction` 경로도 deprecation 표기로 호환 유지

### 변경
- `transaction_form_page.dart`: `copyFromId` 파라미터, `_loadCopyFromTransaction` 헬퍼, `_prefillFromTransaction` 추출
- `app_router.dart`: `copyFromId` query param 처리
- `transaction_detail_page.dart` / `transaction_list_page.dart`: push 시 query param 사용

### 이미 적용 (audit outdated)
- E-2 CSV 내보내기: `_exportCsv` 존재
- E-4 프로필 편집: `profile_edit_page.dart` 존재

### 미적용 (큰 refactor — 별도 결정 필요)
- F-1 UseCase 레이어
- F-2 BLoC 패턴 통일
- E-3 다국어 i18n 완성
- H-3 위젯 테스트 대량 추가

## Test plan
- [x] flutter analyze
- [x] flutter test transaction tests
- [ ] 라이브: 거래 복사 → 새로고침 → prefill 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)