### PR TITLE
feat(auth): 카카오 OAuth2 배포 환경변수 주입

### DIFF
--- a/.github/workflows/deploy-nas.yml
+++ b/.github/workflows/deploy-nas.yml
@@ -120,6 +120,8 @@ jobs:
           NAS_JWT_SECRET: ${{ secrets.NAS_JWT_SECRET }}
           GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
           GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
+          KAKAO_CLIENT_ID: ${{ secrets.KAKAO_CLIENT_ID }}
+          KAKAO_CLIENT_SECRET: ${{ secrets.KAKAO_CLIENT_SECRET }}
         run: |
           # env 파일을 SSH 경유로 NAS 에 작성 (secrets 노출 최소화: stdin heredoc).
           ssh -i ~/.ssh/nas_key -p ${{ secrets.NAS_SSH_PORT }} \
@@ -136,6 +138,8 @@ jobs:
           FRONTEND_URL=https://aiva-bb.duckdns.org
           GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID}
           GOOGLE_CLIENT_SECRET=${GOOGLE_CLIENT_SECRET}
+          KAKAO_CLIENT_ID=${KAKAO_CLIENT_ID:-disabled}
+          KAKAO_CLIENT_SECRET=${KAKAO_CLIENT_SECRET:-disabled}
           REDIS_URL=redis://host.docker.internal:6380
           FLYWAY_ENABLED=true
           SERVER_FORWARD_HEADERS_STRATEGY=framework

