### PR TITLE
fix(filter): URL ↔ state desync — 자산 재선택 시 필터 미적용 회귀

### DIFF
--- a/frontend/lib/features/payment_method/presentation/pages/payment_method_page.dart
+++ b/frontend/lib/features/payment_method/presentation/pages/payment_method_page.dart
@@ -237,7 +237,7 @@ class _PaymentMethodPageState extends State<PaymentMethodPage> {
                 } else if (action == 'delete') {
                   _showDeleteDialog(context, method);
                 } else if (action == 'history') {
-                  context.push('/transactions?paymentMethodId=${method.id}&paymentMethodName=${Uri.encodeComponent(method.name)}&year=$_year&month=$_month');
+                  context.go('/transactions?paymentMethodId=${method.id}&paymentMethodName=${Uri.encodeComponent(method.name)}&year=$_year&month=$_month');
                 } else if (action == 'adjust_balance') {
                   _showBalanceAdjustment(context, method);
                 }

--- a/frontend/lib/features/statistics/presentation/widgets/payment_method_stats_tab.dart
+++ b/frontend/lib/features/statistics/presentation/widgets/payment_method_stats_tab.dart
@@ -126,7 +126,7 @@ class PaymentMethodStatsTab extends StatelessWidget {
             clipBehavior: Clip.antiAlias,
             child: InkWell(
               onTap: () {
-                context.push('/transactions?year=$year&month=$month&paymentMethodId=${stat.paymentMethodId}&paymentMethodName=${Uri.encodeComponent(stat.paymentMethodName)}');
+                context.go('/transactions?year=$year&month=$month&paymentMethodId=${stat.paymentMethodId}&paymentMethodName=${Uri.encodeComponent(stat.paymentMethodName)}');
               },
               child: Padding(
                 padding: const EdgeInsets.all(12),

--- a/frontend/lib/features/transaction/presentation/pages/transaction_list_page.dart
+++ b/frontend/lib/features/transaction/presentation/pages/transaction_list_page.dart
@@ -264,8 +264,79 @@ class _TransactionListPageState extends State<TransactionListPage> {
         newState = newState.copyWith(paymentMethodName: name);
       }
     }
+
+    // 회차 1 (2026-05-18) — URL ↔ state desync 회귀 fix.
+    // 사용자 시나리오: 자산 → 국민 선택 → /transactions?paymentMethodId=X 진입
+    // → 거래탭 필터 chip 으로 X 제거 → 자산 재선택(같은 자산) → 필터 미적용 회귀.
+    //
+    // 근본 원인: GoRouter StatefulShellRoute branch 는 **동일 URL 재진입 시
+    // builder 를 재실행하지 않음**. X chip 제거 시점에 _filterState/BLoC 는
+    // 클리어되지만 URL 은 그대로 → 자산 재선택 시 context.go(같은 URL) → no-op →
+    // BLoC reload 미발생.
+    //
+    // 해결: nav 필터(paymentMethodId/categoryId/categoryGroupId) 의 단일↔단일,
+    // 단일→empty, empty→단일 transition 시 URL 도 함께 정리. 다음 navigation
+    // 이 새 URL 로 인식되어 router builder 가 정상 실행. multi-select 케이스는
+    // URL 에 표현 불가 → 변경 안 함 (in-memory BLoC/UI 동기화 유지).
+    final oldPm = _filterState.paymentMethodIds.length == 1
+        ? _filterState.paymentMethodIds.first
+        : null;
+    final newPm = newState.paymentMethodIds.length == 1
+        ? newState.paymentMethodIds.first
+        : null;
+    final oldCat = _filterState.categoryIds.length == 1
+        ? _filterState.categoryIds.first
+        : null;
+    final newCat = newState.categoryIds.length == 1
+        ? newState.categoryIds.first
+        : null;
+    final oldGroup = _filterState.categoryGroupIds.length == 1
+        ? _filterState.categoryGroupIds.first
+        : null;
+    final newGroup = newState.categoryGroupIds.length == 1
+        ? newState.categoryGroupIds.first
+        : null;
+    final oldWasSingleOrNone = _filterState.paymentMethodIds.length <= 1 &&
+        _filterState.categoryIds.length <= 1 &&
+        _filterState.categoryGroupIds.length <= 1;
+    final newIsSingleOrNone = newState.paymentMethodIds.length <= 1 &&
+        newState.categoryIds.length <= 1 &&
+        newState.categoryGroupIds.length <= 1;
+    final navTransition = oldPm != newPm || oldCat != newCat || oldGroup != newGroup;
+    final shouldSyncUrl =
+        navTransition && oldWasSingleOrNone && newIsSingleOrNone;
+
     setState(() => _filterState = newState);
     _reloadWithFilters();
+
+    if (shouldSyncUrl) {
+      _syncUrlForNavigationFilter(newState);
+    }
+  }
+
+  /// nav 필터를 URL 에 반영 (회차 1 — 2026-05-18).
+  /// 단일 nav 필터 (paymentMethodId / categoryId / categoryGroupId) 가 있으면 URL
+  /// 에 포함, 없으면 strip. year/month 는 URL 에서 제외 (BLoC/MonthCubit 가 보존).
+  void _syncUrlForNavigationFilter(UnifiedFilterState s) {
+    final params = <String>[];
+    if (s.paymentMethodIds.length == 1) {
+      params.add('paymentMethodId=${s.paymentMethodIds.first}');
+      if (s.paymentMethodName != null) {
+        params.add(
+            'paymentMethodName=${Uri.encodeComponent(s.paymentMethodName!)}');
+      }
+    }
+    if (s.categoryIds.length == 1) {
+      params.add('categoryId=${s.categoryIds.first}');
+      if (s.categoryName != null) {
+        params.add('categoryName=${Uri.encodeComponent(s.categoryName!)}');
+      }
+    }
+    if (s.categoryGroupIds.length == 1) {
+      params.add('categoryGroupId=${s.categoryGroupIds.first}');
+    }
+    final query = params.isEmpty ? '' : '?${params.join('&')}';
+    context.go('/transactions$query');
   }
 
   /// 회차 1 (2026-05-10) — HARD GUARANTEE: 필터 UI ↔ BE 동기화.


### PR DESCRIPTION
## Root Cause

GoRouter `StatefulShellRoute` branch 가 **동일 URL 재진입 시 builder 를 재실행하지 않음**.

이전 PR #235(`context.push → context.go`) 는 cross-branch BottomNav 손상이라는 별개 문제를 해결한 것이고, 이 버그의 진짜 원인인 URL ↔ state desync 는 손대지 않았음. 라이브 검증 단계에서 사용자가 재현하여 재발 확인됨.

## Reproduction

1. 자산 탭 → 국민 선택 → URL `/transactions?paymentMethodId=X`
2. 거래탭에서 필터 chip X 로 제거 → `_filterState`/BLoC 클리어, **URL 은 그대로 잔존**
3. 자산 탭 → 같은 국민 재선택 → `context.go('/transactions?paymentMethodId=X')` → branch location 과 동일 → GoRouter no-op → builder 미실행 → `bloc.add(LoadTransactions)` 미발생 → 필터 미적용

## Fix

`transaction_list_page.dart::_onFilterChanged` 에 URL sync 추가:
- nav 필터 (`paymentMethodId` / `categoryId` / `categoryGroupId`) 가 단일↔단일 / 단일→empty / empty→단일 transition 시 `context.go` 로 URL 도 함께 정리
- 다음 navigation 이 새 URL 로 인식되어 router builder 정상 실행
- multi-select 케이스는 URL 표현 불가 → 변경 없음

## 재발 방지 (process)

이전 세션은 도착지 코드(`transaction_list_page.dart` / `app_router.dart`) 미열람 + fix 후 시나리오 시뮬레이션 누락으로 **패턴 매칭 fix** 가 됨. 다음 5개 규칙 강제:

- **R1** 재현 시나리오를 code path 표로 매핑 필수 (각 step → file:line → state 변화)
- **R2** fix → symptom 차단 1문장 기술 의무 (못 적으면 분석 미완)
- **R3** navigation/router 변경 시 URL ↔ state invariant 점검 필수
- **R4** 도착지 코드 미열람 상태로 출발지만 변경 금지
- **R5** PR 머지 ≠ 완료. user 라이브 검증 PASS 까지 "완료" 표현 금지

## Test plan

- [x] `flutter analyze lib/` — No issues
- [x] `flutter test test/features/transaction/` — All passed
- [ ] 라이브: 자산 → 국민 선택 → 필터 적용 확인
- [ ] 라이브: 거래탭 X 로 필터 제거 → URL 에서 `paymentMethodId` 빠지는지 확인
- [ ] 라이브: 자산 → 같은 국민 재선택 → 필터 재적용 확인
- [ ] 라이브: 통계 탭 → 결제수단 통계 → 거래 진입도 동일 확인
- [ ] 라이브: 통계 탭 → 카테고리 통계 → 거래 진입 동일 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)