### PR TITLE
feat(layout): 분석/자산 탭 MonthNavigator 상단 위치 통일

### DIFF
--- a/frontend/lib/features/analysis/presentation/pages/analysis_page.dart
+++ b/frontend/lib/features/analysis/presentation/pages/analysis_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'package:budget_book/core/di/injection.dart';
+import 'package:budget_book/core/widgets/month_navigator.dart';
 import 'package:budget_book/features/budget/presentation/bloc/budget_bloc.dart';
 import 'package:budget_book/features/budget/presentation/bloc/budget_event.dart';
 import 'package:budget_book/features/budget/presentation/pages/budget_list_page.dart';
@@ -33,10 +34,22 @@ class AnalysisPage extends StatelessWidget {
             ],
           ),
         ),
-        body: const TabBarView(
+        // 회차 12 follow-up (2026-05-04) — 사용자 요구 반영.
+        // 이전: TabBar 아래의 각 sub-tab 안에 MonthNavigator (예산은 월간/주간
+        // SegmentedButton 아래) → 가독성 떨어짐.
+        // 신규: TabBar 바로 아래에 단일 MonthNavigator. 예산/통계 두 sub-tab
+        // 공유. MonthCubit 단일 source 라 sync 자동.
+        body: const Column(
           children: [
-            _BudgetTabWrapper(),
-            _StatisticsTabWrapper(),
+            MonthNavigator(),
+            Expanded(
+              child: TabBarView(
+                children: [
+                  _BudgetTabWrapper(),
+                  _StatisticsTabWrapper(),
+                ],
+              ),
+            ),
           ],
         ),
       ),
@@ -56,7 +69,7 @@ class _BudgetTabWrapper extends StatelessWidget {
           year: DateTime.now().year,
           month: DateTime.now().month,
         )),
-      child: const BudgetListPage(showAppBar: false),
+      child: const BudgetListPage(showAppBar: false, showMonthNavigator: false),
     );
   }
 }
@@ -74,7 +87,7 @@ class _StatisticsTabWrapper extends StatelessWidget {
       value: getIt<StatisticsBloc>()
         ..add(LoadAllStatistics(year: now.year, month: now.month))
         ..add(LoadPaymentMethodStats(year: now.year, month: now.month)),
-      child: const StatisticsPage(showAppBar: false),
+      child: const StatisticsPage(showAppBar: false, showMonthNavigator: false),
     );
   }
 }

