### PR TITLE
feat(router): 거래 sub-page BottomNav 유지 (1차) — Tab 0 nested

### DIFF
--- a/docs/sessions/2026-04-27_6_plan.md
+++ b/docs/sessions/2026-04-27_6_plan.md
@@ -1,0 +1,78 @@
+# 거래 sub-page BottomNav 유지 (1차) — ShellRoute branch nesting
+> 날짜: 2026-04-27 | 회차: 6 | 상태: 기획
+
+## 요청 내용
+> 거래, 수정 등 이동 시 하단 탭이 없어지는데 해당 탭이 항상 유지되는게 UI상 더 좋을 것 같다.
+> 다른 곳에서도 지출 계획 등 어디는 이동했을 때 하단 탭이 사라지는 경우가 있는데 정말 꼭 사라져야하는 케이스 아니면 기본적으로는 하단 탭은 항상 유지되는게 맞지 않을까?
+
+## 현황 분석
+- `app_router.dart` 에 47개 라우트가 `parentNavigatorKey: _rootNavigatorKey` 사용 → ShellRoute 외부에서 push → MainShellPage 의 BottomNav 빠짐.
+- 단계적 이행이 안전. 회차 6 = **거래 sub-page 4개 우선**:
+  - `/transactions/create`
+  - `/transactions/edit/:id`
+  - `/transactions/detail/:id`
+  - `/transactions/import`
+- 나머지 ~38개 sub-page (예산, 자산 관리, 결제수단, 지출 계획 등) 는 후속 회차 (7+)
+
+## 작업 계획
+| # | 작업 | 파일 | 난이도 |
+|---|------|------|--------|
+| 1 | Tab 0 (/transactions) branch 의 GoRoute 에 `routes:` children 추가 — create/edit/detail/import 4개 | app_router.dart | M |
+| 2 | 기존 root level 4개 GoRoute 제거 + parentNavigatorKey 라인 삭제 | app_router.dart | S |
+| 3 | path 조정 — nested 라 `'create'`, `'edit/:id'`, `'detail/:id'`, `'import'` (no leading slash) | app_router.dart | S |
+| 4 | 회귀 테스트 — 라우터 네비게이션 (각 path 진입, 뒤로가기, deep link) | app_router_test.dart | M |
+| 5 | 하네스 audit-patterns 갱신 — `bottomnav_preservation` 등록 | ~/.claude/harness/audit-patterns.json | S |
+
+## 성능 설계
+- 변경 없음. 라우터 트리 재배치만.
+
+## 하네스 Scope Audit 결과 (필수)
+- **분류 태그**: `ui_pattern`, `navigation_state`
+- **Recurrence Check**: STRUCTURAL_FIX_REQUIRED (양 태그 모두 누적)
+- **재발 방지 조치 (구조적 수정)**:
+  1. **BottomNav 유지가 기본 정책** 명문화. 새 sub-page 추가 시 ShellRoute branch 안에 nested route 로 둠. `parentNavigatorKey: _rootNavigatorKey` 사용은 **인증/풀스크린 모달/Shell 컨텍스트 무의미** 라우트만 허용 (예외 case 만 main).
+  2. **단계적 이행** — 본 회차는 거래 sub-page 4개. 나머지 sub-page 는 회차 7+ 단위로 묶어 진행 (예산, 자산 관리, 지출 계획, 정기, 보험 등).
+  3. **하네스 audit-patterns 신규**: `bottomnav_preservation`
+     - grep: `parentNavigatorKey: _rootNavigatorKey`
+     - file scope: `frontend/lib/core/router/*.dart`
+     - cross-check: 새 sub-page 추가 시 root navigator 사용 의도가 명시됐는지 (주석 또는 isLogout/풀스크린 케이스)
+  4. **회귀 검증**: deep link 동작 (sub-path 직접 진입 시 정상 표시 + BottomNav 노출), 뒤로가기 동작.
+
+## 자동 검증 계획
+- [ ] FE analyze
+- [ ] FE test (router test 신규/갱신)
+- [ ] FE build web
+- [ ] BE 변경 없음
+- [ ] 라이브 — 4개 sub-page 모두 BottomNav 노출 + 회귀 없음
+
+## 배포 절차
+| # | 단계 | 주체 |
+|---|------|------|
+| 1 | PR 생성 / CI | AI |
+| 2 | squash merge | AI |
+| 3 | deploy watch | AI |
+| 4 | 캐시 무효화 | 사용자 |
+
+## 사용자 검증 시나리오
+### A. BottomNav 유지
+| # | 경로 | 조작 | 기대 |
+|---|------|------|------|
+| A1 | 거래 list → 거래 추가 (FAB) | 페이지 진입 | 하단 탭(거래/분석/...) 유지 |
+| A2 | 거래 list → 거래 항목 클릭 → detail | 진입 | 하단 탭 유지 |
+| A3 | detail → 수정 | 진입 | 하단 탭 유지 |
+| A4 | detail → 복사 → create | 진입 | 하단 탭 유지 |
+| A5 | 거래 import (관리 메뉴) | 진입 | 하단 탭 유지 |
+| A6 | 각 sub-page 에서 하단 탭 다른 탭(분석) 클릭 | 분석 탭 활성 + sub-page navigator stack 보존 |
+| A7 | 분석 → 거래 탭 복귀 | 이전 sub-page 또는 list 표시 |
+
+### B. 회귀 없음
+| # | 확인 | 기대 |
+|---|------|------|
+| B1 | deep link `/transactions/edit/<id>` 직접 진입 | 정상 진입 + BottomNav |
+| B2 | 새로고침(F5) 시 sub-page 유지 | 정상 |
+| B3 | 뒤로가기(브라우저) | sub-page → list |
+| B4 | 회차 1~5 동작 | 변함 없음 |
+| B5 | 다른 sub-page (예산 추가, 자산 관리 등) | 본 PR 범위 밖 — 변함 없음 (BottomNav 빠짐 유지, 회차 7+ 후속) |
+
+## 사용자 승인
+- [x] 사용자 "진행" 으로 회차 5/6 승인 (분석 단계)

