### PR TITLE
fix(auth): 카카오 OAuth scope를 콘솔 통합 ID(profile)로 변경

### DIFF
--- a/backend/src/main/resources/application-local-supabase.yml
+++ b/backend/src/main/resources/application-local-supabase.yml
@@ -35,7 +35,7 @@ spring:
             client-authentication-method: client_secret_post
             authorization-grant-type: authorization_code
             redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
-            scope: profile_nickname,account_email
+            scope: profile,account_email
         provider:
           kakao:
             authorization-uri: https://kauth.kakao.com/oauth/authorize

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -27,7 +27,7 @@ spring:
             client-authentication-method: client_secret_post
             authorization-grant-type: authorization_code
             redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
-            scope: profile_nickname,account_email
+            scope: profile,account_email
         provider:
           kakao:
             authorization-uri: https://kauth.kakao.com/oauth/authorize

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -36,7 +36,7 @@ spring:
             client-authentication-method: client_secret_post
             authorization-grant-type: authorization_code
             redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
-            scope: profile_nickname,account_email
+            scope: profile,account_email
         provider:
           kakao:
             authorization-uri: https://kauth.kakao.com/oauth/authorize


### PR DESCRIPTION
## Problem
카카오 콘솔 동의항목을 모두 "필수 동의"로 활성화했음에도 `KOE006 / 설정하지 않은 동의 항목: profile_nickname` 에러로 OAuth 로그인 거부.

## Root Cause
카카오 콘솔 최신 UI는 동의항목 ID가 `profile`로 통합 (닉네임 + 프로필 사진). 우리 백엔드는 OAuth scope 요청 시 `profile_nickname`을 보내는데, 콘솔에서 매핑되는 항목이 없어 거부됨.

## Fix
3개 yml 파일에서 scope를 `profile_nickname,account_email` → `profile,account_email`로 변경.

- `application-prod.yml`
- `application-local-supabase.yml`
- `application-local.yml`

## No-Op
`CustomOAuth2UserService.extractKakaoUserInfo`는 응답에서 `kakao_account.profile.nickname` 경로를 읽음. 카카오 응답 구조는 scope ID와 무관하게 동일하므로 BE 파싱 코드 변경 불필요.

## Test plan
- [x] 라이브 https://aiva-bb.duckdns.org → /oauth2/authorization/kakao 302 확인 (scope=profile%20account_email로 변경됨)
- [ ] 카카오 로그인 → 동의 화면 → 홈 진입 확인 (사용자 시나리오 A)

🤖 Generated with [Claude Code](https://claude.com/claude-code)