--- a/frontend/lib/features/budget/presentation/pages/budget_list_page.dart
+++ b/frontend/lib/features/budget/presentation/pages/budget_list_page.dart
@@ -30,7 +30,15 @@ class BudgetListPage extends StatefulWidget {
   /// Phase 25 Step 11 — 분석 탭 wrapper 에서는 false. 자체 진입(/budgets) 시 true.
   final bool showAppBar;
 
-  const BudgetListPage({super.key, this.showAppBar = true});
+  /// 회차 12 follow-up (2026-05-04) — 분석 탭 wrapper 에서 MonthNavigator 를
+  /// 부모 (AnalysisPage) 가 단일 표시. 이 페이지의 자체 MonthNavigator 는 hide.
+  final bool showMonthNavigator;
+
+  const BudgetListPage({
+    super.key,
+    this.showAppBar = true,
+    this.showMonthNavigator = true,
+  });
 
   @override
   State<BudgetListPage> createState() => _BudgetListPageState();
@@ -256,14 +264,16 @@ class _BudgetListPageState extends State<BudgetListPage> {
 
     return Column(
       children: [
-        MonthNavigator(
-          year: state.year,
-          month: state.month,
-          onMonthChanged: (m) {
-            getIt<WeeklyBudgetBloc>()
-                .add(LoadWeeklyOverview(year: m.year, month: m.month));
-          },
-        ),
+        // 회차 12 follow-up — 분석 탭 wrapper 에서는 부모가 단일 표시 (hide).
+        if (widget.showMonthNavigator)
+          MonthNavigator(
+            year: state.year,
+            month: state.month,
+            onMonthChanged: (m) {
+              getIt<WeeklyBudgetBloc>()
+                  .add(LoadWeeklyOverview(year: m.year, month: m.month));
+            },
+          ),
         Expanded(
           child: RefreshIndicator(
       onRefresh: () async {
@@ -552,7 +562,8 @@ class _BudgetListPageState extends State<BudgetListPage> {
     return Column(
       children: [
         // MonthNavigator는 MonthCubit.state를 자동으로 watch하여 표시/업데이트.
-        const MonthNavigator(),
+        // 회차 12 follow-up — 분석 탭 wrapper 에서는 부모가 단일 표시 (hide).
+        if (widget.showMonthNavigator) const MonthNavigator(),
         if (state.summary != null)
           BudgetSummaryCard(summary: state.summary!),
         Expanded(

--- a/frontend/lib/features/settings/presentation/pages/asset_management_page.dart
+++ b/frontend/lib/features/settings/presentation/pages/asset_management_page.dart
@@ -107,8 +107,12 @@ class AssetManagementPage extends StatelessWidget {
                 ],
               ),
             ),
+            // 회차 12 follow-up (2026-05-04) — 사용자 요구: 자산 금액
+            // (_AssetSummaryHeader) 와 사용 금액 (_CardSettlementHeader) 사이에
+            // 있던 MonthNavigator 를 페이지 최상단으로 이동.
             body: const Column(
               children: [
+                MonthNavigator(),
                 _AssetSummaryHeader(),
                 _CardSettlementHeader(),
                 Expanded(
@@ -1678,17 +1682,15 @@ class _CardSettlementHeader extends StatelessWidget {
             if (!hasCredit) return const SizedBox.shrink();
 
             final summary = state.cardSettlementSummary;
+            // 회차 12 follow-up — MonthNavigator 는 부모 (자산 페이지 최상단)
+            // 가 단일 표시. 여기서는 cards 만.
             if (summary == null) {
-              return const Padding(
-                padding: EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-                child: MonthNavigator(),
-              );
+              return const SizedBox.shrink();
             }
 
             final theme = Theme.of(context);
             return Column(
               children: [
-                const MonthNavigator(),
                 Padding(
                   padding: const EdgeInsets.fromLTRB(12, 4, 12, 8),
                   child: Row(

--- a/frontend/lib/features/statistics/presentation/pages/statistics_page.dart
+++ b/frontend/lib/features/statistics/presentation/pages/statistics_page.dart
@@ -17,7 +17,15 @@ class StatisticsPage extends StatelessWidget {
   /// Phase 25 Step 11 — 분석 탭 wrapper 에서는 false. 자체 진입(/statistics) 시 true.
   final bool showAppBar;
 
-  const StatisticsPage({super.key, this.showAppBar = true});
+  /// 회차 12 follow-up (2026-05-04) — 분석 탭 wrapper 가 부모 단일 MonthNavigator
+  /// 표시. 이 페이지의 자체 MonthNavigator hide.
+  final bool showMonthNavigator;
+
+  const StatisticsPage({
+    super.key,
+    this.showAppBar = true,
+    this.showMonthNavigator = true,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -54,7 +62,8 @@ class StatisticsPage extends StatelessWidget {
             return Column(
               children: [
                 // Month navigator (hidden when date range is active)
-                if (!state.hasDateRange)
+                // 회차 12 follow-up — 분석 탭 wrapper 시 부모 단일 표시 (hide).
+                if (showMonthNavigator && !state.hasDateRange)
                   // MonthNavigator는 MonthCubit.state를 자동 watch
                   const MonthNavigator(),
                 // Date range indicator (shown when active)


### PR DESCRIPTION
## Summary
회차 12 follow-up — 사용자 UX 요구.

### 분석 탭
- 이전: 월간/주간 SegmentedButton 아래에 MonthNavigator
- 신규: TabBar 바로 아래 단일 MonthNavigator (두 sub-tab 공유)

### 자산 관리
- 이전: 자산 금액 (총자산) 과 사용 금액 (전월/미결제/이번달) 사이
- 신규: 페이지 최상단 (TabBar 아래)

## 구현
- `BudgetListPage` / `StatisticsPage` 에 `showMonthNavigator` param 추가
- `AnalysisPage` body 최상단에 단일 `MonthNavigator()`
- `AssetManagementPage` body Column 최상단에 `MonthNavigator()`
- `_CardSettlementHeader`: 자체 MonthNavigator 제거

## Out of scope (다음 PR — Phase 2)
- 자산/사용 금액 영역 통합 (PageView 스와핑) — 사용자 요구의 후반부.
- 단일 영역에서 좌우 스와이프로 자산 ↔ 사용 데이터 전환.

## Test plan
- [x] flutter analyze, test (717 PASS), build PASS
- [ ] 라이브: 분석 탭 → MonthNavigator 가 TabBar 바로 아래
- [ ] 라이브: 분석 → 예산 탭 / 통계 탭 전환 시 MonthNavigator 한 인스턴스만
- [ ] 라이브: 자산 관리 → MonthNavigator 가 최상단
- [ ] 라이브: 자산 관리 → 결제수단 탭에서 _CardSettlementHeader cards 정상
- [ ] 회귀: BudgetListPage / StatisticsPage 직접 진입 (/budgets, /statistics) 시 자체 MonthNavigator 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)