### PR TITLE
fix(settings): 개인정보/약관 링크를 실제 도메인 정적 페이지로 교체

### DIFF
--- a/frontend/lib/features/settings/presentation/pages/app_info_page.dart
+++ b/frontend/lib/features/settings/presentation/pages/app_info_page.dart
@@ -5,8 +5,8 @@ class AppInfoPage extends StatelessWidget {
   const AppInfoPage({super.key});
 
   static const _version = '1.0.0';
-  static const _privacyUrl = 'https://budget-book.app/privacy';
-  static const _termsUrl = 'https://budget-book.app/terms';
+  static const _privacyUrl = 'https://aiva-bb.duckdns.org/privacy.html';
+  static const _termsUrl = 'https://aiva-bb.duckdns.org/terms.html';
 
   @override
   Widget build(BuildContext context) {

--- a/frontend/web/privacy.html
+++ b/frontend/web/privacy.html
@@ -1,0 +1,218 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="robots" content="index, follow">
+  <title>개인정보처리방침 · Budget Book</title>
+  <style>
+    :root {
+      --primary: #4CAF50;
+      --primary-dark: #388E3C;
+      --text: #1a1a1a;
+      --text-muted: #5f6368;
+      --border: #e0e0e0;
+      --bg: #ffffff;
+      --bg-soft: #f6f8f6;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+        "Apple SD Gothic Neo", "Noto Sans KR", "Malgun Gothic", sans-serif;
+      color: var(--text);
+      background: var(--bg-soft);
+      line-height: 1.7;
+      -webkit-text-size-adjust: 100%;
+    }
+    .wrap { max-width: 760px; margin: 0 auto; padding: 0 20px 80px; }
+    header {
+      background: var(--primary);
+      color: #fff;
+      padding: 32px 0 28px;
+      margin-bottom: 28px;
+    }
+    header .wrap { padding-bottom: 0; }
+    header h1 { margin: 0 0 6px; font-size: 1.6rem; }
+    header .sub { margin: 0; opacity: 0.92; font-size: 0.95rem; }
+    main {
+      background: var(--bg);
+      border: 1px solid var(--border);
+      border-radius: 14px;
+      padding: 28px 26px;
+    }
+    h2 {
+      font-size: 1.15rem;
+      margin: 32px 0 10px;
+      padding-top: 8px;
+      border-top: 1px solid var(--border);
+      color: var(--primary-dark);
+    }
+    main > h2:first-of-type { border-top: none; padding-top: 0; margin-top: 8px; }
+    h3 { font-size: 1rem; margin: 18px 0 6px; }
+    p, li { font-size: 0.95rem; }
+    ul { padding-left: 20px; }
+    li { margin-bottom: 6px; }
+    table { width: 100%; border-collapse: collapse; margin: 12px 0; font-size: 0.9rem; }
+    th, td { border: 1px solid var(--border); padding: 9px 10px; text-align: left; vertical-align: top; }
+    th { background: var(--bg-soft); font-weight: 600; }
+    .muted { color: var(--text-muted); font-size: 0.88rem; }
+    .effective {
+      background: var(--bg-soft);
+      border-left: 3px solid var(--primary);
+      padding: 10px 14px;
+      border-radius: 6px;
+      margin-bottom: 4px;
+      font-size: 0.92rem;
+    }
+    a { color: var(--primary-dark); }
+    footer { text-align: center; margin-top: 28px; }
+    code { background: var(--bg-soft); padding: 1px 5px; border-radius: 4px; font-size: 0.88em; }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="wrap">
+      <h1>개인정보처리방침</h1>
+      <p class="sub">Budget Book · 부부 공유 가계부</p>
+    </div>
+  </header>
+
+  <div class="wrap">
+    <main>
+      <p class="effective">
+        <strong>시행일:</strong> 2026년 6월 4일 &nbsp;|&nbsp;
+        <strong>최종 개정일:</strong> 2026년 6월 4일
+      </p>
+      <p>
+        Budget Book(이하 "서비스")은 「개인정보 보호법」 등 관련 법령을 준수하며,
+        이용자의 개인정보를 안전하게 보호하기 위해 다음과 같은 처리방침을 두고 있습니다.
+        본 방침은 서비스가 제공하는 부부 공유 가계부 기능(수입·지출 관리, 예산, 통계,
+        파트너 간 실시간 공유)에 적용됩니다.
+      </p>
+
+      <h2>1. 수집하는 개인정보 항목</h2>
+      <p>서비스는 회원가입 및 서비스 이용 과정에서 아래와 같은 개인정보를 수집합니다.</p>
+
+      <h3>가. 소셜 로그인을 통해 수집하는 정보</h3>
+      <p>
+        서비스는 자체 회원가입 절차 없이 Google 및 Kakao 소셜 로그인(OAuth2)으로만
+        가입·인증합니다. 별도의 비밀번호는 수집하지 않습니다.
+      </p>
+      <table>
+        <thead>
+          <tr><th>제공자</th><th>수집 항목</th><th>비고</th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Google</td>
+            <td>이메일 주소, 이름(닉네임), 프로필 이미지, 고유 식별자(provider ID)</td>
+            <td>scope: <code>openid, profile, email</code></td>
+          </tr>
+          <tr>
+            <td>Kakao</td>
+            <td>카카오계정 이메일, 닉네임, 프로필 이미지, 고유 식별자(provider ID)</td>
+            <td>scope: <code>profile, account_email</code> (이메일은 이용자 동의 시 제공)</td>
+          </tr>
+        </tbody>
+      </table>
+      <p class="muted">
+        Kakao 로그인 시 이메일 제공에 동의하지 않은 경우, 서비스는 파트너 연결 등
+        기능 제공을 위해 임시 대체 식별값을 부여하며 실제 이메일은 수집하지 않습니다.
+      </p>
+
+      <h3>나. 서비스 이용 과정에서 생성·수집되는 정보</h3>
+      <ul>
+        <li>가계부 데이터: 수입·지출 내역(금액, 분류 카테고리, 메모, 거래 일자, 결제수단)</li>
+        <li>예산 및 지출 계획, 구매 위시리스트, 카테고리 설정</li>
+        <li>파트너(커플) 연결 정보 및 초대 코드</li>
+        <li>피드백 게시판에 이용자가 직접 작성한 게시물·문의 내용</li>
+        <li>서비스 이용 기록, 접속 일시, 기기·브라우저 정보(쿠키 포함)</li>
+      </ul>
+
+      <h2>2. 개인정보의 수집 및 이용 목적</h2>
+      <ul>
+        <li>회원 식별 및 소셜 로그인 기반 인증·인증 토큰 발급</li>
+        <li>부부(파트너) 간 가계부 공유 및 실시간 동기화 제공</li>
+        <li>수입·지출 관리, 예산·통계·분석 등 핵심 기능 제공</li>
+        <li>피드백 처리, 고객 문의 응대 및 공지 전달</li>
+        <li>서비스 개선, 오류 분석 및 안정적 운영</li>
+      </ul>
+
+      <h2>3. 개인정보의 보유 및 이용 기간</h2>
+      <ul>
+        <li>원칙적으로 회원 탈퇴 시 지체 없이 파기합니다.</li>
+        <li>
+          파트너와 공유된 가계부 데이터는 탈퇴 시 처리되며, 공동 데이터의 경우
+          상대방 이용자의 이용에 필요한 범위에서 처리 방식이 달라질 수 있습니다.
+        </li>
+        <li>관련 법령에서 보존을 요구하는 경우 해당 기간 동안 보관 후 파기합니다.</li>
+      </ul>
+
+      <h2>4. 개인정보의 제3자 제공</h2>
+      <p>
+        서비스는 이용자의 개인정보를 외부에 제공하지 않습니다. 다만 법령에 근거가
+        있거나 수사기관의 적법한 요청이 있는 경우에 한해 제공할 수 있습니다.
+      </p>
+
+      <h2>5. 개인정보 처리의 위탁</h2>
+      <p>서비스는 원활한 서비스 제공을 위해 아래 업무를 위탁하고 있습니다.</p>
+      <table>
+        <thead>
+          <tr><th>수탁자</th><th>위탁 업무</th></tr>
+        </thead>
+        <tbody>
+          <tr><td>Google LLC</td><td>소셜 로그인(OAuth2) 인증</td></tr>
+          <tr><td>Kakao Corp.</td><td>소셜 로그인(OAuth2) 인증</td></tr>
+        </tbody>
+      </table>
+      <p class="muted">
+        서비스 인프라(애플리케이션 서버·데이터베이스)는 자체 운영 서버에서 처리됩니다.
+      </p>
+
+      <h2>6. 정보주체의 권리·의무 및 행사 방법</h2>
+      <ul>
+        <li>이용자는 언제든지 본인의 개인정보 열람·정정·삭제·처리정지를 요청할 수 있습니다.</li>
+        <li>앱 내 설정에서 직접 정보를 수정하거나 회원 탈퇴(계정 삭제)를 할 수 있습니다.</li>
+        <li>
+          권리 행사는 아래 연락처를 통해 요청할 수 있으며, 서비스는 지체 없이 조치합니다.
+        </li>
+      </ul>
+
+      <h2>7. 개인정보의 파기</h2>
+      <p>
+        보유 기간 경과 또는 처리 목적 달성 시 해당 정보를 지체 없이 파기합니다.
+        전자적 파일은 복구·재생이 불가능한 방법으로 영구 삭제합니다.
+      </p>
+
+      <h2>8. 개인정보의 안전성 확보 조치</h2>
+      <ul>
+        <li>전송 구간 암호화(HTTPS/TLS) 적용</li>
+        <li>인증 토큰의 안전한 저장 및 접근 권한 통제</li>
+        <li>개인정보에 대한 접근 권한 최소화 및 접근 기록 관리</li>
+      </ul>
+
+      <h2>9. 쿠키 및 토큰의 사용</h2>
+      <p>
+        서비스는 로그인 상태 유지 및 인증을 위해 인증 토큰과 쿠키를 사용합니다.
+        이용자는 브라우저 설정을 통해 쿠키 저장을 거부할 수 있으나, 이 경우 로그인 등
+        일부 기능 이용이 제한될 수 있습니다.
+      </p>
+
+      <h2>10. 개인정보 보호책임자 및 문의처</h2>
+      <ul>
+        <li><strong>서비스명:</strong> Budget Book</li>
+        <li><strong>문의 이메일:</strong> <a href="mailto:donghyunele@wemeetmobility.com">donghyunele@wemeetmobility.com</a></li>
+      </ul>
+
+      <h2>11. 개인정보처리방침의 변경</h2>
+      <p>
+        본 방침은 법령·서비스 변경에 따라 개정될 수 있으며, 변경 시 시행일과 변경
+        내용을 본 페이지를 통해 공지합니다.
+      </p>
+
+      <footer class="muted">© 2026 Budget Book. 본 방침은 2026년 6월 4일부터 적용됩니다.</footer>
+    </main>
+  </div>
+</body>
+</html>

--- a/frontend/web/terms.html
+++ b/frontend/web/terms.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="robots" content="index, follow">
+  <title>이용약관 · Budget Book</title>
+  <style>
+    :root {
+      --primary: #4CAF50;
+      --primary-dark: #388E3C;
+      --text: #1a1a1a;
+      --text-muted: #5f6368;
+      --border: #e0e0e0;
+      --bg: #ffffff;
+      --bg-soft: #f6f8f6;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+        "Apple SD Gothic Neo", "Noto Sans KR", "Malgun Gothic", sans-serif;
+      color: var(--text);
+      background: var(--bg-soft);
+      line-height: 1.7;
+      -webkit-text-size-adjust: 100%;
+    }
+    .wrap { max-width: 760px; margin: 0 auto; padding: 0 20px 80px; }
+    header {
+      background: var(--primary);
+      color: #fff;
+      padding: 32px 0 28px;
+      margin-bottom: 28px;
+    }
+    header .wrap { padding-bottom: 0; }
+    header h1 { margin: 0 0 6px; font-size: 1.6rem; }
+    header .sub { margin: 0; opacity: 0.92; font-size: 0.95rem; }
+    main {
+      background: var(--bg);
+      border: 1px solid var(--border);
+      border-radius: 14px;
+      padding: 28px 26px;
+    }
+    h2 {
+      font-size: 1.12rem;
+      margin: 30px 0 8px;
+      padding-top: 8px;
+      border-top: 1px solid var(--border);
+      color: var(--primary-dark);
+    }
+    main > h2:first-of-type { border-top: none; padding-top: 0; margin-top: 8px; }
+    p, li { font-size: 0.95rem; }
+    ol, ul { padding-left: 20px; }
+    li { margin-bottom: 6px; }
+    .muted { color: var(--text-muted); font-size: 0.88rem; }
+    .effective {
+      background: var(--bg-soft);
+      border-left: 3px solid var(--primary);
+      padding: 10px 14px;
+      border-radius: 6px;
+      margin-bottom: 4px;
+      font-size: 0.92rem;
+    }
+    a { color: var(--primary-dark); }
+    footer { text-align: center; margin-top: 28px; }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="wrap">
+      <h1>이용약관</h1>
+      <p class="sub">Budget Book · 부부 공유 가계부</p>
+    </div>
+  </header>
+
+  <div class="wrap">
+    <main>
+      <p class="effective">
+        <strong>시행일:</strong> 2026년 6월 4일
+      </p>
+
+      <h2>제1조 (목적)</h2>
+      <p>
+        본 약관은 Budget Book(이하 "서비스")이 제공하는 부부 공유 가계부 서비스의
+        이용과 관련하여 서비스와 이용자 간의 권리·의무 및 책임사항, 이용 조건과
+        절차 등 기본적인 사항을 규정함을 목적으로 합니다.
+      </p>
+
+      <h2>제2조 (정의)</h2>
+      <ol>
+        <li>"이용자"란 본 약관에 따라 서비스를 이용하는 회원을 말합니다.</li>
+        <li>"회원"이란 Google 또는 Kakao 소셜 로그인을 통해 가입하여 서비스를 이용하는 자를 말합니다.</li>
+        <li>"파트너(커플)"란 초대 코드를 통해 서로의 가계부 데이터를 공유하도록 연결된 두 이용자를 말합니다.</li>
+        <li>"콘텐츠"란 이용자가 서비스에 입력·등록한 거래 내역, 예산, 게시물 등 일체의 데이터를 말합니다.</li>
+      </ol>
+
+      <h2>제3조 (약관의 효력 및 변경)</h2>
+      <ol>
+        <li>본 약관은 서비스 화면 또는 본 페이지에 게시함으로써 효력이 발생합니다.</li>
+        <li>서비스는 관련 법령을 위반하지 않는 범위에서 약관을 개정할 수 있으며, 변경 시 시행일과 내용을 공지합니다.</li>
+        <li>이용자가 변경된 약관에 동의하지 않을 경우 서비스 이용을 중단하고 탈퇴할 수 있습니다.</li>
+      </ol>
+
+      <h2>제4조 (서비스의 제공)</h2>
+      <ol>
+        <li>서비스는 다음 기능을 제공합니다: 수입·지출 관리, 카테고리별 예산 계획, 통계·분석, 파트너 간 실시간 공유, 지출 계획 및 구매 위시리스트, 피드백 게시판.</li>
+        <li>서비스는 운영상·기술상 필요에 따라 제공 내용을 변경하거나 일부를 중단할 수 있습니다.</li>
+      </ol>
+
+      <h2>제5조 (서비스 이용 및 회원의 의무)</h2>
+      <ol>
+        <li>이용자는 본인의 소셜 계정으로 안전하게 로그인하며, 계정 관리 책임은 이용자에게 있습니다.</li>
+        <li>이용자는 타인의 정보를 도용하거나 서비스 운영을 방해하는 행위를 해서는 안 됩니다.</li>
+        <li>이용자가 입력하는 가계부 데이터의 정확성에 대한 책임은 이용자에게 있습니다.</li>
+        <li>파트너 연결 시 가계부 데이터가 상대방과 공유됨에 동의한 것으로 봅니다.</li>
+      </ol>
+
+      <h2>제6조 (게시물 및 콘텐츠의 관리)</h2>
+      <ol>
+        <li>이용자가 작성한 콘텐츠의 권리와 책임은 작성자에게 있습니다.</li>
+        <li>서비스는 법령 위반·타인의 권리 침해·운영 방해에 해당하는 게시물을 사전 통지 없이 삭제하거나 이용을 제한할 수 있습니다.</li>
+      </ol>
+
+      <h2>제7조 (서비스 이용 제한)</h2>
+      <p>
+        서비스는 이용자가 본 약관 또는 관련 법령을 위반하는 경우 이용을 경고·제한·중지하거나
+        이용 계약을 해지할 수 있습니다.
+      </p>
+
+      <h2>제8조 (계약 해지 및 회원 탈퇴)</h2>
+      <ol>
+        <li>이용자는 앱 내 설정을 통해 언제든지 회원 탈퇴(계정 삭제)를 신청할 수 있습니다.</li>
+        <li>탈퇴 시 개인정보 및 데이터는 「개인정보처리방침」에 따라 처리됩니다.</li>
+      </ol>
+
+      <h2>제9조 (면책조항)</h2>
+      <ol>
+        <li>서비스는 무료로 제공되는 가계 관리 보조 도구이며, 제공되는 통계·분석 결과는 참고용입니다.</li>
+        <li>서비스는 천재지변, 외부 서비스(소셜 로그인 등) 장애 등 불가항력으로 인한 손해에 대해 책임을 지지 않습니다.</li>
+        <li>이용자가 입력한 데이터의 오류나 이를 기반으로 한 의사결정의 결과에 대해 서비스는 책임을 지지 않습니다.</li>
+      </ol>
+
+      <h2>제10조 (문의처)</h2>
+      <ul>
+        <li><strong>서비스명:</strong> Budget Book</li>
+        <li><strong>문의 이메일:</strong> <a href="mailto:donghyunele@wemeetmobility.com">donghyunele@wemeetmobility.com</a></li>
+      </ul>
+
+      <h2>제11조 (준거법 및 관할)</h2>
+      <p>
+        본 약관은 대한민국 법령에 따라 해석되며, 서비스 이용과 관련한 분쟁에 대하여는
+        관련 법령에 따른 관할 법원을 제1심 관할 법원으로 합니다.
+      </p>
+
+      <footer class="muted">© 2026 Budget Book. 본 약관은 2026년 6월 4일부터 적용됩니다.</footer>
+    </main>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## 문제
앱 정보 화면의 **개인정보 처리방침 / 이용약관** 링크가 미등록 placeholder 도메인 `budget-book.app` 을 가리켜 접속 시 `DNS_PROBE_FINISHED_NXDOMAIN` 발생.

## 원인 (hard evidence)
- `budget-book.app` → NXDOMAIN (등록된 적 없는 placeholder)
- `aiva-bb.duckdns.org` → 정상 (실제 프로덕션 도메인)
- 게다가 실제 개인정보처리방침 콘텐츠 자체가 repo 어디에도 없었음

## 변경
- `frontend/web/privacy.html` — 개인정보처리방침 신규 (PIPA 필수 11개 섹션, 실제 수집 데이터 기반)
- `frontend/web/terms.html` — 이용약관 신규
- `app_info_page.dart` — URL → `https://aiva-bb.duckdns.org/privacy.html`, `/terms.html`

## 검증
- `flutter analyze`: No issues found
- nginx 활성 conf `try_files $uri $uri/ /index.html` → 물리 `.html` 을 SPA fallback보다 먼저 서빙 확인
- 배포 파이프라인: `flutter build web` 이 `web/*.html` → `build/web/` 복사 → NAS 전개

## 비고
- 운영자/상호명 미정 → 문의 이메일만 기재 (확정 시 추가)
- 이 개인정보처리방침 URL 은 카카오 비즈니스(이메일 필수 동의) 심사에도 사용 가능

🤖 Generated with [Claude Code](https://claude.com/claude-code)