### PR TITLE
docs(sessions): 2026-05-03 회차 12 PASS — 5+3 회귀 분석 + sweep fix

### DIFF
--- a/docs/sessions/2026-05-03_1_result.md
+++ b/docs/sessions/2026-05-03_1_result.md
@@ -1,0 +1,123 @@
+# 회차 12 — 5개 회귀 분석 + sweep fix — 결과
+> 날짜: 2026-05-03 ~ 2026-05-04 | 회차: 12 (multi-day) | 상태: **완료 — 라이브 검증 통과 ("모두 잘 된다")**
+
+회차 8/9/10/11 라이브 검증 통과 후 사용자 추가 검증에서 5개 문제 발견 → 분석 보고서 (`2026-05-03_1_analysis.md`) → 단계별 fix → 추가 발견 → 추가 fix → 최종 라이브 통과.
+
+## 사용자 보고 (5건 + 추가 3건)
+
+### 초기 5건
+1. **분석 탭 아이콘 미노출** (모바일 PWA)
+2. **거래 4월 → 자산 → 결제수단 클릭 → 5월 거래** 데이터 desync
+3. **카테고리 표시 통일** (자동 선택 vs 직접 선택)
+4. **예산 "계획됨" 분리** + 입력 안 한 달에도 표시
+5. **거래 폼 이체 탭** 진입 시 공통 입력 손실
+
+### 추가 보고
+6. 자산 페이지 **모바일 UI 깨짐** (Switch 큼, chip 겹침)
+7. **MonthNavigator 위치** 이동 (분석/자산 상단으로) + **자산/사용 PageView 통합**
+8. **PaymentMethodBloc race** — 자산 탭 진입 시 깜박임 → BLoC sweep 12개
+
+## 머지된 PR 목록 (회차 12)
+
+| PR | 제목 | 핵심 변경 |
+|----|------|---------|
+| #212 | P2 Phase A — month desync 위급 5개 instance | main_shell_page case 0/2 + sync_event_handler 4곳 + transaction_form_page + balance_adjustment_sheet → MonthCubit.state 사용 |
+| #213 | P5 — 거래 폼 controller 단일화 | _transferAmountController 등 3개 제거 |
+| #214 | P3 — 카테고리 표시 통일 (자동 선택도 그룹 > 하위) | formatCategoryDisplay helper 도입 |
+| #215 | P4 — 예산-계획 도메인 분리 (Phase A+B) | BE month 필터 fix + UI plannedAmount 제거 |
+| #216 | B/C follow-up — 이체 widget 통일 + categoryGroupName | CalculatorAmountField 통일 + BE/FE categoryGroupName 추가 |
+| #217 | A — TransactionListPage _filterState desync | didUpdateWidget 추가 |
+| #218 | PWA cache stale — SW 비활성 + cache-control no-cache | --pwa-strategy=none + index.html 갱신 |
+| #219 | 모바일 자산 UI 깨짐 | Switch 컴팩트 + chip Wrap + 잔액 ellipsis |
+| #220 | MonthNavigator 상단 위치 통일 | 분석/자산 페이지 단일 인스턴스 최상단 |
+| #221 | Phase 2 — 자산/사용 PageView 스와핑 | _AssetPagerHeader + dot indicator |
+| #222 | PaymentMethodBloc Load race | Loaded 보존 + Loading skip |
+| #223 | Bloc Load race sweep — 12개 BLoC | 동일 패턴 일괄 fix |
+
+총 12 PR + 분석 보고서 1편.
+
+## Root Cause 정리 + 향후 수정 방향
+
+### 1. 분석 탭 아이콘 미노출 (PR #218)
+- **Cause**: Service Worker 가 회차 10 이전 빌드의 tree-shaken MaterialIcons font 영구 cache. 새 빌드의 Icons.insights codepoint 못 받음. iOS Safari standalone PWA cache 가 일반 Chrome cache 와 분리.
+- **Fix**: `--pwa-strategy=none` (SW 자동 등록 안 함) + index.html cache-control no-cache + 옛 SW 강제 unregister 스크립트.
+- **사용자 일회**: PWA 재설치 (홈 아이콘 → 삭제 → Safari 재방문 → 공유 → 홈 화면에 추가).
+
+### 2. 거래 4월 → 자산 → 5월 데이터 desync (PR #212/#217)
+- **Cause 1 (PR #212)**: `main_shell_page._onDestinationSelected case 0/2` 와 `sync_event_handler` 4곳, `transaction_form_page` / `balance_adjustment_sheet` 가 `now.year/month` 강제 사용. MonthCubit (사용자 보던 month) 무시 → BLoC 에는 5월 reload 됐지만 MonthNavigator 는 4월 → desync.
+- **Cause 2 (PR #217)**: `TransactionListPage._filterState` 가 `late` initializer → State 재사용 시 widget.initialPaymentMethodId 변경에 sync 안 됨 → list 는 BE 필터 적용 (2건) 되지만 UI chip "전체" 표시.
+- **Fix**: MonthCubit 단일 source of truth + didUpdateWidget 동기화.
+
+### 3. 카테고리 표시 통일 (PR #214/#216)
+- **Cause**: SuggestionPattern, AiClassifyResult 응답에 categoryGroupName 정보 없음. helper 의 CategoryGroupBloc lookup 실패 시 categoryName 만 반환 (fallback).
+- **Fix**: BE 응답 확장 (옵션 B). SuggestionPattern DTO + Query + Service 에 categoryGroupName 추가. FE 4 instance 에서 직접 사용. helper 는 fallback 유지.
+
+### 4. 예산-계획 도메인 분리 (PR #215)
+- **Cause 1**: BE `spendingPlanRepository.sumPlannedAmount*` 3개 메서드가 month 필터 없음 → 입력 안 한 달에도 모든 plan 합산.
+- **Cause 2**: budget UI (3-segment progress bar, subtitle) 에 spending_plan 데이터 mix → 도메인 분리 위반.
+- **Fix**: BE month 필터 추가 (targetDate IS NULL 은 모든 월 포함) + UI plannedAmount 표시 제거.
+
+### 5. 거래 폼 이체 탭 입력 손실 (PR #213/#216)
+- **Cause 1 (PR #213)**: transaction_form_page 가 transfer tab 별도 controllers 사용 → expense/income 의 _amountController 와 sync 안 됨.
+- **Cause 2 (PR #216)**: controller 단일화 후에도 widget 자체가 다름 (CalculatorAmountField vs AmountInputField) → text 표시 깨짐.
+- **Fix**: 별도 controller 제거 + widget CalculatorAmountField 통일.
+
+### 6. 모바일 자산 UI 깨짐 (PR #219)
+- **Cause**: Switch 가 trailing 공간 과도 차지 + 카드 결제수단 subtitle 의 3 chip Row overflow.
+- **Fix**: Transform.scale(0.85) + materialTapTargetSize.shrinkWrap + chip Row → Wrap.
+
+### 7. MonthNavigator 위치 + 자산/사용 PageView (PR #220/#221)
+- **사용자 UX 요구**: 분석 탭의 MonthNavigator 가 월간/주간 SegmentedButton 아래 → 상단으로. 자산 페이지의 MonthNavigator 가 자산/사용 사이 → 상단으로. 자산/사용 영역 통합 (스와핑).
+- **Fix**: AnalysisPage / AssetManagementPage body 최상단에 단일 MonthNavigator. _AssetPagerHeader (PageView + dot indicator) 신규.
+
+### 8. BLoC Load race (PR #222/#223)
+- **Cause**: BLoC 의 _onLoadXxx 가 항상 emit Loading. 이미 Loaded 상태에서 reload 시 잠시 Loading transition → BlocBuilder fallback (SizedBox.shrink / empty UI) → 깜박임.
+- **Fix**: Loaded 가 있으면 Loading 단계 skip. 기존 data 보존. 12 BLoC sweep + audit-patterns 등록.
+
+## audit-patterns 갱신 (v1.12.0)
+회귀 방지 신규 패턴 등록:
+- `bloc_load_race_loaded_preservation` — _onLoadXxx 의 emit Loading 가드 grep
+- `pwa_cache_stale_invalidation` — pwa-strategy / cache-control 검출
+
+## 자동 검증 결과
+| 항목 | 결과 |
+|------|------|
+| BE tests (PR #215, #216) | PASS |
+| FE 717 tests (모든 PR) | PASS |
+| FE build web | PASS |
+| CI (12 PR) | PASS |
+| 배포 (12 PR) | SUCCESS |
+
+## 사용자 라이브 검증 결과
+- A 검증 (월/필터 desync): **PASS**
+- B 검증 (이체 입력 보존): **PASS** (PR #216 후)
+- C 검증 (카테고리 표시): **PASS** (PR #216 후)
+- D 검증 (예산-계획 분리): **PASS**
+- 자산 모바일 UI: **PASS**
+- MonthNavigator 위치: **PASS**
+- PageView 스와핑: 사용자 검증 대기 → 후속 보고 없음 = 통과
+- 자산 탭 깜박임 (PaymentMethodBloc): **PASS**
+- 카테고리 깜박임 + 12 BLoC sweep: **PASS** ("모두 잘 된다")
+
+## 회고
+
+### 회차 8/9/10/11 검증 통과 후 회귀 발견
+회차 8~11 의 라이브 검증 통과 후에도 사용자 추가 검증에서 5건 발견. 검증 시나리오의 한계 — 사용자 동선 일부만 cover. 회차 9 의 currentFilter 보존 fix 가 month 필드 누락한 것이 회차 12 에서야 발견.
+
+### 패턴 sweep 의 가치
+사용자가 카테고리 깜박임 보고 → "비슷한 문제 전부 해결" 요구 → 12 BLoC 일괄 sweep + audit-patterns 등록 → 향후 신규 BLoC 도 자동 가드.
+
+### iOS PWA 캐시 특수성
+회차 10 의 분석 탭 아이콘 추가가 회차 12 에야 모바일 PWA 사용자에게 표시됨. SW cache 의 영구성 + iOS standalone webview 의 분리 cache 영역 학습. --pwa-strategy=none 으로 근본 해결.
+
+### Domain 분리 (Budget vs SpendingPlan)
+사용자 도메인 모델 명확 — "계획됨은 예산이 아님". UI 코드에 spending_plan 데이터 mix 가 결합 위반. Phase A (BE 버그 fix) + Phase B (UI 분리) 단계 처리.
+
+### Follow-up (회차 13 후보)
+- BudgetSummaryItem.plannedAmount entity field 완전 제거 (BE 응답 정리)
+- 분석 탭 메인 화면에 "계획 분석" widget 신규 (총 예산 중 계획 비율 + 결제 진행도)
+- statistics_bloc 의 multi-filter (categoryIds 등) UI 제공 시 함께 plumbing
+- P2 Phase B+C — sub-page builder 11곳 통합 + MonthCubit 단일 강화 + audit `month_source_of_truth` 강제
+
+## 롤백 정보
+12 PR 각각 별도 revert 가능. 또는 회차 11 SHA `f64e463` (PR #211) 으로 일괄 revert.


### PR DESCRIPTION
## Summary
회차 12 (2026-05-03 ~ 05-04) 라이브 검증 통과 ("모두 잘 된다").

회차 8~11 검증 통과 후 사용자 추가 검증에서 5+3 건 회귀 발견:
- 분석 탭 아이콘 미노출 (PWA cache stale)
- 거래 4월/5월 desync (month + filterState)
- 카테고리 표시 통일 (자동/직접 선택)
- 예산-계획 도메인 분리
- 거래 폼 이체 탭 입력 손실
- 모바일 자산 UI 깨짐 (추가)
- MonthNavigator 위치 + PageView 통합 (추가)
- BLoC Load race 12개 sweep (추가)

총 12 PR 머지 + audit-patterns v1.12.0 갱신.

## Test plan
- 문서만 — 코드 변경 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)