### PR TITLE
fix(category): 카테고리 이름/그룹 수정이 통계에 반영 안 되던 문제

### DIFF
--- a/frontend/lib/core/di/injection.dart
+++ b/frontend/lib/core/di/injection.dart
@@ -166,7 +166,12 @@ Future<void> configureDependencies() async {
         remoteDataSource: getIt<CategoryRemoteDataSource>()),
   );
   getIt.registerLazySingleton<CategoryBloc>(
-    () => CategoryBloc(categoryRepository: getIt<CategoryRepository>()),
+    () => CategoryBloc(
+      categoryRepository: getIt<CategoryRepository>(),
+      // 카테고리 변경 → 통계/거래/대시보드 갱신 (self-authored sync 는 skip 되므로
+      // 본인 변경은 이 로컬 트리거로만 의존 화면이 갱신됨).
+      onChanged: () => getIt<SyncEventHandler>().refreshCategoryDependents(),
+    ),
     dispose: (bloc) => bloc.close(),
   );
 
@@ -241,7 +246,9 @@ Future<void> configureDependencies() async {
   );
   getIt.registerLazySingleton<CategoryGroupBloc>(
     () => CategoryGroupBloc(
-        categoryGroupRepository: getIt<CategoryGroupRepository>()),
+      categoryGroupRepository: getIt<CategoryGroupRepository>(),
+      onChanged: () => getIt<SyncEventHandler>().refreshCategoryDependents(),
+    ),
     dispose: (bloc) => bloc.close(),
   );
 

--- a/frontend/lib/core/websocket/sync_event_handler.dart
+++ b/frontend/lib/core/websocket/sync_event_handler.dart
@@ -20,6 +20,8 @@ import 'package:budget_book/features/home/presentation/bloc/dashboard_bloc.dart'
 import 'package:budget_book/features/home/presentation/bloc/dashboard_event.dart';
 import 'package:budget_book/features/transfer/presentation/bloc/transfer_bloc.dart';
 import 'package:budget_book/features/transfer/presentation/bloc/transfer_event.dart';
+import 'package:budget_book/features/statistics/presentation/bloc/statistics_bloc.dart';
+import 'package:budget_book/features/statistics/presentation/bloc/statistics_event.dart';
 
 import 'sync_event.dart';
 
@@ -57,10 +59,16 @@ class SyncEventHandler {
         _refreshDashboard();
       case 'CATEGORY':
         _refreshCategories();
+        // 카테고리 이름/그룹 변경은 통계 breakdown·거래 목록·대시보드의
+        // 카테고리 표시에 영향 → 의존 화면 함께 갱신.
+        refreshCategoryDependents();
       case 'PAYMENT_METHOD':
         _refreshPaymentMethods();
       case 'CATEGORY_GROUP':
         _refreshCategoryGroups();
+        // 그룹 변경은 카테고리의 그룹 표시에도 영향.
+        _refreshCategories();
+        refreshCategoryDependents();
       case 'POCKET':
         _refreshPockets();
         _refreshDashboard();
@@ -197,6 +205,32 @@ class SyncEventHandler {
       _logger.d('Dispatched LoadDashboard refresh');
     } catch (e) {
       _logger.e('Failed to refresh dashboard: $e');
+    }
+  }
+
+  /// Refreshes views whose displayed data depends on category name / group /
+  /// membership: statistics breakdown, transaction list, dashboard.
+  ///
+  /// Called both from the partner's CATEGORY / CATEGORY_GROUP sync events and
+  /// locally after the user's own category/group mutation — the latter is
+  /// necessary because self-authored sync events are skipped (see [handle]),
+  /// and statistics has no other refresh trigger tied to category changes.
+  void refreshCategoryDependents() {
+    _refreshStatistics();
+    _refreshTransactions();
+    _refreshDashboard();
+  }
+
+  void _refreshStatistics() {
+    try {
+      final monthState = _getIt<MonthCubit>().state;
+      final bloc = _getIt<StatisticsBloc>();
+      bloc.add(LoadAllStatistics(year: monthState.year, month: monthState.month));
+      bloc.add(LoadPaymentMethodStats(year: monthState.year, month: monthState.month));
+      bloc.add(LoadYearComparison(year: monthState.year, month: monthState.month));
+      _logger.d('Dispatched statistics refresh');
+    } catch (e) {
+      _logger.e('Failed to refresh statistics: $e');
     }
   }
 }

