### PR TITLE
fix(budget): P4 — 예산-계획 도메인 분리 (Phase A+B)

### DIFF
--- a/backend/src/main/kotlin/com/budgetbook/budget/service/BudgetService.kt
+++ b/backend/src/main/kotlin/com/budgetbook/budget/service/BudgetService.kt
@@ -644,21 +644,23 @@ class BudgetService(
             emptyMap()
         }
 
-        // Pre-compute planned amounts from spending plans (WISHLIST/PLANNED status)
+        // 회차 12 P4 (2026-05-03) — month 필터 추가. 이전: 모든 spending plan
+        // 합산 → 입력 안 한 달에도 plannedAmount 표시. targetDate IS NULL 인
+        // plan 은 모든 월 포함 (날짜 미지정 의도 반영).
         val categoryIds = budgets.mapNotNull { it.category?.id }.toSet()
         val plannedByCategory: Map<UUID, Long> = if (categoryIds.isNotEmpty()) {
-            spendingPlanRepository.sumPlannedAmountByCategoryIds(couple.id, categoryIds, userId)
+            spendingPlanRepository.sumPlannedAmountByCategoryIds(couple.id, categoryIds, userId, startDate, endDate)
                 .associate { row -> (row[0] as UUID) to (row[1] as Long) }
         } else {
             emptyMap()
         }
         val plannedByGroup: Map<UUID, Long> = if (groupIds.isNotEmpty()) {
-            spendingPlanRepository.sumPlannedAmountByGroupIds(couple.id, groupIds, userId)
+            spendingPlanRepository.sumPlannedAmountByGroupIds(couple.id, groupIds, userId, startDate, endDate)
                 .associate { row -> (row[0] as UUID) to (row[1] as Long) }
         } else {
             emptyMap()
         }
