### PR TITLE
fix(transaction): 잔액 조정 수정 prefill 통일 — '-1' 표시 + 부호 충돌 fix

### DIFF
--- a/frontend/lib/features/transaction/presentation/pages/transaction_form_page.dart
+++ b/frontend/lib/features/transaction/presentation/pages/transaction_form_page.dart
@@ -350,17 +350,13 @@ class _TransactionFormPageState extends State<TransactionFormPage>
         },
         (transaction) {
           if (mounted) {
+            // 회차 5 회귀 fix — _prefillFromTransaction 단일 진입점 사용.
+            // 이전: raw amount 직접 set + ADJUSTMENT 분기 누락 → 감소(-1) 거래
+            // 수정 시 controller 에 "-1" 표시 + 라디오 부호 충돌로 수정 불가.
             setState(() {
               _isLoadingTransaction = false;
-              _amountController.text = CurrencyFormatter.format(transaction.amount);
-              _descriptionController.text = transaction.description;
-              _memoController.text = transaction.memo ?? '';
-              _selectedType = transaction.type;
-              _selectedCategoryId = transaction.category?.id;
-              _selectedCategoryDisplayName = transaction.category?.displayName;
-              _selectedPaymentMethodId = transaction.paymentMethodId;
-              _selectedPocketId = transaction.pocketId;
               _selectedDate = DateTime.parse(transaction.transactionDate);
+              _prefillFromTransaction(transaction);
             });
           }
         },


### PR DESCRIPTION
## Summary
- 감소 등록 후 수정 진입 시 form amount 필드 "-1" 표시 + 증가/감소 라디오 부호 충돌 회귀 fix
- 원인: \`_loadTransaction\` 가 \`_prefillFromTransaction\` 와 별도로 raw amount 인라인 set + ADJUSTMENT 분기 누락
- fix: \`_loadTransaction\` 의 prefill 인라인 코드를 \`_prefillFromTransaction\` 호출로 통일
- prefill 진입점 단일화 — 향후 ADJUSTMENT 외 다른 분기 추가 시 한 곳만 수정

## Test plan
- [x] flutter analyze
- [x] flutter test 717 PASS
- [ ] 라이브: 잔액 조정(-1) → 수정 진입 → amount "1" 표시 + 감소 라디오 활성
- [ ] 라이브: 라디오 변경 + 저장 → 정상 부호 반영
- [ ] 라이브: 회귀 — EXPENSE/INCOME 수정 prefill 정상

🤖 Generated with [Claude Code](https://claude.com/claude-code)