### PR TITLE
feat(budget): 주간 예산 행 동선 통일 — BudgetRowActions 공통 위젯

### DIFF
--- a/docs/sessions/2026-04-27_1_plan.md
+++ b/docs/sessions/2026-04-27_1_plan.md
@@ -1,0 +1,135 @@
+# 주간 예산 행에 수정/거래 보기 동선 적용 + 행 컴포넌트 통일
+> 날짜: 2026-04-27 | 회차: 1 | 상태: 기획
+
+## 요청 내용
+> 예산 > 주간의 경우 각 주차별 예산만 보이는데 주차별 예산 수정이나 거래 보기 기능은 여기선 적용이 안되어있어 분석 후 수정 필요하다.
+
+## 현황 분석
+
+### 월간 모드 (`_buildBudgetTile`, budget_list_page.dart:607~)
+- 행 클릭 = `/budgets/edit/<budgetId>` 진입 (편집)
+- trailing PopupMenu = **거래 보기 / 수정 / 삭제** 통일
+- 카테고리 / 그룹 / 총 예산 모두 동일 동선 (Phase 25 후속 U-1 완료)
+
+### 주간 모드 (현재)
+1. **이번 주 hero 카드** (`_buildCurrentWeekHero`, budget_list_page.dart:350~)
+   - 항목 InkWell `onTap` 이 `item.categoryId != null` 일 때만 활성 → **거래 보기만**, 그룹/총 예산은 비활성
+   - **수정 진입 동선 없음**, **삭제 없음**
+2. **각 주차 카드** (`WeekSummaryCard`)
+   - 항목 InkWell `onTap` 이 `item.categoryId != null` 일 때만 활성 → **거래 보기만**
+   - **수정 진입 동선 없음**, **삭제 없음**
+   - 그룹 예산 행 비활성 (`groupId` 무시)
+3. **카드 단위 메뉴**: 주차 헤더에 거래 보기/관리 메뉴 없음
+
+### BE 측 데이터 현황
+- `WeeklyBudgetItemResponse` 가 이미 `budgetId / categoryId / groupId` 모두 포함 (WeeklyBudgetService.kt:149)
+- `WeeklyWeekResponse` 에 `weekStart / weekEnd` 노출
+- 주간 예산은 모델상 `MonthlyBudget.weeklyAmount` 로 저장 → 편집 진입 = 기존 `/budgets/edit/<budgetId>` 재사용 OK
+- **BE 변경 불필요**
+
+### 영향 범위
+- 변경 파일:
+  - **신규**: `frontend/lib/features/budget/presentation/widgets/budget_row_actions.dart` (공통 위젯)
+  - **수정**: `budget_list_page.dart` (월간 + 주간 hero 행)
+  - **수정**: `weekly_budget/presentation/widgets/week_summary_card.dart` (주차 카드 행)
+  - **수정**: 회귀 테스트 추가 — `frontend/test/features/budget/presentation/widgets/budget_row_actions_test.dart`
+- 기존 코드: monthly `_buildBudgetTile` 의 PopupMenu/onTap 블록을 공통 위젯 호출로 치환
+- 라우트/state: 변경 없음 (`/budgets/edit/:id` + `DeleteBudget` event 재사용)
+
+## 작업 계획
+| # | 작업 | 담당 | 파일 | 난이도 |
+|---|------|------|------|--------|
+| 1 | `BudgetRowActions` 공통 위젯 신설 — onTap=편집, PopupMenu=거래보기/수정/삭제 | FE | budget_row_actions.dart (신규) | M |
+| 2 | 월간 `_buildBudgetTile` 리팩터 → 공통 위젯 사용 | FE | budget_list_page.dart | S |
+| 3 | 주간 hero 카드 행에 공통 위젯 적용 — 그룹/총 예산도 활성화 | FE | budget_list_page.dart | M |
+| 4 | `WeekSummaryCard` 행에 공통 위젯 적용 + 부모 callback 변경 (`onItemEdit`, `onItemDelete`, `onItemTransactions`) | FE | week_summary_card.dart | M |
+| 5 | 그룹/총 예산 거래 보기에 `categoryGroupId` / dateRange 전수 전파 | FE | budget_list_page.dart | S |
+| 6 | 위젯 골든/유닛 테스트 — 카테고리/그룹/총 3가지 행 모두 PopupMenu + onTap 동작 검증 | FE | budget_row_actions_test.dart | M |
+| 7 | 하네스 audit-patterns 갱신 — `budget_row_action_unification` 패턴 등록 | DevOps | ~/.claude/harness/audit-patterns.json | S |
+
+## 성능 설계
+- **데이터 접근**: 변경 없음. 기존 `/budgets/edit/:id` 단건 조회 + `showBudgetTransactionsSheet` 의 transaction 페이징 호출. 추가 API/쿼리 없음.
+- **예상 규모**: 한 달 weekly budget 행 ≤ 30개 (5주 × ~6 카테고리). 모든 행에 PopupMenu 위젯 + 콜백 1개씩 — 메모리/렌더 영향 미미.
+- **리소스 제약**: 모바일 메모리 영향 없음. PopupMenu 는 lazy build.
+- **설계 결정**:
+  - `BudgetRowActions` 는 **stateless**. 콜백만 받아서 build 한다 → 행 위젯 캐시 기존 PageStorageKey 유지.
+  - 거래 보기 시트는 호출 시점 `TransactionBloc` 신규 인스턴스 (기존 동작 유지) — 주간 행에서 호출해도 동일.
+
+## 하네스 Scope Audit 결과 (필수 — Step 1.5)
+- **실행 명령**: `pre-change-audit.sh /Users/kdh/kdh/github/AIVA-SaaS/budget-book "ui_pattern,filter_propagation"`
+- **분류 태그**: `ui_pattern`, `filter_propagation`
+- **Scope Audit 발견**:
+  - 월간 `_buildBudgetTile` (PopupMenu + onTap 인라인) ↔ 주간 hero `_buildCurrentWeekHero` (InkWell만, 카테고리만) ↔ `WeekSummaryCard` (InkWell만, 카테고리만) — 동일 의미 행이 3 구현으로 분기.
+  - `categoryGroupId` 가 월간 PopupMenu 거래 보기에는 전달되지만, 주간 hero / 주차 카드의 그룹 행에는 전달되지 않음 (애초에 UI 가 비활성).
+  - `dateFrom/dateTo` 는 주간 hero / 주차 카드 거래 보기에 전달되고 있으나, 월간 → 주간 통합 후에도 일관 보장 필요.
+- **Recurrence Check**: **🚫 STRUCTURAL_FIX_REQUIRED**
+  - `ui_pattern`: 인시던트 누적 4건 (2026-04-25 분석 sub-tab 회색화면 / 2026-04-25 잔액 요약 재추가 / 2026-04-26 주간예산 체크박스 누락 / 2026-04-26 카드 더보기 메뉴 불일치)
+  - `filter_propagation`: 인시던트 누적 3건 (2026-04-14 dateFrom/To 미전달 / 2026-04-14 PeriodSummary 필터 미전달 / 2026-04-15 LoadCardSettlementSummary year/month 미전달)
+- **재발 방지 조치 (구조적 수정)**:
+  1. **공통 위젯 강제**: 모든 budget 행은 `BudgetRowActions` 공통 위젯을 통해서만 PopupMenu/onTap 을 노출. 직접 `PopupMenuButton` + `/budgets/edit` push 인라인 작성 금지.
+  2. **단일 거래 보기 진입점 유지**: 거래 보기는 `showBudgetTransactionsSheet` 단일 함수 사용. `BudgetRowActions` 가 내부적으로 호출하여 호출부 누락 가능성 차단.
+  3. **컴파일 타임 가드 — 함수 시그니처에 required**:
+     - `BudgetRowActions({ required String budgetId, required String? categoryId, required String? categoryGroupId, required String label, String? dateFrom, String? dateTo, required int year, required int month, required VoidCallback onAfterDelete })`
+     - 모든 호출부에서 `categoryGroupId` 누락 시 컴파일 에러.
+  4. **하네스 audit-patterns 신규 패턴**:
+     - `budget_row_action_unification` — `presentation/widgets/budget_row_actions.dart` 외 파일에 `PopupMenuButton<String>.*'transactions'` 패턴 발견 시 위반 경고.
+     - `weekly_filter_propagation` — `WeeklyBudgetItem` 의 `groupId` 가 거래 보기 호출에 전달되는지 grep 검증.
+  5. **회귀 테스트**: `budget_row_actions_test.dart` — 카테고리/그룹/총 3 종류 행에서 (a) onTap → push edit (b) PopupMenu → 거래 보기/수정/삭제 동작 검증.
+
+## 자동 검증 계획 (CI/로컬)
+- [ ] BE 변경 없음 — 회귀 테스트 (`./gradlew test`) 통과
+- [ ] FE analyze (`flutter analyze`) — info 외 0 warning
+- [ ] FE test (`flutter test`) — 신규 위젯 테스트 포함 전체 통과
+- [ ] FE build web (`flutter build web`) 성공
+- [ ] BE↔FE↔Spec 일치 확인 — 응답 변경 없음 (주간 응답 그대로 사용)
+- [ ] 성능 설계대로 구현되었는지 확인 — 추가 쿼리 없음 verify
+- [ ] 하네스 audit 전수 목록 반영 확인 — `BudgetRowActions` 외 PopupMenu 인라인 0건
+- [ ] 보안: 변경 없음 (기존 인증 라우트 재사용)
+
+## 배포 절차 (필수)
+| # | 단계 | 주체 | 확인 방법 |
+|---|------|------|----------|
+| 1 | PR 생성 / CI | AI | `gh pr checks <N>` |
+| 2 | squash merge | AI | `gh pr merge <N> --squash --delete-branch` |
+| 3 | deploy-nas.yml watch | AI | `gh run watch <id>` 또는 `gh run list --workflow=deploy-nas.yml -L 1` |
+| 4 | 캐시 무효화 | 사용자 | F12 → Network → Disable cache → 새로고침 |
+
+## 사용자 검증 시나리오 (필수)
+
+### A. 기능 (신규 동작)
+| # | 경로 | 조작 | 기대 결과 |
+|---|------|------|----------|
+| A1 | 예산 → 주간 | "이번 주" hero 카드의 카테고리 행 클릭 | 편집 페이지로 진입, 해당 budget 의 주간 amount 수정 가능 |
+| A2 | 예산 → 주간 | hero 카드 행 우측 더보기 → "거래 보기" | 해당 주 dateFrom~dateTo 범위로 거래 시트 표시 |
+| A3 | 예산 → 주간 | hero 카드 행 우측 더보기 → "수정" | 편집 페이지 진입 (= A1) |
+| A4 | 예산 → 주간 | hero 카드 행 우측 더보기 → "삭제" | 확인 다이얼로그 후 monthly budget 삭제, 주간 목록 갱신 |
+| A5 | 예산 → 주간 | 그룹 예산 행 (카테고리 없음) 클릭 | 편집 페이지 진입 (그룹 budget) |
+| A6 | 예산 → 주간 | 그룹 예산 행 더보기 → "거래 보기" | `categoryGroupId` 필터 적용, 해당 주 범위 거래 |
+| A7 | 예산 → 주간 | 총 예산 행 (카테고리/그룹 없음) 더보기 → "거래 보기" | 해당 주 전체 거래 |
+| A8 | 예산 → 주간 → 다음 달 | 다음 달 N주차 카드 카테고리 행 클릭 | 편집 페이지 진입 |
+| A9 | 예산 → 주간 → 다음 달 | 다음 달 N주차 카드 행 더보기 → "거래 보기" | 해당 주 dateFrom~dateTo 범위로 거래 시트 |
+
+### B. 회귀 없음 (Zero regression)
+| # | 확인 | 기대 |
+|---|------|------|
+| B1 | 예산 → 월간 행 클릭 | 편집 페이지 진입 (기존 U-1 동작) |
+| B2 | 예산 → 월간 행 더보기 → 거래 보기 / 수정 / 삭제 | 기존과 동일 동작 |
+| B3 | 예산 추가 시 "주간" 기간 선택 + 등록 | 정상 등록 후 주간 카드에 노출 (E-1) |
+| B4 | 주간 모드 → 달 변경 | 데이터 갱신 (`LoadWeeklyOverview`) — 기존 동작 유지 |
+| B5 | 주간 모드 빈 상태 | "주간 예산이 설정되지 않았습니다" empty state 정상 표시 |
+
+### C. 데이터 정합성
+| # | 상황 | 기대 |
+|---|------|------|
+| C1 | 주간 행에서 "수정" → applyToFuture 체크 후 저장 | 다음달 이후 TEMPLATE 갱신 (Phase 25 C-2.7 동작 유지) |
+| C2 | 주간 행에서 "삭제" → 확인 | monthly budget 삭제 → 주간/월간 모두 즉시 사라짐 |
+| C3 | 주간 행 거래 보기 dateFrom/dateTo | 해당 주차 범위 거래만 시트에 표시 (다른 주 거래 미포함) |
+
+## 기획 검증 결과
+- **API 계약**: BE 변경 0. 기존 `WeeklyBudgetItemResponse.budgetId / groupId / categoryId` + `WeeklyWeekResponse.weekStart/weekEnd` 그대로 활용. Spec 영향 없음.
+- **상태 일관성**: 주간 삭제 시 `BudgetBloc.add(DeleteBudget(id))` → BudgetBloc 상태만 갱신되고 `WeeklyBudgetBloc` 은 stale 가능 → **삭제 후 `LoadWeeklyOverview` + `LoadCurrentWeek` 재발행 보장**해야 함 (작업 #4 콜백에 포함).
+- **applyToFuture / TEMPLATE/OVERRIDE**: 주간 편집은 기존 monthly form 재사용 → C-2.7 split semantic 그대로 적용 (별도 처리 불필요).
+- **이전 세션 참고**: 2026-04-26 회차 5 result 의 follow-up #3 (`applyToFuture=true + TEMPLATE 시작월 < viewing 분리`) 는 이번 작업 범위 밖. 본 PR 에서는 동선 통일만.
+
+## 사용자 승인
+- [ ] 승인 / 수정 요청: ___

--- a/frontend/lib/features/budget/presentation/pages/budget_list_page.dart
+++ b/frontend/lib/features/budget/presentation/pages/budget_list_page.dart
@@ -8,6 +8,7 @@ import 'package:budget_book/features/budget/domain/entities/budget.dart';
 import 'package:budget_book/features/budget/presentation/bloc/budget_bloc.dart';
 import 'package:budget_book/features/budget/presentation/bloc/budget_event.dart';
 import 'package:budget_book/features/budget/presentation/bloc/budget_state.dart';
+import 'package:budget_book/features/budget/presentation/widgets/budget_row_actions.dart';
 import 'package:budget_book/features/budget/presentation/widgets/budget_summary_card.dart';
 import 'package:budget_book/core/widgets/icon_picker.dart';
 import 'package:budget_book/core/widgets/month_navigator.dart';
@@ -16,7 +17,6 @@ import 'package:budget_book/core/widgets/error_widget.dart';
 import 'package:budget_book/core/widgets/skeleton_loader.dart';
 import 'package:budget_book/core/di/injection.dart';
 import 'package:budget_book/core/widgets/account_balance_card.dart';
-import 'package:budget_book/features/budget/presentation/widgets/budget_transactions_sheet.dart';
 import 'package:budget_book/features/payment_method/presentation/bloc/payment_method_bloc.dart';
 import 'package:budget_book/features/payment_method/presentation/bloc/payment_method_event.dart';
 import 'package:budget_book/features/payment_method/presentation/bloc/payment_method_state.dart';
@@ -292,25 +292,55 @@ class _BudgetListPageState extends State<BudgetListPage> {
             ...state.overview!.weeks.map((week) {
               final isCurrent = state.currentWeek != null &&
                   week.weekNumber == state.currentWeek!.weekNumber;
+              final parts = state.overview!.yearMonth.split('-');
+              final year = int.parse(parts[0]);
+              final month = int.parse(parts[1]);
               return Padding(
                 padding: const EdgeInsets.only(bottom: 8),
                 child: WeekSummaryCard(
-                    weekSummary: week,
-                    isCurrentWeek: isCurrent,
-                    onItemTap: (item) {
-                      final parts = state.overview!.yearMonth.split('-');
-                      final year = int.parse(parts[0]);
-                      final month = int.parse(parts[1]);
-                      showBudgetTransactionsSheet(
-                        context: context,
-                        year: year,
-                        month: month,
-                        categoryId: item.categoryId,
-                        categoryName: item.displayName,
-                        dateFrom: week.weekStart,
-                        dateTo: week.weekEnd,
-                      );
-                    }),
+                  weekSummary: week,
+                  isCurrentWeek: isCurrent,
+                  itemRowBuilder: (ctx, item, rowBody) {
+                    void reloadWeekly() {
+                      getIt<WeeklyBudgetBloc>()
+                        ..add(LoadWeeklyOverview(year: year, month: month))
+                        ..add(const LoadCurrentWeek());
+                    }
+
+                    return Row(
+                      children: [
+                        Expanded(
+                          child: BudgetRowActions(
+                            budgetId: item.budgetId,
+                            categoryId: item.categoryId,
+                            categoryGroupId:
+                                item.categoryId == null ? item.groupId : null,
+                            label: item.displayName,
+                            dateFrom: week.weekStart,
+                            dateTo: week.weekEnd,
+                            year: year,
+                            month: month,
+                            onAfterDelete: reloadWeekly,
+                            child: rowBody,
+                          ),
+                        ),
+                        BudgetRowActions.menuButton(
+                          context: ctx,
+                          budgetId: item.budgetId,
+                          categoryId: item.categoryId,
+                          categoryGroupId:
+                              item.categoryId == null ? item.groupId : null,
+                          label: item.displayName,
+                          dateFrom: week.weekStart,
+                          dateTo: week.weekEnd,
+                          year: year,
+                          month: month,
+                          onAfterDelete: reloadWeekly,
+                        ),
+                      ],
+                    );
+                  },
+                ),
               );
             }),
           ],
