### PR TITLE
fix(form): 거래 폼 날짜 ±1일 — 지출 탭 swipe blank 회귀 fix

### DIFF
--- a/frontend/lib/features/transaction/presentation/pages/transaction_form_page.dart
+++ b/frontend/lib/features/transaction/presentation/pages/transaction_form_page.dart
@@ -1771,9 +1771,12 @@ class _TransactionFormPageState extends State<TransactionFormPage>
 
   Widget _buildDatePicker(BuildContext context) {
     final formattedDate = DateFormat('yyyy-MM-dd').format(_selectedDate);
-    // 회차 1 (2026-05-10) — 이슈 Y: ±1일 버튼 추가.
-    // 날짜 양 옆 [−][+] 으로 한 손 사용 시 빠른 1일 증감.
-    // 가운데 텍스트 영역 탭은 기존 calendar picker 유지.
+    // 회차 1 (2026-05-10) 회차 2 — 이슈 Y: ±1일 버튼.
+    // 1차 구현 (Row[IconButton, Expanded(InkWell), IconButton]) 는 TabBarView
+    // swipe 중 지출 탭이 blank 되는 회귀를 유발 — InkWell+InputDecorator 가
+    // Expanded 안에서 트랜지션 중 layout 이상 가능성. 본 fix 는 InkWell +
+    // InputDecorator 의 원본 구조를 그대로 두고 ±1일 버튼을 **별도 sibling**
+    // Row 로 분리하여 결합 제거.
     final firstDate = DateTime(2020);
     final lastDate = DateTime(2030, 12, 31);
     final canDec = _selectedDate.isAfter(firstDate);
@@ -1783,41 +1786,56 @@ class _TransactionFormPageState extends State<TransactionFormPage>
       if (next.isBefore(firstDate) || next.isAfter(lastDate)) return;
       setState(() => _selectedDate = next);
     }
-    return Row(
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        IconButton(
-          onPressed: canDec ? () => shiftDays(-1) : null,
-          icon: const Icon(Icons.remove),
-          tooltip: '이전 날짜',
-          visualDensity: VisualDensity.compact,
-        ),
-        Expanded(
-          child: InkWell(
-            onTap: () async {
-              final picked = await showCalendarPickerDialog(
-                context: context,
-                initialDate: _selectedDate,
-                firstDate: firstDate,
-                lastDate: lastDate,
-              );
-              if (picked != null) {
-                setState(() => _selectedDate = picked);
-              }
-            },
-            child: InputDecorator(
-              decoration: const InputDecoration(
-                labelText: '날짜',
-                suffixIcon: Icon(Icons.calendar_today),
-              ),
-              child: Text(formattedDate),
+        InkWell(
+          onTap: () async {
+            final picked = await showCalendarPickerDialog(
+              context: context,
+              initialDate: _selectedDate,
+              firstDate: firstDate,
+              lastDate: lastDate,
+            );
+            if (picked != null) {
+              setState(() => _selectedDate = picked);
+            }
+          },
+          child: InputDecorator(
+            decoration: const InputDecoration(
+              labelText: '날짜',
+              suffixIcon: Icon(Icons.calendar_today),
             ),
+            child: Text(formattedDate),
           ),
         ),
-        IconButton(
-          onPressed: canInc ? () => shiftDays(1) : null,
-          icon: const Icon(Icons.add),
-          tooltip: '다음 날짜',
-          visualDensity: VisualDensity.compact,
+        const SizedBox(height: 6),
+        Row(
+          children: [
+            Expanded(
+              child: OutlinedButton.icon(
+                onPressed: canDec ? () => shiftDays(-1) : null,
+                icon: const Icon(Icons.remove, size: 16),
+                label: const Text('1일 전'),
+                style: OutlinedButton.styleFrom(
+                  padding: const EdgeInsets.symmetric(vertical: 6),
+                  visualDensity: VisualDensity.compact,
+                ),
+              ),
+            ),
+            const SizedBox(width: 8),
+            Expanded(
+              child: OutlinedButton.icon(
+                onPressed: canInc ? () => shiftDays(1) : null,
+                icon: const Icon(Icons.add, size: 16),
+                label: const Text('1일 후'),
+                style: OutlinedButton.styleFrom(
+                  padding: const EdgeInsets.symmetric(vertical: 6),
+                  visualDensity: VisualDensity.compact,
+                ),
+              ),
+            ),
+          ],
         ),
       ],
     );


### PR DESCRIPTION
## Summary

PR #231 의 이슈 Y (날짜 ±1일 버튼) 회귀 fix. 사용자 보고: "좌우로 스왑 중 지출에서만 화면이 사라지는 버그".

## 원인

1차 구현 (`Row[IconButton, Expanded(InkWell→InputDecorator), IconButton]`) 가 TabBarView swipe transition 중 지출 탭 widget tree 를 blank 되게 함. 두 form 탭 (지출/수입) 이 동일 `_formKey` GlobalKey 의 Form 을 공유 — pre-existing 구조 — 트랜지션 시점의 constraint 변화에 새 Row 의 Expanded > InkWell > InputDecorator 가 layout 이상.

## Fix

- `InkWell` + `InputDecorator` 원본 구조 100% 보존 (PR #231 이전 그대로).
- ±1일 버튼을 sibling Row 의 OutlinedButton.icon ('1일 전' / '1일 후') 로 분리.
- Column[InkWell, Row[버튼]] — 결합 제거.

## Test plan

- [x] flutter analyze: clean
- [x] flutter test: 729 PASS
- [ ] 라이브 검증:
  - [ ] 지출/수입/이체 탭 swipe — blank 없음
  - [ ] 날짜 텍스트 클릭 → calendar picker
  - [ ] '1일 전' / '1일 후' 버튼 → 날짜 ±1
  - [ ] 경계 (2020-01-01 / 2030-12-31) clamp + 버튼 비활성

🤖 Generated with [Claude Code](https://claude.com/claude-code)