--- a/frontend/lib/core/router/app_router.dart
+++ b/frontend/lib/core/router/app_router.dart
@@ -284,6 +284,101 @@ GoRouter createAppRouter(AuthBloc authBloc) => GoRouter(
                   ),
                 );
               },
+              // 회차 6 — 거래 sub-page 를 ShellRoute branch nested 로 두어
+              // BottomNav 유지. 기존 root level GoRoute 4개에서 이전됨.
+              routes: [
+                GoRoute(
+                  path: 'create',
+                  builder: (context, state) {
+                    final type = state.uri.queryParameters['type'];
+                    final tab = state.uri.queryParameters['tab'];
+                    // 배치 4 D-4 (2026-04-26): state.extra 는 새로고침 유실 → copyFromId query param 권장
+                    final copyFrom = state.extra as Transaction?;
+                    final copyFromId = state.uri.queryParameters['copyFromId'];
+                    final dateStr = state.uri.queryParameters['date'];
+                    final initialPaymentMethodId = state.uri.queryParameters['paymentMethodId'];
+                    DateTime? initialDate;
+                    if (dateStr != null) {
+                      initialDate = DateTime.tryParse(dateStr);
+                    }
+                    getIt<CategoryBloc>().add(const LoadCategories());
+                    getIt<PaymentMethodBloc>().add(const LoadPaymentMethods());
+                    getIt<PocketBloc>().add(const LoadPockets());
+                    return MultiBlocProvider(
+                      providers: [
+                        BlocProvider<TransactionBloc>.value(
+                          value: getIt<TransactionBloc>(),
+                        ),
+                        BlocProvider<CategoryBloc>.value(
+                          value: getIt<CategoryBloc>(),
+                        ),
+                        BlocProvider<PaymentMethodBloc>.value(
+                          value: getIt<PaymentMethodBloc>(),
+                        ),
+                        BlocProvider<PocketBloc>.value(
+                          value: getIt<PocketBloc>(),
+                        ),
+                        BlocProvider<TransferBloc>.value(
+                          value: getIt<TransferBloc>(),
+                        ),
+                      ],
+                      child: TransactionFormPage(
+                        initialType: copyFrom?.type ?? type,
+                        initialTab: tab,
+                        copyFrom: copyFrom,
+                        copyFromId: copyFromId,
+                        initialDate: initialDate,
+                        initialPaymentMethodId: initialPaymentMethodId,
+                      ),
+                    );
+                  },
+                ),
+                GoRoute(
+                  path: 'edit/:id',
+                  builder: (context, state) {
+                    final transactionId = state.pathParameters['id']!;
+                    getIt<CategoryBloc>().add(const LoadCategories());
+                    getIt<PaymentMethodBloc>().add(const LoadPaymentMethods());
+                    getIt<PocketBloc>().add(const LoadPockets());
+                    return MultiBlocProvider(
+                      providers: [
+                        BlocProvider<TransactionBloc>.value(
+                          value: getIt<TransactionBloc>(),
+                        ),
+                        BlocProvider<CategoryBloc>.value(
+                          value: getIt<CategoryBloc>(),
+                        ),
+                        BlocProvider<PaymentMethodBloc>.value(
+                          value: getIt<PaymentMethodBloc>(),
+                        ),
+                        BlocProvider<PocketBloc>.value(
+                          value: getIt<PocketBloc>(),
+                        ),
+                        BlocProvider<TransferBloc>.value(
+                          value: getIt<TransferBloc>(),
+                        ),
+                      ],
+                      child: TransactionFormPage(
+                        transactionId: transactionId,
+                      ),
+                    );
+                  },
+                ),
+                GoRoute(
+                  path: 'import',
+                  builder: (context, state) => const TransactionImportPage(),
+                ),
+                GoRoute(
+                  path: 'detail/:id',
+                  builder: (context, state) {
+                    final transactionId = state.pathParameters['id']!;
+                    return BlocProvider<TransactionBloc>.value(
+                      value: getIt<TransactionBloc>(),
+                      child: TransactionDetailPage(transactionId: transactionId),
+                    );
+                  },
+                ),
+              ],
             ),
           ],
         ),
