### PR TITLE
fix(form): 지출↔수입 탭 스와이프 검은 화면 — GlobalKey 충돌 fix

### DIFF
--- a/frontend/lib/features/transaction/presentation/pages/transaction_form_page.dart
+++ b/frontend/lib/features/transaction/presentation/pages/transaction_form_page.dart
@@ -96,7 +96,8 @@ class TransactionFormPage extends StatefulWidget {
 
 class _TransactionFormPageState extends State<TransactionFormPage>
     with SingleTickerProviderStateMixin {
-  final _formKey = GlobalKey<FormState>();
+  final _expenseFormKey = GlobalKey<FormState>();
+  final _incomeFormKey = GlobalKey<FormState>();
   late final TextEditingController _amountController;
   String _amountHint = '';
   late final TextEditingController _descriptionController;
@@ -677,9 +678,9 @@ class _TransactionFormPageState extends State<TransactionFormPage>
                 controller: _tabController,
                 children: [
                   // Tab 0: Expense form
-                  _buildTransactionFormBody(context),
+                  _buildTransactionFormBody(context, formKey: _expenseFormKey),
                   // Tab 1: Income form
-                  _buildTransactionFormBody(context),
+                  _buildTransactionFormBody(context, formKey: _incomeFormKey),
                   // Tab 2: Transfer form (embedded)
                   _buildTransferFormBody(context),
                 ],
@@ -688,14 +689,14 @@ class _TransactionFormPageState extends State<TransactionFormPage>
     );
   }
 
-  Widget _buildTransactionFormBody(BuildContext context) {
+  Widget _buildTransactionFormBody(BuildContext context, {GlobalKey<FormState>? formKey}) {
     // BlocListener is now in the top-level MultiBlocListener in build()
     return SingleChildScrollView(
         padding: const EdgeInsets.all(24),
         child: FocusTraversalGroup(
           policy: OrderedTraversalPolicy(),
           child: Form(
-            key: _formKey,
+            key: formKey ?? _expenseFormKey,
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
@@ -2035,7 +2036,8 @@ class _TransactionFormPageState extends State<TransactionFormPage>
       setState(() => _paymentMethodError = null);
     }
 
-    if (hasPickerError || !(_formKey.currentState?.validate() ?? false)) {
+    final activeFormKey = _tabController.index == 1 ? _incomeFormKey : _expenseFormKey;
+    if (hasPickerError || !(activeFormKey.currentState?.validate() ?? false)) {
       return;
     }
 


### PR DESCRIPTION
## Summary

- **근본 원인**: `_formKey` 하나를 지출(tab 0)·수입(tab 1) 두 탭이 공유 → TabBarView 스와이프 중 두 탭이 동시 렌더링되면 Flutter가 동일 GlobalKey를 트리 2곳에서 발견 → 렌더 예외 → 지출 탭 검은 화면
- **이체 탭(tab 2)** 은 `_transferFormKey` 를 별도 사용하여 영향 없었음
- **fix**: `_expenseFormKey` / `_incomeFormKey` 로 분리, `_onSubmit` 은 `_tabController.index` 기준으로 activeFormKey 선택

## Changed

- `_formKey` → `_expenseFormKey` + `_incomeFormKey`
- `_buildTransactionFormBody` 에 `formKey` named parameter 추가
- TabBarView 각 탭에 독립 키 전달
- `_onSubmit` validation 시 현재 활성 탭의 키 사용

## Test plan

- [ ] 거래 추가 → 지출↔수입 탭 스와이프: 검은 화면 미발생
- [ ] 살짝 스와이프 후 릴리즈 (partial swipe): 검은 화면 미발생
- [ ] 수입→지출→수입 반복 스와이프: 정상
- [ ] 저장 버튼: validation 정상 동작 (빈 필드 에러 표시)
- [ ] 이체 탭 스와이프: 기존과 동일하게 정상

🤖 Generated with [Claude Code](https://claude.com/claude-code)