### PR TITLE
fix(profile): 저장 후 페이지 닫히지 않는 회귀 — Navigator.pop → context.pop (GoRouter)

### DIFF
--- a/frontend/lib/features/settings/presentation/pages/profile_edit_page.dart
+++ b/frontend/lib/features/settings/presentation/pages/profile_edit_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:budget_book/features/auth/presentation/bloc/auth_bloc.dart';
 import 'package:budget_book/features/auth/presentation/bloc/auth_event.dart';
@@ -122,11 +123,14 @@ class _ProfileEditPageState extends State<ProfileEditPage> {
       listener: (context, state) {
         if (state is AuthAuthenticated) {
           if (_isSubmitting) {
+            // Capture messenger before route pop so the snackbar is shown on
+            // the destination (settings) page.
+            final messenger = ScaffoldMessenger.of(context);
             setState(() => _isSubmitting = false);
-            ScaffoldMessenger.of(context).showSnackBar(
+            context.pop();
+            messenger.showSnackBar(
               const SnackBar(content: Text('프로필이 수정되었습니다')),
             );
-            Navigator.of(context).pop();
           }
           if (_isUploadingImage) {
             setState(() => _isUploadingImage = false);


### PR DESCRIPTION
## Symptom
PR #240 적용 후, 저장 클릭 시 "프로필이 수정되었습니다" 스낵바는 보이지만 페이지가 닫히지 않고 수정 화면이 그대로 노출됨.

## Root Cause
`Navigator.of(context).pop()`이 GoRouter의 location stack과 sync되지 않음. GoRouter는 declarative 라우팅이므로 url 갱신은 GoRouter API(`context.pop()`)를 통해야 함.

## Fix
- `Navigator.of(context).pop()` → `context.pop()` (go_router 확장)
- ScaffoldMessenger를 pop 전에 capture하여 destination(설정) 페이지에서 스낵바 표시

## Test plan
- [x] auth + settings 63건 통과
- [ ] 라이브: 저장 → 페이지 자동 닫힘 → 설정 페이지에 스낵바

🤖 Generated with [Claude Code](https://claude.com/claude-code)