### PR TITLE
fix(transaction): B/C follow-up — 이체 widget 통일 + suggestion categoryGroupName

### DIFF
--- a/backend/src/main/kotlin/com/budgetbook/transaction/dto/TransactionDtos.kt
+++ b/backend/src/main/kotlin/com/budgetbook/transaction/dto/TransactionDtos.kt
@@ -132,6 +132,9 @@ data class SuggestionResponse(
 data class SuggestionPattern(
     val categoryId: UUID? = null,
     val categoryName: String? = null,
+    // 회차 12 follow-up (2026-05-04) — 카테고리 표시 통일.
+    // FE 가 "그룹 > 하위" 형식으로 표시할 때 group lookup 부하 없이 사용.
+    val categoryGroupName: String? = null,
     val categoryIcon: String? = null,
     val categoryColor: String? = null,
     val paymentMethodId: UUID? = null,

--- a/backend/src/main/kotlin/com/budgetbook/transaction/repository/TransactionRepository.kt
+++ b/backend/src/main/kotlin/com/budgetbook/transaction/repository/TransactionRepository.kt
@@ -255,9 +255,11 @@ interface TransactionRepository : JpaRepository<Transaction, UUID>, JpaSpecifica
         @Param("visFilter") visFilter: String = "ALL"
     ): List<Array<Any>>
 
+    // 회차 12 follow-up (2026-05-04) — categoryGroupName 추가 (FE 카테고리 표시 통일).
     @Query("""
         SELECT t.description,
                t.category.id, t.category.name, t.category.icon, t.category.color,
+               t.category.group.name,
                t.paymentMethod.id, t.paymentMethod.name,
                COUNT(t)
         FROM Transaction t
@@ -265,6 +267,7 @@ interface TransactionRepository : JpaRepository<Transaction, UUID>, JpaSpecifica
         AND LOWER(t.description) LIKE LOWER(CONCAT(:query, '%'))
         GROUP BY t.description,
                  t.category.id, t.category.name, t.category.icon, t.category.color,
+                 t.category.group.name,
                  t.paymentMethod.id, t.paymentMethod.name
         ORDER BY t.description, COUNT(t) DESC
     """)

--- a/backend/src/main/kotlin/com/budgetbook/transaction/service/TransactionService.kt
+++ b/backend/src/main/kotlin/com/budgetbook/transaction/service/TransactionService.kt
@@ -419,9 +419,11 @@ class TransactionService(
                 categoryName = row[2] as? String,
                 categoryIcon = row[3] as? String,
                 categoryColor = row[4] as? String,
-                paymentMethodId = row[5] as? UUID,
-                paymentMethodName = row[6] as? String,
-                count = (row[7] as Long)
+                // 회차 12 follow-up — categoryGroupName 추가 (인덱스 5)
+                categoryGroupName = row[5] as? String,
+                paymentMethodId = row[6] as? UUID,
+                paymentMethodName = row[7] as? String,
+                count = (row[8] as Long)
             )
             grouped.getOrPut(description) { mutableListOf() }.add(pattern)
         }

