### PR TITLE
feat(transaction): 확인/입력 필요 플래그 + 메모 카드 + 0원/사칙연산 회귀 fix

### DIFF
--- a/backend/src/main/kotlin/com/budgetbook/common/dto/CommonFilterParams.kt
+++ b/backend/src/main/kotlin/com/budgetbook/common/dto/CommonFilterParams.kt
@@ -31,7 +31,9 @@ data class CommonFilterParams(
     // 단수 `type` 과 병존 시 Service 계층에서 `transactionTypes` 우선 (FE `toQueryParams` 와 일치).
     // 빈/null = 필터 없음. 유효 값: EXPENSE / INCOME / ADJUSTMENT (TRANSFER 는 FE 의사-타입).
     val transactionTypes: List<String>? = null,
-    val status: String? = null
+    val status: String? = null,
+    // V61 (2026-05-06) — true 면 needs_review=true 거래만 (확인/입력 필요만 보기).
+    val needsReviewOnly: Boolean? = null
 ) {
     /**
      * Resolves effective date range from dateFrom/dateTo or year/month.

--- a/backend/src/main/kotlin/com/budgetbook/transaction/controller/TransactionController.kt
+++ b/backend/src/main/kotlin/com/budgetbook/transaction/controller/TransactionController.kt
@@ -68,7 +68,9 @@ class TransactionController(
             paymentMethodIds = filter.paymentMethodIds,
             pocketIds = filter.pocketIds,
             // Phase 22 T10: 다중 타입 필터. `transactionTypes=EXPENSE&transactionTypes=INCOME`.
-            transactionTypes = filter.transactionTypes
+            transactionTypes = filter.transactionTypes,
+            // V61 (2026-05-06) — 확인/입력 필요만 보기.
+            needsReviewOnly = filter.needsReviewOnly
         ))
     }
 

--- a/backend/src/main/kotlin/com/budgetbook/transaction/domain/Transaction.kt
+++ b/backend/src/main/kotlin/com/budgetbook/transaction/domain/Transaction.kt
@@ -76,7 +76,15 @@ class Transaction(
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "owner_id")
-    var owner: User? = null
+    var owner: User? = null,
+
+    /**
+     * 사용자가 "확인/입력 필요" 로 마킹한 거래 여부.
+     * V61 (2026-05-06) — 메모만으로는 부족한 follow-up 항목을 별도 플래그로 빠르게 식별.
+     * 통계/예산 합계 계산에는 영향 없음 (단순 디스플레이 + 필터링용).
+     */
+    @Column(name = "needs_review", nullable = false)
+    var needsReview: Boolean = false
 ) : BaseTimeEntity()
 
 /**

--- a/backend/src/main/kotlin/com/budgetbook/transaction/dto/TransactionDtos.kt
+++ b/backend/src/main/kotlin/com/budgetbook/transaction/dto/TransactionDtos.kt
@@ -32,6 +32,8 @@ data class TransactionResponse(
     val pocketName: String? = null,
     val visibility: String = "SHARED",
     val ownerId: UUID? = null,
+    // V61 (2026-05-06) — 확인/입력 필요 플래그
+    val needsReview: Boolean = false,
     val createdAt: Instant,
     val updatedAt: Instant
 )
@@ -73,7 +75,10 @@ data class CreateTransactionRequest(
 
     val pocketId: UUID? = null,
 
-    val visibility: String? = "SHARED"
+    val visibility: String? = "SHARED",
+
+    // V61 (2026-05-06) — 확인/입력 필요 플래그. 미지정 시 false.
+    val needsReview: Boolean = false
 )
 
 data class UpdateTransactionRequest(
@@ -100,7 +105,10 @@ data class UpdateTransactionRequest(
     @JsonDeserialize(using = UUIDPatchValueDeserializer::class)
     val pocketId: PatchValue<UUID>? = null,
 
-    val visibility: String? = null
+    val visibility: String? = null,
+
+    // V61 (2026-05-06) — null 이면 미변경, true/false 면 토글.
+    val needsReview: Boolean? = null
 )
 
 data class PageResponse<T>(

--- a/backend/src/main/kotlin/com/budgetbook/transaction/repository/TransactionSpecifications.kt
+++ b/backend/src/main/kotlin/com/budgetbook/transaction/repository/TransactionSpecifications.kt
@@ -34,7 +34,10 @@ object TransactionSpecifications {
         paymentMethodIds: Set<UUID> = emptySet(),
         pocketIds: Set<UUID> = emptySet(),
         // Phase 22 T10 다중 타입 필터. 단수 `type` 과 병존 시 호출자(Service) 에서 단수를 null 로 넘김.
-        types: Set<TransactionType> = emptySet()
+        types: Set<TransactionType> = emptySet(),
+        // V61 (2026-05-06) — true 면 needs_review=true 거래만 (확인/입력 필요만 보기).
+        // null/false 모두 미적용으로 처리 — "false 만 보기" 시나리오는 현재 요구 없음.
+        needsReviewOnly: Boolean? = null
     ): Specification<Transaction> {
         return Specification { root: Root<Transaction>, _: CriteriaQuery<*>, cb: CriteriaBuilder ->
             val predicates = mutableListOf<Predicate>()
@@ -84,6 +87,11 @@ object TransactionSpecifications {
 
             amountMax?.let {
                 predicates.add(cb.lessThanOrEqualTo(root.get("amount"), it))
+            }
+
+            // V61 — 확인/입력 필요만 보기. true 일 때만 조건 추가.
+            if (needsReviewOnly == true) {
+                predicates.add(cb.isTrue(root.get("needsReview")))
             }
 
             // Visibility 필터:

--- a/backend/src/main/kotlin/com/budgetbook/transaction/service/TransactionService.kt
+++ b/backend/src/main/kotlin/com/budgetbook/transaction/service/TransactionService.kt
@@ -76,7 +76,9 @@ class TransactionService(
         pocketIds: List<UUID> = emptyList(),
         // Phase 22 T10: 다중 타입 필터. null/빈 리스트 = 필터 없음.
         // 단수 `type` 과 병존 시 `transactionTypes` 우선 (FE toQueryParams 와 일치).
-        transactionTypes: List<String>? = null
+        transactionTypes: List<String>? = null,
+        // V61 (2026-05-06) — true 면 needs_review=true 거래만.
+        needsReviewOnly: Boolean? = null
     ): PageResponse<TransactionResponse> {
         val couple = getActiveCouple(userId)
 
@@ -150,7 +152,8 @@ class TransactionService(
             effectiveTransactionTypes.isNotEmpty()
         val hasExtendedFilters = keyword != null || paymentMethodId != null ||
             pocketId != null || amountMin != null || amountMax != null ||
-            visibilityFilter != null || hasMultiFilters
+            visibilityFilter != null || hasMultiFilters ||
+            needsReviewOnly == true
 
         val result = if (hasExtendedFilters) {
             // 단수 categoryId 는 Set 에 이미 합쳐졌으므로 Spec 에는 Set 만 전달 (중복 조건 방지).
@@ -176,7 +179,8 @@ class TransactionService(
                 categoryIds = effectiveCategoryIds,
                 paymentMethodIds = effectivePaymentMethodIds,
                 pocketIds = effectivePocketIds,
-                types = effectiveTransactionTypes
+                types = effectiveTransactionTypes,
+                needsReviewOnly = needsReviewOnly
             )
             transactionRepository.findAll(spec, pageable)
         } else {
@@ -260,7 +264,8 @@ class TransactionService(
             settlementDate = settlementDate,
             pocket = pocket,
             visibility = effectiveVisibility,
-            owner = if (effectiveVisibility == Visibility.PRIVATE) user else null
+            owner = if (effectiveVisibility == Visibility.PRIVATE) user else null,
+            needsReview = request.needsReview
         )
 
         val saved = transactionRepository.save(transaction)
@@ -303,6 +308,8 @@ class TransactionService(
         request.description?.let { transaction.description = it }
         request.transactionDate?.let { transaction.transactionDate = it }
         request.memo?.let { transaction.memo = it.value }
+        // V61 (2026-05-06) — null 이면 미변경, true/false 면 명시적 토글
+        request.needsReview?.let { transaction.needsReview = it }
 
         // Handle categoryId with PatchValue (before visibility, as category may force PRIVATE)
         request.categoryId?.let { patchValue ->
@@ -583,6 +590,7 @@ class TransactionService(
         pocketName = pocket?.name,
         visibility = visibility.name,
         ownerId = owner?.id,
+        needsReview = needsReview,
         createdAt = createdAt,
         updatedAt = updatedAt
     )

--- a/backend/src/main/resources/db/migration/V61__add_transaction_needs_review.sql
+++ b/backend/src/main/resources/db/migration/V61__add_transaction_needs_review.sql
@@ -1,0 +1,11 @@
+-- V61: Add needs_review flag to transactions for "확인/입력 필요" marker.
+-- 사용자가 거래 등록 후 "나중에 확인 필요" 또는 "내용 입력 필요" 로 마킹할 수 있는 플래그.
+-- partial index 로 "확인 필요만 보기" 필터 페이징을 빠르게 한다.
+-- 기존 row 는 default false 로 backfill 된다 (NOT NULL DEFAULT false).
+
+ALTER TABLE transactions
+    ADD COLUMN IF NOT EXISTS needs_review BOOLEAN NOT NULL DEFAULT false;
+
+CREATE INDEX IF NOT EXISTS idx_transactions_needs_review
+    ON transactions (couple_id, transaction_date DESC)
+    WHERE needs_review = true;

--- a/docs/sessions/2026-05-06_1_plan.md
+++ b/docs/sessions/2026-05-06_1_plan.md
@@ -1,0 +1,181 @@
+# 거래 플래그(확인/입력 필요) + 메모 개선 + 회귀 fix (0원/사칙연산)
+> 날짜: 2026-05-06 | 회차: 1 | 상태: 기획
+
+## 요청 내용
+> (사용자 원문)
+>
+> 1. 느낌표 같은걸로 기억 안 나지만 내역 등록해놓고 **확인 또는 입력 필요** 같은 표시할 수 있는 기능 (메모 통해 선택으로 해당 기능 추가, 현재 메모가 가운데 표시 안되는데 가운데 표시되면서 여러 줄 입력 가능한 형태로 개선)
+> 2. 확인/입력 필요 항목만 모아볼 수 있는 기능도 추가 필요
+>
+> 개편되며 되돌아간 기능
+> 3. 금액 0원 입력 가능해야하는데 개편되며 반영 안됨
+> 4. 금액 입력 시 사칙연산 가능했는데 마찬가지로 개편되며 사라졌고, 모바일에서는 숫자만 입력 가능해서 금액 옆에 계산기 아이콘을 만들어 클릭 시 팝업으로 계산기가 나와 계산 가능하도록 만들어지면 좋을 것 같다. () 같은 연산도 반영 필요
+>
+> 키보드로 사칙연산 기호를 직접 입력하면 계산은 되지만 모바일에서는 숫자 밖에 안 나와 연산 불가
+
+## 영향 범위 분석
+
+### F1. 거래 플래그(확인/입력 필요)
+**BE**
+- DB 마이그레이션: `transactions` 테이블에 `needs_review BOOLEAN NOT NULL DEFAULT false` 컬럼 추가 + 부분 인덱스
+- Entity: `Transaction.needsReview: Boolean`
+- DTO: `TransactionResponse`, `CreateTransactionRequest`, `UpdateTransactionRequest` 각각 필드 추가 (Update 는 PatchValue 가 아닌 nullable Boolean — 단순 토글이므로)
+- Service: 생성/수정 시 needsReview 반영
+- Repository/Specification: `needsReview` 필터 지원
+
+**FE**
+- Entity: `Transaction.needsReview` 추가, props 포함
+- Repository/DataSource: 요청/응답에 필드 매핑
+- Form: 메모 카드 안에 토글 1개 추가 ("확인/입력 필요로 표시")
+- ListTile: title 옆에 `!` 뱃지(amber) 표시
+- 캘린더 뷰 dot 색에 영향 없음 (별도 인디케이터)
+
+**제약**
+- Transfer 에는 적용하지 않음 (이체는 단순 자금 이동, 확인 사유 거의 없음 — 추후 요구 시 추가)
+
+### F2. 확인/입력 필요 필터
+- `UnifiedFilterState.status` 가 이미 존재(미사용) → 의미 충돌 회피 위해 **`needsReviewOnly: bool`** 필드 신규 추가
+- `TransactionFilter` 도 동일 필드 추가, `toQueryParams()` 에 직렬화
+- `UnifiedFilterBar` 에 "확인 필요" 빠른 토글 chip 추가 (카운트는 페이로드 절약을 위해 1차 미포함 — 후속)
+
+### F3. 0원 입력 회귀 (`CalculatorAmountField`)
+**원인 (코드 확인 완료):**
+- `frontend/lib/core/widgets/calculator_amount_field.dart:89-98` — `_evaluateAndReplace()` 가 `result <= 0` 시 `controller.text = ''` 로 비워버림 → 5-5 같은 입력 결과 0 손실
+- 거래 폼 validator(line 707) 자체는 `amount < 0` 으로만 reject (0 은 허용) — DB(V46)도 EXPENSE/INCOME 0 허용
+- Transfer 폼은 `<= 0` 거부 유지 (이체 0원은 무의미)
+
+**조치:**
+- `_evaluateAndReplace`: `result < 0` 일 때만 비움. `result == 0` 은 그대로 수용 후 "0" 표시.
+- 거래 폼 hint(`_updateAmountHint`)와 `_amountController` 동작에서 0 정상 처리 확인.
+
+### F4. 메모 개선 + 모바일 계산기 popup
+**메모(form_page line 786-799):**
+- `maxLines: 2` → `minLines: 3, maxLines: 6` 로 확장
+- `textAlign: TextAlign.center`, `textAlignVertical: TextAlignVertical.center`
+- `prefixIcon` 제거 (중앙 정렬 방해) → labelText 위 아이콘 또는 컨테이너 헤더로 대체
+- 컨테이너 카드 형태로 묶고 안에 [메모 multi-line] + [확인/입력 필요 토글] 배치
+
+**금액 입력 — 계산기 popup:**
+- `CalculatorAmountField.suffixIcon` 에 `Icons.calculate` 아이콘 추가 (현재 backspace 좌측)
+- 클릭 시 `showDialog` → `_CalculatorPopup` 위젯
+  - 디스플레이(현재 표현식 + 미리보기 결과)
+  - 버튼 그리드: 0~9, `.`, `+`, `-`, `*`, `/`, `(`, `)`, `C`, `←`, `=`
+  - 괄호 지원을 위해 `evaluateExpression` 을 **shunting-yard** 기반으로 재작성 (현 코드는 단순 left-to-right precedence)
+- 확인 시 결과를 `controller.text` 에 반영 (0 포함, 음수 거부)
+- 키보드 입력으로 `+ - * /` 직접 타이핑 케이스도 함께 지원 유지 (PC)
+
+### 변경 파일 목록
+| # | 파일 | 변경 |
+|---|------|------|
+| 1 | `backend/src/main/resources/db/migration/V61__add_transaction_needs_review.sql` | 신규 |
+| 2 | `backend/src/main/kotlin/com/budgetbook/transaction/domain/Transaction.kt` | needsReview 필드 |
+| 3 | `backend/src/main/kotlin/com/budgetbook/transaction/dto/TransactionDtos.kt` | DTO 3종 + (선택) 필터 응답 |
+| 4 | `backend/src/main/kotlin/com/budgetbook/transaction/repository/TransactionSpecifications.kt` | needsReview 필터 |
+| 5 | `backend/src/main/kotlin/com/budgetbook/transaction/service/TransactionService.kt` | 생성/수정 매핑 |
+| 6 | `backend/src/main/kotlin/com/budgetbook/transaction/controller/TransactionController.kt` | 쿼리 파라미터 |
+| 7 | BE 테스트 (TransactionServiceTest) | needsReview 토글 케이스 |
+| 8 | `frontend/lib/features/transaction/domain/entities/transaction.dart` | needsReview |
+| 9 | `frontend/lib/features/transaction/data/models/transaction_model.dart` | 매핑 |
+| 10 | `frontend/lib/features/transaction/data/datasources/transaction_remote_datasource.dart` | 요청/응답 |
+| 11 | `frontend/lib/features/transaction/domain/entities/transaction_filter.dart` | needsReviewOnly |
+| 12 | `frontend/lib/core/models/unified_filter_state.dart` | needsReviewOnly + clear flag |
+| 13 | `frontend/lib/core/widgets/filters/unified_filter_bar.dart` | "확인 필요" chip |
+| 14 | `frontend/lib/features/transaction/presentation/pages/transaction_form_page.dart` | 메모 카드 개편 + 토글 |
+| 15 | `frontend/lib/features/transaction/presentation/pages/transaction_list_page.dart` | filter wiring |
+| 16 | `frontend/lib/features/transaction/presentation/widgets/transaction_list_tile.dart` | `!` 뱃지 |
+| 17 | `frontend/lib/core/widgets/calculator_amount_field.dart` | 0원 fix + 계산기 popup + 괄호 지원 |
+| 18 | FE 테스트 | calculator popup, evaluator(괄호), filter |
+
+## 작업 계획
+| # | 작업 | 담당 | 파일 | 난이도 |
+|---|------|------|------|--------|
+| 1 | V61 마이그레이션 작성 | BE | (1) | S |
+| 2 | Transaction 엔티티 + DTO 확장 | BE | (2,3) | S |
+| 3 | Specification + 필터 쿼리 + Controller 파라미터 | BE | (4,6) | M |
+| 4 | Service create/update 반영 + 테스트 | BE | (5,7) | M |
+| 5 | FE 엔티티/모델/datasource | FE | (8,9,10) | S |
+| 6 | TransactionFilter / UnifiedFilterState 확장 | FE | (11,12) | S |
+| 7 | "확인 필요" filter chip + list page wiring | FE | (13,15) | M |
+| 8 | Form 메모 카드 redesign + 토글 | FE | (14) | M |
+| 9 | List tile `!` 뱃지 | FE | (16) | S |
+| 10 | CalculatorAmountField — 0원 fix + 괄호 evaluator + popup | FE | (17) | L |
+| 11 | FE 테스트 (evaluator 괄호, filter, form 토글) | FE | (18) | M |
+| 12 | 교차 검증 / e2e 시나리오 | Tester | — | M |
+
+## 성능 설계 (원칙 1.4)
+- **데이터 접근**: needs_review 필터는 단일 BOOLEAN 컬럼 동등 비교. partial index `idx_transactions_needs_review` (couple_id, transaction_date DESC) WHERE needs_review = true 로 "확인 필요만 보기" 페이징 O(log N) 보장.
+- **예상 규모**: 1 커플 월 평균 거래 ~200건. needs_review=true 비율은 1~5% 가정 → 인덱스 매우 작음.
+- **응답 규모**: 기존 페이지네이션(20건/페이지) 그대로. 추가 필드 1바이트 → 페이로드 영향 무시 가능.
+- **연산 복잡도**: evaluator 괄호 지원은 shunting-yard O(N) — 입력 길이 < 50자 한계 (UI 가드).
+- **리소스 제약**: 추가 BLoC 도입 없음 (UnifiedFilterState 확장만). 메모리 영향 없음.
+- **설계 결정**:
+  - Transfer 에는 needs_review 미적용 (필요 시 후속 PR — 도메인 다름).
+  - 필터 chip 의 카운트는 1차 미포함 (별도 count API 호출 부하 회피).
+  - Calculator popup 은 별도 페이지가 아닌 modal — Navigator stack 부담 최소화.
+
+## 하네스 Scope Audit 결과 (Step 1.5)
+- **실행 명령**: `bash ~/.claude/harness/scripts/pre-change-audit.sh . "db_schema,ui_pattern,amount_calculation"`
+- **분류 태그**: db_schema, ui_pattern, amount_calculation
+- **Scope Audit 발견**:
+  - db_schema 다수 (V46/V54 amount 제약, V19 unique 등) — 본 작업과 직접 충돌 없음 (새 컬럼만 추가)
+  - amount_calculation 인시던트 6건 — 모두 합계 누락/이중 계산 패턴. 본 작업은 신규 필드 단순 토글이라 합계 영향 없음. 단 통계/예산 쿼리에서 `needs_review` 가 합계 계산 식에 끼어들지 않도록 주의 (BE Service 변경 없음 정책).
+  - ui_pattern 인시던트 7건 — 특히:
+    - "거부한 UI 다시 추가 금지" → 본 작업의 메모 카드/토글은 사용자가 명시 요청한 신규 영역 (재추가 아님)
+    - singleton bloc 회귀 → 본 작업은 BLoC 신규 도입 없음
+    - 필터 카운트 stale → 본 작업의 chip 은 카운트 표시 없음 (회피)
+- **Recurrence Check**: ✅ OK (Verdict 그대로)
+- **재발 방지 조치**: 해당 없음 (STRUCTURAL_FIX_REQUIRED 아님)
+
+## 자동 검증 계획 (CI/로컬)
+- [ ] BE 테스트 통과 (`./gradlew test`)
+- [ ] FE 분석+테스트+빌드 (`flutter analyze && flutter test && flutter build web`)
+- [ ] BE↔FE↔Spec 일치 확인 (DTO 필드명/타입)
+- [ ] V61 마이그레이션 idempotent 확인 (`IF NOT EXISTS`)
+- [ ] needs_review default false → 기존 거래 모두 false 로 backfill 자동
+- [ ] evaluator 괄호 케이스 테스트: `(1+2)*3 = 9`, `((1+2)*3)/9 = 1`, `1+(2*(3+4)) = 15`
+- [ ] 0원 케이스: `0` 수용 / `5-5` → 0 표시 / 음수 거부
+- [ ] 모바일 viewport 에서 계산기 아이콘 노출 확인
+
+## 배포 절차 (필수)
+| # | 단계 | 주체 | 확인 방법 |
+|---|------|------|----------|
+| 1 | PR 생성 / CI | AI | `gh pr checks <N>` |
+| 2 | squash merge | AI | `gh pr merge <N> --squash --delete-branch` |
+| 3 | deploy-nas.yml watch | AI | `gh run watch <id>` |
+| 4 | 캐시 무효화 | 사용자 | F12 → Network → Disable cache → 새로고침 |
+
+## 사용자 검증 시나리오
+
+### A. 기능 (신규 동작)
+| # | 경로 | 조작 | 기대 결과 |
+|---|------|------|----------|
+| A1 | 거래 추가 | 메모 카드의 "확인/입력 필요" 토글 ON, 저장 | 리스트 항목 제목 옆 `!` 뱃지 표시 |
+| A2 | 거래 추가 | 토글 OFF 로 저장 | 뱃지 미표시 (기존 동일) |
+| A3 | 거래 수정 | 기존 거래의 토글을 ON↔OFF | 즉시 리스트에 반영 |
+| A4 | 필터 바 | "확인 필요" chip 클릭 | needs_review=true 거래만 표시, 카운트 일치 |
+| A5 | 필터 바 | chip 다시 클릭(해제) | 전체 표시 복원 |
+| A6 | 거래 추가 | 금액 `0` 입력 + 저장 | 0원 거래 정상 저장 (지출/수입 둘 다) |
+| A7 | 거래 추가 | 금액 `5-5` 입력 → focus blur | "0" 으로 평가됨 (비워지지 않음) |
+| A8 | 거래 추가 | 금액 우측 계산기 아이콘 클릭 | popup 등장, `(2+3)*4=` 입력 시 20 반영 |
+| A9 | 모바일 | 키보드는 숫자만이지만 계산기 아이콘 사용 가능 | 사칙연산 + 괄호 모두 가능 |
+| A10 | 거래 추가 | 메모 영역에 줄바꿈 포함 3줄 입력 | 줄바꿈 보존, 가운데 정렬 표시 |
+
+### B. 회귀 없음 (Zero regression)
+| # | 확인 | 기대 |
+|---|------|------|
+| B1 | 기존 거래(needs_review 없는 데이터) | 정상 표시, 뱃지 없음 |
+| B2 | 이체(Transfer) 등록/수정 | needs_review 무관(영향 없음), amount<=0 거부 유지 |
+| B3 | ADJUSTMENT(잔액 조정) 등록 | 음수 amount 입력 가능, 0원도 정상(현재 정책) |
+| B4 | PC 키보드 `+ - * /` 직접 입력 | 기존대로 동작 + 괄호도 가능 |
+| B5 | 분석/자산 탭 통계 | needs_review 와 무관 (합계 변경 없음) |
+| B6 | 백업/복원/CSV import | needs_review 컬럼 누락 시 기본값 false 적용 |
+
+### C. 데이터 정합성
+| # | 상황 | 기대 |
+|---|------|------|
+| C1 | V61 신규 적용 직후 | 모든 기존 transaction.needs_review = false |
+| C2 | 토글 OFF→ON→OFF | DB 값이 false 로 정확히 복귀 |
+| C3 | 계산기 popup 결과 | controller.text 정확 반영, 음수 거부 |
+
+## 사용자 승인
+- [ ] 승인 / 수정 요청: ___

--- a/frontend/lib/core/models/unified_filter_state.dart
+++ b/frontend/lib/core/models/unified_filter_state.dart
@@ -10,6 +10,7 @@ enum FilterType {
   transactionType,
   visibility,
   status,
+  needsReview,
 }
 
 class UnifiedFilterState extends Equatable {
@@ -32,6 +33,9 @@ class UnifiedFilterState extends Equatable {
   final String? visibility;
   final String? status;
 
+  /// V61 (2026-05-06) — true 면 needs_review=true 거래만 (확인/입력 필요만 보기).
+  final bool needsReviewOnly;
+
   const UnifiedFilterState({
     this.dateFrom,
     this.dateTo,
@@ -48,6 +52,7 @@ class UnifiedFilterState extends Equatable {
     this.transactionTypes = const {},
     this.visibility,
     this.status,
+    this.needsReviewOnly = false,
   });
 
   /// Legacy single-value accessor. Returns the first selected type, or null.
@@ -67,7 +72,8 @@ class UnifiedFilterState extends Equatable {
       (keyword != null && keyword!.isNotEmpty) ||
       transactionTypes.isNotEmpty ||
       (visibility != null && visibility != 'ALL') ||
-      status != null;
+      status != null ||
+      needsReviewOnly;
 
   bool get hasDateRange => dateFrom != null && dateTo != null;
 
@@ -87,6 +93,7 @@ class UnifiedFilterState extends Equatable {
     Set<String>? transactionTypes,
     String? visibility,
     String? status,
+    bool? needsReviewOnly,
     bool clearDateRange = false,
     bool clearCategory = false,
     bool clearPaymentMethod = false,
@@ -96,6 +103,7 @@ class UnifiedFilterState extends Equatable {
     bool clearTransactionType = false,
     bool clearVisibility = false,
     bool clearStatus = false,
+    bool clearNeedsReview = false,
   }) {
     return UnifiedFilterState(
       dateFrom: clearDateRange ? null : (dateFrom ?? this.dateFrom),
@@ -125,6 +133,9 @@ class UnifiedFilterState extends Equatable {
       visibility:
           clearVisibility ? null : (visibility ?? this.visibility),
       status: clearStatus ? null : (status ?? this.status),
+      needsReviewOnly: clearNeedsReview
+          ? false
+          : (needsReviewOnly ?? this.needsReviewOnly),
     );
   }
 
@@ -149,5 +160,6 @@ class UnifiedFilterState extends Equatable {
         transactionTypes,
         visibility,
         status,
+        needsReviewOnly,
       ];
 }

--- a/frontend/lib/core/widgets/calculator_amount_field.dart
+++ b/frontend/lib/core/widgets/calculator_amount_field.dart
@@ -2,12 +2,14 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:budget_book/core/utils/currency_formatter.dart';
 
-/// A TextFormField for amount input that supports simple arithmetic (+/-).
+/// A TextFormField for amount input that supports arithmetic (+ - * /) with
+/// parentheses, and a calculator popup for mobile (where number-only keyboards
+/// block operators).
 ///
-/// When the user types `+` or `-`, it switches to expression mode,
-/// showing a preview of the evaluated result below the field.
-/// On focus loss or pressing `=`, the expression is evaluated
-/// and the result replaces the input.
+/// 회차 1 (2026-05-06):
+///   - 0원 회귀 fix: `5-5=0` 이 비워지지 않고 `0` 으로 표시됨. 음수만 거부.
+///   - 괄호 지원: shunting-yard 기반 evaluator, `(1+2)*3` 가능.
+///   - 모바일 계산기 popup: suffixIcon 의 [Icons.calculate] 클릭 → 버튼 그리드 dialog.
 class CalculatorAmountField extends StatefulWidget {
   final TextEditingController controller;
   final InputDecoration? decoration;
@@ -56,14 +58,8 @@ class _CalculatorAmountFieldState extends State<CalculatorAmountField> {
 
   void _onTextChanged() {
     final text = widget.controller.text;
-    final hasOperator = text.contains('+') || text.contains('-') ||
-        text.contains('*') || text.contains('/');
-
-    // Detect if this is entering expression mode (has operator beyond just digits+commas)
-    // But the first character '-' does not count (negative number, though we don't support negative)
     final cleanText = text.replaceAll(',', '');
-    final isExpression = hasOperator && cleanText.length > 1 &&
-        RegExp(r'\d[+\-*/]').hasMatch(cleanText);
+    final isExpression = _looksLikeExpression(cleanText);
 
     if (isExpression != _isExpressionMode) {
       setState(() {
@@ -86,14 +82,14 @@ class _CalculatorAmountFieldState extends State<CalculatorAmountField> {
   void _evaluateAndReplace() {
     final text = widget.controller.text.replaceAll(',', '');
     final result = evaluateExpression(text);
-    if (result != null && result > 0) {
+    // 회차 1 (2026-05-06) — 0원 회귀 fix: 0 은 정상 결과로 간주, 음수만 비움.
+    if (result != null && result >= 0) {
       final formatted = CurrencyFormatter.format(result);
       widget.controller.text = formatted;
       widget.controller.selection =
           TextSelection.collapsed(offset: formatted.length);
       widget.onAmountChanged?.call(result);
-    } else if (result != null && result <= 0) {
-      // Negative or zero result: set to empty so validation catches it
+    } else if (result != null && result < 0) {
       widget.controller.text = '';
     }
     setState(() {
@@ -102,74 +98,134 @@ class _CalculatorAmountFieldState extends State<CalculatorAmountField> {
     });
   }
 
-  /// Evaluates an arithmetic expression with +, -, *, /.
-  /// Respects operator precedence: * and / before + and -.
-  /// Input should have commas already stripped.
-  /// e.g. "50000+3000*2" → 56000, "100000/4-5000" → 20000
+  /// True if the cleaned input looks like an expression that should be
+  /// evaluated (contains an operator after a digit, or has parentheses).
+  static bool _looksLikeExpression(String cleanText) {
+    if (cleanText.length <= 1) return false;
+    if (cleanText.contains('(') || cleanText.contains(')')) return true;
+    return RegExp(r'\d[+\-*/]').hasMatch(cleanText);
+  }
+
+  /// Evaluates an arithmetic expression with `+ - * /` and parentheses using a
+  /// shunting-yard algorithm. Input should have commas already stripped.
+  /// Returns null on syntax errors or division-by-zero.
+  ///
+  /// Examples:
+  ///   `(1+2)*3` → 9
+  ///   `((1+2)*3)/9` → 1
+  ///   `1+(2*(3+4))` → 15
+  ///   `5-5` → 0  (회차 1 fix — 이전 evaluator 도 0 반환했으나 caller 가 비웠음)
   static int? evaluateExpression(String expr) {
     if (expr.isEmpty) return null;
+    if (expr.length > 100) return null;
 
-    // Tokenize: split into numbers and operators (+, -, *, /)
-    final numbers = <double>[];
-    final operators = <String>[];
-    var current = '';
-
+    // Tokenize.
+    final tokens = <String>[];
+    var current = StringBuffer();
     for (var i = 0; i < expr.length; i++) {
       final ch = expr[i];
-      if ((ch == '+' || ch == '-' || ch == '*' || ch == '/') && i > 0 && current.isNotEmpty) {
-        final num = double.tryParse(current);
-        if (num == null) return null;
-        numbers.add(num);
-        operators.add(ch);
-        current = '';
+      if (RegExp(r'[0-9.]').hasMatch(ch)) {
+        current.write(ch);
+      } else if ('+-*/()'.contains(ch)) {
+        if (current.isNotEmpty) {
+          tokens.add(current.toString());
+          current = StringBuffer();
+        }
+        tokens.add(ch);
       } else {
-        current += ch;
+        return null;
       }
     }
-    if (current.isNotEmpty) {
-      final num = double.tryParse(current);
-      if (num == null) return null;
-      numbers.add(num);
-    }
-    if (numbers.isEmpty) return null;
+    if (current.isNotEmpty) tokens.add(current.toString());
+    if (tokens.isEmpty) return null;
 
-    // Phase 1: process * and / (higher precedence)
-    final addNumbers = <double>[numbers[0]];
-    final addOperators = <String>[];
-    for (var i = 0; i < operators.length; i++) {
-      if (operators[i] == '*') {
-        addNumbers.last = addNumbers.last * numbers[i + 1];
-      } else if (operators[i] == '/') {
-        if (numbers[i + 1] == 0) return null; // division by zero
-        addNumbers.last = addNumbers.last / numbers[i + 1];
+    // Convert infix → postfix (shunting-yard).
+    final output = <String>[];
+    final ops = <String>[];
+    const precedence = {'+': 1, '-': 1, '*': 2, '/': 2};
+    for (final t in tokens) {
+      if (precedence.containsKey(t)) {
+        while (ops.isNotEmpty &&
+            ops.last != '(' &&
+            (precedence[ops.last] ?? 0) >= precedence[t]!) {
+          output.add(ops.removeLast());
+        }
+        ops.add(t);
+      } else if (t == '(') {
+        ops.add(t);
+      } else if (t == ')') {
+        while (ops.isNotEmpty && ops.last != '(') {
+          output.add(ops.removeLast());
+        }
+        if (ops.isEmpty) return null; // unbalanced
+        ops.removeLast(); // pop '('
       } else {
-        addOperators.add(operators[i]);
-        addNumbers.add(numbers[i + 1]);
+        final n = double.tryParse(t);
+        if (n == null) return null;
+        output.add(t);
       }
+    }
+    while (ops.isNotEmpty) {
+      final op = ops.removeLast();
+      if (op == '(' || op == ')') return null; // unbalanced
+      output.add(op);
     }
 
-    // Phase 2: process + and -
-    var result = addNumbers[0];
-    for (var i = 0; i < addOperators.length; i++) {
-      if (addOperators[i] == '+') {
-        result += addNumbers[i + 1];
+    // Evaluate postfix.
+    final stack = <double>[];
+    for (final t in output) {
+      if (precedence.containsKey(t)) {
+        if (stack.length < 2) return null;
+        final b = stack.removeLast();
+        final a = stack.removeLast();
+        switch (t) {
+          case '+': stack.add(a + b); break;
+          case '-': stack.add(a - b); break;
+          case '*': stack.add(a * b); break;
+          case '/':
+            if (b == 0) return null;
+            stack.add(a / b);
+            break;
+        }
       } else {
-        result -= addNumbers[i + 1];
+        final n = double.tryParse(t);
+        if (n == null) return null;
+        stack.add(n);
       }
     }
-    return result.round();
+    if (stack.length != 1) return null;
+    return stack.first.round();
+  }
+
+  Future<void> _openCalculatorPopup() async {
+    final initial = widget.controller.text.replaceAll(',', '');
+    final result = await showDialog<String>(
+      context: context,
+      builder: (ctx) => _CalculatorPopup(initialExpression: initial),
+    );
+    if (result == null || !mounted) return;
+    final value = evaluateExpression(result);
+    if (value != null && value >= 0) {
+      final formatted = CurrencyFormatter.format(value);
+      widget.controller.text = formatted;
+      widget.controller.selection =
+          TextSelection.collapsed(offset: formatted.length);
+      widget.onAmountChanged?.call(value);
+      setState(() {
+        _isExpressionMode = false;
+        _previewResult = null;
+      });
+    }
   }
 
   @override
   Widget build(BuildContext context) {
     final baseDecoration = widget.decoration ?? const InputDecoration();
 
-    // Build helper text: show preview when in expression mode, otherwise original helper
     String? helperText;
     if (_isExpressionMode && _previewResult != null) {
-      final prefix = _previewResult! <= 0 ? '' : '= ';
       helperText =
-          '$prefix${CurrencyFormatter.format(_previewResult!)}원';
+          '= ${CurrencyFormatter.format(_previewResult!)}원';
     } else {
       helperText = widget.helperText;
     }
@@ -187,60 +243,66 @@ class _CalculatorAmountFieldState extends State<CalculatorAmountField> {
                 fontWeight: FontWeight.w600,
               )
             : null,
-        suffixIcon: widget.controller.text.isNotEmpty
-            ? Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  if (_isExpressionMode)
-                    IconButton(
-                      icon: Icon(
-                        Icons.check_circle,
-                        color: Theme.of(context).colorScheme.primary,
-                      ),
-                      tooltip: '계산',
-                      onPressed: _evaluateAndReplace,
-                    ),
-                  GestureDetector(
-                    onLongPress: () {
-                      widget.controller.clear();
-                    },
-                    child: IconButton(
-                      icon: const Icon(Icons.backspace_outlined, size: 20),
-                      tooltip: '지우기 (길게 누르면 전체 삭제)',
-                      onPressed: () {
-                        final text = widget.controller.text;
-                        if (text.isNotEmpty) {
-                          // Remove last character, then reformat if needed
-                          final newText = text.substring(0, text.length - 1);
-                          if (!_isExpressionMode) {
-                            // In normal mode, strip commas, remove last digit, reformat
-                            final digits =
-                                newText.replaceAll(RegExp(r'[^\d]'), '');
-                            if (digits.isEmpty) {
-                              widget.controller.text = '';
-                            } else {
-                              final num = int.tryParse(digits);
-                              if (num != null) {
-                                final formatted = CurrencyFormatter.format(num);
-                                widget.controller.text = formatted;
-                                widget.controller.selection =
-                                    TextSelection.collapsed(
-                                        offset: formatted.length);
-                              }
-                            }
-                          } else {
-                            widget.controller.text = newText;
+        suffixIcon: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            // V61 (2026-05-06) — 모바일 계산기 popup. 항상 노출 (PC 도 사용 가능).
+            IconButton(
+              icon: const Icon(Icons.calculate_outlined, size: 22),
+              tooltip: '계산기',
+              onPressed: _openCalculatorPopup,
+              visualDensity: VisualDensity.compact,
+            ),
+            if (widget.controller.text.isNotEmpty) ...[
+              if (_isExpressionMode)
+                IconButton(
+                  icon: Icon(
+                    Icons.check_circle,
+                    color: Theme.of(context).colorScheme.primary,
+                  ),
+                  tooltip: '계산',
+                  onPressed: _evaluateAndReplace,
+                  visualDensity: VisualDensity.compact,
+                ),
+              GestureDetector(
+                onLongPress: () {
+                  widget.controller.clear();
+                },
+                child: IconButton(
+                  icon: const Icon(Icons.backspace_outlined, size: 20),
+                  tooltip: '지우기 (길게 누르면 전체 삭제)',
+                  visualDensity: VisualDensity.compact,
+                  onPressed: () {
+                    final text = widget.controller.text;
+                    if (text.isNotEmpty) {
+                      final newText = text.substring(0, text.length - 1);
+                      if (!_isExpressionMode) {
+                        final digits =
+                            newText.replaceAll(RegExp(r'[^\d]'), '');
+                        if (digits.isEmpty) {
+                          widget.controller.text = '';
+                        } else {
+                          final num = int.tryParse(digits);
+                          if (num != null) {
+                            final formatted = CurrencyFormatter.format(num);
+                            widget.controller.text = formatted;
                             widget.controller.selection =
                                 TextSelection.collapsed(
-                                    offset: newText.length);
+                                    offset: formatted.length);
                           }
                         }
-                      },
-                    ),
-                  ),
-                ],
-              )
-            : null,
+                      } else {
+                        widget.controller.text = newText;
+                        widget.controller.selection =
+                            TextSelection.collapsed(offset: newText.length);
+                      }
+                    }
+                  },
+                ),
+              ),
+            ],
+          ],
+        ),
       ),
       keyboardType: TextInputType.number,
       inputFormatters: [_CalculatorInputFormatter()],
@@ -249,9 +311,273 @@ class _CalculatorAmountFieldState extends State<CalculatorAmountField> {
   }
 }
 
-/// Input formatter that allows digits, commas, +, and -.
-/// In normal mode (no operators), it formats with commas.
-/// In expression mode (has operators), it allows raw input with operators.
+/// Modal calculator popup with button grid. Supports digits, parentheses, and
+/// `+ - * /`. On `=`, returns the current expression to caller.
+class _CalculatorPopup extends StatefulWidget {
+  final String initialExpression;
+  const _CalculatorPopup({required this.initialExpression});
+
+  @override
+  State<_CalculatorPopup> createState() => _CalculatorPopupState();
+}
+
+class _CalculatorPopupState extends State<_CalculatorPopup> {
+  late String _expr;
+  int? _preview;
+
+  @override
+  void initState() {
+    super.initState();
+    _expr = widget.initialExpression;
+    _recomputePreview();
+  }
+
+  void _recomputePreview() {
+    if (_expr.isEmpty) {
+      _preview = null;
+      return;
+    }
+    _preview = _CalculatorAmountFieldState.evaluateExpression(_expr);
+  }
+
+  void _append(String s) {
+    setState(() {
+      _expr = _expr + s;
+      _recomputePreview();
+    });
+  }
+
+  void _backspace() {
+    if (_expr.isEmpty) return;
+    setState(() {
+      _expr = _expr.substring(0, _expr.length - 1);
+      _recomputePreview();
+    });
+  }
+
+  void _clear() {
+    setState(() {
+      _expr = '';
+      _preview = null;
+    });
+  }
+
+  void _equals() {
+    if (_preview == null) return;
+    if (_preview! < 0) return;
+    Navigator.of(context).pop(_preview!.toString());
+  }
+
+  String _formatExpressionForDisplay(String expr) {
+    if (expr.isEmpty) return '0';
+    final buffer = StringBuffer();
+    var currentNum = '';
+    for (var i = 0; i < expr.length; i++) {
+      final ch = expr[i];
+      if ('+-*/()'.contains(ch)) {
+        if (currentNum.isNotEmpty) {
+          final n = int.tryParse(currentNum);
+          buffer.write(n != null ? CurrencyFormatter.format(n) : currentNum);
+          currentNum = '';
+        }
+        buffer.write(ch);
+      } else {
+        currentNum += ch;
+      }
+    }
+    if (currentNum.isNotEmpty) {
+      final n = int.tryParse(currentNum);
+      buffer.write(n != null ? CurrencyFormatter.format(n) : currentNum);
+    }
+    return buffer.toString();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final previewText = _preview == null
+        ? '—'
+        : '= ${CurrencyFormatter.format(_preview!)}원';
+
+    return AlertDialog(
+      title: const Text('계산기'),
+      contentPadding: const EdgeInsets.fromLTRB(16, 12, 16, 0),
+      content: SizedBox(
+        width: 320,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Container(
+              width: double.infinity,
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: theme.colorScheme.surfaceContainerHighest,
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.end,
+                children: [
+                  Text(
+                    _formatExpressionForDisplay(_expr),
+                    style: theme.textTheme.titleMedium,
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    previewText,
+                    style: theme.textTheme.bodyMedium?.copyWith(
+                      color: _preview == null
+                          ? theme.colorScheme.error
+                          : theme.colorScheme.primary,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 12),
+            _buildButtonGrid(),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('취소'),
+        ),
+        FilledButton(
+          onPressed: _preview != null && _preview! >= 0 ? _equals : null,
+          child: const Text('확인'),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildButtonGrid() {
+    final rows = <List<_BtnSpec>>[
+      [
+        _BtnSpec('C', _clear, _BtnKind.danger),
+        _BtnSpec('(', () => _append('('), _BtnKind.op),
+        _BtnSpec(')', () => _append(')'), _BtnKind.op),
+        _BtnSpec('⌫', _backspace, _BtnKind.op),
+      ],
+      [
+        _BtnSpec('7', () => _append('7'), _BtnKind.digit),
+        _BtnSpec('8', () => _append('8'), _BtnKind.digit),
+        _BtnSpec('9', () => _append('9'), _BtnKind.digit),
+        _BtnSpec('÷', () => _append('/'), _BtnKind.op),
+      ],
+      [
+        _BtnSpec('4', () => _append('4'), _BtnKind.digit),
+        _BtnSpec('5', () => _append('5'), _BtnKind.digit),
+        _BtnSpec('6', () => _append('6'), _BtnKind.digit),
+        _BtnSpec('×', () => _append('*'), _BtnKind.op),
+      ],
+      [
+        _BtnSpec('1', () => _append('1'), _BtnKind.digit),
+        _BtnSpec('2', () => _append('2'), _BtnKind.digit),
+        _BtnSpec('3', () => _append('3'), _BtnKind.digit),
+        _BtnSpec('−', () => _append('-'), _BtnKind.op),
+      ],
+      [
+        _BtnSpec('0', () => _append('0'), _BtnKind.digit),
+        _BtnSpec('00', () => _append('00'), _BtnKind.digit),
+        _BtnSpec('=', _equals, _BtnKind.equals),
+        _BtnSpec('+', () => _append('+'), _BtnKind.op),
+      ],
+    ];
+
+    return Column(
+      children: rows
+          .map(
+            (row) => Padding(
+              padding: const EdgeInsets.only(bottom: 6),
+              child: Row(
+                children: row
+                    .map((b) => Expanded(child: _buildButton(b)))
+                    .toList(),
+              ),
+            ),
+          )
+          .toList(),
+    );
+  }
+
+  Widget _buildButton(_BtnSpec spec) {
+    final theme = Theme.of(context);
+    Color bg;
+    Color fg;
+    switch (spec.kind) {
+      case _BtnKind.digit:
+        bg = theme.colorScheme.surfaceContainerHighest;
+        fg = theme.colorScheme.onSurface;
+        break;
+      case _BtnKind.op:
+        bg = theme.colorScheme.secondaryContainer;
+        fg = theme.colorScheme.onSecondaryContainer;
+        break;
+      case _BtnKind.equals:
+        bg = theme.colorScheme.primary;
+        fg = theme.colorScheme.onPrimary;
+        break;
+      case _BtnKind.danger:
+        bg = theme.colorScheme.errorContainer;
+        fg = theme.colorScheme.onErrorContainer;
+        break;
+    }
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 3),
+      child: SizedBox(
+        height: 48,
+        child: Material(
+          color: bg,
+          borderRadius: BorderRadius.circular(8),
+          child: InkWell(
+            borderRadius: BorderRadius.circular(8),
+            onTap: spec.onTap,
+            child: Center(
+              child: Text(
+                spec.label,
+                style: TextStyle(
+                  fontSize: 18,
+                  fontWeight: FontWeight.w600,
+                  color: fg,
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Public accessor for the evaluator — for unit tests.
+///
+/// The evaluator itself lives as a static method on the private state class.
+/// This proxy keeps the State private while exposing the algorithm for tests.
+class CalculatorAmountFieldEvaluator {
+  CalculatorAmountFieldEvaluator._();
+
+  /// Evaluates an arithmetic expression with `+ - * /` and parentheses.
+  /// Returns `null` on syntax error or division-by-zero.
+  static int? evaluate(String expr) =>
+      _CalculatorAmountFieldState.evaluateExpression(expr);
+}
+
+enum _BtnKind { digit, op, equals, danger }
+
+class _BtnSpec {
+  final String label;
+  final VoidCallback onTap;
+  final _BtnKind kind;
+  _BtnSpec(this.label, this.onTap, this.kind);
+}
+
+/// Input formatter that allows digits, commas, +, -, *, /, ( and ).
+/// In normal mode (no operators / parens), it formats with commas.
+/// In expression mode, it formats each numeric segment with commas.
 class _CalculatorInputFormatter extends TextInputFormatter {
   static const _numberFormat = CurrencyFormatter.format;
 
@@ -264,8 +590,8 @@ class _CalculatorInputFormatter extends TextInputFormatter {
 
     final text = newValue.text;
 
-    // Only allow digits, commas, +, -, *, /
-    final cleaned = text.replaceAll(RegExp(r'[^\d,+\-*/]'), '');
+    // Allow digits, commas, +, -, *, /, ( and ).
+    final cleaned = text.replaceAll(RegExp(r'[^\d,+\-*/()]'), '');
     if (cleaned != text) {
       return TextEditingValue(
         text: cleaned,
@@ -273,14 +599,10 @@ class _CalculatorInputFormatter extends TextInputFormatter {
       );
     }
 
-    // Check if expression mode (has +, -, *, / after a digit)
     final noCommas = text.replaceAll(',', '');
-    final isExpression =
-        noCommas.length > 1 && RegExp(r'\d[+\-*/]').hasMatch(noCommas);
+    final isExpression = _CalculatorAmountFieldState._looksLikeExpression(noCommas);
 
     if (isExpression) {
-      // In expression mode: format each numeric segment with commas
-      // e.g. "50000+3000" → "50,000+3,000"
       final formatted = _formatExpression(noCommas);
       return TextEditingValue(
         text: formatted,
@@ -288,7 +610,7 @@ class _CalculatorInputFormatter extends TextInputFormatter {
       );
     }
 
-    // Normal mode: standard comma formatting
+    // Normal mode: standard comma formatting.
     final digits = text.replaceAll(RegExp(r'[^\d]'), '');
     if (digits.isEmpty) {
       return const TextEditingValue(
@@ -307,38 +629,27 @@ class _CalculatorInputFormatter extends TextInputFormatter {
     );
   }
 
-  /// Formats an expression like "50000+3000*2" → "50,000+3,000*2"
+  /// Formats an expression like `(50000+3000)*2` → `(50,000+3,000)*2`.
   static String _formatExpression(String expr) {
     final buffer = StringBuffer();
     var currentNum = '';
-
     for (var i = 0; i < expr.length; i++) {
       final ch = expr[i];
-      if ((ch == '+' || ch == '-' || ch == '*' || ch == '/') && i > 0) {
-        // Format the accumulated number
-        final num = int.tryParse(currentNum);
-        if (num != null) {
-          buffer.write(_numberFormat(num));
-        } else {
-          buffer.write(currentNum);
+      if ('+-*/()'.contains(ch)) {
+        if (currentNum.isNotEmpty) {
+          final n = int.tryParse(currentNum);
+          buffer.write(n != null ? _numberFormat(n) : currentNum);
+          currentNum = '';
         }
         buffer.write(ch);
-        currentNum = '';
       } else {
         currentNum += ch;
       }
     }
-
-    // Format the last number segment
     if (currentNum.isNotEmpty) {
-      final num = int.tryParse(currentNum);
-      if (num != null) {
-        buffer.write(_numberFormat(num));
-      } else {
-        buffer.write(currentNum);
-      }
+      final n = int.tryParse(currentNum);
+      buffer.write(n != null ? _numberFormat(n) : currentNum);
     }
-
     return buffer.toString();
   }
 }

--- a/frontend/lib/core/widgets/filters/unified_filter_bar.dart
+++ b/frontend/lib/core/widgets/filters/unified_filter_bar.dart
@@ -53,6 +53,7 @@ class UnifiedFilterBar extends StatelessWidget {
     if (enabledFilters.contains(FilterType.pocket) && state.pocketIds.isNotEmpty) count++;
     if (enabledFilters.contains(FilterType.amountRange) && (state.amountMin != null || state.amountMax != null)) count++;
     if (enabledFilters.contains(FilterType.dateRange) && state.hasDateRange) count++;
+    if (enabledFilters.contains(FilterType.needsReview) && state.needsReviewOnly) count++;
     return count;
   }
 
@@ -120,6 +121,13 @@ class UnifiedFilterBar extends StatelessWidget {
       chips.add(_ChipData(
         label: state.dateRangeLabel ?? '기간 설정됨',
         onRemove: () => onFilterChanged(state.copyWith(clearDateRange: true)),
+      ));
+    }
+    if (enabledFilters.contains(FilterType.needsReview) && state.needsReviewOnly) {
+      chips.add(_ChipData(
+        label: '확인 필요만',
+        onRemove: () =>
+            onFilterChanged(state.copyWith(clearNeedsReview: true)),
       ));
     }
     return chips;
@@ -202,7 +210,8 @@ class UnifiedFilterBar extends StatelessWidget {
       enabledFilters.contains(FilterType.pocket) ||
       enabledFilters.contains(FilterType.amountRange) ||
       enabledFilters.contains(FilterType.transactionType) ||
-      enabledFilters.contains(FilterType.visibility);
+      enabledFilters.contains(FilterType.visibility) ||
+      enabledFilters.contains(FilterType.needsReview);
 
   void _showAdvancedFilterSheet(BuildContext context) {
     final amountMinController = TextEditingController(
@@ -220,6 +229,7 @@ class UnifiedFilterBar extends StatelessWidget {
     // PR-C: Multi-select transaction types (EXPENSE/INCOME/TRANSFER).
     final Set<String> tempTransactionTypes = Set.of(state.transactionTypes);
     String? tempVisibility = state.visibility;
+    bool tempNeedsReviewOnly = state.needsReviewOnly;
     // 기간도 다른 필터와 동일하게 임시 상태로 보관 → "적용" 버튼 클릭 시 일괄 propagate.
     DateTime? tempDateFrom = state.dateFrom;
     DateTime? tempDateTo = state.dateTo;
@@ -430,6 +440,22 @@ class UnifiedFilterBar extends StatelessWidget {
                           ),
                           const SizedBox(height: 16),
                         ],
+                        // V61 (2026-05-06) — 확인/입력 필요만 보기 토글
+                        if (enabledFilters
+                            .contains(FilterType.needsReview)) ...[
+                          SwitchListTile(
+                            contentPadding: EdgeInsets.zero,
+                            title: const Text('확인/입력 필요만 보기'),
+                            subtitle: const Text(
+                              '느낌표 표시한 거래만 표시합니다',
+                              style: TextStyle(fontSize: 12),
+                            ),
+                            value: tempNeedsReviewOnly,
+                            onChanged: (v) =>
+                                setSheetState(() => tempNeedsReviewOnly = v),
+                          ),
+                          const SizedBox(height: 8),
+                        ],
                         const SizedBox(height: 8),
                         Row(
                           children: [
@@ -445,6 +471,7 @@ class UnifiedFilterBar extends StatelessWidget {
                                     clearDateRange: true,
                                     clearTransactionType: true,
                                     clearVisibility: true,
+                                    clearNeedsReview: true,
                                   ));
                                 },
                                 child: const Text('초기화'),
@@ -486,6 +513,7 @@ class UnifiedFilterBar extends StatelessWidget {
                                     transactionTypes: tempTransactionTypes,
                                     visibility: tempVisibility,
                                     status: state.status,
+                                    needsReviewOnly: tempNeedsReviewOnly,
                                   ));
                                 },
                                 child: const Text('적용'),

--- a/frontend/lib/features/transaction/data/datasources/transaction_remote_datasource.dart
+++ b/frontend/lib/features/transaction/data/datasources/transaction_remote_datasource.dart
@@ -24,6 +24,7 @@ abstract class TransactionRemoteDataSource {
     String? dateFrom,
     String? dateTo,
     String? visibility,
+    bool? needsReviewOnly,
     int page = 0,
     int size = 20,
   });
@@ -59,6 +60,7 @@ class TransactionRemoteDataSourceImpl implements TransactionRemoteDataSource {
     String? dateFrom,
     String? dateTo,
     String? visibility,
+    bool? needsReviewOnly,
     int page = 0,
     int size = 20,
   }) async {
@@ -81,6 +83,7 @@ class TransactionRemoteDataSourceImpl implements TransactionRemoteDataSource {
       type: type,
       transactionTypes: transactionTypes,
       visibility: visibility,
+      needsReviewOnly: needsReviewOnly,
     );
     final queryParams = <String, dynamic>{
       'page': page,

--- a/frontend/lib/features/transaction/data/models/transaction_model.dart
+++ b/frontend/lib/features/transaction/data/models/transaction_model.dart
@@ -21,6 +21,7 @@ class TransactionModel extends Transaction {
     super.pocketName,
     super.visibility,
     super.ownerId,
+    super.needsReview,
     required super.createdAt,
     required super.updatedAt,
   });
@@ -48,6 +49,7 @@ class TransactionModel extends Transaction {
       pocketName: json['pocketName'] as String?,
       visibility: json['visibility'] as String? ?? 'SHARED',
       ownerId: json['ownerId'] as String?,
+      needsReview: json['needsReview'] as bool? ?? false,
       createdAt: DateTime.parse(json['createdAt'] as String),
       updatedAt: DateTime.parse(json['updatedAt'] as String),
     );

--- a/frontend/lib/features/transaction/data/repositories/transaction_repository_impl.dart
+++ b/frontend/lib/features/transaction/data/repositories/transaction_repository_impl.dart
@@ -31,6 +31,7 @@ class TransactionRepositoryImpl implements TransactionRepository {
     String? dateFrom,
     String? dateTo,
     String? visibility,
+    bool? needsReviewOnly,
     int page = 0,
     int size = 20,
   }) async {
@@ -53,6 +54,7 @@ class TransactionRepositoryImpl implements TransactionRepository {
         dateFrom: dateFrom,
         dateTo: dateTo,
         visibility: visibility,
+        needsReviewOnly: needsReviewOnly,
         page: page,
         size: size,
       );
@@ -86,6 +88,7 @@ class TransactionRepositoryImpl implements TransactionRepository {
     String? memo,
     String? paymentMethodId,
     String? pocketId,
+    bool needsReview = false,
   }) async {
     try {
       final data = <String, dynamic>{
@@ -97,6 +100,8 @@ class TransactionRepositoryImpl implements TransactionRepository {
         if (memo != null) 'memo': memo,
         if (paymentMethodId != null) 'paymentMethodId': paymentMethodId,
         if (pocketId != null) 'pocketId': pocketId,
+        // V61 (2026-05-06) — false 도 명시적으로 보낸다 (BE default 와 일치하지만 명확성).
+        'needsReview': needsReview,
       };
       final result = await remoteDataSource.createTransaction(data);
       return Right(result);
@@ -118,6 +123,7 @@ class TransactionRepositoryImpl implements TransactionRepository {
     bool clearMemo = false,
     String? paymentMethodId,
     String? pocketId,
+    bool? needsReview,
   }) async {
     try {
       final data = <String, dynamic>{
@@ -128,6 +134,8 @@ class TransactionRepositoryImpl implements TransactionRepository {
         if (memo != null) 'memo': memo else if (clearMemo) 'memo': null,
         if (paymentMethodId != null) 'paymentMethodId': paymentMethodId,
         if (pocketId != null) 'pocketId': pocketId,
+        // V61 (2026-05-06) — null 이면 미변경, true/false 면 명시적 토글.
+        if (needsReview != null) 'needsReview': needsReview,
       };
       final result = await remoteDataSource.updateTransaction(id, data);
       return Right(result);

--- a/frontend/lib/features/transaction/domain/entities/transaction.dart
+++ b/frontend/lib/features/transaction/domain/entities/transaction.dart
@@ -20,6 +20,8 @@ class Transaction extends Equatable {
   final String? pocketName;
   final String visibility;
   final String? ownerId;
+  /// V61 (2026-05-06) — 사용자가 "확인/입력 필요" 로 마킹한 거래.
+  final bool needsReview;
   final DateTime createdAt;
   final DateTime updatedAt;
 
@@ -41,6 +43,7 @@ class Transaction extends Equatable {
     this.pocketName,
     this.visibility = 'SHARED',
     this.ownerId,
+    this.needsReview = false,
     required this.createdAt,
     required this.updatedAt,
   });
@@ -70,6 +73,7 @@ class Transaction extends Equatable {
         pocketName,
         visibility,
         ownerId,
+        needsReview,
         createdAt,
         updatedAt,
       ];

--- a/frontend/lib/features/transaction/domain/entities/transaction_filter.dart
+++ b/frontend/lib/features/transaction/domain/entities/transaction_filter.dart
@@ -35,6 +35,10 @@ class TransactionFilter extends Equatable {
   final Set<String> transactionTypes;
   final String? visibility;
 
+  /// V61 (2026-05-06) — true 면 needs_review=true 거래만 (확인/입력 필요만 보기).
+  /// null/false 모두 미적용으로 처리.
+  final bool? needsReviewOnly;
+
   const TransactionFilter({
     this.keyword,
     this.categoryId,
@@ -51,6 +55,7 @@ class TransactionFilter extends Equatable {
     this.type,
     this.transactionTypes = const {},
     this.visibility,
+    this.needsReviewOnly,
   });
 
   /// 비어있는 필터 (기본값).
@@ -72,7 +77,8 @@ class TransactionFilter extends Equatable {
       dateTo != null ||
       type != null ||
       transactionTypes.isNotEmpty ||
-      visibility != null;
+      visibility != null ||
+      needsReviewOnly == true;
 
   TransactionFilter copyWith({
     String? keyword,
@@ -90,6 +96,7 @@ class TransactionFilter extends Equatable {
     String? type,
     Set<String>? transactionTypes,
     String? visibility,
+    bool? needsReviewOnly,
   }) {
     return TransactionFilter(
       keyword: keyword ?? this.keyword,
@@ -107,6 +114,7 @@ class TransactionFilter extends Equatable {
       type: type ?? this.type,
       transactionTypes: transactionTypes ?? this.transactionTypes,
       visibility: visibility ?? this.visibility,
+      needsReviewOnly: needsReviewOnly ?? this.needsReviewOnly,
     );
   }
 
@@ -127,6 +135,7 @@ class TransactionFilter extends Equatable {
         type,
         transactionTypes,
         visibility,
+        needsReviewOnly,
       ];
 }
 
@@ -184,6 +193,10 @@ extension TransactionFilterQueryParams on TransactionFilter {
     if (dateTo != null) params['dateTo'] = dateTo;
     if (visibility != null && visibility != 'ALL') {
       params['visibility'] = visibility;
+    }
+    // V61 (2026-05-06) — true 일 때만 전송 (false/null 모두 미적용).
+    if (needsReviewOnly == true) {
+      params['needsReviewOnly'] = true;
     }
     return params;
   }

--- a/frontend/lib/features/transaction/domain/repositories/transaction_repository.dart
+++ b/frontend/lib/features/transaction/domain/repositories/transaction_repository.dart
@@ -22,6 +22,7 @@ abstract class TransactionRepository {
     String? dateFrom,
     String? dateTo,
     String? visibility,
+    bool? needsReviewOnly,
     int page = 0,
     int size = 20,
   });
@@ -37,6 +38,7 @@ abstract class TransactionRepository {
     String? memo,
     String? paymentMethodId,
     String? pocketId,
+    bool needsReview = false,
   });
 
   Future<Either<Failure, Transaction>> updateTransaction({
@@ -49,6 +51,7 @@ abstract class TransactionRepository {
     bool clearMemo = false,
     String? paymentMethodId,
     String? pocketId,
+    bool? needsReview,
   });
 
   Future<Either<Failure, void>> deleteTransaction(String id);

--- a/frontend/lib/features/transaction/presentation/bloc/transaction_bloc.dart
+++ b/frontend/lib/features/transaction/presentation/bloc/transaction_bloc.dart
@@ -33,6 +33,7 @@ class TransactionBloc extends Bloc<TransactionEvent, TransactionState> {
   String? _currentType;
   Set<String> _currentTransactionTypes = const {};
   String? _currentVisibility;
+  bool? _currentNeedsReviewOnly;
 
   /// 전체 필터 상태의 단일 스냅샷.
   /// MonthSyncHandler 등 외부 consumer 가 필드 drop 없이 전체 필터를 전파하도록
@@ -54,6 +55,7 @@ class TransactionBloc extends Bloc<TransactionEvent, TransactionState> {
         type: _currentType,
         transactionTypes: _currentTransactionTypes,
         visibility: _currentVisibility,
+        needsReviewOnly: _currentNeedsReviewOnly,
       );
 
   int get currentYear => _currentYear;
@@ -93,6 +95,7 @@ class TransactionBloc extends Bloc<TransactionEvent, TransactionState> {
       _currentType = event.type;
       _currentTransactionTypes = event.transactionTypes;
       _currentVisibility = event.visibility;
+      _currentNeedsReviewOnly = event.needsReviewOnly;
       // Only show full loading skeleton on initial load, not during search/filter
       if (previousState is! TransactionLoaded) {
         emit(const TransactionLoading());
@@ -120,6 +123,7 @@ class TransactionBloc extends Bloc<TransactionEvent, TransactionState> {
         type: event.type,
         transactionTypes: event.transactionTypes,
         visibility: event.visibility,
+        needsReviewOnly: event.needsReviewOnly,
         page: 0,
         size: _pageSize,
       );
@@ -242,6 +246,7 @@ class TransactionBloc extends Bloc<TransactionEvent, TransactionState> {
         type: _currentType,
         transactionTypes: _currentTransactionTypes,
         visibility: _currentVisibility,
+        needsReviewOnly: _currentNeedsReviewOnly,
         page: nextPage,
         size: _pageSize,
       );
@@ -315,6 +320,7 @@ class TransactionBloc extends Bloc<TransactionEvent, TransactionState> {
         memo: event.memo,
         paymentMethodId: event.paymentMethodId,
         pocketId: event.pocketId,
+        needsReview: event.needsReview,
       );
       result.fold(
         (failure) => emit(TransactionError(failure.message)),
@@ -337,6 +343,7 @@ class TransactionBloc extends Bloc<TransactionEvent, TransactionState> {
               type: _currentType,
               transactionTypes: _currentTransactionTypes,
               visibility: _currentVisibility,
+              needsReviewOnly: _currentNeedsReviewOnly,
             )),
       );
     } catch (e) {
@@ -372,6 +379,7 @@ class TransactionBloc extends Bloc<TransactionEvent, TransactionState> {
         clearMemo: event.clearMemo,
         paymentMethodId: event.paymentMethodId,
         pocketId: event.pocketId,
+        needsReview: event.needsReview,
       );
       result.fold(
         (failure) => emit(TransactionError(failure.message)),
@@ -394,6 +402,7 @@ class TransactionBloc extends Bloc<TransactionEvent, TransactionState> {
               type: _currentType,
               transactionTypes: _currentTransactionTypes,
               visibility: _currentVisibility,
+              needsReviewOnly: _currentNeedsReviewOnly,
             )),
       );
     } catch (e) {

--- a/frontend/lib/features/transaction/presentation/bloc/transaction_event.dart
+++ b/frontend/lib/features/transaction/presentation/bloc/transaction_event.dart
@@ -26,6 +26,8 @@ class LoadTransactions extends TransactionEvent {
   final String? type;
   final Set<String> transactionTypes;
   final String? visibility;
+  /// V61 (2026-05-06) — true 면 needs_review=true 거래만 (확인/입력 필요만 보기).
+  final bool? needsReviewOnly;
 
   const LoadTransactions({
     required this.year,
@@ -46,6 +48,7 @@ class LoadTransactions extends TransactionEvent {
     this.type,
     this.transactionTypes = const {},
     this.visibility,
+    this.needsReviewOnly,
   });
 
   @override
@@ -68,6 +71,7 @@ class LoadTransactions extends TransactionEvent {
         type,
         transactionTypes,
         visibility,
+        needsReviewOnly,
       ];
 }
 
@@ -80,6 +84,8 @@ class CreateTransaction extends TransactionEvent {
   final String? memo;
   final String? paymentMethodId;
   final String? pocketId;
+  /// V61 (2026-05-06) — 확인/입력 필요 플래그.
+  final bool needsReview;
 
   const CreateTransaction({
     required this.type,
@@ -90,11 +96,12 @@ class CreateTransaction extends TransactionEvent {
     this.memo,
     this.paymentMethodId,
     this.pocketId,
+    this.needsReview = false,
   });
 
   @override
   List<Object?> get props =>
-      [type, amount, description, categoryId, transactionDate, memo, paymentMethodId, pocketId];
+      [type, amount, description, categoryId, transactionDate, memo, paymentMethodId, pocketId, needsReview];
 }
 
 class UpdateTransaction extends TransactionEvent {
@@ -107,6 +114,8 @@ class UpdateTransaction extends TransactionEvent {
   final bool clearMemo;
   final String? paymentMethodId;
   final String? pocketId;
+  /// V61 (2026-05-06) — null 이면 미변경, true/false 면 토글.
+  final bool? needsReview;
 
   const UpdateTransaction({
     required this.id,
@@ -118,11 +127,12 @@ class UpdateTransaction extends TransactionEvent {
     this.clearMemo = false,
     this.paymentMethodId,
     this.pocketId,
+    this.needsReview,
   });
 
   @override
   List<Object?> get props =>
-      [id, amount, description, categoryId, transactionDate, memo, clearMemo, paymentMethodId, pocketId];
+      [id, amount, description, categoryId, transactionDate, memo, clearMemo, paymentMethodId, pocketId, needsReview];
 }
 
 class LoadMoreTransactions extends TransactionEvent {

--- a/frontend/lib/features/transaction/presentation/pages/transaction_form_page.dart
+++ b/frontend/lib/features/transaction/presentation/pages/transaction_form_page.dart
@@ -119,6 +119,8 @@ class _TransactionFormPageState extends State<TransactionFormPage>
   bool _isSubmitting = false;
   bool _continueMode = false;
   bool _keepSameItems = false;
+  /// V61 (2026-05-06) — 사용자가 "확인/입력 필요" 로 마킹한 거래 여부.
+  bool _needsReview = false;
   String? _categoryError;
   String? _paymentMethodError;
 
@@ -226,6 +228,7 @@ class _TransactionFormPageState extends State<TransactionFormPage>
     _selectedCategoryDisplayName = src.category?.displayName;
     _selectedPaymentMethodId = src.paymentMethodId;
     _selectedPocketId = src.pocketId;
+    _needsReview = src.needsReview;
     // 회차 4 — ADJUSTMENT 거래 prefill: sentinel 카테고리 + 부호로 방향 추정.
     if (src.type == 'ADJUSTMENT') {
       _selectedCategoryId = kAdjustmentSentinel;
@@ -784,18 +787,12 @@ class _TransactionFormPageState extends State<TransactionFormPage>
                     ),
                   ),
                   const SizedBox(height: 16),
-                  // Memo
+                  // V61 (2026-05-06) — 메모 카드 + needs_review 토글.
+                  // 이전: prefixIcon 있는 좌측정렬 단행 입력 + maxLines:2.
+                  // 변경: 카드 컨테이너 안에 [멀티라인 가운데정렬 메모] + [확인/입력 필요 토글].
                   FocusTraversalOrder(
                     order: const NumericFocusOrder(6),
-                    child: TextFormField(
-                      controller: _memoController,
-                      decoration: const InputDecoration(
-                        labelText: '메모 (선택)',
-                        hintText: '추가 메모',
-                        prefixIcon: Icon(Icons.note),
-                      ),
-                      maxLines: 2,
-                    ),
+                    child: _buildMemoCard(context),
                   ),
                   const SizedBox(height: 24),
                   // Continue mode options (new transactions only)
@@ -1152,6 +1149,104 @@ class _TransactionFormPageState extends State<TransactionFormPage>
             ),
           ],
         ),
+      ),
+    );
+  }
+
+  /// V61 (2026-05-06) — 메모 + needs_review 통합 카드.
+  ///
+  /// 사용자 요청 (2026-05-06):
+  ///   - 메모를 가운데 정렬 + 여러 줄 입력 가능
+  ///   - 메모 영역에 "확인/입력 필요" 토글 (느낌표 표시 활성화)
+  Widget _buildMemoCard(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surfaceContainerHighest.withValues(alpha: 0.4),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(
+          color: theme.colorScheme.outlineVariant.withValues(alpha: 0.5),
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 12, 16, 0),
+            child: Row(
+              children: [
+                Icon(
+                  Icons.note_outlined,
+                  size: 18,
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+                const SizedBox(width: 6),
+                Text(
+                  '메모',
+                  style: theme.textTheme.labelLarge?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(12, 4, 12, 8),
+            child: TextFormField(
+              controller: _memoController,
+              minLines: 3,
+              maxLines: 6,
+              textAlign: TextAlign.center,
+              textAlignVertical: TextAlignVertical.center,
+              decoration: const InputDecoration(
+                hintText: '추가 메모 (여러 줄 입력 가능)',
+                border: InputBorder.none,
+                isDense: true,
+                contentPadding: EdgeInsets.symmetric(vertical: 8),
+              ),
+            ),
+          ),
+          Divider(
+            height: 1,
+            thickness: 1,
+            color: theme.colorScheme.outlineVariant.withValues(alpha: 0.4),
+          ),
+          SwitchListTile(
+            value: _needsReview,
+            onChanged: (v) => setState(() => _needsReview = v),
+            dense: true,
+            contentPadding:
+                const EdgeInsets.symmetric(horizontal: 12, vertical: 0),
+            title: Row(
+              children: [
+                Container(
+                  width: 18,
+                  height: 18,
+                  decoration: BoxDecoration(
+                    color: Colors.amber.shade700,
+                    shape: BoxShape.circle,
+                  ),
+                  alignment: Alignment.center,
+                  child: const Text(
+                    '!',
+                    style: TextStyle(
+                      color: Colors.white,
+                      fontSize: 12,
+                      fontWeight: FontWeight.bold,
+                      height: 1.0,
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                const Text('확인/입력 필요로 표시'),
+              ],
+            ),
+            subtitle: const Text(
+              '나중에 확인하거나 정보를 채워넣어야 하는 거래로 마킹합니다.',
+              style: TextStyle(fontSize: 12),
+            ),
+          ),
+        ],
       ),
     );
   }
@@ -1836,6 +1931,7 @@ class _TransactionFormPageState extends State<TransactionFormPage>
       _amountHint = '';
       _descriptionController.clear();
       _memoController.clear();
+      _needsReview = false;
       _suggestions = [];
       _aiResult = null;
       _aiLoading = false;
@@ -1924,6 +2020,7 @@ class _TransactionFormPageState extends State<TransactionFormPage>
         clearMemo: memo == null,
         paymentMethodId: _selectedPaymentMethodId,
         pocketId: _selectedPocketId,
+        needsReview: _needsReview,
       ));
     } else {
       bloc.add(CreateTransaction(
@@ -1935,6 +2032,7 @@ class _TransactionFormPageState extends State<TransactionFormPage>
         memo: memo,
         paymentMethodId: _selectedPaymentMethodId,
         pocketId: _selectedPocketId,
+        needsReview: _needsReview,
       ));
     }
   }

--- a/frontend/lib/features/transaction/presentation/pages/transaction_list_page.dart
+++ b/frontend/lib/features/transaction/presentation/pages/transaction_list_page.dart
@@ -204,6 +204,8 @@ class _TransactionListPageState extends State<TransactionListPage> {
           dateTo: _filterState.dateTo != null ? fmt.format(_filterState.dateTo!) : null,
           transactionTypes: _filterState.transactionTypes,
           visibility: _filterState.visibility,
+          needsReviewOnly:
+              _filterState.needsReviewOnly ? true : null,
         ));
     context.read<TransferBloc>().add(LoadTransfers(year: year, month: month));
   }
@@ -467,6 +469,7 @@ class _TransactionListPageState extends State<TransactionListPage> {
             FilterType.paymentMethod,
             FilterType.pocket,
             FilterType.amountRange,
+            FilterType.needsReview,
           },
           state: _filterState,
           onFilterChanged: _onFilterChanged,

--- a/frontend/lib/features/transaction/presentation/widgets/transaction_list_tile.dart
+++ b/frontend/lib/features/transaction/presentation/widgets/transaction_list_tile.dart
@@ -110,6 +110,31 @@ class TransactionListTile extends StatelessWidget {
               ),
               const SizedBox(width: 4),
             ],
+            // V61 (2026-05-06) — needs_review 뱃지. 사용자가 "확인/입력 필요" 로 마킹한 거래.
+            if (transaction.needsReview) ...[
+              Tooltip(
+                message: '확인/입력 필요',
+                child: Container(
+                  width: 18,
+                  height: 18,
+                  decoration: BoxDecoration(
+                    color: Colors.amber.shade700,
+                    shape: BoxShape.circle,
+                  ),
+                  alignment: Alignment.center,
+                  child: const Text(
+                    '!',
+                    style: TextStyle(
+                      color: Colors.white,
+                      fontSize: 12,
+                      fontWeight: FontWeight.bold,
+                      height: 1.0,
+                    ),
+                  ),
+                ),
+              ),
+              const SizedBox(width: 6),
+            ],
             if (isAdjustment) ...[
               Container(
                 padding:

--- a/frontend/test/core/widgets/calculator_amount_field_test.dart
+++ b/frontend/test/core/widgets/calculator_amount_field_test.dart
@@ -1,0 +1,66 @@
+import 'package:budget_book/core/widgets/calculator_amount_field.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// V61 (2026-05-06) — calculator_amount_field 회귀 fix + 괄호 evaluator 단위 테스트.
+///
+/// 이전 evaluator 는 left-to-right precedence 만 지원, 괄호 미지원.
+/// 또한 `_evaluateAndReplace` 가 `result <= 0` 시 controller 를 비워
+/// `5-5` 같은 0 결과 입력이 손실되었음 (회차 1 에서 fix).
+void main() {
+  int? eval(String s) => CalculatorAmountFieldEvaluator.evaluate(s);
+
+  group('CalculatorAmountFieldEvaluator', () {
+    test('basic + - * /', () {
+      expect(eval('5+3'), 8);
+      expect(eval('10-7'), 3);
+      expect(eval('4*5'), 20);
+      expect(eval('20/4'), 5);
+    });
+
+    test('precedence: * and / before + and -', () {
+      expect(eval('1+2*3'), 7);
+      expect(eval('10-6/2'), 7);
+      expect(eval('2*3+4*5'), 26);
+    });
+
+    test('parentheses change precedence', () {
+      expect(eval('(1+2)*3'), 9);
+      expect(eval('2*(3+4)'), 14);
+      expect(eval('(10-2)/4'), 2);
+      expect(eval('((1+2)*3)/9'), 1);
+      expect(eval('1+(2*(3+4))'), 15);
+    });
+
+    test('zero result is supported (회차 1 fix)', () {
+      // evaluator 자체는 0 반환 — 이전에도 그러했지만 caller 에서 비웠음.
+      expect(eval('5-5'), 0);
+      expect(eval('(3-3)*5'), 0);
+      expect(eval('0'), 0);
+    });
+
+    test('division by zero returns null', () {
+      expect(eval('10/0'), null);
+    });
+
+    test('unbalanced parentheses returns null', () {
+      expect(eval('(1+2'), null);
+      expect(eval('1+2)'), null);
+      expect(eval('((1+2)'), null);
+    });
+
+    test('rounds float results (round half-up via .round())', () {
+      expect(eval('10/3'), 3); // 3.333... → 3
+      expect(eval('10/4'), 3); // 2.5 → 2 or 3 depending on banker (Dart .round() returns 3)
+    });
+
+    test('empty / invalid input returns null', () {
+      expect(eval(''), null);
+      expect(eval('+'), null);
+      expect(eval('abc'), null);
+    });
+
+    test('negative result is allowed by evaluator (caller decides reject)', () {
+      expect(eval('5-10'), -5);
+    });
+  });
+}

--- a/frontend/test/features/transaction/data/repositories/transaction_repository_impl_test.dart
+++ b/frontend/test/features/transaction/data/repositories/transaction_repository_impl_test.dart
@@ -33,6 +33,7 @@ class MockTransactionRemoteDataSource extends Mock
     String? dateFrom,
     String? dateTo,
     String? visibility,
+    bool? needsReviewOnly,
     int page = 0,
     int size = 20,
   }) =>
@@ -55,6 +56,7 @@ class MockTransactionRemoteDataSource extends Mock
           #dateFrom: dateFrom,
           #dateTo: dateTo,
           #visibility: visibility,
+          #needsReviewOnly: needsReviewOnly,
           #page: page,
           #size: size,
         }),
@@ -263,6 +265,8 @@ void main() {
           'transactionDate': '2024-01-15',
           'categoryId': 'cat-1',
           'memo': '팀 점심',
+          // V61 (2026-05-06) — repo 가 항상 needsReview 포함하여 전송
+          'needsReview': false,
         };
         when(mockDataSource.createTransaction(expectedData))
             .thenAnswer((_) async => tTransactionModel);
@@ -286,6 +290,8 @@ void main() {
           'amount': 0,
           'description': '',
           'transactionDate': '2024-01-15',
+          // V61 (2026-05-06) — repo 가 항상 needsReview 포함하여 전송
+          'needsReview': false,
         };
         final dioException = DioException(
           requestOptions: RequestOptions(path: '/api/v1/transactions'),

--- a/frontend/test/features/transaction/presentation/bloc/transaction_bloc_test.dart
+++ b/frontend/test/features/transaction/presentation/bloc/transaction_bloc_test.dart
@@ -33,6 +33,7 @@ class MockTransactionRepository extends Mock
     String? dateFrom,
     String? dateTo,
     String? visibility,
+    bool? needsReviewOnly,
     int page = 0,
     int size = 20,
   }) =>
@@ -55,6 +56,7 @@ class MockTransactionRepository extends Mock
           #dateFrom: dateFrom,
           #dateTo: dateTo,
           #visibility: visibility,
+          #needsReviewOnly: needsReviewOnly,
           #page: page,
           #size: size,
         }),
@@ -92,7 +94,7 @@ class MockTransactionRepository extends Mock
     String? memo,
     String? paymentMethodId,
     String? pocketId,
-    String visibility = 'SHARED',
+    bool needsReview = false,
   }) =>
       super.noSuchMethod(
         Invocation.method(#createTransaction, [], {
@@ -104,7 +106,7 @@ class MockTransactionRepository extends Mock
           #memo: memo,
           #paymentMethodId: paymentMethodId,
           #pocketId: pocketId,
-          #visibility: visibility,
+          #needsReview: needsReview,
         }),
         returnValue: Future.value(
           Right<Failure, Transaction>(_dummyTransaction),
@@ -122,6 +124,7 @@ class MockTransactionRepository extends Mock
     bool clearMemo = false,
     String? paymentMethodId,
     String? pocketId,
+    bool? needsReview,
   }) =>
       super.noSuchMethod(
         Invocation.method(#updateTransaction, [], {
@@ -134,6 +137,7 @@ class MockTransactionRepository extends Mock
           #clearMemo: clearMemo,
           #paymentMethodId: paymentMethodId,
           #pocketId: pocketId,
+          #needsReview: needsReview,
         }),
         returnValue: Future.value(
           Right<Failure, Transaction>(_dummyTransaction),


### PR DESCRIPTION
## Summary
- 거래에 "확인/입력 필요" 플래그 추가. 토글 마킹 → 리스트에 amber `!` 뱃지. 필터에서 "확인 필요만 보기" 가능.
- 메모 입력 영역을 카드 컨테이너 + 가운데 정렬 멀티라인(3~6줄) 으로 개편.
- CalculatorAmountField 회귀 fix: 0원 입력 정상화(`5-5=0` 보존), 괄호 지원(shunting-yard), 모바일 계산기 popup 추가.

## DB
- V61: `transactions.needs_review BOOLEAN NOT NULL DEFAULT false` + partial index. 통계/예산 합계 영향 없음.

## 변경 파일
- BE: V61, Transaction entity, DTO 3종, Specification, Service, Controller, CommonFilterParams
- FE: Transaction entity/model/datasource/repo/bloc, form_page(메모 카드+토글), list_tile(! 뱃지), unified_filter_state/bar, calculator_amount_field 재작성
- Tests: repo, bloc mock, 신규 evaluator 단위 테스트 9개 (괄호/0원/division-by-zero/unbalanced 등)

## Test plan
- [x] BE compile + 전체 테스트 PASS (`./gradlew test`)
- [x] FE analyze (error 0)
- [x] FE 전체 테스트 PASS (726/726)
- [x] FE web build 성공
- [ ] 사용자 라이브 검증: 기획서 §사용자 검증 시나리오 A1~A10, B1~B6, C1~C3
  - A6: 0원 거래 등록 가능 (지출/수입)
  - A7: `5-5` → 0 표시 (비워지지 않음)
  - A8: 계산기 popup 으로 `(2+3)*4=20` 입력
  - A9: 모바일에서도 사칙연산/괄호 가능
  - A10: 메모 3줄 입력 + 가운데 정렬 표시
  - A1~A5: 토글 ON/OFF 동작 + 뱃지 + 필터

## 기획서
docs/sessions/2026-05-06_1_plan.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)