### PR TITLE
fix(profile): 저장 직후 화면 깜빡임 (홈→수정 회귀처럼 보이는 현상) 차단

### DIFF
--- a/frontend/lib/features/settings/presentation/pages/profile_edit_page.dart
+++ b/frontend/lib/features/settings/presentation/pages/profile_edit_page.dart
@@ -154,6 +154,12 @@ class _ProfileEditPageState extends State<ProfileEditPage> {
           title: const Text('프로필 수정'),
         ),
         body: BlocBuilder<AuthBloc, AuthState>(
+          buildWhen: (previous, current) {
+            // While save/upload is in flight, AuthLoading is emitted as a
+            // transient state; keep the previous user-rendered frame to avoid
+            // a flash of an empty (user=null) page.
+            return current is! AuthLoading;
+          },
           builder: (context, state) {
             final user =
                 state is AuthAuthenticated ? state.user : null;


### PR DESCRIPTION
## Symptom
PR #239(_onUpdateProfile에 AuthLoading emit) 적용 후, 저장 버튼 클릭 시 화면이 잠깐 비었다가(=홈처럼 보임) 다시 수정 페이지로 돌아온 후 닫히는 깜빡임 발생.

## Root Cause
profile_edit_page의 BlocBuilder가 모든 state를 받음:
- `AuthAuthenticated` → `AuthLoading`(transient) → `AuthAuthenticated`
- 중간 AuthLoading 프레임에서 `state is AuthAuthenticated`가 false → user=null
- CircleAvatar/TextFormField 등이 빈 화면으로 한 프레임 그려져 사용자에게 "홈으로 갔다 돌아옴"으로 보임

## Fix
BlocBuilder에 `buildWhen` 추가하여 transient AuthLoading 무시. 이전 user-rendered 프레임 유지. BlocListener는 그대로 두어 결과 처리(pop / 스낵바) 보장.

## Test plan
- [x] `flutter test test/features/auth/ test/features/settings/` 63건 통과
- [ ] 라이브: 저장 시 깜빡임 없이 스피너만 짧게 → 스낵바 + 페이지 닫힘

🤖 Generated with [Claude Code](https://claude.com/claude-code)