@@ -411,77 +441,104 @@ class _BudgetListPageState extends State<BudgetListPage> {
                     : item.usageRate > 80
                         ? Colors.orange
                         : Colors.green;
-                return InkWell(
-                  onTap: item.categoryId != null
-                      ? () {
-                          // Parse yearMonth for the API call
-                          final parts = currentWeek.yearMonth.split('-');
-                          final year = int.parse(parts[0]);
-                          final month = int.parse(parts[1]);
-                          showBudgetTransactionsSheet(
-                            context: context,
-                            year: year,
-                            month: month,
-                            categoryId: item.categoryId,
-                            categoryName: item.displayName,
-                            dateFrom: currentWeek.weekStart,
-                            dateTo: currentWeek.weekEnd,
-                          );
-                        }
-                      : null,
-                  borderRadius: BorderRadius.circular(8),
-                  child: Padding(
-                    padding: const EdgeInsets.only(bottom: 12),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Row(
-                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                          children: [
-                            Row(
+                final parts = currentWeek.yearMonth.split('-');
+                final year = int.parse(parts[0]);
+                final month = int.parse(parts[1]);
+                final rowBody = Padding(
+                  padding: const EdgeInsets.only(bottom: 12),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: [
+                          Expanded(
+                            child: Row(
                               children: [
-                                Text(
-                                  item.displayName,
-                                  style: theme.textTheme.bodyMedium?.copyWith(
-                                    fontWeight: FontWeight.w600,
-                                    color: theme.colorScheme.onPrimaryContainer,
+                                Flexible(
+                                  child: Text(
+                                    item.displayName,
+                                    style:
+                                        theme.textTheme.bodyMedium?.copyWith(
+                                      fontWeight: FontWeight.w600,
+                                      color:
+                                          theme.colorScheme.onPrimaryContainer,
+                                    ),
+                                    overflow: TextOverflow.ellipsis,
                                   ),
                                 ),
-                                if (item.categoryId != null) ...[
-                                  const SizedBox(width: 4),
-                                  Icon(
-                                    Icons.chevron_right,
-                                    size: 16,
-                                    color: theme.colorScheme.onPrimaryContainer
-                                        .withValues(alpha: 0.5),
-                                  ),
-                                ],
+                                const SizedBox(width: 4),
+                                Icon(
+                                  Icons.chevron_right,
+                                  size: 16,
+                                  color: theme.colorScheme.onPrimaryContainer
+                                      .withValues(alpha: 0.5),
+                                ),
                               ],
                             ),
-                            Text(
-                              '${numberFormat.format(item.spentAmount)}원 / ${numberFormat.format(item.budgetAmount)}원',
-                              style: theme.textTheme.bodySmall?.copyWith(
-                                color: theme.colorScheme.onPrimaryContainer,
-                              ),
-                            ),
-                          ],
-                        ),
-                        const SizedBox(height: 6),
-                        ClipRRect(
-                          borderRadius: BorderRadius.circular(4),
-                          child: LinearProgressIndicator(
-                            value: progress,
-                            minHeight: 6,
-                            backgroundColor: theme
-                                .colorScheme.onPrimaryContainer
-                                .withValues(alpha: 0.15),
-                            valueColor:
-                                AlwaysStoppedAnimation<Color>(statusColor),
                           ),
+                          Text(
+                            '${numberFormat.format(item.spentAmount)}원 / ${numberFormat.format(item.budgetAmount)}원',
+                            style: theme.textTheme.bodySmall?.copyWith(
+                              color: theme.colorScheme.onPrimaryContainer,
+                            ),
+                          ),
+                        ],
+                      ),
+                      const SizedBox(height: 6),
+                      ClipRRect(
+                        borderRadius: BorderRadius.circular(4),
+                        child: LinearProgressIndicator(
+                          value: progress,
+                          minHeight: 6,
+                          backgroundColor: theme.colorScheme.onPrimaryContainer
+                              .withValues(alpha: 0.15),
+                          valueColor:
+                              AlwaysStoppedAnimation<Color>(statusColor),
                         ),
-                      ],
-                    ),
+                      ),
+                    ],
                   ),
+                );
+                return Row(
+                  children: [
+                    Expanded(
+                      child: BudgetRowActions(
+                        budgetId: item.budgetId,
+                        categoryId: item.categoryId,
+                        categoryGroupId:
+                            item.categoryId == null ? item.groupId : null,
+                        label: item.displayName,
+                        dateFrom: currentWeek.weekStart,
+                        dateTo: currentWeek.weekEnd,
+                        year: year,
+                        month: month,
+                        onAfterDelete: () {
+                          getIt<WeeklyBudgetBloc>()
+                            ..add(LoadWeeklyOverview(year: year, month: month))
+                            ..add(const LoadCurrentWeek());
+                        },
+                        child: rowBody,
+                      ),
+                    ),
+                    BudgetRowActions.menuButton(
+                      context: context,
+                      budgetId: item.budgetId,
+                      categoryId: item.categoryId,
+                      categoryGroupId:
+                          item.categoryId == null ? item.groupId : null,
+                      label: item.displayName,
+                      dateFrom: currentWeek.weekStart,
+                      dateTo: currentWeek.weekEnd,
+                      year: year,
+                      month: month,
+                      onAfterDelete: () {
+                        getIt<WeeklyBudgetBloc>()
+                          ..add(LoadWeeklyOverview(year: year, month: month))
+                          ..add(const LoadCurrentWeek());
+                      },
+                    ),
+                  ],
                 );
               }),
             ],