--- a/frontend/lib/features/category/presentation/bloc/category_bloc.dart
+++ b/frontend/lib/features/category/presentation/bloc/category_bloc.dart
@@ -7,7 +7,13 @@ import 'category_state.dart';
 class CategoryBloc extends Bloc<CategoryEvent, CategoryState> {
   final CategoryRepository categoryRepository;
 
-  CategoryBloc({required this.categoryRepository})
+  /// Invoked after a successful category mutation (create/update/delete) so
+  /// dependent views (statistics breakdown, transaction list, dashboard) can
+  /// refresh. Wired in DI to [SyncEventHandler.refreshCategoryDependents];
+  /// left null in tests.
+  final void Function()? onChanged;
+
+  CategoryBloc({required this.categoryRepository, this.onChanged})
       : super(const CategoryInitial()) {
     on<LoadCategories>(_onLoadCategories);
     on<CreateCategory>(_onCreateCategory);
@@ -64,7 +70,10 @@ class CategoryBloc extends Bloc<CategoryEvent, CategoryState> {
       result.fold(
         (failure) => emit(CategoryLoaded(currentCategories,
             operationError: failure.message)),
-        (category) => emit(CategoryLoaded([...currentCategories, category])),
+        (category) {
+          emit(CategoryLoaded([...currentCategories, category]));
+          onChanged?.call();
+        },
       );
     } catch (_) {
       if (state is CategoryLoaded) {
@@ -99,6 +108,7 @@ class CategoryBloc extends Bloc<CategoryEvent, CategoryState> {
               .map((c) => c.id == updated.id ? updated : c)
               .toList();
           emit(CategoryLoaded(updatedList));
+          onChanged?.call();
         },
       );
     } catch (_) {
@@ -157,6 +167,7 @@ class CategoryBloc extends Bloc<CategoryEvent, CategoryState> {
           final updatedList =
               currentCategories.where((c) => c.id != event.id).toList();
           emit(CategoryLoaded(updatedList));
+          onChanged?.call();
         },
       );
     } catch (_) {

--- a/frontend/lib/features/category_group/presentation/bloc/category_group_bloc.dart
+++ b/frontend/lib/features/category_group/presentation/bloc/category_group_bloc.dart
@@ -8,7 +8,13 @@ class CategoryGroupBloc
     extends Bloc<CategoryGroupEvent, CategoryGroupState> {
   final CategoryGroupRepository categoryGroupRepository;
 
-  CategoryGroupBloc({required this.categoryGroupRepository})
+  /// Invoked after a successful group mutation (create/update/delete) so
+  /// dependent views (statistics breakdown, transaction list, dashboard) can
+  /// refresh. Wired in DI to [SyncEventHandler.refreshCategoryDependents];
+  /// left null in tests.
+  final void Function()? onChanged;
+
+  CategoryGroupBloc({required this.categoryGroupRepository, this.onChanged})
       : super(const CategoryGroupInitial()) {
     on<LoadCategoryGroups>(_onLoadCategoryGroups);
     on<CreateCategoryGroup>(_onCreateCategoryGroup);
@@ -65,7 +71,10 @@ class CategoryGroupBloc
       result.fold(
         (failure) => emit(CategoryGroupLoaded(currentGroups,
             operationError: failure.message)),
-        (group) => emit(CategoryGroupLoaded([...currentGroups, group])),
+        (group) {
+          emit(CategoryGroupLoaded([...currentGroups, group]));
+          onChanged?.call();
+        },
       );
     } catch (e) {
       emit(CategoryGroupLoaded(currentGroups,
@@ -98,6 +107,7 @@ class CategoryGroupBloc
               .map((g) => g.id == updated.id ? updated : g)
               .toList();
           emit(CategoryGroupLoaded(updatedList));
+          onChanged?.call();
         },
       );
     } catch (e) {
@@ -124,6 +134,7 @@ class CategoryGroupBloc
           final updatedList =
               currentGroups.where((g) => g.id != event.id).toList();
           emit(CategoryGroupLoaded(updatedList));
+          onChanged?.call();
         },
       );
     } catch (e) {

--- a/frontend/test/features/category/presentation/bloc/category_bloc_test.dart
+++ b/frontend/test/features/category/presentation/bloc/category_bloc_test.dart
@@ -356,6 +356,70 @@ void main() {
         ],
       );
     });