--- a/backend/src/test/kotlin/com/budgetbook/transaction/service/TransactionServiceTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/transaction/service/TransactionServiceTest.kt
@@ -441,8 +441,8 @@ class TransactionServiceTest : BehaviorSpec({
 
         When("matching descriptions exist") {
             every { transactionRepository.findSuggestionPatterns(couple.id, "점심") } returns listOf(
-                arrayOf<Any?>("점심 식사", null, null, null, null, null, null, 3L),
-                arrayOf<Any?>("점심 도시락", null, null, null, null, null, null, 1L)
+                arrayOf<Any?>("점심 식사", null, null, null, null, null, null, null, 3L),
+                arrayOf<Any?>("점심 도시락", null, null, null, null, null, null, null, 1L)
             )
 
             val result = service.getSuggestions(user1.id, "점심", 10)
@@ -466,7 +466,7 @@ class TransactionServiceTest : BehaviorSpec({
 
         When("limit exceeds max") {
             every { transactionRepository.findSuggestionPatterns(couple.id, "점심") } returns listOf(
-                arrayOf<Any?>("점심", null, null, null, null, null, null, 1L)
+                arrayOf<Any?>("점심", null, null, null, null, null, null, null, 1L)
             )
 
             val result = service.getSuggestions(user1.id, "점심", 100)
@@ -479,8 +479,8 @@ class TransactionServiceTest : BehaviorSpec({
 
         When("limit is zero or negative") {
             every { transactionRepository.findSuggestionPatterns(couple.id, "점심") } returns listOf(
-                arrayOf<Any?>("점심 식사", null, null, null, null, null, null, 5L),
-                arrayOf<Any?>("점심 도시락", null, null, null, null, null, null, 2L)
+                arrayOf<Any?>("점심 식사", null, null, null, null, null, null, null, 5L),
+                arrayOf<Any?>("점심 도시락", null, null, null, null, null, null, null, 2L)
             )
 
             val result = service.getSuggestions(user1.id, "점심", 0)

--- a/frontend/lib/features/transaction/data/datasources/transaction_remote_datasource.dart
+++ b/frontend/lib/features/transaction/data/datasources/transaction_remote_datasource.dart
@@ -164,6 +164,8 @@ class TransactionRemoteDataSourceImpl implements TransactionRemoteDataSource {
         return SuggestionPattern(
           categoryId: pm['categoryId'] as String?,
           categoryName: pm['categoryName'] as String?,
+          // 회차 12 follow-up — BE 응답에 categoryGroupName 추가됨
+          categoryGroupName: pm['categoryGroupName'] as String?,
           categoryIcon: pm['categoryIcon'] as String?,
           categoryColor: pm['categoryColor'] as String?,
           paymentMethodId: pm['paymentMethodId'] as String?,

--- a/frontend/lib/features/transaction/domain/repositories/transaction_repository.dart
+++ b/frontend/lib/features/transaction/domain/repositories/transaction_repository.dart
@@ -78,6 +78,8 @@ class SuggestionGroup {
 class SuggestionPattern {
   final String? categoryId;
   final String? categoryName;
+  // 회차 12 follow-up — 카테고리 표시 통일 ("$groupName > $categoryName")
+  final String? categoryGroupName;
   final String? categoryIcon;
   final String? categoryColor;
   final String? paymentMethodId;
@@ -87,6 +89,7 @@ class SuggestionPattern {
   const SuggestionPattern({
     this.categoryId,
     this.categoryName,
+    this.categoryGroupName,
     this.categoryIcon,
     this.categoryColor,
     this.paymentMethodId,

--- a/frontend/lib/features/transaction/presentation/pages/transaction_form_page.dart
+++ b/frontend/lib/features/transaction/presentation/pages/transaction_form_page.dart
@@ -10,7 +10,6 @@ import 'package:budget_book/core/services/couple_prefs.dart';
 import 'package:flutter/services.dart';
 import 'package:budget_book/core/utils/currency_formatter.dart';
 import 'package:budget_book/core/widgets/calculator_amount_field.dart';
-import 'package:budget_book/core/widgets/amount_input_field.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
@@ -435,12 +434,15 @@ class _TransactionFormPageState extends State<TransactionFormPage>
           TextSelection.collapsed(offset: group.description.length);
       if (pattern != null) {
         _selectedCategoryId = pattern.categoryId;
-        // 회차 12 P3 — 자동 선택도 picker 직접 선택과 동일한 "그룹 > 하위" 형식.
+        // 회차 12 P3 + follow-up — 자동 선택도 picker 직접 선택과 동일한 "그룹 > 하위" 형식.
+        // BE 응답의 categoryGroupName 우선 사용. fallback 으로 helper (group lookup).
         _selectedCategoryDisplayName = pattern.categoryName != null
-            ? formatCategoryDisplay(
-                pattern.categoryId,
-                categoryName: pattern.categoryName!,
-              )
+            ? (pattern.categoryGroupName != null && pattern.categoryGroupName!.isNotEmpty
+                ? '${pattern.categoryGroupName} > ${pattern.categoryName}'
+                : formatCategoryDisplay(
+                    pattern.categoryId,
+                    categoryName: pattern.categoryName!,
+                  ))
             : null;
         _selectedPaymentMethodId = pattern.paymentMethodId;
       }
@@ -474,11 +476,11 @@ class _TransactionFormPageState extends State<TransactionFormPage>
   void _applyAiCategory(AiClassifyResult result) {
     setState(() {
       _selectedCategoryId = result.categoryId;
-      // 회차 12 P3 — AI 추천도 "그룹 > 하위" 형식 통일.
-      _selectedCategoryDisplayName = formatCategoryDisplay(
-        result.categoryId,
-        categoryName: result.categoryName,
-      );
+      // 회차 12 P3 + follow-up — AI 추천도 "그룹 > 하위" 형식 통일.
+      // AiClassifyResult.groupName 직접 사용 (BE 응답).
+      _selectedCategoryDisplayName = result.groupName.isNotEmpty
+          ? '${result.groupName} > ${result.categoryName}'
+          : result.categoryName;
       _aiResult = null;
     });
   }
@@ -738,8 +740,11 @@ class _TransactionFormPageState extends State<TransactionFormPage>
                       padding: const EdgeInsets.only(top: 8, bottom: 4),
                       child: ActionChip(
                         avatar: const Icon(Icons.auto_awesome, size: 16),
-                        // 회차 12 P3 — AI 추천 chip 도 "그룹 > 하위" 형식.
-                        label: Text('AI 추천: ${formatCategoryDisplay(_aiResult!.categoryId, categoryName: _aiResult!.categoryName)}'),
+                        // 회차 12 P3 + follow-up — AI 추천 chip 도 "그룹 > 하위" 형식.
+                        // result.groupName 직접 사용.
+                        label: Text(_aiResult!.groupName.isNotEmpty
+                            ? 'AI 추천: ${_aiResult!.groupName} > ${_aiResult!.categoryName}'
+                            : 'AI 추천: ${_aiResult!.categoryName}'),
                         onPressed: () => _applyAiCategory(_aiResult!),
                       ),
                     ),
@@ -1009,13 +1014,18 @@ class _TransactionFormPageState extends State<TransactionFormPage>
               ),
             ),
             const SizedBox(height: 16),
-            // Amount — 회차 12 P5: 공통 controller 사용 (수입/지출/이체 간 유지).
-            AmountInputField(
+            // Amount — 회차 12 P5/B-fix: 지출/수입 탭과 동일한 CalculatorAmountField
+            // 사용. 이전: AmountInputField 였으나 controller 단일화에도 widget 차이로
+            // 텍스트 표시 깨짐. 사용자 요구 "공통화" 의도 반영하여 widget 도 통일.
+            CalculatorAmountField(
               controller: _amountController,
-              labelText: '금액',
-              filterDigitsOnly: true,
+              decoration: const InputDecoration(
+                labelText: '금액',
+                suffixText: '원',
+                prefixIcon: Icon(Icons.payments),
+              ),
               validator: (value) {
-                if (value == null || value.isEmpty) return '금액을 입력하세요';
+                if (value == null || value.trim().isEmpty) return '금액을 입력하세요';
                 final amount = CurrencyFormatter.parse(value);
                 if (amount == null || amount <= 0) return '유효한 금액을 입력하세요';
                 if (amount > 999999999) {
@@ -1202,10 +1212,13 @@ class _TransactionFormPageState extends State<TransactionFormPage>
             const SizedBox(height: 4),
             // Grouped patterns sorted by count
             ..._expandedSuggestion!.patterns.map((p) {
-              // 회차 12 P3 — suggestion picker label 도 "그룹 > 하위" 형식.
-              final categoryLabel = p.categoryId != null && p.categoryName != null
-                  ? formatCategoryDisplay(p.categoryId, categoryName: p.categoryName!)
-                  : p.categoryName;
+              // 회차 12 P3 + follow-up — suggestion picker label 도 "그룹 > 하위" 형식.
+              // BE 응답의 categoryGroupName 우선 사용.
+              final categoryLabel = p.categoryName == null
+                  ? null
+                  : (p.categoryGroupName != null && p.categoryGroupName!.isNotEmpty
+                      ? '${p.categoryGroupName} > ${p.categoryName}'
+                      : formatCategoryDisplay(p.categoryId, categoryName: p.categoryName!));
               final label = [
                 categoryLabel,
                 p.paymentMethodName,


### PR DESCRIPTION
## Summary
회차 12 follow-up — 라이브 검증 후 발견된 회귀.

## B: 이체 탭 widget 미통일
사용자 보고: 지출↔수입 OK, 이체 탭 진입 시 금액/내용/메모 사라짐.

Root cause: PR #213 에서 controller 단일화 했으나 widget 이 다름.
- 지출/수입: CalculatorAmountField
- 이체: AmountInputField (build-time formatter 미작동)

Fix: 이체 탭도 CalculatorAmountField 사용. 사용자 의도 "공통화" 반영.

## C: suggestion 자동 선택 그룹 prefix 미적용
사용자 보고: suggestion 에서 하위만, 선택해도 하위만.

Root cause: helper CategoryGroupBloc lookup 실패 시 categoryName 만 반환.

Fix (옵션 B):
- BE SuggestionPattern DTO + Query + Service 에 categoryGroupName 추가
- FE entity / data source / form 4곳에서 categoryGroupName 우선 사용
- AI 추천: AiClassifyResult.groupName 직접 사용

## Test plan
- [x] BE TransactionServiceTest PASS (Suggestion 갱신)
- [x] FE 717 tests PASS, build PASS
- [ ] 라이브: 거래 폼 → 지출 100,000 입력 → 이체 → 100,000 유지
- [ ] 라이브: 거래 폼 → 내용/메모 입력 → 이체 → 유지
- [ ] 라이브: 내용 입력 → suggestion 자동 선택 → "그룹 > 하위" 표시
- [ ] 라이브: AI 추천 chip → "그룹 > 하위"
- [ ] 라이브: suggestion picker pattern label → "그룹 > 하위 · 결제수단"

🤖 Generated with [Claude Code](https://claude.com/claude-code)