### PR TITLE
fix(spendingplan): amount 수정 검증 생성과 일치 + PatchValue 검증 누락 가드

### DIFF
--- a/backend/src/main/kotlin/com/budgetbook/insurance/service/InsuranceService.kt
+++ b/backend/src/main/kotlin/com/budgetbook/insurance/service/InsuranceService.kt
@@ -93,10 +93,26 @@ class InsuranceService(
         val insurance = findInsuranceWithAccess(insuranceId, couple.id, userId)
 
         request.name?.let { insurance.name = it }
-        request.insurer?.let { insurance.insurer = it.value }
+        request.insurer?.let { patchValue ->
+            // Mirror create-side @Size(max=100); PatchValue wrapper bypasses Bean Validation.
+            patchValue.value?.let { insurer ->
+                if (insurer.length > 100) {
+                    throw BusinessException("VALIDATION_ERROR", "insurer must be 100 characters or less.")
+                }
+            }
+            insurance.insurer = patchValue.value
+        }
         request.insuranceType?.let { insurance.insuranceType = it }
         request.premiumAmount?.let { insurance.premiumAmount = it }
-        request.paymentDay?.let { insurance.paymentDay = it.value }
+        request.paymentDay?.let { patchValue ->
+            // Mirror create-side @Min(1)@Max(31); PatchValue wrapper bypasses Bean Validation.
+            patchValue.value?.let { day ->
+                if (day < 1 || day > 31) {
+                    throw BusinessException("VALIDATION_ERROR", "paymentDay must be between 1 and 31.")
+                }
+            }
+            insurance.paymentDay = patchValue.value
+        }
         request.paymentCycle?.let { insurance.paymentCycle = it }
 
         request.paymentMethodId?.let { patchValue ->

--- a/backend/src/main/kotlin/com/budgetbook/spendingplan/dto/SpendingPlanDtos.kt
+++ b/backend/src/main/kotlin/com/budgetbook/spendingplan/dto/SpendingPlanDtos.kt
@@ -50,7 +50,7 @@ data class UpdateSpendingPlanRequest(
     @field:Size(max = 100)
     val name: String? = null,
 
-    @field:Min(1)
+    @field:Min(0)
     val amount: Long? = null,
 
     val targetDate: LocalDate? = null,

--- a/backend/src/main/kotlin/com/budgetbook/transaction/service/TransactionService.kt
+++ b/backend/src/main/kotlin/com/budgetbook/transaction/service/TransactionService.kt
@@ -307,7 +307,16 @@ class TransactionService(
         }
         request.description?.let { transaction.description = it }
         request.transactionDate?.let { transaction.transactionDate = it }
-        request.memo?.let { transaction.memo = it.value }
+        request.memo?.let { patchValue ->
+            // Mirror create-side @Size(max=1000); PatchValue wrapper bypasses Bean Validation
+            // and the DB column is unbounded TEXT, so guard here.
+            patchValue.value?.let { memo ->
+                if (memo.length > 1000) {
+                    throw BusinessException("VALIDATION_ERROR", "memo must be 1000 characters or less.")
+                }
+            }
+            transaction.memo = patchValue.value
+        }
         // V61 (2026-05-06) — null 이면 미변경, true/false 면 명시적 토글
         request.needsReview?.let { transaction.needsReview = it }
 

--- a/backend/src/main/kotlin/com/budgetbook/transfer/service/TransferService.kt
+++ b/backend/src/main/kotlin/com/budgetbook/transfer/service/TransferService.kt
@@ -111,7 +111,15 @@ class TransferService(
 
         request.amount?.let { transfer.amount = it }
         request.transferDate?.let { transfer.transferDate = it }
-        request.description?.let { transfer.description = it.value }
+        request.description?.let { patchValue ->
+            // Mirror create-side @Size(max=255); PatchValue wrapper bypasses Bean Validation.
+            patchValue.value?.let { desc ->
+                if (desc.length > 255) {
+                    throw BusinessException("VALIDATION_ERROR", "description must be 255 characters or less.")
+                }
+            }
+            transfer.description = patchValue.value
+        }
         request.memo?.let { transfer.memo = it.value }
 
         request.sourcePaymentMethodId?.let { patchValue ->

--- a/backend/src/test/kotlin/com/budgetbook/spendingplan/dto/SpendingPlanDtoValidationTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/spendingplan/dto/SpendingPlanDtoValidationTest.kt
@@ -1,0 +1,52 @@
+package com.budgetbook.spendingplan.dto
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeTrue
+import jakarta.validation.Validation
+import jakarta.validation.Validator
+
+/**
+ * Guards the create/update amount-validation consistency.
+ *
+ * A spending plan does not require an amount (WISHLIST plans are stored with amount = 0).
+ * The "amount >= 1" rule only applies to PLANNED status and is enforced in the service layer,
+ * not via the DTO annotation. Both DTOs must therefore allow amount = 0 (and reject negatives).
+ *
+ * Regression: UpdateSpendingPlanRequest previously used @Min(1), which rejected editing
+ * amount-less plans whose stored amount was 0.
+ */
+class SpendingPlanDtoValidationTest : FunSpec({
+
+    val validator: Validator = Validation.buildDefaultValidatorFactory().validator
+
+    fun amountViolations(amount: Long?, create: Boolean): Int {
+        val violations = if (create) {
+            validator.validate(CreateSpendingPlanRequest(name = "Plan", amount = amount))
+        } else {
+            validator.validate(UpdateSpendingPlanRequest(name = "Plan", amount = amount))
+        }
+        return violations.count { it.propertyPath.toString() == "amount" }
+    }
+
+    context("create request amount") {
+        test("allows null (no amount)") { (amountViolations(null, create = true) == 0).shouldBeTrue() }
+        test("allows zero (no amount)") { (amountViolations(0, create = true) == 0).shouldBeTrue() }
+        test("allows positive") { (amountViolations(100000, create = true) == 0).shouldBeTrue() }
+        test("rejects negative") { (amountViolations(-1, create = true) > 0).shouldBeTrue() }
+    }
+
+    context("update request amount — must match create semantics") {
+        test("allows null (no change)") { (amountViolations(null, create = false) == 0).shouldBeTrue() }
+        test("allows zero (no amount)") { (amountViolations(0, create = false) == 0).shouldBeTrue() }
+        test("allows positive") { (amountViolations(100000, create = false) == 0).shouldBeTrue() }
+        test("rejects negative") { (amountViolations(-1, create = false) > 0).shouldBeTrue() }
+    }
+
+    test("create and update agree on every amount boundary") {
+        for (amount in listOf(null, 0L, 1L, 100000L, -1L, -5L)) {
+            val createOk = amountViolations(amount, create = true) == 0
+            val updateOk = amountViolations(amount, create = false) == 0
+            (createOk == updateOk).shouldBeTrue()
+        }
+    }
+})


### PR DESCRIPTION
## 문제
지출 계획은 금액이 없어도 생성 가능(WISHLIST는 `amount=0`으로 저장)한데, **수정 시에만 amount가 1 이상**이어야 하는 버그.

## 근본 원인
`SpendingPlanDtos.kt`에서 amount 제약이 생성/수정 DTO 간 불일치:
- 생성 `CreateSpendingPlanRequest.amount`: `@field:Min(0)` (0/null 허용)
- 수정 `UpdateSpendingPlanRequest.amount`: `@field:Min(1)` ← **버그**

"amount ≥ 1"은 **PLANNED 상태에만** 적용되는 규칙이며 `SpendingPlanService.kt:123`(서비스 레이어)가 담당. DTO 어노테이션은 음수만 막으면 됨. 생성은 이 분리를 지켰으나 수정 DTO만 `@Min(1)`을 잘못 하드코딩 → 금액 없는 WISHLIST 계획(저장값 0)을 편집할 때 FE가 `amount=0` 재전송 시 검증 거부.

## 전수 감사 (Create vs Update DTO 11개 파일)
**숫자 경계 불일치(이번 버그 유형):** SpendingPlan.amount가 유일. 나머지(PaymentMethod settlementDay/closingDay, Pocket allocatedAmount/goalAmount, Transaction amount, Insurance premiumAmount, Recurring amount, Transfer amount)는 Create/Update 경계 동일 확인.

**PatchValue 래퍼가 Create 검증을 Update에서 무력화(추가 발견):** Bean Validation이 `PatchValue<T>` 내부로 cascade 안 됨 → 서비스 레벨 가드로 보완.

## 변경
- `SpendingPlanDtos.kt` — amount `@Min(1)`→`@Min(0)` (생성과 일치)
- `SpendingPlanDtoValidationTest.kt` (신규) — 생성/수정 amount 경계 일치 회귀 테스트
- `InsuranceService.kt` — `paymentDay` 1~31 가드 (DB backstop 없는 실제 무결성 버그)
- `TransactionService.kt` — `memo` ≤1000자 가드 (DB TEXT라 backstop 없음)
- `TransferService.kt` — `description` ≤255자 가드 (500→400 정리)
- `InsuranceService.kt` — `insurer` ≤100자 가드 (동일)

## 검증
`./gradlew test` 전체 통과 (BUILD SUCCESSFUL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)