### PR TITLE
fix(transaction): A — TransactionListPage _filterState desync (자산→결제수단 클릭 시 UI 전체 표시)

### DIFF
--- a/frontend/lib/features/transaction/presentation/pages/transaction_list_page.dart
+++ b/frontend/lib/features/transaction/presentation/pages/transaction_list_page.dart
@@ -107,6 +107,41 @@ class _TransactionListPageState extends State<TransactionListPage> {
     _loadViewMode();
   }
 
+  @override
+  void didUpdateWidget(covariant TransactionListPage oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // 회차 12 follow-up A (2026-05-04) — _filterState desync 회귀 fix.
+    // GoRouter 가 같은 path 재진입 시 State 재사용 → `late _filterState` initializer
+    // 가 한 번만 fire → widget.initialPaymentMethodId 새 값이라도 _filterState 는
+    // 빈 값 그대로 → UI "전체" 표시 / 필터 chip 제거 안 됨 / list 는 BE 필터 적용
+    // (sync 깨짐).
+    //
+    // 자산 → 결제수단 클릭 (`/transactions?paymentMethodId=X`) 시 widget 새 prop
+    // 으로 _filterState 동기화. payment_method/category/categoryGroup 모두 처리.
+    final pmChanged = widget.initialPaymentMethodId != oldWidget.initialPaymentMethodId;
+    final catChanged = widget.initialCategoryId != oldWidget.initialCategoryId;
+    final groupChanged = widget.initialCategoryGroupId != oldWidget.initialCategoryGroupId;
+    if (pmChanged || catChanged || groupChanged) {
+      setState(() {
+        _filterState = _filterState.copyWith(
+          paymentMethodIds: widget.initialPaymentMethodId != null
+              ? {widget.initialPaymentMethodId!}
+              : const {},
+          paymentMethodName: widget.initialPaymentMethodName,
+          categoryIds: widget.initialCategoryId != null
+              ? {widget.initialCategoryId!}
+              : const {},
+          categoryName: widget.initialCategoryName,
+          categoryGroupIds: widget.initialCategoryGroupId != null
+              ? {widget.initialCategoryGroupId!}
+              : const {},
+          // copyWith 의 clearCategory/clearPaymentMethod 는 nullable name 까지
+          // 클리어. 위 explicit 값 set 으로 동일 효과 (initialXxxId == null 시 빈 set).
+        );
+      });
+    }
+  }
+
   Future<void> _loadViewMode() async {
     final prefs = await SharedPreferences.getInstance();
     final saved = prefs.getString(_kTxViewModePrefKey);


### PR DESCRIPTION
## Summary
회차 12 follow-up A — 자산에서 결제수단 클릭 시 거래 list 는 BE 필터 적용되지만 UI 의 필터 chip / AppBar 가 "전체" 로 표시되어 필터 해제도 안 되는 회귀.

## Root cause
TransactionListPage 의 `late _filterState` initializer 가 한 번만 fire. GoRouter 가 같은 path (`/transactions`) 재진입 시 Flutter element diffing 으로 State 재사용 → widget.initialPaymentMethodId 새 값이라도 _filterState 는 첫 번째 build 의 빈 값 그대로. transaction_bloc 은 별도 (builder 가 직접 LoadTransactions 호출) 라 정상 필터.

→ list 는 필터 적용 (2건), UI 는 "전체" 표시. sync 깨짐.

## Fix
`didUpdateWidget` 에서 widget 의 initialPaymentMethodId/CategoryId/GroupId 변경 감지 → `_filterState` 동기화.

## Test plan
- [x] FE 717 tests PASS, build PASS
- [ ] 라이브: 거래 탭 (필터 없음) → 자산 → 결제수단 클릭 → 거래 list 2건 + AppBar "거래 (결제수단명)" + 필터 chip 활성
- [ ] 라이브: 필터 chip 클릭 → 결제수단 deselect → 13건 / "거래 (전체)" 표시
- [ ] 라이브: 다른 결제수단 클릭 후 다시 다른 결제수단 클릭 → UI 동기화
- [ ] 라이브: category/categoryGroup 진입도 동일 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)