-        val totalPlannedAmount = spendingPlanRepository.sumTotalPlannedAmount(couple.id, userId)
+        val totalPlannedAmount = spendingPlanRepository.sumTotalPlannedAmount(couple.id, userId, startDate, endDate)
 
         val items = budgets.map { budget ->
             val categoryId = budget.category?.id

--- a/backend/src/main/kotlin/com/budgetbook/spendingplan/repository/SpendingPlanRepository.kt
+++ b/backend/src/main/kotlin/com/budgetbook/spendingplan/repository/SpendingPlanRepository.kt
@@ -65,6 +65,10 @@ interface SpendingPlanRepository : JpaRepository<SpendingPlan, UUID> {
         @Param("endDate") endDate: LocalDate
     ): List<SpendingPlan>
 
+    // 회차 12 P4 (2026-05-03) — month 필터 추가.
+    // 이전 버그: target month 무관하게 모든 spending plan 합산 → budget UI 에서
+    // 입력 안 한 달에도 plannedAmount 0 아닌 값 표시 (도메인 분리 위반).
+    // targetDate IS NULL (날짜 미지정 plan) 은 모든 월에 포함.
     @Query("""
         SELECT sp.category.id, COALESCE(SUM(sp.amount), 0)
         FROM SpendingPlan sp
@@ -72,12 +76,15 @@ interface SpendingPlanRepository : JpaRepository<SpendingPlan, UUID> {
         AND sp.category.id IN :categoryIds
         AND sp.status IN (com.budgetbook.spendingplan.domain.SpendingPlanStatus.WISHLIST, com.budgetbook.spendingplan.domain.SpendingPlanStatus.PLANNED)
         AND (sp.visibility = com.budgetbook.common.entity.Visibility.SHARED OR sp.owner.id = :userId)
+        AND (sp.targetDate IS NULL OR sp.targetDate BETWEEN :startDate AND :endDate)
         GROUP BY sp.category.id
     """)
     fun sumPlannedAmountByCategoryIds(
         @Param("coupleId") coupleId: UUID,
         @Param("categoryIds") categoryIds: Set<UUID>,
-        @Param("userId") userId: UUID
+        @Param("userId") userId: UUID,
+        @Param("startDate") startDate: LocalDate,
+        @Param("endDate") endDate: LocalDate
     ): List<Array<Any>>
 
     @Query("""
@@ -86,10 +93,13 @@ interface SpendingPlanRepository : JpaRepository<SpendingPlan, UUID> {
         WHERE sp.couple.id = :coupleId
         AND sp.status IN (com.budgetbook.spendingplan.domain.SpendingPlanStatus.WISHLIST, com.budgetbook.spendingplan.domain.SpendingPlanStatus.PLANNED)
         AND (sp.visibility = com.budgetbook.common.entity.Visibility.SHARED OR sp.owner.id = :userId)
+        AND (sp.targetDate IS NULL OR sp.targetDate BETWEEN :startDate AND :endDate)
     """)
     fun sumTotalPlannedAmount(
         @Param("coupleId") coupleId: UUID,
-        @Param("userId") userId: UUID
+        @Param("userId") userId: UUID,
+        @Param("startDate") startDate: LocalDate,
+        @Param("endDate") endDate: LocalDate
     ): Long
 
     @Query("""
@@ -101,12 +111,15 @@ interface SpendingPlanRepository : JpaRepository<SpendingPlan, UUID> {
         AND cg.id IN :groupIds
         AND sp.status IN (com.budgetbook.spendingplan.domain.SpendingPlanStatus.WISHLIST, com.budgetbook.spendingplan.domain.SpendingPlanStatus.PLANNED)
         AND (sp.visibility = com.budgetbook.common.entity.Visibility.SHARED OR sp.owner.id = :userId)
+        AND (sp.targetDate IS NULL OR sp.targetDate BETWEEN :startDate AND :endDate)
         GROUP BY cg.id
     """)
     fun sumPlannedAmountByGroupIds(
         @Param("coupleId") coupleId: UUID,
         @Param("groupIds") groupIds: Set<UUID>,
-        @Param("userId") userId: UUID
+        @Param("userId") userId: UUID,
+        @Param("startDate") startDate: LocalDate,
+        @Param("endDate") endDate: LocalDate
     ): List<Array<Any>>
 
     fun findByIdAndCoupleId(id: UUID, coupleId: UUID): SpendingPlan?

--- a/backend/src/main/kotlin/com/budgetbook/statistics/service/StatisticsService.kt
+++ b/backend/src/main/kotlin/com/budgetbook/statistics/service/StatisticsService.kt
@@ -495,17 +495,18 @@ class StatisticsService(
             couple.id, dateFrom, dateTo, TransactionType.EXPENSE, userId
         )
 
+        // 회차 12 P4 — month 필터 적용 (period-summary 의 dateFrom/To 기준).
         val plannedByCategory = if (budgetCategoryIds.isNotEmpty()) {
-            spendingPlanRepository.sumPlannedAmountByCategoryIds(couple.id, budgetCategoryIds, userId)
+            spendingPlanRepository.sumPlannedAmountByCategoryIds(couple.id, budgetCategoryIds, userId, dateFrom, dateTo)
                 .associate { (it[0] as UUID) to (it[1] as Long) }
         } else emptyMap()
 
         val plannedByGroup = if (budgetGroupIds.isNotEmpty()) {
-            spendingPlanRepository.sumPlannedAmountByGroupIds(couple.id, budgetGroupIds, userId)
+            spendingPlanRepository.sumPlannedAmountByGroupIds(couple.id, budgetGroupIds, userId, dateFrom, dateTo)
                 .associate { (it[0] as UUID) to (it[1] as Long) }
         } else emptyMap()
 
-        val totalPlanned = spendingPlanRepository.sumTotalPlannedAmount(couple.id, userId)
+        val totalPlanned = spendingPlanRepository.sumTotalPlannedAmount(couple.id, userId, dateFrom, dateTo)
 
         val byBudget = allBudgets.map { budget ->
             val catId = budget.category?.id

--- a/backend/src/test/kotlin/com/budgetbook/budget/service/BudgetServiceTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/budget/service/BudgetServiceTest.kt
@@ -60,9 +60,9 @@ class BudgetServiceTest : BehaviorSpec({
     val category = Category(couple = couple, name = "식비", type = CategoryType.EXPENSE, icon = "restaurant", color = "#FF5733", isDefault = true)
 
     // Default: no planned spending (individual tests can override)
-    every { spendingPlanRepository.sumPlannedAmountByCategoryIds(any(), any(), any()) } returns emptyList()
-    every { spendingPlanRepository.sumPlannedAmountByGroupIds(any(), any(), any()) } returns emptyList()
-    every { spendingPlanRepository.sumTotalPlannedAmount(any(), any()) } returns 0L
+    every { spendingPlanRepository.sumPlannedAmountByCategoryIds(any(), any(), any(), any(), any()) } returns emptyList()
+    every { spendingPlanRepository.sumPlannedAmountByGroupIds(any(), any(), any(), any(), any()) } returns emptyList()
+    every { spendingPlanRepository.sumTotalPlannedAmount(any(), any(), any(), any()) } returns 0L
 
     // --- createBudget ---
 
@@ -771,10 +771,11 @@ class BudgetServiceTest : BehaviorSpec({
         ) } returns 80000L
 
         // Planned spending: 30000 for category, 50000 total
-        every { spendingPlanRepository.sumPlannedAmountByCategoryIds(couple.id, setOf(category.id), user1.id) } returns listOf(
+        // 회차 12 P4 — month 필터 인자 추가
+        every { spendingPlanRepository.sumPlannedAmountByCategoryIds(couple.id, setOf(category.id), user1.id, any(), any()) } returns listOf(
             arrayOf(category.id as Any, 30000L as Any)
         )
-        every { spendingPlanRepository.sumTotalPlannedAmount(couple.id, user1.id) } returns 50000L
+        every { spendingPlanRepository.sumTotalPlannedAmount(couple.id, user1.id, any(), any()) } returns 50000L
 
         When("getBudgetSummary is called") {
             val result = service.getBudgetSummary(user1.id, 2026, 3)

--- a/backend/src/test/kotlin/com/budgetbook/statistics/service/StatisticsServiceTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/statistics/service/StatisticsServiceTest.kt
@@ -498,7 +498,7 @@ class StatisticsServiceTest : BehaviorSpec({
             } returns 3200000L
 
             // spending plan
-            every { spendingPlanRepository.sumTotalPlannedAmount(couple.id, user1.id) } returns 0L
+            every { spendingPlanRepository.sumTotalPlannedAmount(couple.id, user1.id, any(), any()) } returns 0L
 
             // byPaymentMethod
             every {
@@ -560,7 +560,7 @@ class StatisticsServiceTest : BehaviorSpec({
                 transactionRepository.sumAmountByCoupleIdAndDateRange(couple.id, dateFrom, dateTo, TransactionType.EXPENSE, user1.id)
             } returns 0L
 
-            every { spendingPlanRepository.sumTotalPlannedAmount(couple.id, user1.id) } returns 0L
+            every { spendingPlanRepository.sumTotalPlannedAmount(couple.id, user1.id, any(), any()) } returns 0L
 
             every {
                 transactionRepository.sumByPaymentMethodWithTypeForCouple(couple.id, dateFrom, dateTo, any(), "ALL")
@@ -615,7 +615,7 @@ class StatisticsServiceTest : BehaviorSpec({
             every {
                 transactionRepository.sumAmountByCoupleIdAndDateRange(couple.id, dateFrom, dateTo, TransactionType.EXPENSE, user1.id)
             } returns 3000000L
-            every { spendingPlanRepository.sumTotalPlannedAmount(couple.id, user1.id) } returns 0L
+            every { spendingPlanRepository.sumTotalPlannedAmount(couple.id, user1.id, any(), any()) } returns 0L
             every {
                 transactionRepository.sumByPaymentMethodWithTypeForCouple(couple.id, dateFrom, dateTo, any(), "ALL")
             } returns emptyList()
@@ -694,7 +694,7 @@ class StatisticsServiceTest : BehaviorSpec({
             every {
                 transactionRepository.sumAmountByCoupleIdAndDateRange(couple.id, dateFrom, dateTo, TransactionType.EXPENSE, user1.id)
             } returns 2500000L
-            every { spendingPlanRepository.sumTotalPlannedAmount(couple.id, user1.id) } returns 0L
+            every { spendingPlanRepository.sumTotalPlannedAmount(couple.id, user1.id, any(), any()) } returns 0L
             every {
                 transactionRepository.sumByPaymentMethodWithTypeForCouple(couple.id, dateFrom, dateTo, any(), "ALL")
             } returns emptyList()
@@ -739,7 +739,7 @@ class StatisticsServiceTest : BehaviorSpec({
             every {
                 transactionRepository.sumAmountByCoupleIdAndDateRange(couple.id, dateFrom, dateTo, TransactionType.EXPENSE, user1.id)
             } returns 0L
-            every { spendingPlanRepository.sumTotalPlannedAmount(couple.id, user1.id) } returns 0L
+            every { spendingPlanRepository.sumTotalPlannedAmount(couple.id, user1.id, any(), any()) } returns 0L
             every {
                 transactionRepository.sumByPaymentMethodWithTypeForCouple(couple.id, dateFrom, dateTo, any(), "ALL")
             } returns emptyList()

--- a/frontend/lib/features/budget/presentation/pages/budget_list_page.dart
+++ b/frontend/lib/features/budget/presentation/pages/budget_list_page.dart
@@ -765,7 +765,10 @@ class _BudgetListPageState extends State<BudgetListPage> {
     );
   }
 
-  /// 3-segment progress bar: spent (solid) + planned (semi-transparent) + remaining (grey).
+  /// 회차 12 P4 (2026-05-03) — 도메인 분리.
+  /// 이전: 3-segment (spent + planned + remaining). 사용자 요구로 plannedAmount
+  /// 표시 제거 (계획 정보는 별도 분석 영역으로 이전 예정). 2-segment
+  /// (spent + remaining) 단순 progress bar.
   Widget _buildBudgetProgressBar(
     BuildContext context,
     BudgetSummaryItem? summaryItem,
@@ -776,81 +779,23 @@ class _BudgetListPageState extends State<BudgetListPage> {
     }
 
     final spentAmount = summaryItem?.spentAmount ?? 0;
-    final plannedAmount = summaryItem?.plannedAmount ?? 0;
-
     final spentRatio = (spentAmount / budgetAmount).clamp(0.0, 1.0);
-    final plannedRatio = (plannedAmount / budgetAmount).clamp(0.0, 1.0 - spentRatio);
     final usageRate = summaryItem?.usageRate ?? 0.0;
     final spentColor = _getProgressColor(usageRate);
 
-    // If no planned amount, use simple progress bar
-    if (plannedAmount <= 0) {
-      return ClipRRect(
-        borderRadius: BorderRadius.circular(4),
-        child: LinearProgressIndicator(
-          value: spentRatio,
-          minHeight: 6,
-          backgroundColor: Theme.of(context).colorScheme.surfaceContainerHighest,
-          color: spentColor,
-        ),
-      );
-    }
-
-    // 3-segment bar using CustomPaint-like approach with stacked bars
     return ClipRRect(
       borderRadius: BorderRadius.circular(4),
-      child: SizedBox(
-        height: 6,
-        child: LayoutBuilder(
-          builder: (context, constraints) {
-            final totalWidth = constraints.maxWidth;
-            final spentWidth = totalWidth * spentRatio;
-            final plannedWidth = totalWidth * plannedRatio;
-
-            return Stack(
-              children: [
-                // Background (remaining)
-                Container(
-                  width: totalWidth,
-                  decoration: BoxDecoration(
-                    color: Theme.of(context).colorScheme.surfaceContainerHighest,
-                    borderRadius: BorderRadius.circular(4),
-                  ),
-                ),
-                // Planned (semi-transparent, behind spent)
-                if (plannedWidth > 0)
-                  Positioned(
-                    left: spentWidth,
-                    child: Container(
-                      width: plannedWidth,
-                      height: 6,
-                      color: spentColor.withValues(alpha: 0.3),
-                    ),
-                  ),
-                // Spent (solid)
-                if (spentWidth > 0)
-                  Container(
-                    width: spentWidth,
-                    height: 6,
-                    decoration: BoxDecoration(
-                      color: spentColor,
-                      borderRadius: BorderRadius.only(
-                        topLeft: const Radius.circular(4),
-                        bottomLeft: const Radius.circular(4),
-                        topRight: plannedWidth > 0 ? Radius.zero : const Radius.circular(4),
-                        bottomRight: plannedWidth > 0 ? Radius.zero : const Radius.circular(4),
-                      ),
-                    ),
-                  ),
-              ],
-            );
-          },
-        ),
+      child: LinearProgressIndicator(
+        value: spentRatio,
+        minHeight: 6,
+        backgroundColor: Theme.of(context).colorScheme.surfaceContainerHighest,
+        color: spentColor,
       ),
     );
   }
 
-  /// Subtitle text showing spent + planned / budget.
+  /// 회차 12 P4 — subtitle 에서 + 계획 표시 제거 (도메인 분리).
+  /// plannedAmount branch 제거. spent/budget 만 표시.
   Widget _buildBudgetSubtitleText(
     BuildContext context,
     BudgetSummaryItem? summaryItem,
@@ -859,17 +804,6 @@ class _BudgetListPageState extends State<BudgetListPage> {
     double usageRate,
   ) {
     final spentAmount = summaryItem?.spentAmount ?? 0;
-    final plannedAmount = summaryItem?.plannedAmount ?? 0;
-
-    if (plannedAmount > 0) {
-      return Text(
-        '사용 ${numberFormat.format(spentAmount)} + 계획 ${numberFormat.format(plannedAmount)}원 / ${numberFormat.format(budgetAmount)}원 (${usageRate.toStringAsFixed(1)}%)',
-        style: Theme.of(context).textTheme.bodySmall,
-        maxLines: 1,
-        overflow: TextOverflow.ellipsis,
-      );
-    }
-
     return Text(
       '${numberFormat.format(spentAmount)}원 / ${numberFormat.format(budgetAmount)}원 (${usageRate.toStringAsFixed(1)}%)',
       style: Theme.of(context).textTheme.bodySmall,

--- a/frontend/lib/features/budget/presentation/widgets/budget_summary_card.dart
+++ b/frontend/lib/features/budget/presentation/widgets/budget_summary_card.dart
@@ -55,9 +55,8 @@ class BudgetSummaryCard extends StatelessWidget {
               children: [
                 Expanded(
                   child: Text(
-                    summary.totalPlanned > 0
-                        ? '사용 ${CurrencyFormatter.format(summary.totalSpent)} + 계획 ${CurrencyFormatter.format(summary.totalPlanned)}원'
-                        : '지출: ${CurrencyFormatter.format(summary.totalSpent)}원',
+                    // 회차 12 P4 — 도메인 분리: 계획 정보 제거. 지출만 표시.
+                    '지출: ${CurrencyFormatter.format(summary.totalSpent)}원',
                     style: Theme.of(context).textTheme.bodyMedium,
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,


### PR DESCRIPTION
## Summary
회차 12 P4 — 예산에 "계획됨" 표시 + 입력 안 한 달에도 표시되는 회귀.

사용자 요구: 계획됨은 예산이 아니라 **별도 분석 영역에**.

## Phase A — BE month 필터 누락 fix
`spendingPlanRepository` 의 sumPlannedAmount 계열 3개 메서드 → month 필터 추가:
- `sumPlannedAmountByCategoryIds` / `sumPlannedAmountByGroupIds` / `sumTotalPlannedAmount`
- `targetDate IS NULL` (날짜 미지정 plan) 은 모든 월 포함

호출부:
- `BudgetService.getBudgetSummary`
- `StatisticsService.getPeriodSummary`

## Phase B — Budget UI 에서 plannedAmount 표시 제거
- `budget_list_page._buildBudgetProgressBar`: 3-segment → 2-segment (plannedAmount overlay 제거)
- `budget_list_page._buildBudgetSubtitleText`: "+ 계획 X" 분기 제거
- `budget_summary_card`: "+ 계획" 분기 제거

BudgetSummaryItem.plannedAmount entity field 는 BE 응답 호환 위해 legacy 유지.

## Out of scope (다음 PR)
- 분석 탭 메인 화면에 "계획 분석" widget 신규 추가 (총 예산 중 계획 비율 + 결제된 건수)
- BudgetSummaryItem.plannedAmount field 완전 제거
- audit-patterns 신규 패턴 등록

## Test plan
- [x] BE tests PASS (BudgetService / StatisticsService / SpendingPlan)
- [x] FE 717 tests PASS
- [x] FE build web PASS
- [ ] 라이브: 분석 탭 → 예산 → 입력 안 한 달 (5월) 이동 → "계획" 표시 사라짐
- [ ] 라이브: 입력한 달 → 예산 segment bar 가 spent/remaining 2-segment
- [ ] 라이브: BudgetSummaryCard 에서 "+ 계획" 분기 사라짐
- [ ] 라이브: spending plan list (지출 계획) 동작 변함 없음
- [ ] 라이브: 회차 1~12-3 동작 변함 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)