### PR TITLE
feat(router): BottomNav 유지 (2차) — Tab 1 분석 9개 nested

### DIFF
--- a/docs/sessions/2026-04-27_7_plan.md
+++ b/docs/sessions/2026-04-27_7_plan.md
@@ -1,0 +1,62 @@
+# BottomNav 유지 (2차) — Tab 1 분석 영역 9 sub-page
+> 날짜: 2026-04-27 | 회차: 7 | 상태: 기획
+
+## 요청 내용
+회차 6 의 거래 sub-page 4개 BottomNav 유지 후속 — 분석 영역 9개를 동일 정책으로 이전.
+
+## 변경 방향 — absolute path nested
+회차 6 은 leading slash 제거 (path: 'create') 로 prefix 매칭 → URL `/transactions/create` 변경 없음.
+회차 7 은 **Tab 1 (/analysis) 의 routes 안에 absolute path 그대로 nested** — URL 변경 없이 navigator stack 만 Tab 1 으로 이동.
+
+GoRouter docs: nested route 의 path 가 absolute (`/start`) 면 그 absolute path 그대로 매칭 (parent prefix 무시). 회차 6 의 prefix 매칭과 동등 동작 + URL 변경 없음.
+
+## 작업 계획
+| # | 작업 | 파일 | 난이도 |
+|---|------|------|------|
+| 1 | Tab 1 (/analysis) GoRoute 의 routes 안에 9개 sub-page 를 absolute path 로 nested 추가 | app_router.dart | M |
+| 2 | root level 의 동일 9개 GoRoute + parentNavigatorKey 라인 삭제 | app_router.dart | S |
+| 3 | analyze + test + build 회귀 검증 | - | S |
+
+대상 9개:
+- /budgets/create
+- /budgets/edit/:id
+- /weekly-budgets
+- /weekly-budgets/settlement
+- /reports
+- /period-summary
+- /spending-plans
+- /spending-plans/create
+- /spending-plans/edit/:id
+
+## 하네스 Scope Audit
+- 태그: `ui_pattern`, `navigation_state`
+- Recurrence: STRUCTURAL_FIX_REQUIRED
+- 재발 방지: `bottomnav_preservation` (v1.8.0) 유지. 본 회차 후 audit 패턴이 root navigator 사용 잔존(~29) 지속 추적.
+
+## 자동 검증
+- [ ] FE analyze
+- [ ] FE test
+- [ ] FE build web
+- [ ] BE 변경 없음
+
+## 사용자 검증 시나리오
+
+### A. BottomNav 유지
+| # | 경로 | 기대 |
+|---|------|------|
+| A1 | 분석 → 예산 추가/수정 | BottomNav 유지 |
+| A2 | 분석 → 주간 예산 / 주간 정산 | BottomNav 유지 |
+| A3 | 분석 → 리포트 | BottomNav 유지 |
+| A4 | 분석 → 기간 요약 | BottomNav 유지 |
+| A5 | 분석 → 지출 계획 / 추가 / 수정 | BottomNav 유지 |
+| A6 | 다른 탭(거래/자산/설정) 클릭 → 복귀 | navigator stack 보존 |
+
+### B. 회귀 없음
+| # | 확인 | 기대 |
+|---|------|------|
+| B1 | deep link `/budgets/create`, `/reports` 등 직접 진입 | 정상 + BottomNav |
+| B2 | 새로고침 / 뒤로가기 | 정상 |
+| B3 | 회차 1~6 동작 | 변함 없음 |
+
+## 사용자 승인
+- [x] 사용자 "1~3번 진행" 승인 (회차 7~10 묶음)

