### PR TITLE
fix(navigation): 자산·통계 탭 → 거래 탭 동일 자산 재선택 시 필터 미적용 (#234)

### DIFF
--- a/frontend/lib/features/payment_method/presentation/pages/payment_method_page.dart
+++ b/frontend/lib/features/payment_method/presentation/pages/payment_method_page.dart
@@ -237,7 +237,7 @@ class _PaymentMethodPageState extends State<PaymentMethodPage> {
                 } else if (action == 'delete') {
                   _showDeleteDialog(context, method);
                 } else if (action == 'history') {
-                  context.push('/transactions?paymentMethodId=${method.id}&paymentMethodName=${Uri.encodeComponent(method.name)}&year=$_year&month=$_month');
+                  context.go('/transactions?paymentMethodId=${method.id}&paymentMethodName=${Uri.encodeComponent(method.name)}&year=$_year&month=$_month');
                 } else if (action == 'adjust_balance') {
                   _showBalanceAdjustment(context, method);
                 }

--- a/frontend/lib/features/statistics/presentation/widgets/payment_method_stats_tab.dart
+++ b/frontend/lib/features/statistics/presentation/widgets/payment_method_stats_tab.dart
@@ -126,7 +126,7 @@ class PaymentMethodStatsTab extends StatelessWidget {
             clipBehavior: Clip.antiAlias,
             child: InkWell(
               onTap: () {
-                context.push('/transactions?year=$year&month=$month&paymentMethodId=${stat.paymentMethodId}&paymentMethodName=${Uri.encodeComponent(stat.paymentMethodName)}');
+                context.go('/transactions?year=$year&month=$month&paymentMethodId=${stat.paymentMethodId}&paymentMethodName=${Uri.encodeComponent(stat.paymentMethodName)}');
               },
               child: Padding(
                 padding: const EdgeInsets.all(12),


### PR DESCRIPTION
## 버그 요약

자산 탭에서 특정 자산 선택 → 필터 제거 → 동일 자산 재선택 시 필터가 적용되지 않는 문제.
다른 자산을 선택했다가 돌아오면 정상 동작.

## 근본 원인

cross-branch 이동(`/payment-methods` → `/transactions`)에 `context.push`를 사용하면, GoRouter가 transactions 브랜치 URL이 이미 동일할 때 탭 전환만 수행하고 **라우터 빌더를 재실행하지 않음**.

- 필터 제거 시 URL은 `/transactions?paymentMethodId=A`로 그대로 유지
- 동일 자산 재선택 → `context.push('/transactions?paymentMethodId=A')` 호출
- GoRouter: transactions 브랜치가 이미 해당 URL → 탭 전환만, 빌더 미실행
- `hasExplicitParams` 조건 미발동 → `BLoC.add(LoadTransactions)` 미발행 → 필터 미적용

`context.go`는 현재 URL과 동일해도 항상 navigation state를 교체 → 빌더 재실행 보장.

## 변경 사항

| 파일 | 변경 |
|---|---|
| `payment_method_page.dart:240` | `context.push` → `context.go` |
| `payment_method_stats_tab.dart:129` | `context.push` → `context.go` |

기존 `category_breakdown_tab.dart`, `dashboard_page.dart`의 cross-branch 이동과 동일 패턴으로 통일.

## 검증

- [ ] 자산 탭 → 자산 선택 → 필터 칩 확인
- [ ] 필터 제거 → 동일 자산 재선택 → 필터 적용 확인
- [ ] 다른 자산 선택 → 필터 적용 확인
- [ ] 통계 탭 결제수단별 행 탭 → 거래 탭 필터 적용 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)