@@ -674,84 +731,35 @@ class _BudgetListPageState extends State<BudgetListPage> {
                     fontWeight: FontWeight.bold,
                   ),
             ),
-            PopupMenuButton<String>(
-              onSelected: (value) async {
+            BudgetRowActions.menuButton(
+              context: context,
+              budgetId: budget.id,
+              categoryId: budget.category?.id,
+              categoryGroupId:
+                  budget.category == null ? budget.groupId : null,
+              label: budget.targetLabel,
+              dateFrom: null,
+              dateTo: null,
+              year: () {
                 final state = context.read<BudgetBloc>().state;
-                final year =
-                    state is BudgetLoaded ? state.year : DateTime.now().year;
-                final month =
-                    state is BudgetLoaded ? state.month : DateTime.now().month;
-                if (value == 'transactions') {
-                  // Phase 25 후속 U-1 — 모든 예산 종류(카테고리/그룹/총) 거래 보기 통일.
-                  showBudgetTransactionsSheet(
-                    context: context,
-                    year: year,
-                    month: month,
-                    categoryId: budget.category?.id,
-                    categoryGroupId:
-                        budget.category == null ? budget.groupId : null,
-                    categoryName: budget.targetLabel,
-                  );
-                } else if (value == 'edit') {
-                  context.push(
-                      '/budgets/edit/${budget.id}?year=$year&month=$month');
-                } else if (value == 'delete') {
-                  final confirmed = await showDeleteConfirmDialog(
-                    context,
-                    title: '예산 삭제',
-                    itemName: budget.targetLabel,
-                  );
-                  if (confirmed && context.mounted) {
-                    context
-                        .read<BudgetBloc>()
-                        .add(DeleteBudget(budget.id));
-                  }
-                }
-              },
-              itemBuilder: (context) => [
-                const PopupMenuItem(
-                  value: 'transactions',
-                  child: Row(
-                    children: [
-                      Icon(Icons.receipt_long, size: 18),
-                      SizedBox(width: 8),
-                      Text('거래 보기'),
-                    ],
-                  ),
-                ),
-                const PopupMenuItem(
-                  value: 'edit',
-                  child: Row(
-                    children: [
-                      Icon(Icons.edit, size: 18),
-                      SizedBox(width: 8),
-                      Text('수정'),
-                    ],
-                  ),
-                ),
-                const PopupMenuItem(
-                  value: 'delete',
-                  child: Row(
-                    children: [
-                      Icon(Icons.delete, size: 18, color: Colors.red),
-                      SizedBox(width: 8),
-                      Text('삭제', style: TextStyle(color: Colors.red)),
-                    ],
-                  ),
-                ),
-              ],
+                return state is BudgetLoaded ? state.year : DateTime.now().year;
+              }(),
+              month: () {
+                final state = context.read<BudgetBloc>().state;
+                return state is BudgetLoaded ? state.month : DateTime.now().month;
+              }(),
+              onAfterDelete: () {},
             ),
           ],
         ),