+
+    // Regression: 카테고리 이름/그룹 수정이 통계에 반영 안 되던 문제.
+    // 수정 성공 시 onChanged 가 호출되어야 의존 화면(통계/거래/대시보드)이 갱신됨.
+    group('onChanged dependent-refresh callback', () {
+      late int changedCount;
+
+      final tUpdated = Category(
+        id: 'cat-1',
+        name: '부모님',
+        type: 'EXPENSE',
+        isDefault: false,
+        displayOrder: 1,
+        createdAt: DateTime.parse('2024-01-01T12:00:00Z'),
+      );
+
+      blocTest<CategoryBloc, CategoryState>(
+        'invokes onChanged after successful update',
+        build: () {
+          when(mockRepository.updateCategory(id: 'cat-1', name: '부모님'))
+              .thenAnswer((_) async => Right(tUpdated));
+          changedCount = 0;
+          return CategoryBloc(
+            categoryRepository: mockRepository,
+            onChanged: () => changedCount++,
+          );
+        },
+        seed: () => CategoryLoaded(tCategories),
+        act: (bloc) => bloc.add(const UpdateCategory(id: 'cat-1', name: '부모님')),
+        verify: (_) => expect(changedCount, 1),
+      );
+
+      blocTest<CategoryBloc, CategoryState>(
+        'does NOT invoke onChanged when update fails',
+        build: () {
+          when(mockRepository.updateCategory(id: 'cat-1', name: '부모님'))
+              .thenAnswer(
+                  (_) async => const Left(ServerFailure('update failed')));
+          changedCount = 0;
+          return CategoryBloc(
+            categoryRepository: mockRepository,
+            onChanged: () => changedCount++,
+          );
+        },
+        seed: () => CategoryLoaded(tCategories),
+        act: (bloc) => bloc.add(const UpdateCategory(id: 'cat-1', name: '부모님')),
+        verify: (_) => expect(changedCount, 0),
+      );
+
+      blocTest<CategoryBloc, CategoryState>(
+        'invokes onChanged after successful delete',
+        build: () {
+          when(mockRepository.deleteCategory('cat-1'))
+              .thenAnswer((_) async => const Right(null));
+          changedCount = 0;
+          return CategoryBloc(
+            categoryRepository: mockRepository,
+            onChanged: () => changedCount++,
+          );
+        },
+        seed: () => CategoryLoaded(tCategories),
+        act: (bloc) => bloc.add(const DeleteCategory('cat-1')),
+        verify: (_) => expect(changedCount, 1),
+      );
+    });
   });
 
   group('CategoryLoaded', () {


### PR DESCRIPTION
## 증상
지출 카테고리의 이름/그룹을 수정(예: \"생활비 > 기타(부모님)\" → \"기타 > 부모님\")해도 **통계 화면에 반영되지 않음**.

## 근본 원인 — FE 반응성 공백 (BE는 정상)
증상-역행 분석 결과:
- **BE 정상**: 카테고리 수정은 기존 엔티티를 mutate(`CategoryService.updateCategory`)하므로 거래의 `category_id` FK 유지. 통계 집계(`TransactionRepository.sumByCategoryForCouple`)는 `GROUP BY category.id` + 이름/그룹을 라이브 JOIN으로 읽고 **캐시가 없음** → 호출 시마다 항상 현재 이름/그룹 반영.
- **FE 공백**: `StatisticsBloc`은 `registerLazySingleton`이라 화면 이동에도 state 유지. 통계 재조회 트리거는 **(a) 탭 최초 진입 (b) 월 변경 (c) 필터/타입 토글 (d) 파트너 sync** 4가지뿐. "카테고리 수정"은 어디에도 해당하지 않음. 게다가 본인이 일으킨 sync 이벤트는 `SyncEventHandler`에서 self-authored로 skip → 의존 화면(통계/거래/대시보드)이 전혀 갱신되지 않음.

## 수정 (공통 적용)
- `SyncEventHandler.refreshCategoryDependents()` 신설 — 통계 + 거래 + 대시보드 갱신. `CATEGORY` / `CATEGORY_GROUP` sync 케이스에서 호출 → **파트너의 카테고리 변경 실시간 반영**.
- `CategoryBloc` / `CategoryGroupBloc`에 `onChanged` 콜백 추가 → 생성/수정/삭제 성공 시 호출. DI에서 `refreshCategoryDependents`로 와이어 → **본인 변경도 즉시 반영**(self-skip 우회). reorder는 집계/이름에 영향 없어 제외.
- 회귀 테스트: 수정/삭제 성공 시 `onChanged` 호출, 실패 시 미호출 검증.

## 검증
- `flutter analyze`: No issues
- `flutter test`: 736/736 통과 (신규 3건 포함)
- `flutter build web --release`: ✓ Built

## 라이브 확인 (배포 후)
카테고리 이름/그룹 수정 → 통계 탭에서 즉시 새 이름/그룹으로 표시되는지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)