--- a/docs/sessions/2026-05-20_1_plan.md
+++ b/docs/sessions/2026-05-20_1_plan.md
@@ -1,0 +1,90 @@
+# 카카오 로그인 연동 활성화 — 2026-05-20
+
+## 1. 요청 내용
+
+- 현재 Google 로그인만 동작. 카카오 로그인 버튼은 UI에 노출되어 있으나 실제 로그인은 동작하지 않음.
+- 카카오 로그인을 실제로 동작시켜 사용자가 카카오 계정으로 가입/로그인 가능하도록 한다.
+
+## 2. 현황 분석 (실측)
+
+**이미 완비된 부분 (코드 변경 불필요)**
+- BE 도메인: `AuthProvider.GOOGLE | KAKAO | SYSTEM` (User.kt:42)
+- BE 서비스: `CustomOAuth2UserService.extractKakaoUserInfo` (kakao_account → profile → nickname/email/thumbnail 매핑)
+- BE 설정: `application-prod.yml`, `application-local-supabase.yml`, `application-local.yml` 모두 kakao registration + provider 등록
+  - scope: `profile_nickname,account_email`
+  - redirect-uri: `{baseUrl}/login/oauth2/code/{registrationId}`
+  - client-authentication-method: `client_secret_post`
+- BE DB 제약: V31, V35 마이그레이션이 `provider IN ('GOOGLE', 'KAKAO', 'SYSTEM')` 허용
+- BE 테스트: `CustomOAuth2UserServiceTest` 존재
+- FE UI: `login_page.dart:128-140` 카카오 로그인 버튼 + `ApiEndpoints.authKakao = '/oauth2/authorization/kakao'`
+- FE i18n: `loginWithKakao` (ko: "카카오로 로그인", en: "Login with Kakao")
+
+**누락된 부분 (이 PR로 해결)**
+1. `.github/workflows/deploy-nas.yml`: `KAKAO_CLIENT_ID/SECRET` secret을 env 단계에서 받아 NAS env 파일로 주입 안 함 (line 121-122, 137-138 추가 필요)
+2. `infra/docker-compose.yml`: `KAKAO_CLIENT_ID/SECRET` 컨테이너 환경변수 전달 안 함 (line 52-53 사이 추가 필요)
+
+**외부 액션 필요 (사용자 작업)**
+- 카카오 개발자 콘솔 (https://developers.kakao.com) 앱 등록 + 키 발급
+- GitHub Secrets에 `KAKAO_CLIENT_ID`, `KAKAO_CLIENT_SECRET` 등록
+
+## 3. 영향 범위
+
+| 파일 | 변경 내용 |
+|---|---|
+| `.github/workflows/deploy-nas.yml` | KAKAO_CLIENT_ID/SECRET env 추가 + heredoc에 키 추가 (default `disabled`) |
+| `infra/docker-compose.yml` | backend 서비스에 KAKAO_CLIENT_ID/SECRET 환경변수 전달 |
+
+**무영향 검증**
+- secret 미등록 상태에서도 GitHub Actions은 빈 문자열로 평가 → heredoc에서 `${KAKAO_CLIENT_ID:-disabled}` 패턴으로 안전한 default 보장
+- Google과 동일 패턴으로 추가 → Spring OAuth2 부팅 정상 (현 상태와 동일하게 카카오 로그인 실패만 발생)
+
+## 4. 작업 계획
+
+| 단계 | 담당 | 작업 |
+|---|---|---|
+| 1 | 사용자 | 카카오 개발자 콘솔 앱 등록 → REST API 키, Client Secret 발급 → Redirect URI `https://aiva-bb.duckdns.org/login/oauth2/code/kakao` 등록 → Kakao Login 활성화 → 동의항목 `profile_nickname`, `account_email` 설정 |
+| 2 | 사용자 | GitHub Repository Settings → Secrets에 `KAKAO_CLIENT_ID`, `KAKAO_CLIENT_SECRET` 등록 |
+| 3 | Claude | `feat/kakao-oauth-deploy` 브랜치 생성 → 위 2개 파일 수정 |
+| 4 | Claude | PR 생성 → CI 통과 확인 |
+| 5 | Claude | PR 머지 → deploy-nas.yml 실행 → 컨테이너 재기동 → health 200 확인 |
+| 6 | 사용자 | 라이브 https://aiva-bb.duckdns.org → 카카오 로그인 버튼 클릭 → 카카오 로그인 → 홈 진입 확인 |
+
+## 5. 자동 검증 계획
+
+- BE 테스트: `./gradlew test` (CustomOAuth2UserServiceTest 포함, 기존 통과 유지)
+- FE 테스트: `flutter test` (login_page_test.dart 포함)
+- CI: GitHub Actions ci-backend + ci-frontend
+- 배포 후: `curl -s -o /dev/null -w "%{http_code}" --max-time 10 https://aiva-bb.duckdns.org/actuator/health` → 200
+- OAuth2 등록 확인: `curl -i https://aiva-bb.duckdns.org/oauth2/authorization/kakao` → 302 redirect to kauth.kakao.com
+
+## 6. 사용자 검증 시나리오
+
+**시나리오 A (신규 카카오 사용자)**
+1. 시크릿 창에서 https://aiva-bb.duckdns.org 접속
+2. "카카오로 로그인" 클릭 → kauth.kakao.com 리다이렉트
+3. 카카오 계정으로 로그인 + 동의
+4. 앱으로 복귀 → 홈 화면 진입 → 닉네임/프로필 이미지 노출 확인
+
+**시나리오 B (이메일 중복)**
+1. 이미 Google로 가입한 동일 이메일 카카오 계정으로 로그인 시도
+2. `account_exists` 에러 → "This email is already registered with GOOGLE" 메시지 → 로그인 페이지로 복귀
+
+**시나리오 C (기존 카카오 사용자 재로그인)**
+1. 카카오 로그인 → 기존 user_id 매칭 → 닉네임/프로필 이미지 업데이트되며 홈 진입
+
+## 7. 배포 절차
+
+- main 브랜치 push 시 deploy-nas.yml 자동 실행
+- 빌드 → JAR + Dockerfile NAS 전송 → env 파일 작성 → `docker build` → `docker run -d` → health check
+
+## 8. 하네스 Scope Audit 결과
+
+- 태그: `oauth2_provider_env` (신규)
+- Recurrence: 0건
+- Gate: ✅ OPEN
+- 결과: 일반 절차 진행 가능
+
+## 9. 롤백 계획
+
+- 환경변수 추가만 하는 변경이므로 secrets만 비우면 즉시 비활성화 (코드 변경은 무해)
+- 또는 `git revert <merge-commit>` 후 재배포

--- a/infra/CLAUDE.md
+++ b/infra/CLAUDE.md
@@ -43,6 +43,8 @@
 | NAS_JWT_SECRET | JWT signing secret |
 | GOOGLE_CLIENT_ID | Google OAuth2 client ID |
 | GOOGLE_CLIENT_SECRET | Google OAuth2 client secret |
+| KAKAO_CLIENT_ID | Kakao OAuth2 REST API key (선택: 미등록 시 카카오 로그인 비활성) |
+| KAKAO_CLIENT_SECRET | Kakao OAuth2 client secret (선택) |
 
 ## Local Development
 - `docker-compose.yml` runs: PostgreSQL (5433), Redis (6380), Backend (8081)

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -51,6 +51,8 @@ services:
       FRONTEND_URL: https://aiva-bb.duckdns.org
       GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID}
       GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET}