-        // Phase 25 후속 U-1 — 행 클릭 = 편집 진입 (모든 예산 통일).
-        // 거래 보기 / 삭제는 PopupMenu 통해 접근.
         onTap: () {
           final state = context.read<BudgetBloc>().state;
           final year =
               state is BudgetLoaded ? state.year : DateTime.now().year;
           final month =
               state is BudgetLoaded ? state.month : DateTime.now().month;
-          context.push('/budgets/edit/${budget.id}?year=$year&month=$month');
+          BudgetRowActions.openEdit(context,
+              budgetId: budget.id, year: year, month: month);
         },
       ),
     );

--- a/frontend/lib/features/budget/presentation/widgets/budget_row_actions.dart
+++ b/frontend/lib/features/budget/presentation/widgets/budget_row_actions.dart
@@ -1,0 +1,190 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
+import 'package:budget_book/core/utils/dialog_helpers.dart';
+import 'package:budget_book/features/budget/presentation/bloc/budget_bloc.dart';
+import 'package:budget_book/features/budget/presentation/bloc/budget_event.dart';
+import 'package:budget_book/features/budget/presentation/widgets/budget_transactions_sheet.dart';
+
+/// 예산 행 공통 액션 — 클릭=편집, PopupMenu=거래보기/수정/삭제.
+///
+/// **이 위젯/메서드 외에서는 budget 행에 PopupMenu / `/budgets/edit` push 인라인 작성 금지.**
+/// (월간 / 주간 hero / 주차 카드의 행 동선 통일 목적, 하네스 audit `budget_row_action_unification` 패턴 강제)
+///
+/// 시그니처는 누락 가능 필드(`categoryGroupId`, `dateFrom/dateTo`)를 explicit nullable 로 받아
+/// 호출부에서 명시적으로 null 또는 값 전달을 강제한다 (filter_propagation 회귀 방지).
+///
+/// 사용 패턴 두 가지:
+///  1. 위젯 형태: `BudgetRowActions(...child: ...)` — 행 전체를 InkWell 로 감싸 onTap=편집.
+///  2. 정적 메서드: ListTile 등 자체 onTap/trailing 이 있는 컨테이너에서는
+///     `BudgetRowActions.openEdit(context, ...)` + `BudgetRowActions.menuButton(...)` 조합.
+class BudgetRowActions extends StatelessWidget {
+  /// 편집/삭제 대상 budget(monthly) ID
+  final String budgetId;
+
+  /// 카테고리 ID (카테고리 단위 예산일 때만 non-null)
+  final String? categoryId;
+
+  /// 카테고리 그룹 ID (그룹 단위 예산일 때만 non-null)
+  final String? categoryGroupId;
+
+  /// 거래 보기 시트 / 삭제 다이얼로그 라벨
+  final String label;
+
+  /// 거래 보기 필터 시작일 (yyyy-MM-dd). 주간 행이면 weekStart, 월간이면 null.
+  final String? dateFrom;
+
+  /// 거래 보기 필터 종료일 (yyyy-MM-dd). 주간 행이면 weekEnd, 월간이면 null.
+  final String? dateTo;
+
+  /// 편집/거래 보기 시트가 사용할 year (PathParam 가 아닌 query)
+  final int year;
+
+  /// 편집/거래 보기 시트가 사용할 month
+  final int month;
+
+  /// 행 자체. 클릭 시 편집 진입.
+  final Widget child;
+
+  /// 삭제 후 호출되는 콜백. `WeeklyBudgetBloc` reload 등 부모 측 갱신용.
+  /// 월간 모드는 BudgetBloc 자체 reload 가 처리하므로 no-op 으로 전달 가능.
+  final VoidCallback onAfterDelete;
+
+  /// PopupMenu icon 위치 — 수직 정렬용. trailing 영역에 끼우려면 [trailingMenu] 사용.
+  final bool showInlineMenu;
+
+  const BudgetRowActions({
+    super.key,
+    required this.budgetId,
+    required this.categoryId,
+    required this.categoryGroupId,
+    required this.label,
+    required this.dateFrom,
+    required this.dateTo,
+    required this.year,
+    required this.month,
+    required this.child,
+    required this.onAfterDelete,
+    this.showInlineMenu = false,
+  });
+
+  /// PopupMenu 위젯만 반환 (trailing 영역에 별도 배치하고 싶을 때).
+  Widget buildMenu(BuildContext context) {
+    return PopupMenuButton<String>(
+      onSelected: (value) => _handleMenu(context, value),
+      itemBuilder: (_) => const [
+        PopupMenuItem(
+          value: 'transactions',
+          child: Row(children: [
+            Icon(Icons.receipt_long, size: 18),
+            SizedBox(width: 8),
+            Text('거래 보기'),
+          ]),
+        ),
+        PopupMenuItem(
+          value: 'edit',
+          child: Row(children: [
+            Icon(Icons.edit, size: 18),
+            SizedBox(width: 8),
+            Text('수정'),
+          ]),
+        ),
+        PopupMenuItem(
+          value: 'delete',
+          child: Row(children: [
+            Icon(Icons.delete, size: 18, color: Colors.red),
+            SizedBox(width: 8),
+            Text('삭제', style: TextStyle(color: Colors.red)),
+          ]),
+        ),
+      ],
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final tappable = InkWell(
+      onTap: () => _pushEdit(context),
+      child: child,
+    );
+
+    if (!showInlineMenu) return tappable;
+
+    return Row(
+      children: [
+        Expanded(child: tappable),
+        buildMenu(context),
+      ],
+    );
+  }
+
+  void _pushEdit(BuildContext context) {
+    openEdit(context, budgetId: budgetId, year: year, month: month);
+  }
+
+  /// 편집 진입 단일 진입점. 인라인 `context.push('/budgets/edit/...')` 대신 항상 이 메서드 사용.
+  static void openEdit(
+    BuildContext context, {
+    required String budgetId,
+    required int year,
+    required int month,
+  }) {
+    context.push('/budgets/edit/$budgetId?year=$year&month=$month');
+  }
+
+  /// PopupMenu 만 별도 trailing 으로 배치하고 싶을 때 사용.
+  /// ListTile.trailing 처럼 자체 onTap 이 있는 컨테이너용.
+  static Widget menuButton({
+    required BuildContext context,
+    required String budgetId,
+    required String? categoryId,
+    required String? categoryGroupId,
+    required String label,
+    required String? dateFrom,
+    required String? dateTo,
+    required int year,
+    required int month,
+    required VoidCallback onAfterDelete,
+  }) {
+    final actions = BudgetRowActions(
+      budgetId: budgetId,
+      categoryId: categoryId,
+      categoryGroupId: categoryGroupId,
+      label: label,
+      dateFrom: dateFrom,
+      dateTo: dateTo,
+      year: year,
+      month: month,
+      onAfterDelete: onAfterDelete,
+      child: const SizedBox.shrink(),
+    );
+    return actions.buildMenu(context);
+  }
+
+  Future<void> _handleMenu(BuildContext context, String value) async {
+    if (value == 'transactions') {
+      showBudgetTransactionsSheet(
+        context: context,
+        year: year,
+        month: month,
+        categoryId: categoryId,
+        categoryGroupId: categoryGroupId,
+        categoryName: label,
+        dateFrom: dateFrom,
+        dateTo: dateTo,
+      );
+    } else if (value == 'edit') {
+      _pushEdit(context);
+    } else if (value == 'delete') {
+      final confirmed = await showDeleteConfirmDialog(
+        context,
+        title: '예산 삭제',
+        itemName: label,
+      );
+      if (confirmed && context.mounted) {
+        context.read<BudgetBloc>().add(DeleteBudget(budgetId));
+        onAfterDelete();
+      }
+    }
+  }
+}

--- a/frontend/lib/features/weekly_budget/presentation/widgets/week_summary_card.dart
+++ b/frontend/lib/features/weekly_budget/presentation/widgets/week_summary_card.dart
@@ -5,13 +5,18 @@ import 'package:budget_book/core/utils/currency_formatter.dart';
 class WeekSummaryCard extends StatelessWidget {
   final WeeklyWeek weekSummary;
   final bool isCurrentWeek;
-  final void Function(WeeklyBudgetItem item)? onItemTap;
+
+  /// 행 builder. 카드는 자체적으로 InkWell/PopupMenu 를 만들지 않고
+  /// 부모가 제공하는 [itemRowBuilder] 를 통해 BudgetRowActions 등을 주입.
+  /// (하네스 audit `budget_row_action_unification` — 행 동선 단일 진입점 강제)
+  final Widget Function(BuildContext context, WeeklyBudgetItem item, Widget rowBody)?
+      itemRowBuilder;
 
   const WeekSummaryCard({
     super.key,
     required this.weekSummary,
     this.isCurrentWeek = false,
-    this.onItemTap,
+    this.itemRowBuilder,
   });
 
   @override
@@ -108,62 +113,64 @@ class WeekSummaryCard extends StatelessWidget {
               ...weekSummary.items.map((item) {
                 final progress = (item.usageRate / 100).clamp(0.0, 1.0);
                 final itemColor = _getUsageColor(item.usageRate);
-                return InkWell(
-                  onTap: onItemTap != null && item.categoryId != null
-                      ? () => onItemTap!(item)
-                      : null,
-                  borderRadius: BorderRadius.circular(6),
-                  child: Padding(
-                    padding: const EdgeInsets.only(bottom: 8),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Row(
-                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                          children: [
-                            Row(
+                final rowBody = Padding(
+                  padding: const EdgeInsets.only(bottom: 8),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: [
+                          Expanded(
+                            child: Row(
                               children: [
                                 Icon(Icons.folder_outlined,
                                     size: 14,
                                     color: theme.colorScheme.onSurface
                                         .withValues(alpha: 0.5)),
                                 const SizedBox(width: 4),
-                                Text(
-                                  item.displayName,
-                                  style: theme.textTheme.bodySmall?.copyWith(
-                                    fontWeight: FontWeight.w600,
+                                Flexible(
+                                  child: Text(
+                                    item.displayName,
+                                    style: theme.textTheme.bodySmall?.copyWith(
+                                      fontWeight: FontWeight.w600,
+                                    ),
+                                    overflow: TextOverflow.ellipsis,
                                   ),
                                 ),
-                                if (onItemTap != null && item.categoryId != null) ...[
-                                  const SizedBox(width: 2),
-                                  Icon(Icons.chevron_right, size: 14,
-                                      color: theme.colorScheme.onSurface
-                                          .withValues(alpha: 0.4)),
-                                ],
+                                const SizedBox(width: 2),
+                                Icon(Icons.chevron_right,
+                                    size: 14,
+                                    color: theme.colorScheme.onSurface
+                                        .withValues(alpha: 0.4)),
                               ],
                             ),
-                            Text(
-                              '${CurrencyFormatter.format(item.spentAmount)}원 / ${CurrencyFormatter.format(item.budgetAmount)}원',
-                              style: theme.textTheme.bodySmall,
-                            ),
-                          ],
-                        ),
-                        const SizedBox(height: 4),
-                        ClipRRect(
-                          borderRadius: BorderRadius.circular(4),
-                          child: LinearProgressIndicator(
-                            value: progress,
-                            minHeight: 5,
-                            backgroundColor: theme.colorScheme.onSurface
-                                .withValues(alpha: 0.1),
-                            valueColor:
-                                AlwaysStoppedAnimation<Color>(itemColor),
                           ),
+                          Text(
+                            '${CurrencyFormatter.format(item.spentAmount)}원 / ${CurrencyFormatter.format(item.budgetAmount)}원',
+                            style: theme.textTheme.bodySmall,
+                          ),
+                        ],
+                      ),
+                      const SizedBox(height: 4),
+                      ClipRRect(
+                        borderRadius: BorderRadius.circular(4),
+                        child: LinearProgressIndicator(
+                          value: progress,
+                          minHeight: 5,
+                          backgroundColor: theme.colorScheme.onSurface
+                              .withValues(alpha: 0.1),
+                          valueColor:
+                              AlwaysStoppedAnimation<Color>(itemColor),
                         ),
-                      ],
-                    ),
+                      ),
+                    ],
                   ),
                 );
+                if (itemRowBuilder != null) {
+                  return itemRowBuilder!(context, item, rowBody);
+                }
+                return rowBody;
               }),
             ],
           ],

--- a/frontend/test/features/budget/presentation/widgets/budget_row_actions_test.dart
+++ b/frontend/test/features/budget/presentation/widgets/budget_row_actions_test.dart
@@ -1,0 +1,196 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:bloc_test/bloc_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:budget_book/features/budget/presentation/bloc/budget_bloc.dart';
+import 'package:budget_book/features/budget/presentation/bloc/budget_event.dart';
+import 'package:budget_book/features/budget/presentation/bloc/budget_state.dart';
+import 'package:budget_book/features/budget/presentation/widgets/budget_row_actions.dart';
+
+class _MockBudgetBloc extends MockBloc<BudgetEvent, BudgetState>
+    implements BudgetBloc {}
+
+class _FakeDeleteBudget extends Fake implements DeleteBudget {}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(_FakeDeleteBudget());
+  });
+
+  late _MockBudgetBloc bloc;
+  late List<String> visitedPaths;
+
+  setUp(() {
+    bloc = _MockBudgetBloc();
+    when(() => bloc.state).thenReturn(const BudgetInitial());
+    visitedPaths = [];
+  });
+
+  GoRouter buildRouter(Widget child) {
+    return GoRouter(
+      initialLocation: '/',
+      routes: [
+        GoRoute(
+          path: '/',
+          builder: (_, __) => Scaffold(body: child),
+        ),
+        GoRoute(
+          path: '/budgets/edit/:id',
+          builder: (ctx, state) {
+            visitedPaths.add(state.uri.toString());
+            return const Scaffold(body: Text('EDIT_PAGE'));
+          },
+        ),
+      ],
+    );
+  }
+
+  Widget wrap(Widget child) {
+    return BlocProvider<BudgetBloc>.value(
+      value: bloc,
+      child: MaterialApp.router(routerConfig: buildRouter(child)),
+    );
+  }
+
+  group('BudgetRowActions', () {
+    testWidgets('row tap navigates to edit page', (tester) async {
+      final widget = BudgetRowActions(
+        budgetId: 'b1',
+        categoryId: 'c1',
+        categoryGroupId: null,
+        label: '식비',
+        dateFrom: null,
+        dateTo: null,
+        year: 2026,
+        month: 4,
+        onAfterDelete: () {},
+        child: const Padding(
+          padding: EdgeInsets.all(16),
+          child: Text('row-content'),
+        ),
+      );
+
+      await tester.pumpWidget(wrap(widget));
+      await tester.tap(find.text('row-content'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('EDIT_PAGE'), findsOneWidget);
+      expect(visitedPaths.first, contains('/budgets/edit/b1'));
+      expect(visitedPaths.first, contains('year=2026'));
+      expect(visitedPaths.first, contains('month=4'));
+    });
+
+    testWidgets('menuButton renders 3 menu items (transactions/edit/delete)',
+        (tester) async {
+      final menu = Builder(
+        builder: (ctx) => BudgetRowActions.menuButton(
+          context: ctx,
+          budgetId: 'b1',
+          categoryId: null,
+          categoryGroupId: 'g1',
+          label: '식비 그룹',
+          dateFrom: '2026-04-01',
+          dateTo: '2026-04-07',
+          year: 2026,
+          month: 4,
+          onAfterDelete: () {},
+        ),
+      );
+
+      await tester.pumpWidget(wrap(menu));
+      await tester.tap(find.byType(PopupMenuButton<String>));
+      await tester.pumpAndSettle();
+
+      expect(find.text('거래 보기'), findsOneWidget);
+      expect(find.text('수정'), findsOneWidget);
+      expect(find.text('삭제'), findsOneWidget);
+    });
+
+    testWidgets('menuButton renders without throwing for total budget (both ids null)',
+        (tester) async {
+      final menu = Builder(
+        builder: (ctx) => BudgetRowActions.menuButton(
+          context: ctx,
+          budgetId: 'b9',
+          categoryId: null,
+          categoryGroupId: null,
+          label: '총 예산',
+          dateFrom: null,
+          dateTo: null,
+          year: 2026,
+          month: 5,
+          onAfterDelete: () {},
+        ),
+      );
+
+      await tester.pumpWidget(wrap(menu));
+      expect(find.byType(PopupMenuButton<String>), findsOneWidget);
+    });
+
+    testWidgets(
+        'menu delete confirmed → DeleteBudget dispatched + onAfterDelete called',
+        (tester) async {
+      var afterDeleteCalled = 0;
+      final menu = Builder(
+        builder: (ctx) => BudgetRowActions.menuButton(
+          context: ctx,
+          budgetId: 'b-del',
+          categoryId: 'c1',
+          categoryGroupId: null,
+          label: '주간 식비',
+          dateFrom: '2026-04-01',
+          dateTo: '2026-04-07',
+          year: 2026,
+          month: 4,
+          onAfterDelete: () => afterDeleteCalled++,
+        ),
+      );
+
+      await tester.pumpWidget(wrap(menu));
+      await tester.tap(find.byType(PopupMenuButton<String>));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('삭제'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('예산 삭제'), findsOneWidget);
+      await tester.tap(find.text('삭제').last);
+      await tester.pumpAndSettle();
+
+      verify(() => bloc.add(any(that: isA<DeleteBudget>()
+          .having((e) => e.id, 'id', 'b-del')))).called(1);
+      expect(afterDeleteCalled, 1);
+    });
+
+    testWidgets('menu delete cancelled → no event, no callback', (tester) async {
+      var afterDeleteCalled = 0;
+      final menu = Builder(
+        builder: (ctx) => BudgetRowActions.menuButton(
+          context: ctx,
+          budgetId: 'b-keep',
+          categoryId: null,
+          categoryGroupId: 'g1',
+          label: '그룹 예산',
+          dateFrom: null,
+          dateTo: null,
+          year: 2026,
+          month: 4,
+          onAfterDelete: () => afterDeleteCalled++,
+        ),
+      );
+
+      await tester.pumpWidget(wrap(menu));
+      await tester.tap(find.byType(PopupMenuButton<String>));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('삭제'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('취소'));
+      await tester.pumpAndSettle();
+
+      verifyNever(() => bloc.add(any(that: isA<DeleteBudget>())));
+      expect(afterDeleteCalled, 0);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- **주간 hero / 주차 카드** 행에 누락되어 있던 **수정/삭제 동선**을 추가하고, 월간 모드와 동일한 클릭=편집 / PopupMenu=거래보기/수정/삭제 패턴으로 통일.
- 그룹 예산 / 총 예산 행도 거래 보기 / 편집 가능. 주간 거래 보기는 해당 주차 dateFrom/dateTo 범위로 필터.
- 행 동선이 4 군데에서 인라인 작성되던 것을 `BudgetRowActions` 공통 위젯/정적 메서드로 단일화 — nullable required 시그니처로 `categoryGroupId / dateFrom / dateTo` 누락 컴파일 타임 가드.
- 하네스 audit `STRUCTURAL_FIX_REQUIRED` 대응 (ui_pattern 4건 + filter_propagation 3건 누적). `audit-patterns.json` v1.3.0 — `budget_row_action_unification` + `weekly_filter_propagation` 등록.
- BE 변경 0. `WeeklyBudgetItemResponse.budgetId / groupId` + `WeeklyWeekResponse.weekStart / weekEnd` 기존 응답 그대로 활용.

## Test plan
- [x] flutter analyze (info 3건 본 PR 무관)
- [x] flutter test — 707건 PASS, 신규 위젯 테스트 5건 포함
- [x] flutter build web 성공
- [ ] 라이브: 주간 hero 카드의 카테고리/그룹/총 행 클릭 → 편집 진입
- [ ] 라이브: 주간 hero 카드 더보기 → 거래 보기 (해당 주 범위)
- [ ] 라이브: 주차 카드 행 클릭 → 편집 / 더보기 → 거래 보기
- [ ] 라이브: 주간 행에서 삭제 → 주간/월간 모두 즉시 갱신
- [ ] 라이브: 월간 모드 동선 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)