### PR TITLE
fix(router): refreshListenable을 auth toggle에만 반응하도록 좁힘

### DIFF
--- a/frontend/lib/core/router/app_router.dart
+++ b/frontend/lib/core/router/app_router.dart
@@ -92,12 +92,49 @@ import 'package:budget_book/features/card_settlement/presentation/bloc/card_sett
 import 'package:budget_book/features/card_settlement/presentation/pages/card_settlement_page.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-/// Adapts a BLoC stream into a [Listenable] for GoRouter.refreshListenable.
+/// Adapts an [AuthBloc] stream into a [Listenable] for
+/// GoRouter.refreshListenable.
+///
+/// IMPORTANT: only notifies on authentication-toggle transitions
+/// (authenticated <-> unauthenticated). Re-emitting the same authentication
+/// group with a different user payload (e.g. profile/nickname/image update)
+/// does NOT trigger a router refresh.
+///
+/// Reason: notifying on every AuthBloc emit causes GoRouter to rebuild its
+/// routerDelegate. When that rebuild races against an in-flight `context.pop()`
+/// inside a BlocListener (both fire from the same stream emit), the rebuild
+/// can re-apply the pre-pop RouteMatchList — the URL never updates and the
+/// previous page is restored ("save → settings flashes in → profile-edit slides
+/// back over it" regression).
+///
+/// The router only cares about coarse auth toggles for its redirect logic;
+/// fine-grained user-data changes are not relevant to navigation.
 class _BlocListenable extends ChangeNotifier {
   late final StreamSubscription _subscription;
+  bool? _wasAuthenticated;
 
-  _BlocListenable(Bloc bloc) {
-    _subscription = bloc.stream.listen((_) => notifyListeners());
+  _BlocListenable(AuthBloc bloc) {
+    _wasAuthenticated = _classify(bloc.state);
+    _subscription = bloc.stream.listen((state) {
+      final isAuth = _classify(state);
+      // Skip transient states (Loading/Initial/Error) — they don't change
+      // the auth group, only intermediate transitions.
+      if (isAuth == null) return;
+      if (isAuth != _wasAuthenticated) {
+        _wasAuthenticated = isAuth;
+        notifyListeners();
+      }
+    });
+  }
+
+  /// Returns:
+  /// - `true` if the state represents authenticated session
+  /// - `false` if explicitly unauthenticated
+  /// - `null` for transient states that should not toggle the listener
+  bool? _classify(AuthState state) {
+    if (state is AuthAuthenticated) return true;
+    if (state is AuthUnauthenticated) return false;
+    return null;
   }
 
   @override


### PR DESCRIPTION
## Root Cause (라이브 측정 기반, 추측 아님)

사용자 환경에서 확정된 hard evidence:
- 닉네임 변경 + 저장: PATCH 200 → context.pop() 호출 → settings transition 시작 → URL 변경 없음 → profile-edit으로 화면 복귀
- 닉네임 미변경 + 저장 (BLoC 우회 short-circuit): 정상 pop
- 차이는 **`authBloc.add(UpdateProfile)` 호출 여부 단 하나**

코드 추적: `_BlocListenable`이 AuthBloc.stream 모든 emit에 `notifyListeners()` 호출 → GoRouter가 redirect 재평가 + routerDelegate rebuild. 같은 emit에서 BlocListener도 깨어나며 `context.pop()` 호출. 두 동작이 같은 microtask cycle에서 경합하면 routerDelegate rebuild가 pop을 덮어 stack/URL이 pre-pop 상태로 복원됨.

## Fix

`_BlocListenable`을 **인증 toggle**(authenticated ↔ unauthenticated)에만 notifyListeners 호출하도록 좁힘. 같은 인증 그룹 내 user-data 변경(닉네임/이미지 등)은 router 동작과 무관하므로 skip.

GoRouter redirect 분기 검토:
- AuthAuthenticated → 로그인 페이지면 onboarding/transactions로, 그 외 null
- AuthUnauthenticated → /login
- AuthLoading/AuthInitial → null

→ router 의사결정이 바뀌어야 하는 경우는 auth toggle뿐이다. 그 외 emit에 refresh를 트리거할 이유가 없다.

## 시나리오별 결과

| 케이스 | 결과 |
|---|---|
| 로그인/로그아웃 (auth toggle) | refresh 트리거 → 라우팅 |
| 프로필 수정 (user-data) | refresh skip → pop 정상 → 회귀 차단 |
| 기타 user-data emit | refresh 불필요한 동작 제거 (부수 개선) |

## Test plan
- [x] frontend/test/features/auth/ + settings/ 63건 통과
- [x] `flutter analyze app_router.dart`: No issues found
- [ ] 라이브: 닉네임 변경 + 저장 → 설정 페이지로 정상 복귀 (회귀 차단 확인)
- [ ] 라이브: 로그아웃 → /login 정상 redirect
- [ ] 라이브: 카카오 로그인 → /transactions 정상 redirect

🤖 Generated with [Claude Code](https://claude.com/claude-code)