### PR TITLE
fix(asset): 모바일 자산 관리 UI 깨짐 — Switch 컴팩트 + chip Wrap

### DIFF
--- a/frontend/lib/features/settings/presentation/pages/asset_management_page.dart
+++ b/frontend/lib/features/settings/presentation/pages/asset_management_page.dart
@@ -1158,41 +1158,47 @@ class _PaymentMethodTabState extends State<_PaymentMethodTab> {
                 color: theme.colorScheme.onSurface.withValues(alpha: 0.55)),
           ),
           const SizedBox(height: 2),
-          Row(
-            children: [
-              if (settlement != null) ...[
+          // 회차 12 follow-up (2026-05-04) — 모바일에서 chip 3개 + trailing
+          // (Switch + PopupMenu) 가로 overflow 방지. Wrap 으로 좁은 화면 시
+          // 자동 줄바꿈.
+          if (settlement != null)
+            Wrap(
+              spacing: 4,
+              runSpacing: 2,
+              children: [
                 _SubChip(
                     label: '전월',
                     value: prevAmount,
                     bg: Colors.grey.shade200,
                     fg: Colors.grey.shade800),
-                const SizedBox(width: 4),
                 _SubChip(
                     label: '미결제',
                     value: unpaidAmount,
                     bg: unpaidAmount > 0 ? Colors.red.shade50 : Colors.green.shade50,
                     fg: unpaidAmount > 0 ? Colors.red.shade800 : Colors.green.shade800),
-                const SizedBox(width: 4),
                 _SubChip(
                     label: '이번달',
                     value: currAmount,
                     bg: Colors.blue.shade50,
                     fg: Colors.blue.shade800),
               ],
-            ],
-          ),
+            ),
         ],
       );
     } else {
       // 비-카드: 잔액 표시 (null 시 0원 fallback) + 기본 결제수단 뱃지
       final balance = method.balance ?? 0;
       final sign = balance >= 0 ? Colors.green.shade800 : Colors.red.shade800;
+      // 회차 12 follow-up — 모바일에서 잔액 + "기본" 라벨 overflow 방지.
       subtitle = Row(
         children: [
-          Text(
-            '잔액: ${CurrencyFormatter.formatWithSign(balance)}',
-            style: TextStyle(
-                fontSize: 13, fontWeight: FontWeight.w700, color: sign),
+          Flexible(
+            child: Text(
+              '잔액: ${CurrencyFormatter.formatWithSign(balance)}',
+              style: TextStyle(
+                  fontSize: 13, fontWeight: FontWeight.w700, color: sign),
+              overflow: TextOverflow.ellipsis,
+            ),
           ),
           if (method.isDefault) ...[
             const SizedBox(width: 8),
@@ -1250,13 +1256,20 @@ class _PaymentMethodTabState extends State<_PaymentMethodTab> {
       trailing: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
-          Switch(
-            value: method.isActive,
-            onChanged: (value) {
-              context.read<PaymentMethodBloc>().add(
-                    UpdatePaymentMethod(id: method.id, isActive: value),
-                  );
-            },
+          // 회차 12 follow-up (2026-05-04) — 모바일에서 Switch 가 trailing 공간
+          // 과도하게 차지하여 subtitle chip overflow 유발. visualDensity +
+          // materialTapTargetSize 로 컴팩트화.
+          Transform.scale(
+            scale: 0.85,
+            child: Switch(
+              value: method.isActive,
+              materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+              onChanged: (value) {
+                context.read<PaymentMethodBloc>().add(
+                      UpdatePaymentMethod(id: method.id, isActive: value),
+                    );
+              },
+            ),
           ),
           PopupMenuButton<String>(
             onSelected: (action) {


### PR DESCRIPTION
## Summary
회차 12 follow-up — 모바일 자산 관리 페이지 UI 깨짐.

사용자 보고:
- 글자 겹침
- On/Off 버튼 너무 큼
- 전월/미결제/이번달 chip 과의 여백 문제

## Fix
1. Switch → Transform.scale(0.85) + shrinkWrap → trailing 공간 절약
2. 카드 결제수단 subtitle 3 chip → Row → Wrap (자동 줄바꿈)
3. 비-카드 잔액 Row → Flexible + ellipsis

## Test plan
- [x] flutter analyze, test (717 PASS), build PASS
- [ ] 라이브 모바일: 카드 결제수단 ListTile 의 chip 정상 표시 (좁으면 줄바꿈)
- [ ] 라이브 모바일: Switch 작아짐, PopupMenu 와 여백 정상
- [ ] 라이브 모바일: 비-카드 잔액 + "기본" 라벨 겹침 없음
- [ ] 회귀 web: 변함 없음 (Wrap + Flexible 은 가로 충분 시 단일 라인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)