### PR TITLE
fix(transaction): 거래 탭 진입 시 filter desync — _filterState reset 시 BLoC 동기 reload (Phase 3)

### DIFF
--- a/frontend/lib/features/transaction/presentation/bloc/transaction_bloc.dart
+++ b/frontend/lib/features/transaction/presentation/bloc/transaction_bloc.dart
@@ -1,5 +1,4 @@
 import 'package:dartz/dartz.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:budget_book/features/transaction/domain/entities/transaction_filter.dart';
 import 'package:budget_book/features/transaction/domain/repositories/transaction_repository.dart';
@@ -79,16 +78,6 @@ class TransactionBloc extends Bloc<TransactionEvent, TransactionState> {
   ) async {
     try {
       final previousState = state;
-      // [FilterMeasure 2026-05-07] LoadTransactions 진입 시점 — 직전 _currentXxx 와 event 비교.
-      // desync 가설 확정용. Phase 3 fix 후 제거.
-      debugPrint('[FilterMeasure] LoadTransactions ENTER '
-          'prev._currentPaymentMethodIds=$_currentPaymentMethodIds '
-          'event.paymentMethodIds=${event.paymentMethodIds} '
-          'prev._currentTransactionTypes=$_currentTransactionTypes '
-          'event.transactionTypes=${event.transactionTypes} '
-          'prev._currentCategoryIds=$_currentCategoryIds '
-          'event.categoryIds=${event.categoryIds} '
-          'event.year=${event.year} event.month=${event.month}');
       _currentYear = event.year;
       _currentMonth = event.month;
       _currentKeyword = event.keyword;
@@ -321,13 +310,6 @@ class TransactionBloc extends Bloc<TransactionEvent, TransactionState> {
     CreateTransaction event,
     Emitter<TransactionState> emit,
   ) async {
-    // [FilterMeasure 2026-05-07] CreateTransaction 진입 — 등록되는 결제수단 ID 와
-    // 현재 BLoC 가 보존하는 필터 비교. 가설: _currentXxx 는 그대로 보존되어
-    // post-create LoadTransactions 가 stale 필터로 호출됨.
-    debugPrint('[FilterMeasure] CreateTransaction ENTER '
-        'event.paymentMethodId=${event.paymentMethodId} '
-        '_currentPaymentMethodIds=$_currentPaymentMethodIds '
-        '_currentTransactionTypes=$_currentTransactionTypes');
     try {
       final result = await transactionRepository.createTransaction(
         type: event.type,

--- a/frontend/lib/features/transaction/presentation/pages/transaction_form_page.dart
+++ b/frontend/lib/features/transaction/presentation/pages/transaction_form_page.dart
@@ -555,16 +555,6 @@ class _TransactionFormPageState extends State<TransactionFormPage>
             } else if (state is TransactionLoaded) {
               _submitTimeoutTimer?.cancel();
               _isSubmitting = false;
-              // [FilterMeasure 2026-05-07] 거래 등록 성공 직후 — TransactionBloc 의
-              // currentFilter 와 form 에서 등록한 paymentMethodId 비교.
-              // 가설: 등록 후 BLoC._currentPaymentMethodIds 가 stale 한 채로
-              // _onCreateTransaction 핸들러가 자체 LoadTransactions 발행 → 잘못된 결과.
-              final txBloc = getIt<TransactionBloc>();
-              debugPrint('[FilterMeasure] TxFormPage.onSuccess '
-                  'BLoC._currentPaymentMethodIds=${txBloc.currentPaymentMethodIds} '
-                  'submitted.paymentMethodId=$_selectedPaymentMethodId '
-                  'state.year=${state.year} state.month=${state.month} '
-                  'state.totalElements=${state.totalElements}');
               // 회차 12 P2 Phase A — 거래 등록 후 dashboard reload 시 사용자가 보던
               // month 유지 (MonthCubit). 이전: now 강제로 다른 월 보던 사용자에게
               // 현재월 dashboard 가 표시되어 sync 깨짐.

--- a/frontend/lib/features/transaction/presentation/pages/transaction_list_page.dart
+++ b/frontend/lib/features/transaction/presentation/pages/transaction_list_page.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 import 'package:dio/dio.dart';
-import 'package:flutter/foundation.dart' show debugPrint, kIsWeb;
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
@@ -96,13 +96,6 @@ class _TransactionListPageState extends State<TransactionListPage> {
   @override
   void initState() {
     super.initState();
-    // [FilterMeasure 2026-05-07] initState — page mount 시점 prop / _filterState 출력.
-    // GoRouter 가 State 재사용하면 이 로그가 다시 안 찍힘 → didUpdateWidget 만 fire.
-    debugPrint('[FilterMeasure] TxListPage.initState '
-        'widget.initialPaymentMethodId=${widget.initialPaymentMethodId} '
-        'widget.initialCategoryId=${widget.initialCategoryId} '
-        '_filterState.paymentMethodIds=${_filterState.paymentMethodIds} '
-        '_filterState.categoryIds=${_filterState.categoryIds}');
     if (widget.initialPaymentMethodId != null && _filterState.paymentMethodName == null) {
       final name = PaymentMethodFilter.resolveName(widget.initialPaymentMethodId!);
       if (name != null) {
@@ -128,14 +121,6 @@ class _TransactionListPageState extends State<TransactionListPage> {
     final pmChanged = widget.initialPaymentMethodId != oldWidget.initialPaymentMethodId;
     final catChanged = widget.initialCategoryId != oldWidget.initialCategoryId;
     final groupChanged = widget.initialCategoryGroupId != oldWidget.initialCategoryGroupId;
-    // [FilterMeasure 2026-05-07] didUpdateWidget — prop change 감지 시 _filterState 만
-    // 갱신하고 BLoC reload 는 안 함. 이 로그로 desync window 의 시작 시점 포착.
-    final blocCurrent = context.read<TransactionBloc>().currentPaymentMethodIds;
-    debugPrint('[FilterMeasure] TxListPage.didUpdateWidget '
-        'pmChanged=$pmChanged old=${oldWidget.initialPaymentMethodId} new=${widget.initialPaymentMethodId} '
-        'catChanged=$catChanged groupChanged=$groupChanged '
-        '_filterState.paymentMethodIds(before)=${_filterState.paymentMethodIds} '
-        'BLoC._currentPaymentMethodIds=$blocCurrent');
     if (pmChanged || catChanged || groupChanged) {
       setState(() {
         _filterState = _filterState.copyWith(
@@ -154,6 +139,15 @@ class _TransactionListPageState extends State<TransactionListPage> {
           // 클리어. 위 explicit 값 set 으로 동일 효과 (initialXxxId == null 시 빈 set).
         );
       });
+      // 회차 1 (2026-05-07) — _filterState 갱신과 동시에 BLoC reload 동기화.
+      // 회차 12 follow-up A 는 _filterState 만 reset 하고 BLoC.currentFilter 는
+      // 이전 값 유지 → 사용자 시나리오: 자산→카카오페이 클릭 후 거래탭 클릭 시
+      // /transactions (paymentMethodId 없는 path) 진입 → didUpdateWidget 가
+      // _filterState 빈 set 으로 reset (UI 는 "전체") 하지만 BLoC._currentPaymentMethodIds
+      // 는 카카오페이 그대로 → BE 호출 시 카카오페이로 필터 → 5건만 노출 (desync).
+      // _reloadWithFilters() 가 _filterState 의 새 값으로 LoadTransactions 발행 →
+      // BLoC._currentXxx 도 동시 갱신 → UI/결과 정합.
+      _reloadWithFilters();
     }
   }
 
@@ -269,15 +263,6 @@ class _TransactionListPageState extends State<TransactionListPage> {
         newState = newState.copyWith(paymentMethodName: name);
       }
     }
-    // [FilterMeasure 2026-05-07] 사용자 명시적 필터 변경 시점.
-    // 이전 _filterState 대비 newState delta + BLoC 의 현재 필터 같이 출력.
-    final blocPm = context.read<TransactionBloc>().currentPaymentMethodIds;
-    debugPrint('[FilterMeasure] TxListPage._onFilterChanged '
-        'old._filterState.paymentMethodIds=${_filterState.paymentMethodIds} '
-        'new.paymentMethodIds=${newState.paymentMethodIds} '
-        'BLoC._currentPaymentMethodIds(pre-reload)=$blocPm '
-        'old.transactionTypes=${_filterState.transactionTypes} '
-        'new.transactionTypes=${newState.transactionTypes}');
     setState(() => _filterState = newState);
     _reloadWithFilters();
   }


### PR DESCRIPTION
## Summary

회차 1 (2026-05-07) — 사용자 신고 이슈 B/C 의 구조적 fix.

> 자산 → 카카오페이 클릭 → 거래 탭 → "필터링 없어지면서 5건 (카카오페이+이체)만 노출"
> 필터에서 "전체" 적용 → 5건 → 26건 점프

## 원인 (사용자 시나리오 + 코드 측정)

`transaction_list_page` 는 두 개의 분리된 필터 상태:
- `_filterState` — page 의 UI 상태 (chip, 헤더 표시용)
- `BLoC.currentFilter` (`_currentXxx` 필드들) — BE 호출 시 사용

회차 12 follow-up A (2026-05-04) 에서 `didUpdateWidget` 가 `_filterState` 만 동기화하고 BLoC reload 는 누락한 채로 머지됨. 사용자 시나리오 재현:

1. 자산 → 카카오페이 → `/transactions?paymentMethodId=kakaopay` → `_filterState=kakaopay`, `BLoC._currentPaymentMethodIds=kakaopay` (정합)
2. **거래 탭 클릭** → `/transactions` (paymentMethodId 없음, 같은 path 재진입)
   → `didUpdateWidget` fire (`pmChanged=true`)
   → `_filterState` 빈 set 으로 reset (UI chip 사라짐, 헤더 "전체")
   → `BLoC._currentPaymentMethodIds` 는 카카오페이 그대로 (**reload 누락**)
   → BE 호출 시 카카오페이 필터로 5건만 반환 (**desync**)
3. 필터 → "전체" → 적용 → `_reloadWithFilters()` → `_filterState` 의 빈 set 이 BLoC 으로 전파 → 26건 (**점프**)

## Fix

`didUpdateWidget` 에서 `setState` 직후 `_reloadWithFilters()` 호출 추가.

```diff
   if (pmChanged || catChanged || groupChanged) {
     setState(() {
       _filterState = _filterState.copyWith(...);
     });
+    _reloadWithFilters();
   }
```

## 회귀 방지

- `pmChanged | catChanged | groupChanged` 일 때만 reload — 같은 prop 재렌더에서는 호출 안 됨 → 무한 루프 없음
- `_reloadWithFilters()` 가 BLoC.state.year/month 로 보던 month 보존 (회차 12 P2 Phase A 동작 그대로)

## 측정 인스트루먼트 cleanup

PR #228 에서 추가한 `[FilterMeasure]` debugPrint 6개 모두 제거. 사용자 시나리오 보고가 이미 hard evidence:
- UI: 필터 chip 없음 (헤더 "전체") = `_filterState` 빈 set
- 결과: 5건 카카오페이만 = `BLoC._currentPaymentMethodIds=kakaopay`
- 위 두 사실의 동시 성립 = desync 직접 증거

> Flutter web release 에서 debugPrint 가 console 에 표시되지 않는 별도 이슈는 본 fix 후 측정 필요 없으므로 follow-up 으로 보류.

## Test plan

- [x] flutter analyze: 신규 회귀 0 (3 기존 info)
- [x] flutter test: 728/728
- [ ] CI 통과 후 squash merge → deploy-nas.yml watch
- [ ] 사용자 라이브 검증 (시나리오 B1-B4, C1-C2)

## 사용자 검증 시나리오 (deploy 후, 캐시 무효화 필수)

### B (이슈 B 해결 검증)
- B1. 결제수단 → 카카오페이 추가
- B2. 거래 등록 → 결제수단=카카오페이 → 저장
- B3. 거래 탭 클릭 → 헤더 "거래 (전체)" + **모든 거래 (이번 달 26건+) 노출** + 필터 chip 없음
- B4. 필터 → "전체" 적용 → 결과 건수 변화 없음 (delta 0)

### C (이슈 C 해결 검증)
- C1. 자산 → 카카오페이 → 거래 탭 클릭 → 헤더 "거래 (전체)" + 26건+ 노출 (5건 아님)
- C2. 필터 → "전체" 적용 → 결과 변화 없음

### D (회귀 없음)
- D1. 자산 → 결제수단 카드 클릭 → /transactions?paymentMethodId=X → "거래 (X)" + 필터 chip + 해당 거래만
- D2. 거래 등록 (기존) → 자산/홈/거래 즉시 반영
- D3. 잔액 수정 (PR #229) → 자산/홈/거래 즉시 반영

## 관련 PR

- 기획서: `docs/sessions/2026-05-07_1_plan.md`
- Phase 1 측정: #228 (머지됨, deploy SUCCESS)
- Phase 2 잔액 수정 fan-out: #229 (머지됨, deploy SUCCESS)
- Phase 3 필터 desync (this PR): #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)