### PR TITLE
feat(measure): filter desync 진단용 debugPrint 인스트루먼트 (Phase 1)

### DIFF
--- a/docs/sessions/2026-05-07_1_plan.md
+++ b/docs/sessions/2026-05-07_1_plan.md
@@ -1,0 +1,185 @@
+# 금액/잔액 변동 화면 자동 반영 + 거래 필터 desync 전수 분석
+> 날짜: 2026-05-07 | 회차: 1 | 상태: 기획 (사용자 승인 대기)
+
+## 요청 내용 (사용자 원문)
+
+> 거래 등록하면 바로 반영되어야하는것처럼 결제수단에서 잔액 수정 시 금액도 자동 반영되어야하는데 새로고침해야하는 문제 존재.
+> 이와 같이 금액 변동, 잔액 조정 가능한 곳에서 새로 등록하면 항상 반영되고, 노출되도록 어디에서 수정 필요한지 전체 분석 필요.
+>
+> 또한 카카오페이라고 은행 항목을 만들었는데 거래 등록 후 거래 탭을 누르면 필터된거 해제된 것처럼 나와서 필터가 아무것도 안 나오는데 카카오페이 항목과 이체 항목 밖에 안 나오는 버그 존재한다.
+> 그러고 필터에서 전체되어있는 그대로 적용 누르면 5건에서 갑자기 26건으로 변하는 버그도 처리 필요하다.
+
+## 핵심 결론 요약
+
+| 이슈 | 분류 | 근거 | 진단 상태 |
+|------|------|------|----------|
+| **이슈 A** — 결제수단 잔액 수정 후 자산/홈 미반영 | 확정 (코드 측정) | `BalanceAdjustmentDialog` 가 `BalanceAdjustmentSheet` 와 다른 fan-out 사용. PaymentMethodBloc 만 reload, Dashboard/Transaction 누락 | 진단 완료 |
+| **이슈 B** — 거래 등록 후 거래탭 진입 시 일부만 노출 (필터 chip 은 비어있음) | 미확정 (측정 필요) | `transaction_list_page._filterState` 와 `TransactionBloc._currentPaymentMethodIds` 가 **두 개의 분리된 상태**. didUpdateWidget 에서만 sync. 본인 거래 등록 흐름에서 desync 발생 가설 | 측정 PR 필요 |
+| **이슈 C** — "전체" 적용 시 5건→26건 점프 | 미확정 (측정 필요) | 이슈 B 와 동일 desync 의 다른 표현 (UI 는 "전체" 인데 BLoC 은 필터 걸려 있음) | 측정 PR 필요 |
+
+> **CLAUDE.md 1.0 (추측 fix 절대 금지) 적용**: 이슈 A 는 hard evidence 있어 1차 fix PR 가능. 이슈 B/C 는 측정 인스트루먼트 PR 먼저 → 사용자 출력 수신 → 2차 fix PR.
+
+---
+
+## 영향 범위 분석
+
+### 변경/조사 대상 파일
+
+| 파일 | 역할 | 이슈 |
+|------|------|------|
+| `frontend/lib/features/payment_method/presentation/widgets/balance_adjustment_dialog.dart` | 결제수단 잔액 수정 다이얼로그 (직접 API 호출, fan-out 누락) | A 핵심 원인 |
+| `frontend/lib/features/payment_method/presentation/pages/payment_method_page.dart:501-511` | 위 dialog 호출자, onSuccess 콜백에서 PaymentMethodBloc 만 reload | A 핵심 원인 |
+| `frontend/lib/core/widgets/balance_adjustment_sheet.dart` | 동일 기능의 **올바른 구현**. TransactionBloc + PaymentMethodBloc + DashboardBloc 모두 reload | A 비교 reference |
+| `frontend/lib/features/transaction/presentation/pages/transaction_list_page.dart:79-143, 247-259` | UnifiedFilterState 와 BLoC currentFilter 의 동기화 지점 | B/C 측정 대상 |
+| `frontend/lib/features/transaction/presentation/bloc/transaction_bloc.dart:13-60` | `_currentPaymentMethodIds` 등 BLoC 내부 필터 상태 + `currentFilter` getter | B/C 측정 대상 |
+| `frontend/lib/features/transaction/presentation/pages/transaction_form_page.dart:561-563, 569` | 거래 등록 성공 후 fan-out (Dashboard, PaymentMethod) — TransactionBloc reload 없음 | B 가설의 근거 |
+| `frontend/lib/core/websocket/sync_event_handler.dart:38-110` | WebSocket sync. **자기 자신 author skip** (line 40-43) — 본인 디바이스 변경은 명시적 reload 필수 | A/B 컨텍스트 |
+| `frontend/lib/core/router/app_router.dart` | `/transactions?paymentMethodId=...` query param 처리, GoRouter State 재사용 동작 | B 측정 대상 |
+
+### 관련 기존 코드/문서
+- `docs/sessions/2026-05-03_1_result.md` — 회차 12 P2 Phase A: 12개 BLoC race sweep
+- `docs/sessions/2026-05-04_*` — 회차 12 follow-up A: `_filterState desync 회귀 fix` (line 113-117 주석). **이미 한 번 잡힌 동일 클래스의 회귀**
+- `docs/sessions/2026-05-06_1_result.md` — PR #225/#226: 거래 0원/계산기 (직전 회차)
+
+### 기술적 제약
+- WebSocket sync 는 **자기 author 이벤트 skip** (sync_event_handler:40-43). 본인 디바이스 내 변경은 명시적 BLoC reload 외 자동 반영 경로가 없음.
+- transaction_list_page 는 GoRouter 가 같은 path 재진입 시 State 재사용. `late _filterState` initializer 는 한 번만 fire.
+- `didUpdateWidget` 은 widget prop 변경 시에만 동기화. BLoC 내부 필터가 외부에서 바뀌어도 page 의 _filterState 는 그대로 (반대 방향 sync 없음).
+
+---
+
+## 작업 계획
+
+### Phase 1 — 측정 PR (이슈 B/C 진단용)
+
+| # | 작업 | 담당 | 파일 | 난이도 |
+|---|------|------|------|--------|
+| 1 | TransactionBloc.LoadTransactions 핸들러에 `debugPrint` 추가 — event.paymentMethodIds, event.transactionTypes, currentFilter 스냅샷 로그 | FE | transaction_bloc.dart | S |
+| 2 | transaction_list_page initState/didUpdateWidget/_onFilterChanged 진입 시 `_filterState`, `widget.initialXxx`, `BLoC.currentFilter` 비교 로그 | FE | transaction_list_page.dart | S |
+| 3 | transaction_form_page 거래 등록 성공 직전/직후 BLoC.currentFilter 로그 | FE | transaction_form_page.dart | S |
+| 4 | 사용자에게 재현 절차 + console 출력 공유 요청 (브라우저 F12 → Console) | — | — | — |
+
+### Phase 2 — 이슈 A 수정 PR (확정 진단 기반)
+
+| # | 작업 | 담당 | 파일 | 난이도 |
+|---|------|------|------|--------|
+| 5 | `BalanceAdjustmentDialog._submit` 가 BLoC 우회 직접 API 호출 → **`BalanceAdjustmentSheet` 와 동일 구조로 통합** (`getIt<TransactionBloc>().add(CreateTransaction(...))` + Dashboard/PaymentMethod fan-out) | FE | balance_adjustment_dialog.dart, payment_method_page.dart | M |
+| 6 | (선택) 두 위젯 중복 제거 — payment_method_page 도 `BalanceAdjustmentSheet` 직접 호출하도록 통합 | FE | payment_method_page.dart, balance_adjustment_dialog.dart 삭제 | M |
+| 7 | 회귀 테스트 추가 — 잔액 수정 후 DashboardBloc / TransactionBloc / PaymentMethodBloc 가 reload 이벤트 받는지 widget test | FE | test/features/payment_method/ | S |
+
+### Phase 3 — 이슈 B/C 수정 PR (측정 결과 수신 후)
+
+> Phase 1 측정 결과 수신 전까지 작성하지 않음. 추측 fix 금지.
+> 가설 후보 (측정으로 검증할 항목):
+> - 거래 등록 시 새 결제수단이 BLoC._currentPaymentMethodIds 에 누설되어 들어가는가?
+> - 또는 GoRouter query param 으로 paymentMethodId 가 박혀서 widget prop 으로 들어오는가?
+> - 또는 _onFilterChanged 가 부분 갱신만 해서 반대 방향 sync 가 깨지는가?
+
+---
+
+## 성능 설계
+
+| 항목 | 설계 |
+|------|------|
+| 데이터 접근 | 잔액 수정 시 추가 fan-out 으로 GET 3건 (PaymentMethod, Dashboard, Transaction). 기존 거래 등록과 동일 패턴이므로 추가 비용 없음 |
+| 예상 규모 | 잔액 수정 빈도 낮음 (월 5-20회). N+1 / 루프 호출 없음 |
+| 리소스 제약 | WebSocket sync 와 중복 reload 가능성 → 자기 author skip 으로 이미 차단됨 |
+| 설계 결정 | **방향 1 권장**: balance_adjustment_dialog 를 ApiClient 직접 호출 → BLoC.add(CreateTransaction) 으로 변경. 거래 등록과 동일 코드 경로로 수렴되므로 fan-out 자동 일치. **방향 2**: BalanceAdjustmentSheet 로 위젯 통합 (코드 중복 제거). |
+
+---
+
+## 하네스 Scope Audit 결과 (Step 1.5)
+
+- **실행 명령**: `bash ~/.claude/harness/scripts/pre-change-audit.sh . "amount_calculation,ui_pattern"`
+- **분류 태그**: `amount_calculation`, `ui_pattern`, `filter_propagation` (이슈 B/C)
+- **Scope Audit 발견 (요약)**: 금액 reload fan-out 패턴 — 정상 13곳 (transaction_form_page, transfer_form_page, card_settlement_page, balance_adjustment_sheet 등) / 누락 1곳 (balance_adjustment_dialog). 그 외 pocket/insurance/recurring/weekly_budget/spending_plan 등은 자체 BLoC 만 reload 하고 dashboard 직접 영향 없음 (별도 화면이라 자동 반영 불요).
+- **Recurrence Check**: WARNING — `_filterState desync 회귀 fix` 가 회차 12 follow-up A (2026-05-04) 에 이미 있음. transaction_list_page didUpdateWidget 주석 line 113-117 명시. 본 이슈 B 는 **다른 경로의 같은 클래스 회귀**. 측정 후 구조적 fix 검토 필요 (BLoC ↔ page filter state 단일화 또는 양방향 sync).
+- **재발 방지 조치**:
+  - 잔액/금액 변동 위젯 작성 표준 추가 (CLAUDE.md 또는 docs/agent-playbook.md): "잔액/금액 변동은 항상 BLoC 이벤트로. ApiClient 직접 호출 금지. fan-out 은 거래 등록 표준과 동일."
+  - filter desync 재발 방지 — `_filterState` 와 `BLoC.currentFilter` 양방향 invariant assert (debug build 만)
+
+---
+
+## 자동 검증 계획 (CI/로컬)
+
+- [ ] BE 테스트 통과 (변경 없음 — FE 만)
+- [ ] `cd frontend && flutter analyze` (error 0)
+- [ ] `cd frontend && flutter test` (전체 PASS)
+- [ ] `cd frontend && flutter build web` 성공
+- [ ] BE↔FE↔Spec 일치 (이슈 A: 변경 없음. 이슈 B/C: 측정 결과 따라)
+- [ ] 잔액 수정 위젯 회귀 테스트 추가
+- [ ] 보안: 변경 없음 (인증/입력 검증 영향 없음)
+
+---
+
+## 배포 절차 (필수)
+
+| # | 단계 | 주체 | 확인 방법 |
+|---|------|------|----------|
+| 1 | Phase 1 측정 PR 생성 / CI | AI | `gh pr checks <N>` |
+| 2 | squash merge | AI | `gh pr merge <N> --squash --delete-branch` |
+| 3 | deploy-nas.yml watch | AI | `gh run watch <id>` |
+| 4 | 캐시 무효화 + 재현 + 콘솔 로그 공유 | 사용자 | F12 → Console |
+| 5 | Phase 2 (이슈 A) PR 생성 → merge → deploy | AI | 동일 |
+| 6 | Phase 3 (이슈 B/C) PR 생성 → merge → deploy | AI | 동일 |
+| 7 | 사용자 캐시 무효화 후 라이브 검증 | 사용자 | F12 → Network → Disable cache → 새로고침 |
+
+---
+
+## 사용자 검증 시나리오
+
+### A. 이슈 A — 결제수단 잔액 수정 → 자동 반영
+| # | 경로 | 조작 | 기대 결과 |
+|---|------|------|----------|
+| A1 | 결제수단 화면 → 카드 long-press 또는 메뉴 → "잔액 수정" | 현재 잔액 = 100,000원 → 80,000원 입력 | dialog 닫힘. 결제수단 카드의 잔액이 즉시 80,000원으로 변경 |
+| A2 | A1 직후 → 자산 탭 클릭 | 새로고침 없음 | 자산 탭의 총자산 / 결제수단 잔액이 새 값 (80,000원) 반영 |
+| A3 | A1 직후 → 홈 탭 → 대시보드 | 새로고침 없음 | 잔액 조정으로 추가된 ADJUSTMENT 거래 1건이 거래 요약에 반영 |
+| A4 | A1 직후 → 거래 탭 | 새로고침 없음 | "잔액 수정" 메모 가진 ADJUSTMENT 거래 1건이 목록 상단에 노출 |
+
+### B. 이슈 B — 거래 등록 후 거래탭 진입 시 필터 desync
+| # | 경로 | 조작 | 기대 결과 |
+|---|------|------|----------|
+| B1 | 결제수단 추가 → "카카오페이" 등록 | — | 결제수단 목록에 추가 |
+| B2 | 거래 등록 → 결제수단 = 카카오페이 → 저장 | — | 등록 성공 후 이전 화면으로 돌아감 |
+| B3 | 거래 탭 클릭 | 새로고침 없음 | 헤더 제목 "거래 (전체)" 가 표시되면 모든 거래 (이번 달 전체) 노출. "거래 (카카오페이)" 면 카카오페이 거래만 노출 + 필터 chip 표시. **두 표시가 일치해야 함** |
+| B4 | 필터 다이얼로그 → "전체" → 적용 | — | B3 시점 결과 건수와 동일해야 함 (delta 0) |
+
+### C. 이슈 C — "전체" 적용 시 결과 건수 점프
+| # | 경로 | 조작 | 기대 결과 |
+|---|------|------|----------|
+| C1 | 거래 탭 어떤 상태든 → 헤더 건수 N 확인 | — | N |
+| C2 | 필터 → "전체" 선택 → 적용 | — | UI 가 "전체" 였다면 결과 건수는 N 과 동일. 다른 필터였다면 변경 사실이 헤더에 반영 |
+
+### D. 회귀 없음 (Zero regression)
+| # | 확인 | 기대 |
+|---|------|------|
+| D1 | 거래 등록 (기존 시나리오) | 자산 / 홈 / 거래 즉시 반영 (회차 12 sweep 회귀 없음) |
+| D2 | partner 가 거래 등록 시 본인 화면 sync (WebSocket) | 변동 없음 |
+| D3 | 자산 → 결제수단 클릭 → /transactions?paymentMethodId=X | filter chip 표시 + 결과 일치 |
+| D4 | 거래 등록 후 "이어서 등록" 모드 | 기존 동작 보존 |
+
+---
+
+## 기획 검증 (자체 점검)
+
+- [x] CLAUDE.md 1.0 (측정 우선) — 이슈 A 만 hard evidence 있어 1차 fix. B/C 는 측정 PR 부터.
+- [x] CLAUDE.md 1.1 (완료 정의) — Phase 별 사용자 라이브 검증 통과까지 = 완료. _result.md 작성 의무.
+- [x] CLAUDE.md 1.4 (성능은 기능) — fan-out 추가 호출량 명시
+- [x] Step 1.5 하네스 audit — `filter_propagation` 회귀 발견, recurrence WARNING 등록
+- [x] BalanceAdjustmentSheet 정상 / Dialog 비정상 → 두 구현 통합 권장 (코드 중복 + 회귀 위험)
+- [x] WebSocket self-author skip 이해 → 본인 변경 시 명시적 reload 필수
+
+## 사용자 승인
+- [ ] 승인 / 수정 요청: ___
+
+### 결정이 필요한 옵션
+1. **이슈 A 수정 방식**:
+   - (a) `BalanceAdjustmentDialog._submit` 에 reload 3건 추가 (최소 변경)
+   - (b) `BalanceAdjustmentDialog` 자체를 삭제하고 `BalanceAdjustmentSheet` 로 통합 (코드 중복 제거, **권장**)
+
+2. **Phase 1 측정 PR 진행 여부**:
+   - (a) 측정 PR 먼저 → 결과 수신 후 Phase 3 fix (CLAUDE.md 1.0 룰 준수, **권장**)
+   - (b) Phase 2 (이슈 A) 와 함께 측정 인스트루먼트만 추가 후 사용자에게 동시 보고
+
+3. **이슈 B/C 우선순위**:
+   - 사용자 임팩트 큼 (거래탭 자체가 신뢰 안 됨) → 이슈 A 와 같은 sprint 처리 권장

