### PR TITLE
fix(month): P2 Phase A — month desync 위급 5개 instance fix

### DIFF
--- a/frontend/lib/core/websocket/sync_event_handler.dart
+++ b/frontend/lib/core/websocket/sync_event_handler.dart
@@ -1,6 +1,7 @@
 import 'package:get_it/get_it.dart';
 import 'package:logger/logger.dart';
 
+import 'package:budget_book/core/bloc/month_cubit.dart';
 import 'package:budget_book/features/transaction/presentation/bloc/transaction_bloc.dart';
 import 'package:budget_book/features/transaction/presentation/bloc/transaction_event.dart';
 import 'package:budget_book/features/budget/presentation/bloc/budget_bloc.dart';
@@ -81,13 +82,16 @@ class SyncEventHandler {
 
   void _refreshTransactions() {
     try {
-      final now = DateTime.now();
+      // 회차 12 P2 Phase A (2026-05-03) — `now.year/month` 강제 사용 회귀 fix.
+      // 사용자가 보던 month (MonthCubit) 유지. 이전: partner 가 거래 추가 시
+      // 사용자 4월 보는 중에도 5월로 list reset.
+      final monthState = _getIt<MonthCubit>().state;
       // 회차 9 — WebSocket sync 시 currentFilter 보존. server-side 변경 시
       // list 가 필터 reset 되지 않도록.
       final bloc = _getIt<TransactionBloc>();
       final f = bloc.currentFilter;
       bloc.add(LoadTransactions(
-        year: now.year, month: now.month,
+        year: monthState.year, month: monthState.month,
         keyword: f.keyword,
         categoryId: f.categoryId,
         categoryIds: f.categoryIds,
@@ -112,9 +116,10 @@ class SyncEventHandler {
 
   void _refreshBudgets() {
     try {
-      final now = DateTime.now();
+      // 회차 12 P2 Phase A — MonthCubit 사용 (사용자가 보던 month 유지).
+      final monthState = _getIt<MonthCubit>().state;
       final bloc = _getIt<BudgetBloc>();
-      bloc.add(LoadBudgets(year: now.year, month: now.month));
+      bloc.add(LoadBudgets(year: monthState.year, month: monthState.month));
       _logger.d('Dispatched LoadBudgets refresh');
     } catch (e) {
       _logger.e('Failed to refresh budgets: $e');
@@ -173,9 +178,10 @@ class SyncEventHandler {
 
   void _refreshTransfers() {
     try {
-      final now = DateTime.now();
+      // 회차 12 P2 Phase A — MonthCubit 사용.
+      final monthState = _getIt<MonthCubit>().state;
       final bloc = _getIt<TransferBloc>();
-      bloc.add(LoadTransfers(year: now.year, month: now.month));
+      bloc.add(LoadTransfers(year: monthState.year, month: monthState.month));
       _logger.d('Dispatched LoadTransfers refresh');
     } catch (e) {
       _logger.e('Failed to refresh transfers: $e');
@@ -184,9 +190,10 @@ class SyncEventHandler {
 
   void _refreshDashboard() {
     try {
-      final now = DateTime.now();
+      // 회차 12 P2 Phase A — MonthCubit 사용.
+      final monthState = _getIt<MonthCubit>().state;
       final bloc = _getIt<DashboardBloc>();
-      bloc.add(LoadDashboard(year: now.year, month: now.month));
+      bloc.add(LoadDashboard(year: monthState.year, month: monthState.month));
       _logger.d('Dispatched LoadDashboard refresh');
     } catch (e) {
       _logger.e('Failed to refresh dashboard: $e');

--- a/frontend/lib/core/widgets/balance_adjustment_sheet.dart
+++ b/frontend/lib/core/widgets/balance_adjustment_sheet.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:budget_book/core/bloc/month_cubit.dart';
 import 'package:budget_book/core/di/injection.dart';
 import 'package:budget_book/core/utils/currency_formatter.dart';
 import 'package:budget_book/core/widgets/calculator_amount_field.dart';
@@ -116,8 +117,10 @@ class _BalanceAdjustmentSheetState extends State<BalanceAdjustmentSheet> {
     ));
 
     // Refresh related blocs
+    // 회차 12 P2 Phase A — dashboard reload 시 보던 month 유지 (MonthCubit).
     getIt<PaymentMethodBloc>().add(const LoadPaymentMethods());
-    getIt<DashboardBloc>().add(LoadDashboard(year: now.year, month: now.month));
+    final monthState = getIt<MonthCubit>().state;
+    getIt<DashboardBloc>().add(LoadDashboard(year: monthState.year, month: monthState.month));
 
     Navigator.of(context).pop(true);
   }

--- a/frontend/lib/core/widgets/main_shell_page.dart
+++ b/frontend/lib/core/widgets/main_shell_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 
+import 'package:budget_book/core/bloc/month_cubit.dart';
 import 'package:budget_book/core/constants/api_endpoints.dart';
 import 'package:budget_book/core/di/injection.dart';
 import 'package:budget_book/core/storage/secure_storage.dart';
@@ -73,7 +74,10 @@ class _MainShellPageState extends State<MainShellPage> {
     // Phase 25 Step 13/14 — 예산/통계 탭 제거. 4탭 최종 인덱스 매핑:
     // 0:거래, 1:분석, 2:자산, 3:더보기
     if (index != previousIndex) {
-      final now = DateTime.now();
+      // 회차 12 P2 Phase A (2026-05-03) — `now.year/month` 강제 사용 회귀 fix.
+      // MonthCubit 단일 source of truth. BottomNav 탭 전환 시 사용자가 보던
+      // month 유지. 이전 회귀: 4월 보던 중 BottomNav 거래 탭 클릭 시 5월로 reset.
+      final monthState = getIt<MonthCubit>().state;
       switch (index) {
         case 0:
           // 회차 9 (2026-04-28) — 탭 전환 시 LoadTransactions 호출 시 currentFilter 보존.
@@ -81,7 +85,7 @@ class _MainShellPageState extends State<MainShellPage> {
           final txnBloc = getIt<TransactionBloc>();
           final f = txnBloc.currentFilter;
           txnBloc.add(LoadTransactions(
-            year: now.year, month: now.month,
+            year: monthState.year, month: monthState.month,
             keyword: f.keyword,
             categoryId: f.categoryId,
             categoryIds: f.categoryIds,
@@ -103,7 +107,7 @@ class _MainShellPageState extends State<MainShellPage> {
           // Tab 2 (Assets) — refresh payment method data + card settlement summary
           getIt<PaymentMethodBloc>().add(const LoadPaymentMethods());
           getIt<PaymentMethodBloc>().add(
-              LoadCardSettlementSummary(year: now.year, month: now.month));
+              LoadCardSettlementSummary(year: monthState.year, month: monthState.month));
         // Tab 3 (Settings) needs no refresh
       }
     }

--- a/frontend/lib/features/transaction/presentation/pages/transaction_form_page.dart
+++ b/frontend/lib/features/transaction/presentation/pages/transaction_form_page.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:budget_book/features/transaction/domain/repositories/transaction_repository.dart';
+import 'package:budget_book/core/bloc/month_cubit.dart';
 import 'package:budget_book/core/utils/dialog_helpers.dart';
 import 'package:budget_book/core/utils/ui_helpers.dart';
 import 'package:budget_book/core/services/couple_prefs.dart';
@@ -530,8 +531,11 @@ class _TransactionFormPageState extends State<TransactionFormPage>
             if (state is TransactionLoaded) {
               _submitTimeoutTimer?.cancel();
               _isSubmitting = false;
-              final now = DateTime.now();
-              getIt<DashboardBloc>().add(LoadDashboard(year: now.year, month: now.month));
+              // 회차 12 P2 Phase A — 거래 등록 후 dashboard reload 시 사용자가 보던
+              // month 유지 (MonthCubit). 이전: now 강제로 다른 월 보던 사용자에게
+              // 현재월 dashboard 가 표시되어 sync 깨짐.
+              final monthState = getIt<MonthCubit>().state;
+              getIt<DashboardBloc>().add(LoadDashboard(year: monthState.year, month: monthState.month));
               getIt<PaymentMethodBloc>().add(const LoadPaymentMethods());
               if (_continueMode) {
                 _resetFormForContinue();

--- a/frontend/test/core/websocket/sync_event_handler_test.dart
+++ b/frontend/test/core/websocket/sync_event_handler_test.dart
@@ -3,6 +3,7 @@ import 'package:get_it/get_it.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:dartz/dartz.dart';
 
+import 'package:budget_book/core/bloc/month_cubit.dart';
 import 'package:budget_book/core/websocket/sync_event.dart';
 import 'package:budget_book/core/websocket/sync_event_handler.dart';
 import 'package:budget_book/core/error/failure.dart';
@@ -131,6 +132,8 @@ void main() {
     testGetIt.registerFactory<CategoryBloc>(() => categoryBloc);
     testGetIt.registerFactory<PaymentMethodBloc>(() => paymentMethodBloc);
     testGetIt.registerFactory<CategoryGroupBloc>(() => categoryGroupBloc);
+    // 회차 12 P2 Phase A — sync handler 가 MonthCubit 사용 (사용자가 보던 month 유지).
+    testGetIt.registerLazySingleton<MonthCubit>(() => MonthCubit());
 
     handler = SyncEventHandler(getIt: testGetIt);
   });

--- a/frontend/test/core/widgets/balance_adjustment_sheet_test.dart
+++ b/frontend/test/core/widgets/balance_adjustment_sheet_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:bloc_test/bloc_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:budget_book/core/bloc/month_cubit.dart';
 import 'package:budget_book/core/di/injection.dart';
 import 'package:budget_book/core/widgets/balance_adjustment_sheet.dart';
 import 'package:budget_book/features/transaction/presentation/bloc/transaction_bloc.dart';
@@ -52,16 +53,20 @@ void main() {
     if (getIt.isRegistered<TransactionBloc>()) getIt.unregister<TransactionBloc>();
     if (getIt.isRegistered<PaymentMethodBloc>()) getIt.unregister<PaymentMethodBloc>();
     if (getIt.isRegistered<DashboardBloc>()) getIt.unregister<DashboardBloc>();
+    if (getIt.isRegistered<MonthCubit>()) getIt.unregister<MonthCubit>();
 
     getIt.registerSingleton<TransactionBloc>(mockTransactionBloc);
     getIt.registerSingleton<PaymentMethodBloc>(mockPaymentMethodBloc);
     getIt.registerSingleton<DashboardBloc>(mockDashboardBloc);
+    // 회차 12 P2 Phase A — sheet 가 MonthCubit 사용 (보던 month 유지).
+    getIt.registerLazySingleton<MonthCubit>(() => MonthCubit());
   });
 
   tearDown(() {
     if (getIt.isRegistered<TransactionBloc>()) getIt.unregister<TransactionBloc>();
     if (getIt.isRegistered<PaymentMethodBloc>()) getIt.unregister<PaymentMethodBloc>();
     if (getIt.isRegistered<DashboardBloc>()) getIt.unregister<DashboardBloc>();
+    if (getIt.isRegistered<MonthCubit>()) getIt.unregister<MonthCubit>();
   });
 
   Widget buildSheet({int currentBalance = 150000}) {


### PR DESCRIPTION
## Summary
회차 12 P2 (2026-05-03) — 월 desync 회귀 위급 fix.

사용자 4월 보던 중:
- BottomNav 거래 탭 재클릭 → 5월 강제 reset
- partner WS sync → 5월 강제 reset
- 거래 등록 후 dashboard reload → 5월 강제 reset

→ MonthCubit (4월) vs BLoC (5월) desync. UX 인지: 달력 4월, 거래 5월.

## 변경 (5개 위급 instance + balance sheet 추가)
**MonthCubit 단일 source of truth 적용**:

| 위치 | 이전 | 이후 |
|------|------|------|
| main_shell_page case 0 (거래 탭) | now.year/month | MonthCubit.state |
| main_shell_page case 2 (자산 탭 settlement) | now | MonthCubit.state |
| sync_event_handler._refreshTransactions | now | MonthCubit.state |
| sync_event_handler._refreshBudgets | now | MonthCubit.state |
| sync_event_handler._refreshTransfers | now | MonthCubit.state |
| sync_event_handler._refreshDashboard | now | MonthCubit.state |
| transaction_form_page submit 후 dashboard | now | MonthCubit.state |
| balance_adjustment_sheet submit 후 dashboard | now | MonthCubit.state |

테스트 setUp 에 MonthCubit 등록 추가.

## Out of scope (별도 PR)
- Phase B: app_router 의 sub-page builder 11곳 (helper 도입)
- Phase C: BLoC `_currentYear/Month` 단일화 + audit-patterns 신규

## Test plan
- [x] flutter analyze (no new issues)
- [x] flutter test (717 PASS)
- [x] flutter build web PASS
- [ ] 라이브: 거래 4월 → 자산 → 결제수단 → 거래 BottomNav 재클릭 → 4월 유지
- [ ] 라이브: partner 거래 추가 시 (WS sync) 보던 4월 유지
- [ ] 라이브: 거래 등록 후 dashboard 보던 month 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)