### PR TITLE
fix(profile): 저장 시 router race condition / 페이지 자동 복귀 정리

### DIFF
--- a/frontend/lib/features/auth/presentation/bloc/auth_bloc.dart
+++ b/frontend/lib/features/auth/presentation/bloc/auth_bloc.dart
@@ -134,7 +134,6 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
     Emitter<AuthState> emit,
   ) async {
     try {
-      emit(const AuthLoading());
       final result = await authRepository.updateProfile(
         nickname: event.nickname,
         profileImageUrl: event.profileImageUrl,

--- a/frontend/lib/features/settings/presentation/pages/profile_edit_page.dart
+++ b/frontend/lib/features/settings/presentation/pages/profile_edit_page.dart
@@ -37,10 +37,25 @@ class _ProfileEditPageState extends State<ProfileEditPage> {
 
   void _onSubmit() {
     if (!_formKey.currentState!.validate()) return;
+    final newNickname = _nicknameController.text.trim();
+    final authBloc = context.read<AuthBloc>();
+    final currentState = authBloc.state;
+
+    // Short-circuit when nothing changed: bypass the BLoC so we don't rely on
+    // state-transition semantics (BLoC drops emits when the state is equal).
+    // Avoids the historical "infinite spinner" + router-race-condition class.
+    if (currentState is AuthAuthenticated &&
+        currentState.user.nickname == newNickname) {
+      final messenger = ScaffoldMessenger.of(context);
+      context.pop();
+      messenger.showSnackBar(
+        const SnackBar(content: Text('변경된 사항이 없습니다')),
+      );
+      return;
+    }
+
     setState(() => _isSubmitting = true);
-    context.read<AuthBloc>().add(
-          UpdateProfile(nickname: _nicknameController.text.trim()),
-        );
+    authBloc.add(UpdateProfile(nickname: newNickname));
   }
 
   Future<void> _showImageOptions() async {
@@ -158,12 +173,6 @@ class _ProfileEditPageState extends State<ProfileEditPage> {
           title: const Text('프로필 수정'),
         ),
         body: BlocBuilder<AuthBloc, AuthState>(
-          buildWhen: (previous, current) {
-            // While save/upload is in flight, AuthLoading is emitted as a
-            // transient state; keep the previous user-rendered frame to avoid
-            // a flash of an empty (user=null) page.
-            return current is! AuthLoading;
-          },
           builder: (context, state) {
             final user =
                 state is AuthAuthenticated ? state.user : null;


### PR DESCRIPTION
## 문제 누적
- PR #239: `_onUpdateProfile`에 `emit(AuthLoading)` 추가 (무한 스피너 fix)
- PR #240: `buildWhen` 추가 (깜빡임 fix)
- PR #241: `context.pop()` (Navigator.pop 비동작 fix)
- 결과: 라이브에서 "설정화면 잠깐 노출 후 다시 수정 페이지로 자동 복귀" 회귀

## Root Cause
`emit(AuthLoading) → emit(AuthAuthenticated)` 두 번 emit이 GoRouter `refreshListenable`을 두 번 트리거 → pop 직후 router가 location 재평가하면서 stack/url 일시 inconsistent.

## Fix (consolidated)
1. `_onUpdateProfile`의 `emit(const AuthLoading())` 제거 (router 이중 트리거 제거)
2. BlocBuilder `buildWhen` 제거 (transient frame 없으므로 불필요)
3. `_onSubmit`에 닉네임 동일 시 short-circuit (BLoC 우회 즉시 pop + 안내 스낵바)
4. `context.pop()` 유지 (PR #241 패턴)

## 시나리오별 결과
| 시나리오 | 동작 |
|---|---|
| 닉네임 변경 + 저장 | BLoC 흐름 → user.props 변화 → listener → pop |
| 닉네임 미변경 + 저장 | 즉시 pop + "변경된 사항이 없습니다" 스낵바 |
| 이미지만 변경 + 저장 | 위 두 케이스 중 닉네임 상태에 따라 분기 |

## Test plan
- [x] auth + settings 63건 통과
- [ ] 라이브: 닉네임 변경 + 저장 → 설정 페이지로 정상 복귀
- [ ] 라이브: 닉네임 미변경 + 저장 → 즉시 설정 페이지로 + 안내 스낵바

🤖 Generated with [Claude Code](https://claude.com/claude-code)