--- a/frontend/lib/core/router/app_router.dart
+++ b/frontend/lib/core/router/app_router.dart
@@ -388,6 +388,196 @@ GoRouter createAppRouter(AuthBloc authBloc) => GoRouter(
             GoRoute(
               path: '/analysis',
               builder: (context, state) => const AnalysisPage(),
+              // 회차 7 — 분석 영역 sub-page 9개를 ShellRoute branch nested 로 이전.
+              // path 가 absolute (leading slash) 라 URL 변경 없이 BottomNav 유지.
+              routes: [
+                GoRoute(
+                  path: '/budgets/create',
+                  builder: (context, state) {
+                    final year = int.tryParse(
+                            state.uri.queryParameters['year'] ?? '') ??
+                        DateTime.now().year;
+                    final month = int.tryParse(
+                            state.uri.queryParameters['month'] ?? '') ??
+                        DateTime.now().month;
+                    getIt<BudgetBloc>().add(LoadBudgets(year: year, month: month));
+                    getIt<CategoryBloc>().add(const LoadCategories());
+                    getIt<PocketBloc>().add(const LoadPockets());
+                    return MultiBlocProvider(
+                      providers: [
+                        BlocProvider<BudgetBloc>.value(
+                          value: getIt<BudgetBloc>(),
+                        ),
+                        BlocProvider<CategoryBloc>.value(
+                          value: getIt<CategoryBloc>(),
+                        ),
+                        BlocProvider<PocketBloc>.value(
+                          value: getIt<PocketBloc>(),
+                        ),
+                      ],
+                      child: BudgetFormPage(year: year, month: month),
+                    );
+                  },
+                ),
+                GoRoute(
+                  path: '/budgets/edit/:id',
+                  builder: (context, state) {
+                    final year = int.tryParse(
+                            state.uri.queryParameters['year'] ?? '') ??
+                        DateTime.now().year;
+                    final month = int.tryParse(
+                            state.uri.queryParameters['month'] ?? '') ??
+                        DateTime.now().month;
+                    getIt<BudgetBloc>().add(LoadBudgets(year: year, month: month));
+                    getIt<CategoryBloc>().add(const LoadCategories());
+                    getIt<PocketBloc>().add(const LoadPockets());
+                    return MultiBlocProvider(
+                      providers: [
+                        BlocProvider<BudgetBloc>.value(
+                          value: getIt<BudgetBloc>(),
+                        ),
+                        BlocProvider<CategoryBloc>.value(
+                          value: getIt<CategoryBloc>(),
+                        ),
+                        BlocProvider<PocketBloc>.value(
+                          value: getIt<PocketBloc>(),
+                        ),
+                      ],
+                      child: BudgetFormPage(
+                        budgetId: state.pathParameters['id'],
+                        year: year,
+                        month: month,
+                      ),
+                    );
+                  },
+                ),
+                GoRoute(
+                  path: '/weekly-budgets',
+                  builder: (context, state) {
+                    final now = DateTime.now();
+                    return BlocProvider<WeeklyBudgetBloc>.value(
+                      value: getIt<WeeklyBudgetBloc>()
+                        ..add(LoadWeeklyOverview(year: now.year, month: now.month))
+                        ..add(const LoadCurrentWeek()),
+                      child: const WeeklyBudgetPage(),
+                    );
+                  },
+                ),
+                GoRoute(
+                  path: '/weekly-budgets/settlement',
+                  builder: (context, state) {
+                    final now = DateTime.now();
+                    return BlocProvider<WeeklySettlementBloc>.value(
+                      value: getIt<WeeklySettlementBloc>()
+                        ..add(LoadSettlements(year: now.year, month: now.month)),
+                      child: const WeeklySettlementPage(),
+                    );
+                  },
+                ),
+                GoRoute(
+                  path: '/reports',
+                  builder: (context, state) {
+                    final now = DateTime.now();
+                    return BlocProvider<ReportBloc>.value(
+                      value: getIt<ReportBloc>()
+                        ..add(LoadMonthlyReport(year: now.year, month: now.month))
+                        ..add(LoadWeeklyReport(
+                            year: now.year, month: now.month, week: 1)),
+                      child: const ReportPage(),
+                    );
+                  },
+                ),
+                GoRoute(
+                  path: '/period-summary',
+                  builder: (context, state) {
+                    final now = DateTime.now();
+                    final dateFrom =
+                        '${now.year}-${now.month.toString().padLeft(2, '0')}-01';
+                    final lastDay = DateTime(now.year, now.month + 1, 0).day;
+                    final dateTo =
+                        '${now.year}-${now.month.toString().padLeft(2, '0')}-${lastDay.toString().padLeft(2, '0')}';
+                    return BlocProvider<PeriodSummaryBloc>.value(
+                      value: getIt<PeriodSummaryBloc>()
+                        ..add(LoadPeriodSummary(dateFrom: dateFrom, dateTo: dateTo)),
+                      child: const PeriodSummaryPage(),
+                    );
+                  },
+                ),
+                GoRoute(
+                  path: '/spending-plans',
+                  builder: (context, state) {
+                    final now = DateTime.now();
+                    final startDate =
+                        '${now.year}-${now.month.toString().padLeft(2, '0')}-01';
+                    final lastDay = DateTime(now.year, now.month + 1, 0).day;
+                    final endDate =
+                        '${now.year}-${now.month.toString().padLeft(2, '0')}-${lastDay.toString().padLeft(2, '0')}';
+                    getIt<SpendingPlanBloc>().add(LoadSpendingPlans(
+                      startDate: startDate,
+                      endDate: endDate,
+                    ));
+                    return BlocProvider<SpendingPlanBloc>.value(
+                      value: getIt<SpendingPlanBloc>(),
+                      child: const SpendingPlanListPage(),
+                    );
+                  },
+                ),
+                GoRoute(
+                  path: '/spending-plans/create',
+                  builder: (context, state) {
+                    getIt<CategoryBloc>().add(const LoadCategories());
+                    getIt<PaymentMethodBloc>().add(const LoadPaymentMethods());
+                    final now = DateTime.now();
+                    getIt<BudgetBloc>().add(LoadBudgets(year: now.year, month: now.month));
+                    return MultiBlocProvider(
+                      providers: [
+                        BlocProvider<SpendingPlanBloc>.value(
+                          value: getIt<SpendingPlanBloc>(),
+                        ),
+                        BlocProvider<CategoryBloc>.value(
+                          value: getIt<CategoryBloc>(),
+                        ),
+                        BlocProvider<PaymentMethodBloc>.value(
+                          value: getIt<PaymentMethodBloc>(),
+                        ),
+                        BlocProvider<BudgetBloc>.value(
+                          value: getIt<BudgetBloc>(),
+                        ),
+                      ],
+                      child: SpendingPlanFormPage(
+                        isWishlist: state.uri.queryParameters['wishlist'] == 'true',
+                      ),
+                    );
+                  },
+                ),
+                GoRoute(
+                  path: '/spending-plans/edit/:id',
+                  builder: (context, state) {
+                    final planId = state.pathParameters['id']!;
+                    getIt<CategoryBloc>().add(const LoadCategories());
+                    getIt<PaymentMethodBloc>().add(const LoadPaymentMethods());
+                    final now = DateTime.now();
+                    getIt<BudgetBloc>().add(LoadBudgets(year: now.year, month: now.month));
+                    return MultiBlocProvider(
+                      providers: [
+                        BlocProvider<SpendingPlanBloc>.value(
+                          value: getIt<SpendingPlanBloc>(),
+                        ),
+                        BlocProvider<CategoryBloc>.value(
+                          value: getIt<CategoryBloc>(),
+                        ),
+                        BlocProvider<PaymentMethodBloc>.value(
+                          value: getIt<PaymentMethodBloc>(),
+                        ),
+                        BlocProvider<BudgetBloc>.value(
+                          value: getIt<BudgetBloc>(),
+                        ),
+                      ],
+                      child: SpendingPlanFormPage(planId: planId),
+                    );
+                  },
+                ),
+              ],
             ),
           ],
         ),