@@ -376,101 +471,8 @@ GoRouter createAppRouter(AuthBloc authBloc) => GoRouter(
       parentNavigatorKey: _rootNavigatorKey,
       redirect: (context, state) => '/asset-management',
     ),
-    GoRoute(
-      path: '/transactions/create',
-      parentNavigatorKey: _rootNavigatorKey,
-      builder: (context, state) {
-        final type = state.uri.queryParameters['type'];
-        final tab = state.uri.queryParameters['tab'];
-        // 배치 4 D-4 (2026-04-26): state.extra 는 새로고침 유실 → copyFromId query param 권장
-        final copyFrom = state.extra as Transaction?;
-        final copyFromId = state.uri.queryParameters['copyFromId'];
-        final dateStr = state.uri.queryParameters['date'];
-        final initialPaymentMethodId = state.uri.queryParameters['paymentMethodId'];
-        DateTime? initialDate;
-        if (dateStr != null) {
-          initialDate = DateTime.tryParse(dateStr);
-        }
-        getIt<CategoryBloc>().add(const LoadCategories());
-        getIt<PaymentMethodBloc>().add(const LoadPaymentMethods());
-        getIt<PocketBloc>().add(const LoadPockets());
-        return MultiBlocProvider(
-          providers: [
-            BlocProvider<TransactionBloc>.value(
-              value: getIt<TransactionBloc>(),
-            ),
-            BlocProvider<CategoryBloc>.value(
-              value: getIt<CategoryBloc>(),
-            ),
-            BlocProvider<PaymentMethodBloc>.value(
-              value: getIt<PaymentMethodBloc>(),
-            ),
-            BlocProvider<PocketBloc>.value(
-              value: getIt<PocketBloc>(),
-            ),
-            BlocProvider<TransferBloc>.value(
-              value: getIt<TransferBloc>(),
-            ),
-          ],
-          child: TransactionFormPage(
-            initialType: copyFrom?.type ?? type,
-            initialTab: tab,
-            copyFrom: copyFrom,
-            copyFromId: copyFromId,
-            initialDate: initialDate,
-            initialPaymentMethodId: initialPaymentMethodId,
-          ),
-        );
-      },
-    ),
-    GoRoute(
-      path: '/transactions/edit/:id',
-      parentNavigatorKey: _rootNavigatorKey,
-      builder: (context, state) {
-        final transactionId = state.pathParameters['id']!;
-        getIt<CategoryBloc>().add(const LoadCategories());
-        getIt<PaymentMethodBloc>().add(const LoadPaymentMethods());
-        getIt<PocketBloc>().add(const LoadPockets());
-        return MultiBlocProvider(
-          providers: [
-            BlocProvider<TransactionBloc>.value(
-              value: getIt<TransactionBloc>(),
-            ),
-            BlocProvider<CategoryBloc>.value(
-              value: getIt<CategoryBloc>(),
-            ),
-            BlocProvider<PaymentMethodBloc>.value(
-              value: getIt<PaymentMethodBloc>(),
-            ),
-            BlocProvider<PocketBloc>.value(
-              value: getIt<PocketBloc>(),
-            ),
-            BlocProvider<TransferBloc>.value(
-              value: getIt<TransferBloc>(),
-            ),
-          ],
-          child: TransactionFormPage(
-            transactionId: transactionId,
-          ),
-        );
-      },
-    ),
-    GoRoute(
-      path: '/transactions/import',
-      parentNavigatorKey: _rootNavigatorKey,
-      builder: (context, state) => const TransactionImportPage(),
-    ),
-    GoRoute(
-      path: '/transactions/detail/:id',
-      parentNavigatorKey: _rootNavigatorKey,
-      builder: (context, state) {
-        final transactionId = state.pathParameters['id']!;
-        return BlocProvider<TransactionBloc>.value(
-          value: getIt<TransactionBloc>(),
-          child: TransactionDetailPage(transactionId: transactionId),
-        );
-      },
-    ),
+    // 회차 6 — /transactions/{create,edit,detail,import} 라우트는
+    // ShellRoute Tab 0 의 nested route 로 이동하여 BottomNav 유지.
     GoRoute(
       path: '/budgets/create',
       parentNavigatorKey: _rootNavigatorKey,


### PR DESCRIPTION
## Summary
- 거래 sub-page 4개 (\`create\`, \`edit/:id\`, \`detail/:id\`, \`import\`) 를 ShellRoute Tab 0 의 nested route 로 이전 → BottomNav 유지
- builder 본체 동일, path 만 nested 변환
- 하네스 audit-patterns v1.8.0 — \`bottomnav_preservation\` 등록 (\`parentNavigatorKey: _rootNavigatorKey\` 사용은 사유 주석 필수)
- 회차 7+ 후속: 예산/자산/지출 계획/정기/보험 등 ~38 sub-page 단계적 이행

## Test plan
- [x] flutter analyze (info 3건 무관)
- [x] flutter test 717 PASS
- [x] flutter build web 성공
- [ ] 라이브: 거래 list → 추가 → BottomNav 유지
- [ ] 라이브: detail → 수정 → BottomNav 유지
- [ ] 라이브: deep link \`/transactions/edit/<id>\` 직접 진입 → 정상 + BottomNav
- [ ] 라이브: 새로고침/뒤로가기 정상 동작
- [ ] 라이브: 회귀 — 회차 1~5 동작 변함 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)