### PR TITLE
fix(profile): 닉네임 미변경 + 저장 시 무한 로딩 fix

### DIFF
--- a/frontend/lib/features/auth/presentation/bloc/auth_bloc.dart
+++ b/frontend/lib/features/auth/presentation/bloc/auth_bloc.dart
@@ -134,6 +134,7 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
     Emitter<AuthState> emit,
   ) async {
     try {
+      emit(const AuthLoading());
       final result = await authRepository.updateProfile(
         nickname: event.nickname,
         profileImageUrl: event.profileImageUrl,


### PR DESCRIPTION
## Problem
설정 > 프로필 > 이미지 변경 후 닉네임을 그대로 두고 **저장** 버튼을 누르면 스피너가 무한 로딩 상태로 머무는 버그. 새로고침 시 BE에는 정상 저장됨.

## Root Cause
- `User` Equatable.props에 `updatedAt`이 없고 id/email/nickname/profileImageUrl/provider/role/coupleId/createdAt만 포함됨
- `AuthAuthenticated.props = [user]`
- 닉네임 동일 시 BE PATCH /me 응답으로 동일 user 반환 → `emit(AuthAuthenticated(sameUser))`가 이전 state와 props 완전 동일 → flutter_bloc이 동일 state 변경을 drop → BlocListener 미호출 → `_isSubmitting` flag가 false로 안 풀려 무한 스피너
- 다른 핸들러 `_onUploadProfileImage`, `_onDeleteProfileImage`는 시작에 `emit(const AuthLoading())`이 있어 항상 transition 보장. `_onUpdateProfile`만 누락.

## Fix
`_onUpdateProfile` 시작에 `emit(const AuthLoading())` 1줄 추가 → 다른 핸들러와 일관된 패턴 적용. AuthLoading → AuthAuthenticated 전이가 항상 일어나 listener 호출 보장.

## Test plan
- [x] `flutter test test/features/auth/` 49건 통과
- [x] `flutter test test/features/settings/` 14건 통과
- [ ] 라이브: 프로필 화면에서 이미지 변경 후 닉네임 미변경 상태로 저장 버튼 → 스낵바 + 페이지 닫힘

🤖 Generated with [Claude Code](https://claude.com/claude-code)