### PR TITLE
docs(sessions): 2026-04-28 회차 10 PASS — BottomNav 분석 nested + (2) 점검

### DIFF
--- a/docs/sessions/2026-04-28_2_result.md
+++ b/docs/sessions/2026-04-28_2_result.md
@@ -1,0 +1,68 @@
+# BottomNav 분석 영역 재시도 + 합계 follow-up 점검 — 결과
+> 날짜: 2026-04-28 | 회차: 10 | 상태: **완료 — 라이브 검증 통과 ("모두 점검 완료")**
+
+회차 8+9 result.md 의 Follow-up (2) + (4) 묶음. (2) 는 점검 결과 회귀 없음 → 변경 불필요. (4) 는 회차 7 (PR #204→#205 revert) 의 absolute path nested 실패 사유를 회피하여 재시도.
+
+## (2) Dashboard / budget summary client fold 점검 — 잔존 회귀 없음
+- **Dashboard (`features/home/...`)**: BE 직접 호출 — `getSummary`, `getBudgetSummary`, `getPaymentMethodStats`, `getMonthlyTrend`, `getCategoryBreakdown`. Client fold (페이지 단위 합계) 사용 안 함.
+- **Budget summary**: `BudgetSummary` 가 BE 응답 entity. `budget.dart:totalPlanned` 의 fold 는 month 단위 budget items 위 (paginated 아님).
+- 점검 범위 외 발견 (회차 8 follow-up (1)): `statistics_bloc` 의 `getSummary` 호출 시 `categoryIds`/`paymentMethodIds`/`pocketIds` 등 multi-filter 미전달 — `StatisticsFilter` 에는 있으나 호출부 누락. **별도 회차로 분리 보류**.
+
+## (4) BottomNav 분석 영역 재시도 — PR #209
+### 회차 7 revert 사유 (PR #205)
+- Tab 1 (`/analysis`) 의 routes 안에 `path: '/budgets/create'` (absolute) 로 nested 시도
+- GoRouter routing table 등록 실패 → `GoException: no routes for /budgets/edit/<id>` → 즉시 revert
+
+### 회차 10 시도 옵션
+| 옵션 | 결과 |
+|------|------|
+| B (parentNavigatorKey 트릭) | 시도 → 실패. branch navigatorKey 가 root-level GoRoute 의 ancestor 가 아님 → GoRouter assertion `parentNavigatorKey must refer to an ancestor ShellRoute's navigatorKey` 위반. 즉시 revert. |
+| **A (prefix nested + URL 변경 + redirect)** | **채택**. URL `/budgets/create` → `/analysis/budgets/create`. root level 에 redirect 으로 backward compat. |
+| C (ShellRoute outer 도입) | 큰 리팩터, 위험 — 미시도. |
+
+### 변경 사항 (PR #209, SHA `004804d`)
+| 파일 | 변경 |
+|------|------|
+| `frontend/lib/core/router/app_router.dart` | StatefulShellBranch Tab 1 에 `_analysisNavigatorKey` 추가. `/analysis` 의 routes 안에 9개 sub-page nested (relative path). root level 의 9개 GoRoute 를 redirect 으로 교체 (query/path params 보존). |
+| `~/.claude/harness/audit-patterns.json` v1.10.0 | `bottomnav_preservation` 강화 + `goroute_absolute_path_nested` 신규. |
+| `docs/sessions/2026-04-28_2_plan.md` | 기획서. |
+
+### 영향 sub-page (9)
+- `/budgets/create`, `/budgets/edit/:id`
+- `/weekly-budgets`, `/weekly-budgets/settlement`
+- `/reports`, `/period-summary`
+- `/spending-plans`, `/spending-plans/create`, `/spending-plans/edit/:id`
+
+각 path 는 root level 에서 `/analysis/{...}$query` 로 redirect. 신규 진입은 모두 Tab 1 navigator stack 에 push → BottomNav 유지.
+
+## 커밋 / PR 이력
+- PR #209 (squash `004804d`) — feat(router): BottomNav 유지 (3차) — Tab 1 분석 9개 nested + URL prefix /analysis/
+- deploy run `25040568132` — success
+
+## 자동 검증 결과
+| 항목 | 결과 |
+|------|------|
+| FE analyze | PASS (3 pre-existing info issues) |
+| FE test | PASS (717건) |
+| FE build web | PASS |
+| CI | PASS |
+| 배포 | SUCCESS |
+
+## 사용자 라이브 검증 결과
+- A1~A9 분석 sub-page 9개 + 탭 전환 navigator stack 보존: **PASS**
+- B1~B3 deep link redirect / 새로고침 / 회차 1~9 회귀 없음: **PASS**
+- 사용자 보고: **"모두 점검 완료"**
+
+## 회고
+- 회차 7 의 absolute path nested 실패 + 회차 10 의 parentNavigatorKey 트릭 실패 → GoRouter 의 routing-tree 제약을 audit-patterns 에 명문화 (`goroute_absolute_path_nested`).
+- URL 변경은 redirect 으로 완전 호환 가능. callsite 변경 없이 deep link / 북마크 모두 작동.
+- 이 패턴은 향후 다른 Tab 의 sub-page 이전에도 재사용 가능 — 회차 8 의 후속 PR (Tab 2 자산 11개, Tab 3 설정 13개) 도 동일 패턴으로 가능.
+
+### Follow-up (회차 11 후보)
+- 회차 8 follow-up (1) — statistics 엔드포인트 multi-filter 누락 (`statistics_bloc` 의 getSummary 호출부에 `categoryIds`/`paymentMethodIds`/`pocketIds` 등 미전달).
+- 회차 8 follow-up (3) — LoadBudgets / LoadStatistics / LoadDashboard 등 Load 이벤트 필터 보존 점검.
+- Tab 2 자산 sub-page 11개 + Tab 3 설정 sub-page 13개 BottomNav 이전 (회차 10 패턴 재사용).
+
+## 롤백 정보
+- PR #209 롤백: `git revert 004804d` (frontend only)
+- 영향 범위: 분석 sub-page 9개 라우팅. URL 형태가 다시 `/budgets/create` 등으로 환원.


### PR DESCRIPTION
## Summary
- 회차 10 result.md — 라이브 검증 통과 ("모두 점검 완료")
- (2) Dashboard / budget summary client fold 점검: 잔존 회귀 없음 (코드 변경 불필요)
- (4) BottomNav 분석 9개 sub-page nested: PR #209 PASS — prefix nested + URL `/analysis/...` + redirect 패턴 (회차 7 revert 후 옵션 B 실패 → 옵션 A 채택)

## Test plan
- 문서만 — 코드 변경 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)