--- a/frontend/lib/features/transaction/presentation/bloc/transaction_bloc.dart
+++ b/frontend/lib/features/transaction/presentation/bloc/transaction_bloc.dart
@@ -1,4 +1,5 @@
 import 'package:dartz/dartz.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:budget_book/features/transaction/domain/entities/transaction_filter.dart';
 import 'package:budget_book/features/transaction/domain/repositories/transaction_repository.dart';
@@ -78,6 +79,16 @@ class TransactionBloc extends Bloc<TransactionEvent, TransactionState> {
   ) async {
     try {
       final previousState = state;
+      // [FilterMeasure 2026-05-07] LoadTransactions 진입 시점 — 직전 _currentXxx 와 event 비교.
+      // desync 가설 확정용. Phase 3 fix 후 제거.
+      debugPrint('[FilterMeasure] LoadTransactions ENTER '
+          'prev._currentPaymentMethodIds=$_currentPaymentMethodIds '
+          'event.paymentMethodIds=${event.paymentMethodIds} '
+          'prev._currentTransactionTypes=$_currentTransactionTypes '
+          'event.transactionTypes=${event.transactionTypes} '
+          'prev._currentCategoryIds=$_currentCategoryIds '
+          'event.categoryIds=${event.categoryIds} '
+          'event.year=${event.year} event.month=${event.month}');
       _currentYear = event.year;
       _currentMonth = event.month;
       _currentKeyword = event.keyword;
@@ -310,6 +321,13 @@ class TransactionBloc extends Bloc<TransactionEvent, TransactionState> {
     CreateTransaction event,
     Emitter<TransactionState> emit,
   ) async {
+    // [FilterMeasure 2026-05-07] CreateTransaction 진입 — 등록되는 결제수단 ID 와
+    // 현재 BLoC 가 보존하는 필터 비교. 가설: _currentXxx 는 그대로 보존되어
+    // post-create LoadTransactions 가 stale 필터로 호출됨.
+    debugPrint('[FilterMeasure] CreateTransaction ENTER '
+        'event.paymentMethodId=${event.paymentMethodId} '
+        '_currentPaymentMethodIds=$_currentPaymentMethodIds '
+        '_currentTransactionTypes=$_currentTransactionTypes');
     try {
       final result = await transactionRepository.createTransaction(
         type: event.type,

--- a/frontend/lib/features/transaction/presentation/pages/transaction_form_page.dart
+++ b/frontend/lib/features/transaction/presentation/pages/transaction_form_page.dart
@@ -555,6 +555,16 @@ class _TransactionFormPageState extends State<TransactionFormPage>
             } else if (state is TransactionLoaded) {
               _submitTimeoutTimer?.cancel();
               _isSubmitting = false;
+              // [FilterMeasure 2026-05-07] 거래 등록 성공 직후 — TransactionBloc 의
+              // currentFilter 와 form 에서 등록한 paymentMethodId 비교.
+              // 가설: 등록 후 BLoC._currentPaymentMethodIds 가 stale 한 채로
+              // _onCreateTransaction 핸들러가 자체 LoadTransactions 발행 → 잘못된 결과.
+              final txBloc = getIt<TransactionBloc>();
+              debugPrint('[FilterMeasure] TxFormPage.onSuccess '
+                  'BLoC._currentPaymentMethodIds=${txBloc.currentPaymentMethodIds} '
+                  'submitted.paymentMethodId=$_selectedPaymentMethodId '
+                  'state.year=${state.year} state.month=${state.month} '
+                  'state.totalElements=${state.totalElements}');
               // 회차 12 P2 Phase A — 거래 등록 후 dashboard reload 시 사용자가 보던
               // month 유지 (MonthCubit). 이전: now 강제로 다른 월 보던 사용자에게
               // 현재월 dashboard 가 표시되어 sync 깨짐.

--- a/frontend/lib/features/transaction/presentation/pages/transaction_list_page.dart
+++ b/frontend/lib/features/transaction/presentation/pages/transaction_list_page.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 import 'package:dio/dio.dart';
-import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter/foundation.dart' show debugPrint, kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
@@ -96,6 +96,13 @@ class _TransactionListPageState extends State<TransactionListPage> {
   @override
   void initState() {
     super.initState();
+    // [FilterMeasure 2026-05-07] initState — page mount 시점 prop / _filterState 출력.
+    // GoRouter 가 State 재사용하면 이 로그가 다시 안 찍힘 → didUpdateWidget 만 fire.
+    debugPrint('[FilterMeasure] TxListPage.initState '
+        'widget.initialPaymentMethodId=${widget.initialPaymentMethodId} '
+        'widget.initialCategoryId=${widget.initialCategoryId} '
+        '_filterState.paymentMethodIds=${_filterState.paymentMethodIds} '
+        '_filterState.categoryIds=${_filterState.categoryIds}');
     if (widget.initialPaymentMethodId != null && _filterState.paymentMethodName == null) {
       final name = PaymentMethodFilter.resolveName(widget.initialPaymentMethodId!);
       if (name != null) {
@@ -121,6 +128,14 @@ class _TransactionListPageState extends State<TransactionListPage> {
     final pmChanged = widget.initialPaymentMethodId != oldWidget.initialPaymentMethodId;
     final catChanged = widget.initialCategoryId != oldWidget.initialCategoryId;
     final groupChanged = widget.initialCategoryGroupId != oldWidget.initialCategoryGroupId;
+    // [FilterMeasure 2026-05-07] didUpdateWidget — prop change 감지 시 _filterState 만
+    // 갱신하고 BLoC reload 는 안 함. 이 로그로 desync window 의 시작 시점 포착.
+    final blocCurrent = context.read<TransactionBloc>().currentPaymentMethodIds;
+    debugPrint('[FilterMeasure] TxListPage.didUpdateWidget '
+        'pmChanged=$pmChanged old=${oldWidget.initialPaymentMethodId} new=${widget.initialPaymentMethodId} '
+        'catChanged=$catChanged groupChanged=$groupChanged '
+        '_filterState.paymentMethodIds(before)=${_filterState.paymentMethodIds} '
+        'BLoC._currentPaymentMethodIds=$blocCurrent');
     if (pmChanged || catChanged || groupChanged) {
       setState(() {
         _filterState = _filterState.copyWith(
@@ -254,6 +269,15 @@ class _TransactionListPageState extends State<TransactionListPage> {
         newState = newState.copyWith(paymentMethodName: name);
       }
     }
+    // [FilterMeasure 2026-05-07] 사용자 명시적 필터 변경 시점.
+    // 이전 _filterState 대비 newState delta + BLoC 의 현재 필터 같이 출력.
+    final blocPm = context.read<TransactionBloc>().currentPaymentMethodIds;
+    debugPrint('[FilterMeasure] TxListPage._onFilterChanged '
+        'old._filterState.paymentMethodIds=${_filterState.paymentMethodIds} '
+        'new.paymentMethodIds=${newState.paymentMethodIds} '
+        'BLoC._currentPaymentMethodIds(pre-reload)=$blocPm '
+        'old.transactionTypes=${_filterState.transactionTypes} '
+        'new.transactionTypes=${newState.transactionTypes}');
     setState(() => _filterState = newState);
     _reloadWithFilters();
   }


### PR DESCRIPTION
## Summary

회차 1 (2026-05-07) — 사용자 신고 이슈 B/C: 카카오페이 결제수단 만들고 거래 등록 후 거래탭 클릭 시 필터 chip 은 비어있는데 결과는 카카오페이+이체만 노출 + '전체' 적용 시 5건→26건 점프.

**CLAUDE.md 1.0 (추측 fix 절대 금지) 준수**: fix 가 아니라 측정 인스트루먼트. `[FilterMeasure]` prefix debugPrint 만 추가.

## 측정 포인트

- `TransactionBloc._onLoadTransactions ENTER` — 직전 _currentXxx vs event.xxx
- `TransactionBloc._onCreateTransaction ENTER` — 등록 paymentMethodId vs 보존된 _currentXxx
- `TxListPage.initState` — mount 시점 prop / _filterState
- `TxListPage.didUpdateWidget` — prop 변경 + _filterState before + BLoC._currentPaymentMethodIds
- `TxListPage._onFilterChanged` — 사용자 명시 변경 시 delta + BLoC 비교
- `TxFormPage.onSuccess` — 등록 직후 BLoC 필터 vs 등록한 paymentMethodId

## 가설 후보

1. `transaction_form_page.onSuccess` 가 TransactionBloc reload 안 함 (Dashboard + PaymentMethod 만). `_onCreateTransaction` 의 자체 LoadTransactions 가 stale `_currentPaymentMethodIds` 보존 → 잘못된 결과.
2. 자산 → 결제수단 클릭 진입 시 path 에 paymentMethodId, pop 시 query 사라짐 → `didUpdateWidget` 가 _filterState 만 갱신, BLoC reload 누락 → desync window.

## 사용자 재현 절차 (배포 후)

1. F12 → Console 열어두기
2. 자산 탭 → 카카오페이 결제수단 카드 클릭 → 거래탭 진입
3. Console 로그 'FilterMeasure' 로 grep
4. FAB → 거래 등록 (카카오페이 선택) → 저장
5. 거래탭 자동 복귀 → console 로그 전체 복사 공유
6. 필터 → '전체' → 적용 → console 로그 추가 복사

## Test plan

- [x] flutter analyze: 신규 회귀 0 (3 기존 info)
- [x] flutter test: 726/726 PASS
- [ ] CI 통과 후 squash merge → deploy-nas.yml watch
- [ ] 사용자 재현 + console 로그 공유 → Phase 3 fix PR

## 기획서

[docs/sessions/2026-05-07_1_plan.md](./docs/sessions/2026-05-07_1_plan.md)

Phase 2 (잔액 수정 위젯 통합 — 이슈 A 확정 fix) 와 **병행** 진행.

🤖 Generated with [Claude Code](https://claude.com/claude-code)