### PR TITLE
feat(router): BottomNav 유지 (3차) — Tab 1 분석 9개 nested + URL prefix /analysis/

### DIFF
--- a/docs/sessions/2026-04-28_2_plan.md
+++ b/docs/sessions/2026-04-28_2_plan.md
@@ -1,0 +1,98 @@
+# BottomNav 분석 영역 재시도 — parentNavigatorKey 트릭 (회차 7 revert follow-up)
+> 날짜: 2026-04-28 | 회차: 10 | 상태: 기획
+
+## 요청 내용
+> "(2) 진행 후 (4) 진행" — 회차 8 result.md 의 Follow-up:
+> (4) BottomNav 분석 영역 재시도 (회차 7 revert 후 follow-up)
+>
+> 회차 7 (PR #204) 은 Tab 1 (/analysis) routes 안에 absolute path 로 9개 sub-page nested 시도 → GoRouter routing table 에 등록 안 됨 → `GoException: no routes for /budgets/edit/<id>` → PR #205 로 즉시 revert.
+
+## 원인 분석 (회차 7)
+- Tab 1 의 parent path = `/analysis`. 회차 7 은 그 routes 안에 `path: '/budgets/create'` (absolute) 로 nested.
+- GoRouter 동작: parent + child 결합은 prefix matching 기반. Parent `/analysis` + child `/budgets/create` 는 같은 prefix 가 아니라 routing table 등록 실패 (no route).
+- 회차 6 Tab 0 sub-page 는 parent `/transactions` + child `'create'` (relative) → `/transactions/create` 등록 성공 (prefix match).
+- Tab 1 의 9개 sub-page 는 prefix 가 다양 (`/budgets`, `/weekly-budgets`, `/reports`, `/period-summary`, `/spending-plans`) → prefix nesting 으로는 URL 보존 불가.
+
+## 변경 방향 — parentNavigatorKey 트릭 (옵션 B)
+GoRouter 의 표준 패턴:
+1. **Sub-page 가 동일 prefix** → routes nested (회차 6 패턴)
+2. **Sub-page 가 다른 prefix** → root level GoRoute + `parentNavigatorKey: <branch_navigator_key>` (회차 10)
+
+각 StatefulShellBranch 의 navigatorKey 를 따로 정의하고, root level GoRoute 의 parentNavigatorKey 를 해당 branch 의 navigatorKey 로 지정 → URL 변경 없이 해당 tab 의 navigator stack 에 push → BottomNav 유지.
+
+회차 7 revert 메시지에서 제안한 두 옵션 ("prefix 매칭 + URL 변경 + redirect" / "ShellRoute outer 도입") 모두 변경 큼. parentNavigatorKey 는 회차 7 plan 에 등장 안 한 옵션이지만 GoRouter 의 정석 패턴이고 변경 최소.
+
+## 작업 계획
+| # | 작업 | 파일 | 난이도 |
+|---|------|------|------|
+| 1 | StatefulShellBranch Tab 1 의 navigatorKey 추가 (`_analysisNavigatorKey`) | app_router.dart | S |
+| 2 | 9개 sub-page GoRoute 의 `parentNavigatorKey` 를 `_rootNavigatorKey` → `_analysisNavigatorKey` 변경 | app_router.dart | S |
+| 3 | URL 변경 없음 검증 (deep link `/budgets/create`, `/reports` 등 정상 + BottomNav 유지) | - | - |
+| 4 | analyze + test + build 회귀 검증 | - | S |
+
+대상 9개 (회차 7 동일):
+- `/budgets/create`
+- `/budgets/edit/:id`
+- `/weekly-budgets`
+- `/weekly-budgets/settlement`
+- `/reports`
+- `/period-summary`
+- `/spending-plans`
+- `/spending-plans/create`
+- `/spending-plans/edit/:id`
+
+## 성능 설계
+- **데이터 접근**: navigation 만 변경. BE 호출 패턴 변동 없음.
+- **예상 규모**: 무관.
+- **리소스 제약**: 무관.
+- **설계 결정**: parentNavigatorKey 트릭은 GoRouter 의 기본 기능. 추가 위젯/state 도입 없음. shell branch 의 기존 navigator stack 재활용.
+
+## 하네스 Scope Audit 결과 (Step 1.5)
+- **실행**: `pre-change-audit.sh . "navigation_state,ui_pattern"`
+- **분류 태그**: `navigation_state`, `ui_pattern`
+- **Recurrence**: ✅ OK (해당 프로젝트 인시던트 0건)
+- **재발 방지 조치**:
+  1. 회차 7 사유 (`absolute path under non-prefix parent`) 를 `audit-patterns.json` 에 신규 패턴 `goroute_absolute_path_nested` 등록.
+  2. `parentNavigatorKey` 누락/잘못 지정 검출 패턴 — `bottomnav_preservation` (v1.8.0) 강화.
+
+## 자동 검증 계획
+- [ ] FE `flutter analyze`
+- [ ] FE `flutter test` (717건 + 추가)
+- [ ] FE `flutter build web`
+- [ ] BE 변경 없음
+
+## 배포 절차
+| # | 단계 | 주체 |
+|---|------|------|
+| 1 | PR 생성 / CI | AI |
+| 2 | squash merge | AI |
+| 3 | deploy watch | AI |
+| 4 | 캐시 무효화 | 사용자 |
+
+## 사용자 검증 시나리오
+
+### A. BottomNav 유지 (URL 변경 없음)
+| # | 경로 | 기대 |
+|---|------|------|
+| A1 | 분석 → 예산 추가 (`/budgets/create`) | BottomNav 유지, URL 변경 없음 |
+| A2 | 분석 → 예산 수정 (`/budgets/edit/:id`) | BottomNav 유지 |
+| A3 | 분석 → 주간 예산 (`/weekly-budgets`) | BottomNav 유지 |
+| A4 | 분석 → 주간 정산 (`/weekly-budgets/settlement`) | BottomNav 유지 |
+| A5 | 분석 → 리포트 (`/reports`) | BottomNav 유지 |
+| A6 | 분석 → 기간 요약 (`/period-summary`) | BottomNav 유지 |
+| A7 | 분석 → 지출 계획 (`/spending-plans`) | BottomNav 유지 |
+| A8 | 지출 계획 → 추가 (`/spending-plans/create`) | BottomNav 유지 |
+| A9 | 지출 계획 → 수정 (`/spending-plans/edit/:id`) | BottomNav 유지 |
+| A10 | 위 페이지 중에서 다른 탭 (거래/자산/설정) 클릭 → 분석 탭 복귀 | navigator stack 보존 |
+
+### B. 회귀 없음
+| # | 확인 | 기대 |
+|---|------|------|
+| B1 | deep link `/budgets/create`, `/reports` 등 직접 진입 | 정상 + BottomNav |
+| B2 | 새로고침 / 뒤로가기 | 정상 |
+| B3 | 회차 1~9 동작 | 변함 없음 |
+| B4 | Tab 0 거래 sub-page (회차 6 패턴) | 변함 없음 |
+| B5 | URL 변경 없이 동작 | path bar 그대로 |
+
+## 사용자 승인
+- [ ] 승인 / 수정 요청: ___

--- a/frontend/lib/core/router/app_router.dart
+++ b/frontend/lib/core/router/app_router.dart
@@ -109,6 +109,12 @@ class _BlocListenable extends ChangeNotifier {
 
 final _rootNavigatorKey = GlobalKey<NavigatorState>();
 
+/// 회차 10 — Tab 1 (분석) navigator key.
+/// 분석 sub-page 9개가 Tab 1 의 nested routes 로 들어가 navigator stack 에 push.
+/// → BottomNav 유지. URL 은 /analysis/budgets/create 등으로 prefix 변경.
+/// 기존 /budgets/create 등 root-level path 는 redirect 으로 backward compat.
+final _analysisNavigatorKey = GlobalKey<NavigatorState>();
+
 /// Key used to store onboarding completion flag in SharedPreferences.
 const String kOnboardingCompleted = 'onboarding_completed';
 
@@ -398,11 +404,202 @@ GoRouter createAppRouter(AuthBloc authBloc) => GoRouter(
           ],
         ),
         // Tab 1: Analysis (Phase 25 Step 11 — 분석 탭 신규, A/B 병존)
+        // 회차 10 — 분석 sub-page 9개를 Tab 1 nested routes 로 이전.
+        // URL prefix `/analysis/` 추가됨. root-level 기존 path 는 redirect 유지.
         StatefulShellBranch(
+          navigatorKey: _analysisNavigatorKey,
           routes: [
             GoRoute(
               path: '/analysis',
               builder: (context, state) => const AnalysisPage(),
+              routes: [
+                GoRoute(
+                  path: 'budgets/create',
+                  builder: (context, state) {
+                    final year = int.tryParse(
+                            state.uri.queryParameters['year'] ?? '') ??
+                        DateTime.now().year;
+                    final month = int.tryParse(
+                            state.uri.queryParameters['month'] ?? '') ??
+                        DateTime.now().month;
+                    getIt<BudgetBloc>().add(LoadBudgets(year: year, month: month));
+                    getIt<CategoryBloc>().add(const LoadCategories());
+                    getIt<PocketBloc>().add(const LoadPockets());
+                    return MultiBlocProvider(
+                      providers: [
+                        BlocProvider<BudgetBloc>.value(
+                          value: getIt<BudgetBloc>(),
+                        ),
+                        BlocProvider<CategoryBloc>.value(
+                          value: getIt<CategoryBloc>(),
+                        ),
+                        BlocProvider<PocketBloc>.value(
+                          value: getIt<PocketBloc>(),
+                        ),
+                      ],
+                      child: BudgetFormPage(year: year, month: month),
+                    );
+                  },
+                ),
+                GoRoute(
+                  path: 'budgets/edit/:id',
+                  builder: (context, state) {
+                    final year = int.tryParse(
+                            state.uri.queryParameters['year'] ?? '') ??
+                        DateTime.now().year;
+                    final month = int.tryParse(
+                            state.uri.queryParameters['month'] ?? '') ??
+                        DateTime.now().month;
+                    getIt<BudgetBloc>().add(LoadBudgets(year: year, month: month));
+                    getIt<CategoryBloc>().add(const LoadCategories());
+                    getIt<PocketBloc>().add(const LoadPockets());
+                    return MultiBlocProvider(
+                      providers: [
+                        BlocProvider<BudgetBloc>.value(
+                          value: getIt<BudgetBloc>(),
+                        ),
+                        BlocProvider<CategoryBloc>.value(
+                          value: getIt<CategoryBloc>(),
+                        ),
+                        BlocProvider<PocketBloc>.value(
+                          value: getIt<PocketBloc>(),
+                        ),
+                      ],
+                      child: BudgetFormPage(
+                        budgetId: state.pathParameters['id'],
+                        year: year,
+                        month: month,
+                      ),
+                    );
+                  },
+                ),
+                GoRoute(
+                  path: 'weekly-budgets',
+                  builder: (context, state) {
+                    final now = DateTime.now();
+                    return BlocProvider<WeeklyBudgetBloc>.value(
+                      value: getIt<WeeklyBudgetBloc>()
+                        ..add(LoadWeeklyOverview(year: now.year, month: now.month))
+                        ..add(const LoadCurrentWeek()),
+                      child: const WeeklyBudgetPage(),
+                    );
+                  },
+                ),
+                GoRoute(
+                  path: 'weekly-budgets/settlement',
+                  builder: (context, state) {
+                    final now = DateTime.now();
+                    return BlocProvider<WeeklySettlementBloc>.value(
+                      value: getIt<WeeklySettlementBloc>()
+                        ..add(LoadSettlements(year: now.year, month: now.month)),
+                      child: const WeeklySettlementPage(),
+                    );
+                  },
+                ),
+                GoRoute(
+                  path: 'reports',
+                  builder: (context, state) {
+                    final now = DateTime.now();
+                    return BlocProvider<ReportBloc>.value(
+                      value: getIt<ReportBloc>()
+                        ..add(LoadMonthlyReport(year: now.year, month: now.month))
+                        ..add(LoadWeeklyReport(
+                            year: now.year, month: now.month, week: 1)),
+                      child: const ReportPage(),
+                    );
+                  },
+                ),
+                GoRoute(
+                  path: 'period-summary',
+                  builder: (context, state) {
+                    final now = DateTime.now();
+                    final dateFrom =
+                        '${now.year}-${now.month.toString().padLeft(2, '0')}-01';
+                    final lastDay = DateTime(now.year, now.month + 1, 0).day;
+                    final dateTo =
+                        '${now.year}-${now.month.toString().padLeft(2, '0')}-${lastDay.toString().padLeft(2, '0')}';
+                    return BlocProvider<PeriodSummaryBloc>.value(
+                      value: getIt<PeriodSummaryBloc>()
+                        ..add(LoadPeriodSummary(dateFrom: dateFrom, dateTo: dateTo)),
+                      child: const PeriodSummaryPage(),
+                    );
+                  },
+                ),
+                GoRoute(
+                  path: 'spending-plans',
+                  builder: (context, state) {
+                    final now = DateTime.now();
+                    final startDate =
+                        '${now.year}-${now.month.toString().padLeft(2, '0')}-01';
+                    final lastDay = DateTime(now.year, now.month + 1, 0).day;
+                    final endDate =
+                        '${now.year}-${now.month.toString().padLeft(2, '0')}-${lastDay.toString().padLeft(2, '0')}';
+                    getIt<SpendingPlanBloc>().add(LoadSpendingPlans(
+                      startDate: startDate,
+                      endDate: endDate,
+                    ));
+                    return BlocProvider<SpendingPlanBloc>.value(
+                      value: getIt<SpendingPlanBloc>(),
+                      child: const SpendingPlanListPage(),
+                    );
+                  },
+                ),
+                GoRoute(
+                  path: 'spending-plans/create',
+                  builder: (context, state) {
+                    getIt<CategoryBloc>().add(const LoadCategories());
+                    getIt<PaymentMethodBloc>().add(const LoadPaymentMethods());
+                    final now = DateTime.now();
+                    getIt<BudgetBloc>().add(LoadBudgets(year: now.year, month: now.month));
+                    return MultiBlocProvider(
+                      providers: [
+                        BlocProvider<SpendingPlanBloc>.value(
+                          value: getIt<SpendingPlanBloc>(),
+                        ),
+                        BlocProvider<CategoryBloc>.value(
+                          value: getIt<CategoryBloc>(),
+                        ),
+                        BlocProvider<PaymentMethodBloc>.value(
+                          value: getIt<PaymentMethodBloc>(),
+                        ),
+                        BlocProvider<BudgetBloc>.value(
+                          value: getIt<BudgetBloc>(),
+                        ),
+                      ],
+                      child: SpendingPlanFormPage(
+                        isWishlist: state.uri.queryParameters['wishlist'] == 'true',
+                      ),
+                    );
+                  },
+                ),
+                GoRoute(
+                  path: 'spending-plans/edit/:id',
+                  builder: (context, state) {
+                    final planId = state.pathParameters['id']!;
+                    getIt<CategoryBloc>().add(const LoadCategories());
+                    getIt<PaymentMethodBloc>().add(const LoadPaymentMethods());
+                    final now = DateTime.now();
+                    getIt<BudgetBloc>().add(LoadBudgets(year: now.year, month: now.month));
+                    return MultiBlocProvider(
+                      providers: [
+                        BlocProvider<SpendingPlanBloc>.value(
+                          value: getIt<SpendingPlanBloc>(),
+                        ),
+                        BlocProvider<CategoryBloc>.value(
+                          value: getIt<CategoryBloc>(),
+                        ),
+                        BlocProvider<PaymentMethodBloc>.value(
+                          value: getIt<PaymentMethodBloc>(),
+                        ),
+                        BlocProvider<BudgetBloc>.value(
+                          value: getIt<BudgetBloc>(),
+                        ),
+                      ],
+                      child: SpendingPlanFormPage(planId: planId),
+                    );
+                  },
+                ),
+              ],
             ),
           ],
         ),
@@ -488,66 +685,24 @@ GoRouter createAppRouter(AuthBloc authBloc) => GoRouter(
     ),
     // 회차 6 — /transactions/{create,edit,detail,import} 라우트는
     // ShellRoute Tab 0 의 nested route 로 이동하여 BottomNav 유지.
+    // 회차 10 — /budgets/{create,edit/:id}, /weekly-budgets, /weekly-budgets/settlement,
+    // /reports, /period-summary, /spending-plans/* 9개는 Tab 1 분석 nested 로 이전.
+    // 기존 path 는 redirect 으로 backward compat (deep link / 북마크).
     GoRoute(
       path: '/budgets/create',
       parentNavigatorKey: _rootNavigatorKey,
-      builder: (context, state) {
-        final year = int.tryParse(
-                state.uri.queryParameters['year'] ?? '') ??
-            DateTime.now().year;
-        final month = int.tryParse(
-                state.uri.queryParameters['month'] ?? '') ??
-            DateTime.now().month;
-        getIt<BudgetBloc>().add(LoadBudgets(year: year, month: month));
-        getIt<CategoryBloc>().add(const LoadCategories());
-        getIt<PocketBloc>().add(const LoadPockets());
-        return MultiBlocProvider(
-          providers: [
-            BlocProvider<BudgetBloc>.value(
-              value: getIt<BudgetBloc>(),
-            ),
-            BlocProvider<CategoryBloc>.value(
-              value: getIt<CategoryBloc>(),
-            ),
-            BlocProvider<PocketBloc>.value(
-              value: getIt<PocketBloc>(),
-            ),
-          ],
-          child: BudgetFormPage(year: year, month: month),
-        );
+      redirect: (context, state) {
+        final q = state.uri.query.isNotEmpty ? '?${state.uri.query}' : '';
+        return '/analysis/budgets/create$q';
       },
     ),
     GoRoute(
       path: '/budgets/edit/:id',
       parentNavigatorKey: _rootNavigatorKey,
-      builder: (context, state) {
-        final year = int.tryParse(
-                state.uri.queryParameters['year'] ?? '') ??
-            DateTime.now().year;
-        final month = int.tryParse(
-                state.uri.queryParameters['month'] ?? '') ??
-            DateTime.now().month;
-        getIt<BudgetBloc>().add(LoadBudgets(year: year, month: month));
-        getIt<CategoryBloc>().add(const LoadCategories());
-        getIt<PocketBloc>().add(const LoadPockets());
-        return MultiBlocProvider(
-          providers: [
-            BlocProvider<BudgetBloc>.value(
-              value: getIt<BudgetBloc>(),
-            ),
-            BlocProvider<CategoryBloc>.value(
-              value: getIt<CategoryBloc>(),
-            ),
-            BlocProvider<PocketBloc>.value(
-              value: getIt<PocketBloc>(),
-            ),
-          ],
-          child: BudgetFormPage(
-            budgetId: state.pathParameters['id'],
-            year: year,
-            month: month,
-          ),
-        );
+      redirect: (context, state) {
+        final id = state.pathParameters['id']!;
+        final q = state.uri.query.isNotEmpty ? '?${state.uri.query}' : '';
+        return '/analysis/budgets/edit/$id$q';
       },
     ),
     GoRoute(
@@ -578,57 +733,33 @@ GoRouter createAppRouter(AuthBloc authBloc) => GoRouter(
     GoRoute(
       path: '/weekly-budgets',
       parentNavigatorKey: _rootNavigatorKey,
-      builder: (context, state) {
-        final now = DateTime.now();
-        return BlocProvider<WeeklyBudgetBloc>.value(
-          value: getIt<WeeklyBudgetBloc>()
-            ..add(LoadWeeklyOverview(year: now.year, month: now.month))
-            ..add(const LoadCurrentWeek()),
-          child: const WeeklyBudgetPage(),
-        );
+      redirect: (context, state) {
+        final q = state.uri.query.isNotEmpty ? '?${state.uri.query}' : '';
+        return '/analysis/weekly-budgets$q';
       },
     ),
     GoRoute(
       path: '/weekly-budgets/settlement',
       parentNavigatorKey: _rootNavigatorKey,
-      builder: (context, state) {
-        final now = DateTime.now();
-        return BlocProvider<WeeklySettlementBloc>.value(
-          value: getIt<WeeklySettlementBloc>()
-            ..add(LoadSettlements(year: now.year, month: now.month)),
-          child: const WeeklySettlementPage(),
-        );
+      redirect: (context, state) {
+        final q = state.uri.query.isNotEmpty ? '?${state.uri.query}' : '';
+        return '/analysis/weekly-budgets/settlement$q';
       },
     ),
     GoRoute(
       path: '/reports',
       parentNavigatorKey: _rootNavigatorKey,
-      builder: (context, state) {
-        final now = DateTime.now();
-        return BlocProvider<ReportBloc>.value(
-          value: getIt<ReportBloc>()
-            ..add(LoadMonthlyReport(year: now.year, month: now.month))
-            ..add(LoadWeeklyReport(
-                year: now.year, month: now.month, week: 1)),
-          child: const ReportPage(),
-        );
+      redirect: (context, state) {
+        final q = state.uri.query.isNotEmpty ? '?${state.uri.query}' : '';
+        return '/analysis/reports$q';
       },
     ),
     GoRoute(
       path: '/period-summary',
       parentNavigatorKey: _rootNavigatorKey,
-      builder: (context, state) {
-        final now = DateTime.now();
-        final dateFrom =
-            '${now.year}-${now.month.toString().padLeft(2, '0')}-01';
-        final lastDay = DateTime(now.year, now.month + 1, 0).day;
-        final dateTo =
-            '${now.year}-${now.month.toString().padLeft(2, '0')}-${lastDay.toString().padLeft(2, '0')}';
-        return BlocProvider<PeriodSummaryBloc>.value(
-          value: getIt<PeriodSummaryBloc>()
-            ..add(LoadPeriodSummary(dateFrom: dateFrom, dateTo: dateTo)),
-          child: const PeriodSummaryPage(),
-        );
+      redirect: (context, state) {
+        final q = state.uri.query.isNotEmpty ? '?${state.uri.query}' : '';
+        return '/analysis/period-summary$q';
       },
     ),
     GoRoute(
@@ -871,82 +1002,30 @@ GoRouter createAppRouter(AuthBloc authBloc) => GoRouter(
         );
       },
     ),
-    // Spending Plans
+    // Spending Plans — 회차 10 redirect to /analysis/spending-plans/*
     GoRoute(
       path: '/spending-plans',
       parentNavigatorKey: _rootNavigatorKey,
-      builder: (context, state) {
-        final now = DateTime.now();
-        final startDate =
-            '${now.year}-${now.month.toString().padLeft(2, '0')}-01';
-        final lastDay = DateTime(now.year, now.month + 1, 0).day;
-        final endDate =
-            '${now.year}-${now.month.toString().padLeft(2, '0')}-${lastDay.toString().padLeft(2, '0')}';
-        getIt<SpendingPlanBloc>().add(LoadSpendingPlans(
-          startDate: startDate,
-          endDate: endDate,
-        ));
-        return BlocProvider<SpendingPlanBloc>.value(
-          value: getIt<SpendingPlanBloc>(),
-          child: const SpendingPlanListPage(),
-        );
+      redirect: (context, state) {
+        final q = state.uri.query.isNotEmpty ? '?${state.uri.query}' : '';
+        return '/analysis/spending-plans$q';
       },
     ),
     GoRoute(
       path: '/spending-plans/create',
       parentNavigatorKey: _rootNavigatorKey,
-      builder: (context, state) {
-        getIt<CategoryBloc>().add(const LoadCategories());
-        getIt<PaymentMethodBloc>().add(const LoadPaymentMethods());
-        final now = DateTime.now();
-        getIt<BudgetBloc>().add(LoadBudgets(year: now.year, month: now.month));
-        return MultiBlocProvider(
-          providers: [
-            BlocProvider<SpendingPlanBloc>.value(
-              value: getIt<SpendingPlanBloc>(),
-            ),
-            BlocProvider<CategoryBloc>.value(
-              value: getIt<CategoryBloc>(),
-            ),
-            BlocProvider<PaymentMethodBloc>.value(
-              value: getIt<PaymentMethodBloc>(),
-            ),
-            BlocProvider<BudgetBloc>.value(
-              value: getIt<BudgetBloc>(),
-            ),
-          ],
-          child: SpendingPlanFormPage(
-            isWishlist: state.uri.queryParameters['wishlist'] == 'true',
-          ),
-        );
+      redirect: (context, state) {
+        final q = state.uri.query.isNotEmpty ? '?${state.uri.query}' : '';
+        return '/analysis/spending-plans/create$q';
       },
     ),
     GoRoute(
       path: '/spending-plans/edit/:id',
       parentNavigatorKey: _rootNavigatorKey,
-      builder: (context, state) {
-        final planId = state.pathParameters['id']!;
-        getIt<CategoryBloc>().add(const LoadCategories());
-        getIt<PaymentMethodBloc>().add(const LoadPaymentMethods());
-        final now = DateTime.now();
-        getIt<BudgetBloc>().add(LoadBudgets(year: now.year, month: now.month));
-        return MultiBlocProvider(
-          providers: [
-            BlocProvider<SpendingPlanBloc>.value(
-              value: getIt<SpendingPlanBloc>(),
-            ),
-            BlocProvider<CategoryBloc>.value(
-              value: getIt<CategoryBloc>(),
-            ),
-            BlocProvider<PaymentMethodBloc>.value(
-              value: getIt<PaymentMethodBloc>(),
-            ),
-            BlocProvider<BudgetBloc>.value(
-              value: getIt<BudgetBloc>(),
-            ),
-          ],
-          child: SpendingPlanFormPage(planId: planId),
-        );
+      redirect: (context, state) {
+        final id = state.pathParameters['id']!;
+        final q = state.uri.query.isNotEmpty ? '?${state.uri.query}' : '';
+        return '/analysis/spending-plans/edit/$id$q';
       },
     ),
     // Insurances


### PR DESCRIPTION
## Summary
- 회차 7 (PR #204→#205 revert) follow-up. absolute path nested 가 GoRouter routing 등록 실패한 사유 → 회차 10 은 **prefix nested + URL `/analysis/...` + redirect** 패턴
- StatefulShellBranch Tab 1 에 `_analysisNavigatorKey` 추가, `/analysis` 의 routes 안에 9개 sub-page 를 relative path 로 nested
- root level 의 기존 9개 GoRoute 를 redirect 으로 교체 (query/path params 보존, deep link 호환)
- audit-patterns v1.10.0 (~/.claude/harness/): `bottomnav_preservation` 강화 + `goroute_absolute_path_nested` 신규

## 옵션 비교
- 옵션 A (채택): URL `/analysis/...` 로 prefix 추가, redirect 으로 backward compat
- 옵션 B (시도→실패): parentNavigatorKey 트릭 — root-level GoRoute 의 parentNavigatorKey 를 branch navigatorKey 로 지정 → GoRouter assertion 위반 (ancestor 가 아님)
- 옵션 C: ShellRoute outer 도입 — 큰 리팩터, 위험

## 영향 sub-page (9)
- /budgets/create, /budgets/edit/:id
- /weekly-budgets, /weekly-budgets/settlement
- /reports, /period-summary
- /spending-plans, /spending-plans/create, /spending-plans/edit/:id

## Test plan
- [x] flutter analyze (no new issues)
- [x] flutter test (717 PASS)
- [x] flutter build web PASS
- [ ] 라이브: 분석 → 예산 추가/수정 → BottomNav 유지
- [ ] 라이브: 주간 예산 / 정산 → BottomNav 유지
- [ ] 라이브: 리포트 / 기간 요약 → BottomNav 유지
- [ ] 라이브: 지출 계획 list/create/edit → BottomNav 유지
- [ ] deep link `/budgets/create`, `/reports` 등 직접 진입 → /analysis/... 로 redirect + BottomNav
- [ ] 회차 1~9 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)