### PR TITLE
fix(transaction): 0원 BE 허용 + 계산기 아이콘 표시 + 무한 로딩 fix (#225 follow-up)

### DIFF
--- a/backend/src/main/kotlin/com/budgetbook/transaction/service/TransactionService.kt
+++ b/backend/src/main/kotlin/com/budgetbook/transaction/service/TransactionService.kt
@@ -512,19 +512,20 @@ class TransactionService(
     /**
      * Phase 22 T11: type 별 amount 부호 검증.
      *
-     * - `EXPENSE` / `INCOME`: 양수만 허용 (> 0). DTO 의 `@Min(0)` 을 대체.
+     * - `EXPENSE` / `INCOME`: 0 이상 허용 (>= 0). V46 (DB 제약 완화) + 회차 1 (2026-05-06 follow-up)
+     *   에서 사용자 요청 "0원 거래 등록 허용" 반영. 음수만 거부.
      * - `ADJUSTMENT`: 부호 있는 증감값. 0 은 의미 없는 조정이므로 거부.
      *
-     * DB CHECK 제약(`ck_transactions_amount`, V54) 과 일치하며,
+     * DB CHECK 제약(`ck_transactions_amount`, V46/V54) 과 일치하며,
      * DTO 에서 일괄 `@Min(0)` 하는 대신 type 별로 정밀하게 검증한다.
      */
     private fun validateAmountForType(type: TransactionType, amount: Long) {
         when (type) {
             TransactionType.EXPENSE, TransactionType.INCOME -> {
-                if (amount <= 0) {
+                if (amount < 0) {
                     throw BusinessException(
                         "VALIDATION_ERROR",
-                        "${type.name} amount 는 0 보다 커야 합니다. (입력: $amount)"
+                        "${type.name} amount 는 0 이상이어야 합니다. (입력: $amount)"
                     )
                 }
             }

--- a/backend/src/test/kotlin/com/budgetbook/transaction/service/TransactionServiceTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/transaction/service/TransactionServiceTest.kt
@@ -995,17 +995,39 @@ class TransactionServiceTest : BehaviorSpec({
         }
 
         When("creating an INCOME with zero amount") {
+            // 회차 1 follow-up (2026-05-06) — V46 정책 일치: 0원 거래 허용.
+            // 이전 동작(거부)에서 변경된 정책. 사용자 요청: "0원 입력 가능해야 한다".
             val request = CreateTransactionRequest(
                 type = "INCOME", amount = 0, description = "0원 수입",
                 transactionDate = LocalDate.of(2024, 1, 15)
             )
+            val txSlot = slot<Transaction>()
+            every { transactionRepository.save(capture(txSlot)) } answers { txSlot.captured }
 
-            Then("throws BusinessException with VALIDATION_ERROR") {
-                val ex = shouldThrow<com.budgetbook.common.exception.BusinessException> {
-                    service.createTransaction(user1.id, request)
-                }
-                ex.code shouldBe "VALIDATION_ERROR"
-                verify(exactly = 0) { transactionRepository.save(any()) }
+            val result = service.createTransaction(user1.id, request)
+
+            Then("creates the transaction with amount = 0") {
+                result.type shouldBe "INCOME"
+                result.amount shouldBe 0
+                txSlot.captured.amount shouldBe 0
+            }
+        }
+
+        When("creating an EXPENSE with zero amount") {
+            // 회차 1 follow-up (2026-05-06) — 0원 지출도 허용 (예: 무료 이벤트 기록).
+            val request = CreateTransactionRequest(
+                type = "EXPENSE", amount = 0, description = "0원 지출",
+                transactionDate = LocalDate.of(2024, 1, 15)
+            )
+            val txSlot = slot<Transaction>()
+            every { transactionRepository.save(capture(txSlot)) } answers { txSlot.captured }
+
+            val result = service.createTransaction(user1.id, request)
+
+            Then("creates the transaction with amount = 0") {
+                result.type shouldBe "EXPENSE"
+                result.amount shouldBe 0
+                txSlot.captured.amount shouldBe 0
             }
         }
 

--- a/docs/sessions/2026-05-06_1_result.md
+++ b/docs/sessions/2026-05-06_1_result.md
@@ -1,0 +1,77 @@
+# 거래 플래그(확인/입력 필요) + 메모 개선 + 회귀 fix - 결과
+> 날짜: 2026-05-06 | 회차: 1 | 상태: 실패+재검증 진행
+
+## 변경 사항 (PR #225)
+| 파일 | 변경 유형 | 설명 |
+|------|----------|------|
+| V61 migration | 신규 | needs_review 컬럼 + partial index |
+| Transaction entity/DTO | 수정 | needsReview 필드 |
+| Specification/Service/Controller | 수정 | needsReviewOnly 필터 |
+| FE entity/model/datasource/repo/bloc | 수정 | needsReview 매핑 |
+| transaction_filter / unified_filter_state/bar | 수정 | "확인 필요만 보기" |
+| transaction_form_page | 수정 | 메모 카드 + 토글 |
+| transaction_list_tile | 수정 | `!` 뱃지 |
+| calculator_amount_field | 재작성 | 0원 fix + 괄호 + popup |
+| 신규 evaluator 테스트 | 신규 | 9 케이스 |
+
+## 커밋 / PR 이력
+- PR #225 (squash SHA `<merged>`) — feat(transaction): 확인/입력 필요 + 메모 카드 + 0원/사칙연산
+- deploy-nas.yml run `25416953137` SUCCESS
+
+## 자동 검증 결과
+| 항목 | 결과 | 비고 |
+|------|------|------|
+| BE 테스트 | PASS | gradlew test 전체 통과 |
+| FE analyze | PASS | error 0, info 3 (기존) |
+| FE test | PASS | 726/726 |
+| FE web build | PASS | — |
+| CI | PASS | frontend-ci 2m18s, backend-ci 3m36s |
+| 배포 | SUCCESS | run-id 25416953137 |
+
+## 사용자 라이브 검증 결과 (1차)
+| 시나리오 | 결과 | 비고 |
+|---------|------|------|
+| A6 — 0원 입력 + 저장 | **FAIL** | "지출은 0보다 커야한다" 응답 메시지 |
+| A8 — 계산기 아이콘 | **FAIL** | 아이콘 자체가 보이지 않음 |
+| A6+A7 → 저장 | **FAIL** | 무한 로딩 |
+
+## 실패 발생 (1차) — 의무 3단계 수행
+
+### 원인 분석
+**근본 원인 A. DB 제약 완화의 의도가 Service-layer 까지 전파되지 않음**
+- V46 마이그레이션이 `transactions.amount` CHECK 를 `> 0` → `>= 0` 으로 완화 (의도: 0원 거래 허용)
+- 그러나 `TransactionService.validateAmountForType` (line 521) 는 EXPENSE/INCOME 에 대해 `amount <= 0` 거부 그대로
+- 회차 1.5 의 db_schema audit 은 V46 발견했지만 'Service 검증 정합성' 까지 확장하지 못함 — file_scopes 에 service/*.kt 누락
+
+**근본 원인 B. FE BlocListener 가 TransactionLoaded(operationError) 를 success 로 처리**
+- BLoC `_onCreateTransaction` 의 catch 블록이 state == TransactionLoaded 일 때 `TransactionLoaded(operationError: ...)` 로 emit
+- form_page BlocListener 는 `if (state is TransactionLoaded)` 만 보고 navigate, operationError 분기 누락 → _isSubmitting 미해제 → 무한 로딩
+
+**근본 원인 C. InputDecoration.suffixIcon 의 sizing collapse**
+- Row + IconButton(visualDensity.compact) 조합에서 `suffixIconConstraints` 미설정 → calculator 아이콘 collapse
+
+### 재발 방지 장치 (코드·규칙 차원)
+- [x] 하네스 인시던트 등록: `~/.claude/harness/data/incidents/2026-05-06_db_constraint_relaxation_service_layer_drift.json`
+- [x] audit-patterns.json: `db_schema` file_scopes 에 `service/*.kt` 추가, known_pitfalls 에 "DB CHECK 완화 마이그레이션 의도 Service 까지 전파 의무" 추가
+- [x] audit-patterns.json: 신규 audit 태그 `constraint_relaxation_service_drift` 추가
+- [x] CLAUDE.md: Step 1.5 에 "DB 제약 완화 동기화 점검" 의무 추가
+- [x] 메모리 등록: `feedback_db_constraint_relaxation_service_sync.md` + MEMORY.md index
+- [x] BE 테스트 추가: EXPENSE/INCOME amount=0 정상 저장 케이스 (TransactionServiceTest)
+- [x] FE BlocListener 보강: `state is TransactionLoaded && state.operationError != null` 분기 추가
+
+### 플로우 개선
+- 마이그레이션이 다음 패턴이면 audit 태그 `constraint_relaxation_service_drift` 필수:
+  - `DROP CONSTRAINT ... CHECK` + 더 느슨한 CHECK 재추가
+  - `DROP NOT NULL`, UNIQUE 제거/완화
+- 발견 시 `grep -rn "validate.*Type|validate.*Amount|<= 0|@Min|@Max"` 로 동일 검증 함수 전수 grep
+- mock-only 테스트 = 의미 drift 못 잡음 → 통합/라이브 검증 의무
+
+### 처리 방식
+- [x] follow-up PR (작은 수정으로 해결 가능 — DB/스키마 변경 없음, Service 검증 1개 + FE listener 1개 + suffixIcon 1개)
+- [ ] git revert (해당 없음 — 이미 통합된 V61 자체는 정상 작동)
+
+## 발견된 추가 이슈
+없음
+
+## 롤백 정보
+필요 없음 (follow-up PR 로 해결).

--- a/frontend/lib/core/widgets/calculator_amount_field.dart
+++ b/frontend/lib/core/widgets/calculator_amount_field.dart
@@ -243,65 +243,100 @@ class _CalculatorAmountFieldState extends State<CalculatorAmountField> {
                 fontWeight: FontWeight.w600,
               )
             : null,
-        suffixIcon: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            // V61 (2026-05-06) — 모바일 계산기 popup. 항상 노출 (PC 도 사용 가능).
-            IconButton(
-              icon: const Icon(Icons.calculate_outlined, size: 22),
-              tooltip: '계산기',
-              onPressed: _openCalculatorPopup,
-              visualDensity: VisualDensity.compact,
-            ),
-            if (widget.controller.text.isNotEmpty) ...[
-              if (_isExpressionMode)
-                IconButton(
-                  icon: Icon(
-                    Icons.check_circle,
-                    color: Theme.of(context).colorScheme.primary,
+        // 회차 1 follow-up (2026-05-06) — suffixIcon 영역 sizing fix.
+        // 이전: Row + IconButton(visualDensity.compact) 조합에서 calculator
+        // 아이콘이 collapse 되어 노출 안 됨. suffixIconConstraints 명시 + 단순
+        // GestureDetector + Padding 으로 재구성하여 항상 가시화.
+        suffixIconConstraints: const BoxConstraints(
+          minWidth: 0,
+          minHeight: 40,
+          maxHeight: 48,
+        ),
+        suffixIcon: Padding(
+          padding: const EdgeInsets.only(right: 4),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              // V61 (2026-05-06) — 모바일 계산기 popup. 항상 노출.
+              InkResponse(
+                onTap: _openCalculatorPopup,
+                radius: 20,
+                child: Tooltip(
+                  message: '계산기',
+                  child: Container(
+                    padding: const EdgeInsets.all(8),
+                    child: Icon(
+                      Icons.calculate_outlined,
+                      size: 22,
+                      color: Theme.of(context).colorScheme.primary,
+                    ),
                   ),
-                  tooltip: '계산',
-                  onPressed: _evaluateAndReplace,
-                  visualDensity: VisualDensity.compact,
-                ),
-              GestureDetector(
-                onLongPress: () {
-                  widget.controller.clear();
-                },
-                child: IconButton(
-                  icon: const Icon(Icons.backspace_outlined, size: 20),
-                  tooltip: '지우기 (길게 누르면 전체 삭제)',
-                  visualDensity: VisualDensity.compact,
-                  onPressed: () {
-                    final text = widget.controller.text;
-                    if (text.isNotEmpty) {
-                      final newText = text.substring(0, text.length - 1);
-                      if (!_isExpressionMode) {
-                        final digits =
-                            newText.replaceAll(RegExp(r'[^\d]'), '');
-                        if (digits.isEmpty) {
-                          widget.controller.text = '';
-                        } else {
-                          final num = int.tryParse(digits);
-                          if (num != null) {
-                            final formatted = CurrencyFormatter.format(num);
-                            widget.controller.text = formatted;
-                            widget.controller.selection =
-                                TextSelection.collapsed(
-                                    offset: formatted.length);
-                          }
-                        }
-                      } else {
-                        widget.controller.text = newText;
-                        widget.controller.selection =
-                            TextSelection.collapsed(offset: newText.length);
-                      }
-                    }
-                  },
                 ),
               ),
+              if (widget.controller.text.isNotEmpty) ...[
+                if (_isExpressionMode)
+                  InkResponse(
+                    onTap: _evaluateAndReplace,
+                    radius: 20,
+                    child: Tooltip(
+                      message: '계산',
+                      child: Container(
+                        padding: const EdgeInsets.all(8),
+                        child: Icon(
+                          Icons.check_circle,
+                          size: 22,
+                          color: Theme.of(context).colorScheme.primary,
+                        ),
+                      ),
+                    ),
+                  ),
+                GestureDetector(
+                  onLongPress: () {
+                    widget.controller.clear();
+                  },
+                  child: InkResponse(
+                    onTap: () {
+                      final text = widget.controller.text;
+                      if (text.isNotEmpty) {
+                        final newText = text.substring(0, text.length - 1);
+                        if (!_isExpressionMode) {
+                          final digits =
+                              newText.replaceAll(RegExp(r'[^\d]'), '');
+                          if (digits.isEmpty) {
+                            widget.controller.text = '';
+                          } else {
+                            final num = int.tryParse(digits);
+                            if (num != null) {
+                              final formatted = CurrencyFormatter.format(num);
+                              widget.controller.text = formatted;
+                              widget.controller.selection =
+                                  TextSelection.collapsed(
+                                      offset: formatted.length);
+                            }
+                          }
+                        } else {
+                          widget.controller.text = newText;
+                          widget.controller.selection =
+                              TextSelection.collapsed(offset: newText.length);
+                        }
+                      }
+                    },
+                    radius: 20,
+                    child: Tooltip(
+                      message: '지우기 (길게 누르면 전체 삭제)',
+                      child: Container(
+                        padding: const EdgeInsets.all(8),
+                        child: const Icon(
+                          Icons.backspace_outlined,
+                          size: 20,
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ],
             ],
-          ],
+          ),
         ),
       ),
       keyboardType: TextInputType.number,

--- a/frontend/lib/features/transaction/presentation/pages/transaction_form_page.dart
+++ b/frontend/lib/features/transaction/presentation/pages/transaction_form_page.dart
@@ -538,7 +538,21 @@ class _TransactionFormPageState extends State<TransactionFormPage>
             // Without this guard, any TransactionLoaded change (e.g., LoadMore
             // from the list page behind) would trigger premature navigation.
             if (!_isSubmitting) return;
-            if (state is TransactionLoaded) {
+            // 회차 1 follow-up (2026-05-06) — TransactionLoaded(operationError)
+            // 케이스를 success 와 분리. 이전: BE 검증 실패 후 BLoC catch 가
+            // operationError 가진 TransactionLoaded 로 emit 했을 때 listener 가
+            // 그대로 navigate 했고, 일부 케이스에서는 _isSubmitting 이 풀리지
+            // 않아 무한 로딩. 이제 operationError 가 있으면 에러 경로로 처리.
+            if (state is TransactionLoaded && state.operationError != null) {
+              _submitTimeoutTimer?.cancel();
+              setState(() => _isSubmitting = false);
+              ScaffoldMessenger.of(context).showSnackBar(
+                SnackBar(
+                  content: Text(state.operationError!),
+                  backgroundColor: Theme.of(context).colorScheme.error,
+                ),
+              );
+            } else if (state is TransactionLoaded) {
               _submitTimeoutTimer?.cancel();
               _isSubmitting = false;
               // 회차 12 P2 Phase A — 거래 등록 후 dashboard reload 시 사용자가 보던


### PR DESCRIPTION
## Summary
PR #225 라이브 검증 1차 실패 3건 fix.

- **A.** BE `validateAmountForType` 가 EXPENSE/INCOME amount<=0 거부 → V46 의도(DB `>= 0`) 일치하도록 `< 0` 으로 변경. 0원 거래 정상 저장.
- **B.** 계산기 suffixIcon collapse → `suffixIconConstraints` 명시 + IconButton → InkResponse + padded container.
- **C.** BLoC catch 의 `TransactionLoaded(operationError)` 가 success 로 잘못 navigate → BlocListener 에 operationError 분기 추가.

## 재발 방지 (의무 3단계)
- 하네스 인시던트 등록
- audit-patterns.json `db_schema` file_scopes 에 service/*.kt 추가
- 신규 태그 `constraint_relaxation_service_drift`
- CLAUDE.md Step 1.5 보강
- 메모리 등록 + MEMORY.md index
- 결과 기록 `docs/sessions/2026-05-06_1_result.md`

## Test plan
- [x] BE TransactionServiceTest PASS (amount=0 신규 케이스 포함)
- [x] FE analyze (error 0)
- [x] FE 관련 테스트 PASS
- [ ] 사용자 라이브 재검증
  - A6: 0원 거래 등록 가능 (지출/수입)
  - A7: `5-5` → 0 표시 + 저장 가능
  - A8: 금액 필드 우측 계산기 아이콘 항상 노출
  - A8: 계산기 popup 으로 `(2+3)*4=20` 입력
  - A9: 모바일 — 계산기 아이콘 가능
  - 무한 로딩 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)