@@ -473,68 +663,7 @@ GoRouter createAppRouter(AuthBloc authBloc) => GoRouter(
     ),
     // 회차 6 — /transactions/{create,edit,detail,import} 라우트는
     // ShellRoute Tab 0 의 nested route 로 이동하여 BottomNav 유지.
-    GoRoute(
-      path: '/budgets/create',
-      parentNavigatorKey: _rootNavigatorKey,
-      builder: (context, state) {
-        final year = int.tryParse(
-                state.uri.queryParameters['year'] ?? '') ??
-            DateTime.now().year;
-        final month = int.tryParse(
-                state.uri.queryParameters['month'] ?? '') ??
-            DateTime.now().month;
-        getIt<BudgetBloc>().add(LoadBudgets(year: year, month: month));
-        getIt<CategoryBloc>().add(const LoadCategories());
-        getIt<PocketBloc>().add(const LoadPockets());
-        return MultiBlocProvider(
-          providers: [
-            BlocProvider<BudgetBloc>.value(
-              value: getIt<BudgetBloc>(),
-            ),
-            BlocProvider<CategoryBloc>.value(
-              value: getIt<CategoryBloc>(),
-            ),
-            BlocProvider<PocketBloc>.value(
-              value: getIt<PocketBloc>(),
-            ),
-          ],
-          child: BudgetFormPage(year: year, month: month),
-        );
-      },
-    ),
-    GoRoute(
-      path: '/budgets/edit/:id',
-      parentNavigatorKey: _rootNavigatorKey,
-      builder: (context, state) {
-        final year = int.tryParse(
-                state.uri.queryParameters['year'] ?? '') ??
-            DateTime.now().year;
-        final month = int.tryParse(
-                state.uri.queryParameters['month'] ?? '') ??
-            DateTime.now().month;
-        getIt<BudgetBloc>().add(LoadBudgets(year: year, month: month));
-        getIt<CategoryBloc>().add(const LoadCategories());
-        getIt<PocketBloc>().add(const LoadPockets());
-        return MultiBlocProvider(
-          providers: [
-            BlocProvider<BudgetBloc>.value(
-              value: getIt<BudgetBloc>(),
-            ),
-            BlocProvider<CategoryBloc>.value(
-              value: getIt<CategoryBloc>(),
-            ),
-            BlocProvider<PocketBloc>.value(
-              value: getIt<PocketBloc>(),
-            ),
-          ],
-          child: BudgetFormPage(
-            budgetId: state.pathParameters['id'],
-            year: year,
-            month: month,
-          ),
-        );
-      },
-    ),
+    // 회차 7 — /budgets/{create,edit/:id} 는 Tab 1 (/analysis) nested 로 이전됨
     GoRoute(
       path: '/payment-methods',
       parentNavigatorKey: _rootNavigatorKey,
@@ -560,62 +689,7 @@ GoRouter createAppRouter(AuthBloc authBloc) => GoRouter(
         );
       },
     ),
