### PR TITLE
fix(payment_method): LoadPaymentMethods race — 자산 탭 진입 시 깜박임 회귀

### DIFF
--- a/frontend/lib/features/payment_method/presentation/bloc/payment_method_bloc.dart
+++ b/frontend/lib/features/payment_method/presentation/bloc/payment_method_bloc.dart
@@ -25,12 +25,41 @@ class PaymentMethodBloc
     Emitter<PaymentMethodState> emit,
   ) async {
     try {
-      emit(const PaymentMethodLoading());
+      // 회차 12 follow-up (2026-05-04) — race 회귀 fix.
+      // 이전: 항상 PaymentMethodLoading emit → fetch → Loaded.
+      //   결과: 자산 탭 진입 시 기존 Loaded data 가 잠시 빈 상태 (Loading) 로
+      //   transition → _AssetSummaryHeader 가 SizedBox.shrink → "총자산 안 나옴"
+      //   + _PaymentMethodTab 도 빈 화면 ("결제수단이 없습니다" 처럼 보임).
+      // 신규: 기존 Loaded 가 있으면 그대로 keep, fetch 후 update. Loading 은 첫
+      //   진입 (Initial/Error 상태) 에서만 emit.
+      final currentLoaded =
+          state is PaymentMethodLoaded ? state as PaymentMethodLoaded : null;
+      if (currentLoaded == null) {
+        emit(const PaymentMethodLoading());
+      }
       final result = await paymentMethodRepository.getPaymentMethods();
       result.fold(
-        (failure) => emit(PaymentMethodError(failure.message)),
+        (failure) {
+          if (currentLoaded != null) {
+            // 기존 data 보존 + 에러만 표시
+            emit(PaymentMethodLoaded(
+              currentLoaded.paymentMethods,
+              cardPendings: currentLoaded.cardPendings,
+              cardSettlementSummary: currentLoaded.cardSettlementSummary,
+              operationError: failure.message,
+            ));
+          } else {
+            emit(PaymentMethodError(failure.message));
+          }
+        },
         (methods) {
-          emit(PaymentMethodLoaded(methods));
+          emit(PaymentMethodLoaded(
+            methods,
+            // 기존 settlement summary / cardPendings 는 별도 event 로 갱신.
+            // 첫 fetch 가 아니면 보존하여 잠시 사라짐 회피.
+            cardPendings: currentLoaded?.cardPendings,
+            cardSettlementSummary: currentLoaded?.cardSettlementSummary,
+          ));
           // Auto-load card settlement summary if credit cards exist
           if (methods.any((pm) => pm.isCredit)) {
             final now = DateTime.now();


### PR DESCRIPTION
## 사용자 보고
자산 탭 들어갔을 때 가끔 "결제수단이 없습니다" + 총자산 안 나옴. 다른 탭 갔다가 돌아오면 나옴.

## Root cause
`PaymentMethodBloc._onLoadPaymentMethods` 가 항상 `PaymentMethodLoading` 을 먼저 emit. 이미 Loaded 상태에서 reload 시:

1. state: PaymentMethodLoaded → 표시 정상
2. event LoadPaymentMethods 도착 (자산 탭 builder + main_shell case 2 + WS sync 등)
3. emit(PaymentMethodLoading) → state 가 잠시 Loading
4. `_AssetSummaryHeader` 의 `if (state is! PaymentMethodLoaded) return SizedBox.shrink()` → 총자산 사라짐
5. `_PaymentMethodTab` → 빈 list → "결제수단 없음"
6. await fetch 완료 → 다시 Loaded → 정상

응답 빠른/느린 차이로 사용자에게 "가끔" 보임.

## Fix
기존 Loaded 가 있으면 Loading 단계 skip. fetch 후 직접 update.
실패 시 기존 data 보존 + operationError. cardPendings / cardSettlementSummary 도 reload 사이 보존.

## Test plan
- [x] flutter analyze, test (717 PASS), build PASS
- [ ] 라이브: 자산 탭 진입 → "결제수단 없음" / 총자산 사라짐 깜박임 없음
- [ ] 라이브: 다른 탭 → 자산 탭 (반복) → 깜박임 없음
- [ ] 라이브: WS sync 시 (partner 가 결제수단 추가) 깜박임 없음
- [ ] 회귀: 첫 진입 (Initial 상태) 시 정상 로딩

🤖 Generated with [Claude Code](https://claude.com/claude-code)