### PR TITLE
fix(web): PWA cache stale — SW 비활성 + cache-control no-cache (iOS PWA 분석 아이콘 빈 글리프 fix)

### DIFF
--- a/.github/workflows/deploy-nas.yml
+++ b/.github/workflows/deploy-nas.yml
@@ -197,8 +197,14 @@ jobs:
       - name: Install dependencies
         run: flutter pub get
 
-      - name: Build Web (release, tree-shake)
-        run: flutter build web --release --dart-define=API_BASE_URL=https://aiva-bb.duckdns.org
+      - name: Build Web (release, no PWA SW)
+        # 회차 12 follow-up (2026-05-04) — PWA cache stale 회귀 fix.
+        # `--pwa-strategy=none`: Service Worker 등록 생략 → asset 매번 fetch
+        # (브라우저 자체 cache 활용). 새 빌드 즉시 반영.
+        # 회차 10 의 분석 탭 Icons.insights 추가가 옛 SW 캐시의 tree-shaken
+        # MaterialIcons font 에 codepoint 없어 빈 글리프 표시 회귀 → 영구 fix.
+        # Trade-off: offline 미지원. budget-book 는 인증 필요 앱이라 무관.
+        run: flutter build web --release --pwa-strategy=none --dart-define=API_BASE_URL=https://aiva-bb.duckdns.org
 
       - name: Setup SSH key
         run: |

--- a/frontend/web/index.html
+++ b/frontend/web/index.html
@@ -4,6 +4,15 @@
   <base href="$FLUTTER_BASE_HREF">
   <meta charset="UTF-8">
   <meta content="IE=Edge" http-equiv="X-UA-Compatible">
+  <!--
+    회차 12 follow-up (2026-05-04) — iOS PWA cache stale 회귀 fix.
+    iOS Safari standalone webview 가 HTML 을 stale cache 로 hold → 새 빌드의
+    asset hash 를 보지 못해 옛 MaterialIcons font 사용 (Icons.insights 빈 글리프).
+    Cache-Control no-cache 로 HTML 매번 fresh fetch 강제.
+  -->
+  <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+  <meta http-equiv="Pragma" content="no-cache">
+  <meta http-equiv="Expires" content="0">
   <meta name="description" content="Budget Book - Shared household budget management">
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
@@ -12,6 +21,34 @@
   <title>Budget Book</title>
 </head>
 <body>
+  <!--
+    회차 12 follow-up (2026-05-04) — 옛 Service Worker 강제 unregister + cache 클리어.
+    --pwa-strategy=none 빌드 후에도 기존 사용자 브라우저에 옛 SW 가 active 로 남아
+    stale cache (예: 회차 10 이전 tree-shake 된 MaterialIcons font) 영구 hold.
+    첫 visit 시 강제 정리 + reload.
+  -->
+  <script>
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.getRegistrations().then(function(regs) {
+        var hadSw = false;
+        regs.forEach(function(reg) {
+          hadSw = true;
+          reg.unregister();
+        });
+        if (hadSw) {
+          if ('caches' in window) {
+            caches.keys().then(function(names) {
+              return Promise.all(names.map(function(n) { return caches.delete(n); }));
+            }).then(function() {
+              window.location.reload();
+            });
+          } else {
+            window.location.reload();
+          }
+        }
+      }).catch(function() {});
+    }
+  </script>
   <script src="flutter_bootstrap.js" async></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
회차 12 follow-up — iOS Safari "홈 화면에 추가" PWA 에서 분석 탭 아이콘 빈 글리프.

## Root cause
회차 10 PR #209 의 Icons.insights 추가 → 새 빌드의 tree-shake 된 MaterialIcons font 에 codepoint 포함. 그러나 사용자 PWA 의 Service Worker 가 옛 font 를 cache 영구 hold.

iOS Safari standalone webview 는:
- Chrome browser cache 와 완전 분리
- 자체 disk cache + SW cache + memory cache 3중 레이어
- 다른 PWA 와도 cache 분리

→ 새 빌드 deploy 후에도 옛 font 사용 → Icons.insights 빈 글리프.

## Fix (3중 방어)
1. **deploy-nas.yml**: `--pwa-strategy=none` 추가 → SW 자동 등록 안 함. Trade-off: offline 미지원 (budget-book 무관)
2. **index.html cache-control no-cache meta**: HTML 매번 fresh fetch 강제
3. **index.html SW unregister 스크립트**: 첫 visit 시 옛 SW 제거 + cache 클리어 + reload

## 사용자 일회 작업 (기존 PWA)
- 홈 화면 PWA 길게 누름 → "북마크 삭제"
- Safari (Chrome 아님) 로 https://aiva-bb.duckdns.org 직접 접속
- 공유 → "홈 화면에 추가"

## Test plan
- [x] flutter build web --pwa-strategy=none 성공
- [x] FE 717 tests PASS
- [ ] 라이브 (PWA 재설치 후): 분석 탭 아이콘 정상 표시
- [ ] 라이브 (Chrome 일반): 변함 없음 (정상 표시 유지)
- [ ] 라이브: 새 빌드 deploy 시 자동 reflect (cache stale 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)