-    GoRoute(
-      path: '/weekly-budgets',
-      parentNavigatorKey: _rootNavigatorKey,
-      builder: (context, state) {
-        final now = DateTime.now();
-        return BlocProvider<WeeklyBudgetBloc>.value(
-          value: getIt<WeeklyBudgetBloc>()
-            ..add(LoadWeeklyOverview(year: now.year, month: now.month))
-            ..add(const LoadCurrentWeek()),
-          child: const WeeklyBudgetPage(),
-        );
-      },
-    ),
-    GoRoute(
-      path: '/weekly-budgets/settlement',
-      parentNavigatorKey: _rootNavigatorKey,
-      builder: (context, state) {
-        final now = DateTime.now();
-        return BlocProvider<WeeklySettlementBloc>.value(
-          value: getIt<WeeklySettlementBloc>()
-            ..add(LoadSettlements(year: now.year, month: now.month)),
-          child: const WeeklySettlementPage(),
-        );
-      },
-    ),
-    GoRoute(
-      path: '/reports',
-      parentNavigatorKey: _rootNavigatorKey,
-      builder: (context, state) {
-        final now = DateTime.now();
-        return BlocProvider<ReportBloc>.value(
-          value: getIt<ReportBloc>()
-            ..add(LoadMonthlyReport(year: now.year, month: now.month))
-            ..add(LoadWeeklyReport(
-                year: now.year, month: now.month, week: 1)),
-          child: const ReportPage(),
-        );
-      },
-    ),
-    GoRoute(
-      path: '/period-summary',
-      parentNavigatorKey: _rootNavigatorKey,
-      builder: (context, state) {
-        final now = DateTime.now();
-        final dateFrom =
-            '${now.year}-${now.month.toString().padLeft(2, '0')}-01';
-        final lastDay = DateTime(now.year, now.month + 1, 0).day;
-        final dateTo =
-            '${now.year}-${now.month.toString().padLeft(2, '0')}-${lastDay.toString().padLeft(2, '0')}';
-        return BlocProvider<PeriodSummaryBloc>.value(
-          value: getIt<PeriodSummaryBloc>()
-            ..add(LoadPeriodSummary(dateFrom: dateFrom, dateTo: dateTo)),
-          child: const PeriodSummaryPage(),
-        );
-      },
-    ),
+    // 회차 7 — /weekly-budgets, /reports, /period-summary 는 Tab 1 nested 로 이전됨
     GoRoute(
       path: '/recurring',
       parentNavigatorKey: _rootNavigatorKey,
@@ -856,84 +930,7 @@ GoRouter createAppRouter(AuthBloc authBloc) => GoRouter(
         );
       },
     ),