+      KAKAO_CLIENT_ID: ${KAKAO_CLIENT_ID:-disabled}
+      KAKAO_CLIENT_SECRET: ${KAKAO_CLIENT_SECRET:-disabled}
       REDIS_URL: redis://redis:6379
       FLYWAY_ENABLED: "true"
       SERVER_FORWARD_HEADERS_STRATEGY: framework


### PR DESCRIPTION
## Summary
- `deploy-nas.yml`에 `KAKAO_CLIENT_ID/SECRET` secret 주입 추가 (없으면 `disabled` default)
- `infra/docker-compose.yml` 백엔드 컨테이너에 카카오 env 전달
- `infra/CLAUDE.md` GitHub Secrets 가이드에 카카오 항목 추가

## Background
BE 코드(`CustomOAuth2UserService.extractKakaoUserInfo`), Spring OAuth2 설정(`application-prod.yml`의 kakao registration/provider), DB 제약(`provider IN ('GOOGLE','KAKAO','SYSTEM')`), FE UI(`login_page.dart` 카카오 버튼), i18n까지 카카오 로그인은 이미 모두 구현되어 있었음. 배포 워크플로우에서 환경변수 주입만 빠져 있어 카카오 로그인이 동작하지 않았던 상태.

## Activation Steps (이 PR 머지 후)
1. 카카오 개발자 콘솔 (https://developers.kakao.com) → 앱 등록 → REST API 키 발급
2. **Redirect URI 등록**: `https://aiva-bb.duckdns.org/login/oauth2/code/kakao`
3. 카카오 로그인 활성화 + 동의항목 (`profile_nickname`, `account_email`) 설정
4. **보안 메뉴**에서 Client Secret 코드 생성 + 활성화
5. GitHub Repository Settings → Secrets: `KAKAO_CLIENT_ID`, `KAKAO_CLIENT_SECRET` 등록
6. main 머지 시 자동 배포 → 카카오 로그인 라이브 활성화

## Safety
- Secrets 미등록 상태에서도 `${KAKAO_CLIENT_ID:-disabled}` default로 컨테이너 부팅 안전 (Google 패턴 동일)
- 코드 변경은 환경변수 주입만으로 한정. 비활성 상태에서도 기존 Google 로그인 무영향.

## Test plan
- [x] BE 단위 테스트 (CustomOAuth2UserServiceTest 포함, 기존)
- [x] FE 단위 테스트 (login_page_test 포함, 기존)
- [ ] CI ci-backend / ci-frontend 통과
- [ ] 머지 후 deploy-nas 워크플로우 성공
- [ ] `curl -s https://aiva-bb.duckdns.org/actuator/health` → 200
- [ ] `curl -i https://aiva-bb.duckdns.org/oauth2/authorization/kakao` → 302 (Secrets 등록 후)
- [ ] 사용자 라이브 검증: 카카오 로그인 → 홈 진입

🤖 Generated with [Claude Code](https://claude.com/claude-code)