### PR TITLE
fix(transaction): P3 — 카테고리 표시 통일 (자동 선택도 그룹 > 하위)

### DIFF
--- a/frontend/lib/core/utils/category_display_helper.dart
+++ b/frontend/lib/core/utils/category_display_helper.dart
@@ -1,0 +1,37 @@
+import 'package:budget_book/core/di/injection.dart';
+import 'package:budget_book/features/category_group/presentation/bloc/category_group_bloc.dart';
+import 'package:budget_book/features/category_group/presentation/bloc/category_group_state.dart';
+
+/// 회차 12 P3 (2026-05-03) — 카테고리 표시 통일 helper.
+///
+/// 자동 선택 (suggestion / AI) 응답은 categoryGroupName 정보 없음 →
+/// CategoryGroupBloc lookup 으로 "$groupName > $categoryName" 형식 build.
+///
+/// 사용처 (모든 categoryName 만 받는 응답 표시):
+/// - transaction_form_page._applySuggestionPattern (suggestion 자동 선택)
+/// - transaction_form_page._applyAiCategory (AI 자동 선택)
+/// - 그 외 categoryName 만 받는 응답 표시 시 통일
+///
+/// fallback: groupName lookup 실패 시 categoryName 만 반환.
+String formatCategoryDisplay(
+  String? categoryId, {
+  required String categoryName,
+}) {
+  if (categoryId == null || categoryId.isEmpty) return categoryName;
+
+  // CategoryGroupBloc 은 singleton (di/injection 등록).
+  final groupBloc = getIt<CategoryGroupBloc>();
+  final state = groupBloc.state;
+  if (state is! CategoryGroupLoaded) return categoryName;
+
+  for (final group in state.groups) {
+    for (final category in group.categories) {
+      if (category.id == categoryId) {
+        return group.name.isNotEmpty
+            ? '${group.name} > $categoryName'
+            : categoryName;
+      }
+    }
+  }
+  return categoryName;
+}

--- a/frontend/lib/features/transaction/presentation/pages/transaction_form_page.dart
+++ b/frontend/lib/features/transaction/presentation/pages/transaction_form_page.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:budget_book/features/transaction/domain/repositories/transaction_repository.dart';
 import 'package:budget_book/core/bloc/month_cubit.dart';
+import 'package:budget_book/core/utils/category_display_helper.dart';
 import 'package:budget_book/core/utils/dialog_helpers.dart';
 import 'package:budget_book/core/utils/ui_helpers.dart';
 import 'package:budget_book/core/services/couple_prefs.dart';
@@ -437,7 +438,13 @@ class _TransactionFormPageState extends State<TransactionFormPage>
           TextSelection.collapsed(offset: group.description.length);
       if (pattern != null) {
         _selectedCategoryId = pattern.categoryId;
-        _selectedCategoryDisplayName = pattern.categoryName;
+        // 회차 12 P3 — 자동 선택도 picker 직접 선택과 동일한 "그룹 > 하위" 형식.
+        _selectedCategoryDisplayName = pattern.categoryName != null
+            ? formatCategoryDisplay(
+                pattern.categoryId,
+                categoryName: pattern.categoryName!,
+              )
+            : null;
         _selectedPaymentMethodId = pattern.paymentMethodId;
       }
       _suggestions = [];
@@ -470,7 +477,11 @@ class _TransactionFormPageState extends State<TransactionFormPage>
   void _applyAiCategory(AiClassifyResult result) {
     setState(() {
       _selectedCategoryId = result.categoryId;
-      _selectedCategoryDisplayName = result.categoryName;
+      // 회차 12 P3 — AI 추천도 "그룹 > 하위" 형식 통일.
+      _selectedCategoryDisplayName = formatCategoryDisplay(
+        result.categoryId,
+        categoryName: result.categoryName,
+      );
       _aiResult = null;
     });
   }
@@ -733,7 +744,8 @@ class _TransactionFormPageState extends State<TransactionFormPage>
                       padding: const EdgeInsets.only(top: 8, bottom: 4),
                       child: ActionChip(
                         avatar: const Icon(Icons.auto_awesome, size: 16),
-                        label: Text('AI 추천: ${_aiResult!.categoryName}'),
+                        // 회차 12 P3 — AI 추천 chip 도 "그룹 > 하위" 형식.
+                        label: Text('AI 추천: ${formatCategoryDisplay(_aiResult!.categoryId, categoryName: _aiResult!.categoryName)}'),
                         onPressed: () => _applyAiCategory(_aiResult!),
                       ),
                     ),
@@ -1195,8 +1207,12 @@ class _TransactionFormPageState extends State<TransactionFormPage>
             const SizedBox(height: 4),
             // Grouped patterns sorted by count
             ..._expandedSuggestion!.patterns.map((p) {
+              // 회차 12 P3 — suggestion picker label 도 "그룹 > 하위" 형식.
+              final categoryLabel = p.categoryId != null && p.categoryName != null
+                  ? formatCategoryDisplay(p.categoryId, categoryName: p.categoryName!)
+                  : p.categoryName;
               final label = [
-                p.categoryName,
+                categoryLabel,
                 p.paymentMethodName,
               ].where((s) => s != null).join(' · ');
               return Padding(


### PR DESCRIPTION
## Summary
회차 12 P3 — 자동 선택 시 카테고리 하위 이름만 표시 → 직접 선택과 동일한 "그룹 > 하위" 형식으로 통일.

Root cause: SuggestionPattern / AiClassifyResult 응답에 categoryGroupName 정보 없음.

## Fix
- 신규 helper `formatCategoryDisplay(categoryId, categoryName)` — CategoryGroupBloc lookup
- 4 instance 수정:
  - `_applySuggestionPattern` (suggestion 자동 선택)
  - `_applyAiCategory` (AI 자동 선택)
  - AI 추천 chip label
  - suggestion picker label

## 동일 패턴 sweep
- 다른 표시 위치 14곳 (list_tile, detail_page, dashboard, 통계, 주간, 예산 list 등) 은 모두 entity 의 `displayName` getter 사용 → 이미 정상
- 변경 불필요

## Test plan
- [x] flutter analyze
- [x] flutter test (717 PASS)
- [x] flutter build web PASS
- [ ] 라이브: 거래 폼에서 내용 입력 → suggestion 자동 선택 시 "그룹 > 하위" 표시
- [ ] 라이브: AI 추천 chip 도 "그룹 > 하위" 형식
- [ ] 라이브: suggestion picker 의 pattern label "그룹 > 하위 · 결제수단" 형식
- [ ] 회귀: 직접 picker 선택 시 변함 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)