-    // Spending Plans
-    GoRoute(
-      path: '/spending-plans',
-      parentNavigatorKey: _rootNavigatorKey,
-      builder: (context, state) {
-        final now = DateTime.now();
-        final startDate =
-            '${now.year}-${now.month.toString().padLeft(2, '0')}-01';
-        final lastDay = DateTime(now.year, now.month + 1, 0).day;
-        final endDate =
-            '${now.year}-${now.month.toString().padLeft(2, '0')}-${lastDay.toString().padLeft(2, '0')}';
-        getIt<SpendingPlanBloc>().add(LoadSpendingPlans(
-          startDate: startDate,
-          endDate: endDate,
-        ));
-        return BlocProvider<SpendingPlanBloc>.value(
-          value: getIt<SpendingPlanBloc>(),
-          child: const SpendingPlanListPage(),
-        );
-      },
-    ),
-    GoRoute(
-      path: '/spending-plans/create',
-      parentNavigatorKey: _rootNavigatorKey,
-      builder: (context, state) {
-        getIt<CategoryBloc>().add(const LoadCategories());
-        getIt<PaymentMethodBloc>().add(const LoadPaymentMethods());
-        final now = DateTime.now();
-        getIt<BudgetBloc>().add(LoadBudgets(year: now.year, month: now.month));
-        return MultiBlocProvider(
-          providers: [
-            BlocProvider<SpendingPlanBloc>.value(
-              value: getIt<SpendingPlanBloc>(),
-            ),
-            BlocProvider<CategoryBloc>.value(
-              value: getIt<CategoryBloc>(),
-            ),
-            BlocProvider<PaymentMethodBloc>.value(
-              value: getIt<PaymentMethodBloc>(),
-            ),
-            BlocProvider<BudgetBloc>.value(
-              value: getIt<BudgetBloc>(),
-            ),
-          ],
-          child: SpendingPlanFormPage(
-            isWishlist: state.uri.queryParameters['wishlist'] == 'true',
-          ),
-        );
-      },
-    ),
-    GoRoute(
-      path: '/spending-plans/edit/:id',
-      parentNavigatorKey: _rootNavigatorKey,
-      builder: (context, state) {
-        final planId = state.pathParameters['id']!;
-        getIt<CategoryBloc>().add(const LoadCategories());
-        getIt<PaymentMethodBloc>().add(const LoadPaymentMethods());
-        final now = DateTime.now();
-        getIt<BudgetBloc>().add(LoadBudgets(year: now.year, month: now.month));
-        return MultiBlocProvider(
-          providers: [
-            BlocProvider<SpendingPlanBloc>.value(
-              value: getIt<SpendingPlanBloc>(),
-            ),
-            BlocProvider<CategoryBloc>.value(
-              value: getIt<CategoryBloc>(),
-            ),
-            BlocProvider<PaymentMethodBloc>.value(
-              value: getIt<PaymentMethodBloc>(),
-            ),
-            BlocProvider<BudgetBloc>.value(
-              value: getIt<BudgetBloc>(),
-            ),
-          ],
-          child: SpendingPlanFormPage(planId: planId),
-        );
-      },
-    ),
+    // 회차 7 — /spending-plans/* 는 Tab 1 nested 로 이전됨
     // Insurances
     GoRoute(
       path: '/insurances',


### PR DESCRIPTION
## Summary
- Tab 1 (/analysis) 의 routes 안에 9개 분석 sub-page 를 absolute path 로 nested
- URL 변경 없음 (회차 6 의 prefix 매칭과 달리 absolute path 사용)
- builder 본체 동일, parentNavigatorKey 라인만 삭제
- 회차 8/9 후속: Tab 0 부속 5 + Tab 2 자산 11 + Tab 3 설정 13

## Test plan
- [x] flutter analyze + test 717 + build 통과
- [ ] 라이브: 분석 → 예산 추가/수정 → BottomNav 유지
- [ ] 라이브: 주간 예산 / 정산 → BottomNav 유지
- [ ] 라이브: 리포트 / 기간 요약 → BottomNav 유지
- [ ] 라이브: 지출 계획 list/create/edit → BottomNav 유지
- [ ] deep link `/budgets/create`, `/reports` 등 직접 진입 정상 + BottomNav
- [ ] 회차 1~6 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)