### PR TITLE
fix(transaction): P5 — 거래 폼 controller 단일화 (이체 탭 공통 입력 보존)

### DIFF
--- a/frontend/lib/features/transaction/presentation/pages/transaction_form_page.dart
+++ b/frontend/lib/features/transaction/presentation/pages/transaction_form_page.dart
@@ -144,10 +144,10 @@ class _TransactionFormPageState extends State<TransactionFormPage>
   late final TabController _tabController;
 
   // Transfer form fields (used when tab index == 2)
+  // 회차 12 P5 (2026-05-03) — 공통 controllers (_amountController/_descriptionController/_memoController)
+  // 사용으로 통일. _transfer*Controller 별도 controllers 제거.
+  // 사용자 요구: 수입/지출/예산/이체 탭 전환 시 공통 항목 (금액/설명/메모) 유지.
   final _transferFormKey = GlobalKey<FormState>();
-  late final TextEditingController _transferAmountController;
-  late final TextEditingController _transferDescriptionController;
-  late final TextEditingController _transferMemoController;
   String? _transferSourcePaymentMethodId;
   String? _transferDestinationPaymentMethodId;
   late DateTime _transferDate;
@@ -199,10 +199,7 @@ class _TransactionFormPageState extends State<TransactionFormPage>
         : 'EXPENSE';
     _selectedDate = widget.initialDate ?? DateTime.now();
 
-    // Initialize transfer form controllers
-    _transferAmountController = TextEditingController();
-    _transferDescriptionController = TextEditingController();
-    _transferMemoController = TextEditingController();
+    // 회차 12 P5 — transfer 별도 controllers 제거. 공통 controller 사용.
     _transferDate = widget.initialDate ?? DateTime.now();
 
     if (isEditing) {
@@ -498,9 +495,6 @@ class _TransactionFormPageState extends State<TransactionFormPage>
     _amountController.dispose();
     _descriptionController.dispose();
     _memoController.dispose();
-    _transferAmountController.dispose();
-    _transferDescriptionController.dispose();
-    _transferMemoController.dispose();
     _categoryFocusNode.dispose();
     _paymentMethodFocusNode.dispose();
     _pocketFocusNode.dispose();
@@ -918,7 +912,8 @@ class _TransactionFormPageState extends State<TransactionFormPage>
       }
     }
 
-    final amount = CurrencyFormatter.parse(_transferAmountController.text);
+    // 회차 12 P5 — 공통 controller 사용으로 통일.
+    final amount = CurrencyFormatter.parse(_amountController.text);
     if (amount == null || amount <= 0) {
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('금액을 입력해주세요')),
@@ -926,12 +921,12 @@ class _TransactionFormPageState extends State<TransactionFormPage>
       return;
     }
 
-    final description = _transferDescriptionController.text.trim().isEmpty
+    final description = _descriptionController.text.trim().isEmpty
         ? null
-        : _transferDescriptionController.text.trim();
-    final memo = _transferMemoController.text.trim().isEmpty
+        : _descriptionController.text.trim();
+    final memo = _memoController.text.trim().isEmpty
         ? null
-        : _transferMemoController.text.trim();
+        : _memoController.text.trim();
     final dateStr = DateFormat('yyyy-MM-dd').format(_transferDate);
 
     setState(() => _isTransferSubmitting = true);
@@ -998,9 +993,9 @@ class _TransactionFormPageState extends State<TransactionFormPage>
               ),
             ),
             const SizedBox(height: 16),
-            // Amount
+            // Amount — 회차 12 P5: 공통 controller 사용 (수입/지출/이체 간 유지).
             AmountInputField(
-              controller: _transferAmountController,
+              controller: _amountController,
               labelText: '금액',
               filterDigitsOnly: true,
               validator: (value) {
@@ -1097,9 +1092,9 @@ class _TransactionFormPageState extends State<TransactionFormPage>
                   value == null ? '입금 결제수단을 선택하세요' : null,
             ),
             const SizedBox(height: 16),
-            // Description
+            // Description — 회차 12 P5: 공통 controller 사용
             TextFormField(
-              controller: _transferDescriptionController,
+              controller: _descriptionController,
               decoration: const InputDecoration(
                 labelText: '내용 (선택)',
                 prefixIcon: Icon(Icons.description),
@@ -1108,9 +1103,9 @@ class _TransactionFormPageState extends State<TransactionFormPage>
               maxLength: 255,
             ),
             const SizedBox(height: 8),
-            // Memo
+            // Memo — 회차 12 P5: 공통 controller 사용
             TextFormField(
-              controller: _transferMemoController,
+              controller: _memoController,
               decoration: const InputDecoration(
                 labelText: '메모 (선택)',
                 prefixIcon: Icon(Icons.notes),


### PR DESCRIPTION
## Summary
회차 12 P5 — 거래 등록 폼 이체 탭 진입 시 금액/설명/메모 사라짐 회귀.

Root cause: transaction_form_page 가 transfer tab 별도 controllers 사용.
- `_amountController` (수입/지출 탭) ↔ `_transferAmountController` (이체 탭)
- `_descriptionController` ↔ `_transferDescriptionController`
- `_memoController` ↔ `_transferMemoController`

탭 전환 시 sync 코드 없음 → 사용자 입력 drop.

## Fix
공통 controller 단일화 — `_transfer*Controller` 3개 제거. 이체 탭도 공통 controller 사용.

## 동일 패턴 sweep
- transfer_form_page / budget_form_page / spending_plan_form_page: 단일 controller 만 — 동일 패턴 없음
- 회차 12 분석에서 transaction_form_page 만 해당 확인됨

## Test plan
- [x] flutter analyze (no new issues)
- [x] flutter test (717 PASS)
- [x] flutter build web PASS
- [ ] 라이브: 거래 등록 폼 → 금액 100,000 입력 → 이체 탭 클릭 → 100,000 유지
- [ ] 라이브: 이체 탭에서 입력 → 지출 탭 → 입력 유지
- [ ] 라이브: 이체 submit 정상 (공통 controller 의 값 사용)
- [ ] 회귀: 거래 1~11-1 동작 변함 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)