### PR TITLE
feat(admin,auth): email 기반 유저 삭제 API + 카카오 placeholder email 정책

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -84,6 +84,8 @@ dependencies {
     testImplementation(libs.kotest.extensions.spring)
     testImplementation(libs.mockk)
     testImplementation(libs.spring.security.test)
+    testImplementation(libs.testcontainers.postgresql)
+    testImplementation(libs.testcontainers.junit.jupiter)
 }
 
 kotlin {
@@ -94,4 +96,15 @@ kotlin {
 
 tasks.withType<Test> {
     useJUnitPlatform()
+    // Pass Docker socket to the forked test JVM so Testcontainers can find Docker Desktop on macOS.
+    // Docker Desktop 4.x proxy rejects /v1.32/info (docker-java default) with empty 400.
+    // Testcontainers uses its own shaded docker-java which reads API version from "api.version"
+    // environment variable (not DOCKER_API_VERSION). Setting this to "1.44" bypasses the v1.32 issue.
+    val varRunSock = "/var/run/docker.sock"
+    val dockerHost = System.getenv("DOCKER_HOST") ?: "unix://$varRunSock"
+    environment("DOCKER_HOST", dockerHost)
+    environment("api.version", "1.44")          // Testcontainers shaded docker-java reads this key
+    environment("TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE", varRunSock)
+    systemProperty("DOCKER_HOST", dockerHost)
+    systemProperty("api.version", "1.44")
 }

--- a/backend/gradle/libs.versions.toml
+++ b/backend/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ jjwt = "0.12.6"
 sentry = "7.14.0"
 micrometer-prometheus = "1.12.5"
 kover = "0.8.0"
+testcontainers = "1.19.8"
 
 [libraries]
 # Spring Boot
@@ -54,6 +55,8 @@ kotest-property = { module = "io.kotest:kotest-property", version.ref = "kotest"
 kotest-extensions-spring = { module = "io.kotest.extensions:kotest-extensions-spring", version.ref = "kotest-spring" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 spring-security-test = { module = "org.springframework.security:spring-security-test" }
+testcontainers-postgresql = { module = "org.testcontainers:postgresql", version.ref = "testcontainers" }
+testcontainers-junit-jupiter = { module = "org.testcontainers:junit-jupiter", version.ref = "testcontainers" }
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }

--- a/backend/src/main/kotlin/com/budgetbook/admin/controller/AdminController.kt
+++ b/backend/src/main/kotlin/com/budgetbook/admin/controller/AdminController.kt
@@ -4,6 +4,8 @@ import com.budgetbook.admin.dto.AdminUserDetailResponse
 import com.budgetbook.admin.dto.AdminUserResponse
 import com.budgetbook.admin.dto.AnnouncementResponse
 import com.budgetbook.admin.dto.CreateAnnouncementRequest
+import com.budgetbook.admin.dto.DeleteUserByEmailRequest
+import com.budgetbook.admin.dto.DeleteUserResult
 import com.budgetbook.admin.dto.PagedResponse
 import com.budgetbook.admin.dto.SystemStatsResponse
 import com.budgetbook.admin.dto.UpdateAnnouncementRequest
@@ -48,6 +50,15 @@ class AdminController(
         @PathVariable userId: UUID
     ): ApiResponse<AdminUserDetailResponse> {
         val result = adminService.getUserDetail(userId)
+        return ApiResponse.ok(result)
+    }
+
+    @DeleteMapping("/users")
+    fun deleteUserByEmail(
+        @AuthUser adminUserId: UUID,
+        @Valid @RequestBody request: DeleteUserByEmailRequest
+    ): ApiResponse<DeleteUserResult> {
+        val result = adminService.deleteUserByEmail(adminUserId, request.email, request.confirm)
         return ApiResponse.ok(result)
     }
 

--- a/backend/src/main/kotlin/com/budgetbook/admin/dto/AdminDtos.kt
+++ b/backend/src/main/kotlin/com/budgetbook/admin/dto/AdminDtos.kt
@@ -2,12 +2,27 @@ package com.budgetbook.admin.dto
 
 import com.budgetbook.admin.domain.Announcement
 import com.budgetbook.auth.domain.User
+import jakarta.validation.constraints.Email
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Size
 import java.time.Instant
 import java.util.UUID
 
 // --- User Management DTOs ---
+
+data class DeleteUserByEmailRequest(
+    @field:NotBlank(message = "Email is required")
+    @field:Email(message = "Invalid email format")
+    val email: String,
+    val confirm: Boolean = false
+)
+
+data class DeleteUserResult(
+    val deletedUserId: UUID,
+    val email: String,
+    val deletedCoupleIds: List<UUID>,
+    val deletedAt: Instant
+)
 
 data class AdminUserResponse(
     val id: UUID,

--- a/backend/src/main/kotlin/com/budgetbook/admin/service/AdminService.kt
+++ b/backend/src/main/kotlin/com/budgetbook/admin/service/AdminService.kt
@@ -5,17 +5,22 @@ import com.budgetbook.admin.dto.AdminUserDetailResponse
 import com.budgetbook.admin.dto.AdminUserResponse
 import com.budgetbook.admin.dto.AnnouncementResponse
 import com.budgetbook.admin.dto.CreateAnnouncementRequest
+import com.budgetbook.admin.dto.DeleteUserResult
 import com.budgetbook.admin.dto.PagedResponse
 import com.budgetbook.admin.dto.SystemStatsResponse
 import com.budgetbook.admin.dto.UpdateAnnouncementRequest
 import com.budgetbook.admin.repository.AnnouncementRepository
+import com.budgetbook.auth.domain.AuthProvider
 import com.budgetbook.auth.domain.User
+import com.budgetbook.auth.domain.UserRole
 import com.budgetbook.auth.repository.UserRepository
 import com.budgetbook.common.exception.BusinessException
 import com.budgetbook.common.exception.NotFoundException
 import com.budgetbook.couple.domain.CoupleStatus
 import com.budgetbook.couple.repository.CoupleRepository
 import com.budgetbook.transaction.repository.TransactionRepository
+import jakarta.persistence.EntityManager
+import org.slf4j.LoggerFactory
 import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -29,8 +34,11 @@ class AdminService(
     private val userRepository: UserRepository,
     private val coupleRepository: CoupleRepository,
     private val transactionRepository: TransactionRepository,
-    private val announcementRepository: AnnouncementRepository
+    private val announcementRepository: AnnouncementRepository,
+    private val entityManager: EntityManager
 ) {
+
+    private val logger = LoggerFactory.getLogger(AdminService::class.java)
 
     // --- User Management ---
 
@@ -194,5 +202,83 @@ class AdminService(
         val announcement = announcementRepository.findById(announcementId)
             .orElseThrow { NotFoundException("ANNOUNCEMENT_NOT_FOUND", "Announcement not found: $announcementId") }
         return AnnouncementResponse.from(announcement)
+    }
+
+    // --- User Hard Delete ---
+
+    @Transactional
+    fun deleteUserByEmail(requestAdminId: UUID, email: String, confirm: Boolean): DeleteUserResult {
+        if (!confirm) throw BusinessException("DELETE_NOT_CONFIRMED", "Deletion must be explicitly confirmed (confirm=true)")
+
+        // email 은 저장 시 lowercase 정규화를 하지 않으므로 trim 만 적용
+        val normalizedEmail = email.trim()
+        val user = userRepository.findByEmail(normalizedEmail)
+            ?: throw NotFoundException("USER_NOT_FOUND", "User not found: $normalizedEmail")
+        if (user.provider == AuthProvider.SYSTEM)
+            throw BusinessException("CANNOT_DELETE_SYSTEM_ACCOUNT", "System account cannot be deleted")
+        if (user.id == requestAdminId)
+            throw BusinessException("CANNOT_DELETE_SELF", "Admin cannot delete their own account")
+        // ADMIN 계정은 이 엔드포인트로 hard-delete 불가 (별도 절차 필요)
+        if (user.role == UserRole.ADMIN)
+            throw BusinessException("CANNOT_DELETE_ADMIN", "Admin accounts cannot be hard-deleted via this endpoint")
+
+        // findAllByUserId 는 status 필터 없이 ACTIVE/DISSOLVED 모두 반환.
+        // DISSOLVED 커플이라도 user2 가 타인이면 과거 공유 데이터가 남아 있어 단순 삭제 불가.
+        val couples = coupleRepository.findAllByUserId(user.id)
+        val hasPartner = couples.any { c ->
+            val partnerId = if (c.user1.id == user.id) c.user2?.id else c.user1.id
+            partnerId != null && partnerId != user.id
+        }
+        if (hasPartner)
+            throw BusinessException(
+                "COUPLE_HAS_PARTNER",
+                "User has or had a partner (active or dissolved); shared-data deletion requires manual review"
+            )
+
+        val uid = user.id
+        val coupleIds = couples.map { it.id }
+
+        // 1) users 직접참조 NO ACTION 자식 선삭제 (couple CASCADE로 안 지워지는 것)
+        execUid("DELETE FROM spending_plan_status_history WHERE changed_by = :uid", uid)
+        execUid("DELETE FROM feedback_comments WHERE author_id = :uid", uid)
+        execUid("DELETE FROM feedback_posts WHERE user_id = :uid", uid)
+        execUid("UPDATE announcements SET created_by = NULL WHERE created_by = :uid", uid) // nullable: 공지 보존
+        execUid("DELETE FROM release_notes WHERE created_by = :uid", uid)
+
+        // 2) couple_id NO ACTION 자식 선삭제 후 couples 삭제 (CASCADE로 나머지 자동삭제)
+        if (coupleIds.isNotEmpty()) {
+            // 외부 입력 절대 금지 — 코드 상수만 사용. SQL injection 방지.
+            COUPLE_SCOPED_NO_ACTION_TABLES.forEach { t ->
+                entityManager.createNativeQuery("DELETE FROM $t WHERE couple_id IN (:cids)")
+                    .setParameter("cids", coupleIds).executeUpdate()
+            }
+            entityManager.createNativeQuery("DELETE FROM couples WHERE id IN (:cids)")
+                .setParameter("cids", coupleIds).executeUpdate()
+        }
+
+        // 3) users 삭제. 누락된 NO ACTION 자식이 있으면 여기서 FK 위반 → 트랜잭션 롤백(안전망)
+        entityManager.createNativeQuery("DELETE FROM users WHERE id = :uid").setParameter("uid", uid).executeUpdate()
+        entityManager.flush()
+        // native DELETE 후 1차 캐시(persistence context)를 비워 stale 엔티티가 조회되는 것을 방지
+        entityManager.clear()
+
+        logger.warn("ADMIN_USER_DELETE admin={} deletedUser={} email={} couples={}", requestAdminId, uid, normalizedEmail, coupleIds)
+        return DeleteUserResult(deletedUserId = uid, email = normalizedEmail, deletedCoupleIds = coupleIds, deletedAt = Instant.now())
+    }
+
+    private fun execUid(sql: String, uid: UUID) =
+        entityManager.createNativeQuery(sql).setParameter("uid", uid).executeUpdate()
+
+    companion object {
+        // couple_id 참조에 ON DELETE NO ACTION 이 걸린 테이블 목록.
+        // couples 삭제 전 반드시 이 순서대로 선삭제해야 FK 위반이 발생하지 않는다.
+        // 외부 입력 절대 금지 — 코드 상수만.
+        private val COUPLE_SCOPED_NO_ACTION_TABLES = listOf(
+            "weekly_budget_settlements",
+            "transfers",
+            "spending_plans",
+            "insurances",
+            "couple_preferences"
+        )
     }
 }

--- a/backend/src/main/kotlin/com/budgetbook/auth/domain/EmailPolicy.kt
+++ b/backend/src/main/kotlin/com/budgetbook/auth/domain/EmailPolicy.kt
@@ -1,0 +1,30 @@
+package com.budgetbook.auth.domain
+
+/**
+ * Central authority for placeholder email policy.
+ * All email generation, detection, and validation must use these helpers.
+ * Never define the placeholder domain elsewhere.
+ */
+object EmailPolicy {
+
+    const val PLACEHOLDER_EMAIL_DOMAIN = "no-email.local"
+
+    /**
+     * Generates a deterministic placeholder email from provider and providerId.
+     * Format: {provider_lowercase}_{providerId}@no-email.local
+     */
+    fun buildPlaceholderEmail(provider: AuthProvider, providerId: String): String =
+        "${provider.name.lowercase()}_${providerId}@$PLACEHOLDER_EMAIL_DOMAIN"
+
+    /**
+     * Returns true if the email is a real, user-provided email address.
+     * An email is NOT real if it is blank or ends with the placeholder domain.
+     */
+    fun isRealEmail(email: String): Boolean =
+        email.isNotBlank() && !email.endsWith("@$PLACEHOLDER_EMAIL_DOMAIN")
+
+    /**
+     * Returns true if the email is a placeholder.
+     */
+    fun isPlaceholderEmail(email: String): Boolean = !isRealEmail(email)
+}

--- a/backend/src/main/kotlin/com/budgetbook/auth/domain/User.kt
+++ b/backend/src/main/kotlin/com/budgetbook/auth/domain/User.kt
@@ -41,3 +41,6 @@ class User(
 
 enum class AuthProvider { GOOGLE, KAKAO, SYSTEM }
 enum class UserRole { USER, ADMIN }
+
+/** Returns true when this user has a real (non-placeholder) email address. */
+fun User.hasRealEmail(): Boolean = EmailPolicy.isRealEmail(email)

--- a/backend/src/main/kotlin/com/budgetbook/auth/dto/AuthDtos.kt
+++ b/backend/src/main/kotlin/com/budgetbook/auth/dto/AuthDtos.kt
@@ -1,6 +1,7 @@
 package com.budgetbook.auth.dto
 
 import com.budgetbook.auth.domain.User
+import jakarta.validation.constraints.Email
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Size
 import java.time.Instant
@@ -26,7 +27,9 @@ data class UpdateProfileRequest(
     @field:Size(min = 1, max = 50, message = "닉네임은 1~50자 이내로 입력해주세요")
     val nickname: String? = null,
     val profileImageUrl: String? = null,
-    val clearProfileImage: Boolean = false
+    val clearProfileImage: Boolean = false,
+    @field:Email(message = "올바른 이메일 형식이 아닙니다")
+    val email: String? = null
 )
 
 data class UserResponse(

--- a/backend/src/main/kotlin/com/budgetbook/auth/service/AuthService.kt
+++ b/backend/src/main/kotlin/com/budgetbook/auth/service/AuthService.kt
@@ -1,5 +1,6 @@
 package com.budgetbook.auth.service
 
+import com.budgetbook.auth.domain.EmailPolicy
 import com.budgetbook.auth.domain.RefreshToken
 import com.budgetbook.auth.dto.LogoutRequest
 import com.budgetbook.auth.dto.RefreshTokenRequest
@@ -103,6 +104,20 @@ class AuthService(
             user.profileImageUrl = null
         } else {
             request.profileImageUrl?.let { user.profileImageUrl = it }
+        }
+
+        request.email?.let { rawEmail ->
+            val trimmed = rawEmail.trim()
+            // Reject direct placeholder domain input
+            if (EmailPolicy.isPlaceholderEmail(trimmed)) {
+                throw BusinessException("INVALID_EMAIL", "Cannot use a reserved email domain.")
+            }
+            // Reject duplicate email belonging to a different user
+            val existing = userRepository.findByEmail(trimmed)
+            if (existing != null && existing.id != user.id) {
+                throw BusinessException("EMAIL_ALREADY_IN_USE", "This email is already in use by another account.")
+            }
+            user.email = trimmed
         }
 
         val savedUser = userRepository.save(user)

--- a/backend/src/main/kotlin/com/budgetbook/auth/service/CustomOAuth2UserService.kt
+++ b/backend/src/main/kotlin/com/budgetbook/auth/service/CustomOAuth2UserService.kt
@@ -1,6 +1,7 @@
 package com.budgetbook.auth.service
 
 import com.budgetbook.auth.domain.AuthProvider
+import com.budgetbook.auth.domain.EmailPolicy
 import com.budgetbook.auth.domain.User
 import com.budgetbook.auth.event.UserCreatedEvent
 import com.budgetbook.auth.repository.UserRepository
@@ -59,9 +60,12 @@ class CustomOAuth2UserService(
         val kakaoAccount = attributes["kakao_account"] as? Map<String, Any> ?: emptyMap()
         val profile = kakaoAccount["profile"] as? Map<String, Any> ?: emptyMap()
 
+        val providerId = attributes["id"].toString()
+        val email = kakaoAccount["email"] as? String
+            ?: EmailPolicy.buildPlaceholderEmail(AuthProvider.KAKAO, providerId)
         return OAuth2UserInfo(
-            providerId = attributes["id"].toString(),
-            email = kakaoAccount["email"] as? String ?: "",
+            providerId = providerId,
+            email = email,
             name = profile["nickname"] as? String ?: "Unknown",
             profileImageUrl = profile["thumbnail_image_url"] as? String
         )
@@ -76,20 +80,23 @@ class CustomOAuth2UserService(
             return userRepository.save(byProvider)
         }
 
-        // 2. Check if email is already registered with a different provider - block auto-linking
-        val byEmail = userRepository.findByEmail(userInfo.email)
-        if (byEmail != null) {
-            log.warn(
-                "OAuth2 login blocked: email={} already registered with provider={}, attempted provider={}",
-                userInfo.email, byEmail.provider, provider
-            )
-            throw OAuth2AuthenticationException(
-                OAuth2Error(
-                    "account_exists",
-                    "This email is already registered with ${byEmail.provider}. Please log in using ${byEmail.provider}.",
-                    null
+        // 2. Check if email is already registered with a different provider - block auto-linking.
+        // Placeholder emails are provider-scoped and inherently unique, so skip this check.
+        if (EmailPolicy.isRealEmail(userInfo.email)) {
+            val byEmail = userRepository.findByEmail(userInfo.email)
+            if (byEmail != null) {
+                log.warn(
+                    "OAuth2 login blocked: email={} already registered with provider={}, attempted provider={}",
+                    userInfo.email, byEmail.provider, provider
                 )
-            )
+                throw OAuth2AuthenticationException(
+                    OAuth2Error(
+                        "account_exists",
+                        "This email is already registered with ${byEmail.provider}. Please log in using ${byEmail.provider}.",
+                        null
+                    )
+                )
+            }
         }
 
         // 3. New user

--- a/backend/src/main/kotlin/com/budgetbook/auth/service/CustomOidcUserService.kt
+++ b/backend/src/main/kotlin/com/budgetbook/auth/service/CustomOidcUserService.kt
@@ -1,6 +1,7 @@
 package com.budgetbook.auth.service
 
 import com.budgetbook.auth.domain.AuthProvider
+import com.budgetbook.auth.domain.EmailPolicy
 import com.budgetbook.auth.security.CustomOAuth2User
 import org.slf4j.LoggerFactory
 import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest
@@ -22,9 +23,12 @@ class CustomOidcUserService(
         val registrationId = userRequest.clientRegistration.registrationId
         val provider = AuthProvider.valueOf(registrationId.uppercase())
 
+        val providerId = oidcUser.subject
+        val email = oidcUser.email
+            ?: EmailPolicy.buildPlaceholderEmail(provider, providerId)
         val userInfo = CustomOAuth2UserService.OAuth2UserInfo(
-            providerId = oidcUser.subject,
-            email = oidcUser.email ?: "",
+            providerId = providerId,
+            email = email,
             name = oidcUser.fullName ?: oidcUser.preferredUsername ?: "Unknown",
             profileImageUrl = oidcUser.picture
         )

--- a/backend/src/main/kotlin/com/budgetbook/couple/repository/CoupleRepository.kt
+++ b/backend/src/main/kotlin/com/budgetbook/couple/repository/CoupleRepository.kt
@@ -31,4 +31,7 @@ interface CoupleRepository : JpaRepository<Couple, UUID> {
         AND c.status = :status
     """)
     fun findRealCoupleByUserIdAndStatus(@Param("userId") userId: UUID, @Param("status") status: CoupleStatus): Couple?
+
+    @Query("SELECT c FROM Couple c WHERE c.user1.id = :userId OR c.user2.id = :userId")
+    fun findAllByUserId(@Param("userId") userId: UUID): List<Couple>
 }

--- a/backend/src/main/kotlin/com/budgetbook/couple/service/CoupleService.kt
+++ b/backend/src/main/kotlin/com/budgetbook/couple/service/CoupleService.kt
@@ -1,5 +1,6 @@
 package com.budgetbook.couple.service
 
+import com.budgetbook.auth.domain.hasRealEmail
 import com.budgetbook.auth.repository.UserRepository
 import com.budgetbook.category.service.CategoryGroupService
 import com.budgetbook.category.service.CategoryService
@@ -92,19 +93,26 @@ class CoupleService(
             throw ConflictException("COUPLE_ALREADY_EXISTS", "User is already in an active couple.")
         }
 
+        // Email gate: inviter must have a real email before linking a partner
+        val inviter = userRepository.findById(userId)
+            .orElseThrow { NotFoundException("USER_NOT_FOUND", "User not found.") }
+        if (!inviter.hasRealEmail()) {
+            throw BusinessException(
+                "EMAIL_REQUIRED_FOR_COUPLE",
+                "Email registration is required before linking a partner."
+            )
+        }
+
         // Cancel any existing pending invitations from this user
         coupleInvitationRepository.updateStatusByInviterIdAndStatus(
             userId, InvitationStatus.PENDING, InvitationStatus.CANCELLED
         )
 
-        val user = userRepository.findById(userId)
-            .orElseThrow { NotFoundException("USER_NOT_FOUND", "User not found.") }
-
         val code = generateInvitationCode()
         val expiresAt = Instant.now().plusSeconds(24 * 60 * 60) // 24 hours
 
         val invitation = CoupleInvitation(
-            inviter = user,
+            inviter = inviter,
             invitationCode = code,
             expiresAt = expiresAt
         )
@@ -134,6 +142,14 @@ class CoupleService(
 
         val acceptingUser = userRepository.findById(userId)
             .orElseThrow { NotFoundException("USER_NOT_FOUND", "User not found.") }
+
+        // Email gate: accepting user must have a real email before linking a partner
+        if (!acceptingUser.hasRealEmail()) {
+            throw BusinessException(
+                "EMAIL_REQUIRED_FOR_COUPLE",
+                "Email registration is required before linking a partner."
+            )
+        }
 
         // Check if accepting user is already in a real couple
         val activeCouple = coupleRepository.findRealCoupleByUserIdAndStatus(userId, CoupleStatus.ACTIVE)

--- a/backend/src/main/resources/db/migration/V62__backfill_placeholder_emails.sql
+++ b/backend/src/main/resources/db/migration/V62__backfill_placeholder_emails.sql
@@ -1,0 +1,7 @@
+-- Backfill placeholder emails for users who have blank or null email.
+-- The system account (00000000-0000-0000-0000-000000000001) has email='system@budgetbook.internal'
+-- and is not affected by the WHERE condition below.
+UPDATE users
+SET email = lower(provider) || '_' || provider_id || '@no-email.local'
+WHERE email = ''
+   OR email IS NULL;

--- a/backend/src/test/kotlin/com/budgetbook/admin/controller/AdminControllerTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/admin/controller/AdminControllerTest.kt
@@ -4,11 +4,15 @@ import com.budgetbook.admin.dto.AdminUserDetailResponse
 import com.budgetbook.admin.dto.AdminUserResponse
 import com.budgetbook.admin.dto.AnnouncementResponse
 import com.budgetbook.admin.dto.CreateAnnouncementRequest
+import com.budgetbook.admin.dto.DeleteUserByEmailRequest
+import com.budgetbook.admin.dto.DeleteUserResult
 import com.budgetbook.admin.dto.PagedResponse
 import com.budgetbook.admin.dto.SystemStatsResponse
 import com.budgetbook.admin.dto.UpdateAnnouncementRequest
 import com.budgetbook.admin.service.AdminService
+import com.budgetbook.common.exception.BusinessException
 import com.budgetbook.common.exception.NotFoundException
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
@@ -176,5 +180,38 @@ class AdminControllerTest : FunSpec({
 
         result.success shouldBe true
         verify { adminService.deleteAnnouncement(announcementId) }
+    }
+
+    // --- DELETE /api/v1/admin/users ---
+
+    test("deleteUserByEmail returns 200 with DeleteUserResult on success") {
+        val deletedUserId = UUID.randomUUID()
+        val coupleId = UUID.randomUUID()
+        val request = DeleteUserByEmailRequest(email = "target@example.com", confirm = true)
+        val resultData = DeleteUserResult(
+            deletedUserId = deletedUserId,
+            email = "target@example.com",
+            deletedCoupleIds = listOf(coupleId),
+            deletedAt = Instant.now()
+        )
+        every { adminService.deleteUserByEmail(adminUserId, "target@example.com", true) } returns resultData
+
+        val result = controller.deleteUserByEmail(adminUserId, request)
+
+        result.success shouldBe true
+        result.data!!.deletedUserId shouldBe deletedUserId
+        result.data!!.email shouldBe "target@example.com"
+        result.data!!.deletedCoupleIds shouldBe listOf(coupleId)
+    }
+
+    test("deleteUserByEmail with confirm=false propagates BusinessException from service") {
+        val request = DeleteUserByEmailRequest(email = "target@example.com", confirm = false)
+        every {
+            adminService.deleteUserByEmail(adminUserId, "target@example.com", false)
+        } throws BusinessException("DELETE_NOT_CONFIRMED", "Deletion must be explicitly confirmed (confirm=true)")
+
+        shouldThrow<BusinessException> {
+            controller.deleteUserByEmail(adminUserId, request)
+        }.code shouldBe "DELETE_NOT_CONFIRMED"
     }
 })

--- a/backend/src/test/kotlin/com/budgetbook/admin/integration/DeleteUserByEmailIntegrationTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/admin/integration/DeleteUserByEmailIntegrationTest.kt
@@ -1,0 +1,350 @@
+package com.budgetbook.admin.integration
+
+import com.budgetbook.admin.service.AdminService
+import com.budgetbook.common.exception.BusinessException
+import com.budgetbook.common.exception.NotFoundException
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.extensions.spring.SpringExtension
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import jakarta.persistence.EntityManager
+import jakarta.persistence.PersistenceContext
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.ApplicationContextInitializer
+import org.springframework.context.ConfigurableApplicationContext
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.support.TestPropertySourceUtils
+import org.springframework.transaction.PlatformTransactionManager
+import org.springframework.transaction.support.TransactionTemplate
+import org.testcontainers.containers.PostgreSQLContainer
+import java.time.LocalDate
+import java.util.UUID
+
+/**
+ * Integration test for [AdminService.deleteUserByEmail].
+ *
+ * Uses a real PostgreSQL container (Testcontainers) with Flyway migrations applied,
+ * so that actual FK CASCADE and NO ACTION constraints are exercised.
+ * H2 mock tests cannot catch: couple ON DELETE RESTRICT, transactions ON DELETE RESTRICT author_id, etc.
+ *
+ * The container is started eagerly in the companion object's init block so that
+ * DataSourceInitializer can read the JDBC URL before the Spring context is created.
+ * (@Container / @Testcontainers lifecycle runs after ApplicationContextInitializer,
+ * so we must start the container ourselves at class-load time.)
+ *
+ * Transactions: Kotest FunSpec does not support @Transactional rollback.
+ * Each test creates its data in a setup transaction and cleans up manually in afterTest,
+ * OR uses TransactionTemplate to run data operations within explicit transactions.
+ */
+@SpringBootTest
+@ActiveProfiles("integration-test")
+@ContextConfiguration(initializers = [DeleteUserByEmailIntegrationTest.DataSourceInitializer::class])
+class DeleteUserByEmailIntegrationTest(
+    private val adminService: AdminService,
+    @PersistenceContext private val em: EntityManager,
+    private val txManager: PlatformTransactionManager,
+) : FunSpec() {
+
+    override fun extensions() = listOf(SpringExtension)
+
+    companion object {
+        val postgres: PostgreSQLContainer<*> = PostgreSQLContainer("postgres:16-alpine")
+            .withDatabaseName("budgetbook_test")
+            .withUsername("test")
+            .withPassword("test")
+
+        init {
+            // Configure Testcontainers to use our custom strategy that forces API version 1.44.
+            // Docker Desktop 4.x proxy rejects /v1.32/info (docker-java default) with an empty 400,
+            // causing all built-in Testcontainers strategies to fail on macOS Docker Desktop.
+            System.setProperty(
+                "testcontainers.docker.client.strategy",
+                "com.budgetbook.admin.integration.HighApiVersionDockerStrategy"
+            )
+            // Start the container at class-load time so the JDBC URL is available
+            // when DataSourceInitializer.initialize() is called by the Spring test framework.
+            postgres.start()
+        }
+    }
+
+    /** Feeds the container's JDBC URL into Spring before context loads. */
+    class DataSourceInitializer : ApplicationContextInitializer<ConfigurableApplicationContext> {
+        override fun initialize(ctx: ConfigurableApplicationContext) {
+            TestPropertySourceUtils.addInlinedPropertiesToEnvironment(
+                ctx,
+                "spring.datasource.url=${postgres.jdbcUrl}",
+                "spring.datasource.username=${postgres.username}",
+                "spring.datasource.password=${postgres.password}",
+                "spring.datasource.driver-class-name=org.postgresql.Driver",
+                "spring.jpa.hibernate.ddl-auto=validate",
+                "spring.flyway.enabled=true",
+                "spring.flyway.baseline-on-migrate=true"
+            )
+        }
+    }
+
+    // ── Transaction helper ────────────────────────────────────────────────────
+
+    private fun <T> inTx(action: () -> T): T {
+        val txTemplate = TransactionTemplate(txManager)
+        return txTemplate.execute { action() }!!
+    }
+
+    // ── Data helpers ──────────────────────────────────────────────────────────
+
+    private fun insertUser(
+        email: String,
+        nickname: String,
+        provider: String = "GOOGLE",
+        providerId: String = UUID.randomUUID().toString(),
+        role: String = "USER",
+    ): UUID {
+        val id = UUID.randomUUID()
+        em.createNativeQuery(
+            """INSERT INTO users (id, email, nickname, provider, provider_id, role, is_active, created_at, updated_at)
+               VALUES (:id, :email, :nickname, :provider, :providerId, :role, true, now(), now())"""
+        )
+            .setParameter("id", id)
+            .setParameter("email", email)
+            .setParameter("nickname", nickname)
+            .setParameter("provider", provider)
+            .setParameter("providerId", providerId)
+            .setParameter("role", role)
+            .executeUpdate()
+        return id
+    }
+
+    private fun insertSelfCouple(userId: UUID): UUID {
+        val id = UUID.randomUUID()
+        em.createNativeQuery(
+            """INSERT INTO couples (id, user1_id, user2_id, status, is_self, created_at, updated_at)
+               VALUES (:id, :userId, null, 'ACTIVE', true, now(), now())"""
+        )
+            .setParameter("id", id)
+            .setParameter("userId", userId)
+            .executeUpdate()
+        return id
+    }
+
+    private fun insertRealCouple(user1Id: UUID, user2Id: UUID, status: String = "ACTIVE"): UUID {
+        val id = UUID.randomUUID()
+        em.createNativeQuery(
+            """INSERT INTO couples (id, user1_id, user2_id, status, is_self, created_at, updated_at)
+               VALUES (:id, :u1, :u2, :status, false, now(), now())"""
+        )
+            .setParameter("id", id)
+            .setParameter("u1", user1Id)
+            .setParameter("u2", user2Id)
+            .setParameter("status", status)
+            .executeUpdate()
+        return id
+    }
+
+    private fun insertCategory(coupleId: UUID): UUID {
+        val id = UUID.randomUUID()
+        em.createNativeQuery(
+            """INSERT INTO categories (id, couple_id, name, type, is_default, display_order, created_at, updated_at)
+               VALUES (:id, :coupleId, '식비', 'EXPENSE', false, 0, now(), now())"""
+        )
+            .setParameter("id", id)
+            .setParameter("coupleId", coupleId)
+            .executeUpdate()
+        return id
+    }
+
+    private fun insertPaymentMethod(coupleId: UUID): UUID {
+        val id = UUID.randomUUID()
+        em.createNativeQuery(
+            """INSERT INTO payment_methods (id, couple_id, name, type, is_active, is_default, display_order, created_at, updated_at)
+               VALUES (:id, :coupleId, '현금', 'CASH', true, true, 0, now(), now())"""
+        )
+            .setParameter("id", id)
+            .setParameter("coupleId", coupleId)
+            .executeUpdate()
+        return id
+    }
+
+    private fun insertTransaction(coupleId: UUID, authorId: UUID, categoryId: UUID): UUID {
+        val id = UUID.randomUUID()
+        em.createNativeQuery(
+            """INSERT INTO transactions (id, couple_id, author_id, category_id, type, amount, description, transaction_date, created_at, updated_at)
+               VALUES (:id, :coupleId, :authorId, :categoryId, 'EXPENSE', 10000, '테스트 지출', :txDate, now(), now())"""
+        )
+            .setParameter("id", id)
+            .setParameter("coupleId", coupleId)
+            .setParameter("authorId", authorId)
+            .setParameter("categoryId", categoryId)
+            .setParameter("txDate", LocalDate.now())
+            .executeUpdate()
+        return id
+    }
+
+    private fun insertRefreshToken(userId: UUID): UUID {
+        val id = UUID.randomUUID()
+        em.createNativeQuery(
+            """INSERT INTO refresh_tokens (id, user_id, token, expires_at, revoked, created_at)
+               VALUES (:id, :userId, :token, now() + interval '7 days', false, now())"""
+        )
+            .setParameter("id", id)
+            .setParameter("userId", userId)
+            .setParameter("token", "test-token-${UUID.randomUUID()}")
+            .executeUpdate()
+        return id
+    }
+
+    private fun countRows(table: String, whereClause: String, id: UUID): Long {
+        @Suppress("UNCHECKED_CAST")
+        return (em.createNativeQuery("SELECT COUNT(*) FROM $table WHERE $whereClause = :id")
+            .setParameter("id", id)
+            .singleResult as Number).toLong()
+    }
+
+    // ── Admin user (idempotent setup) ─────────────────────────────────────────
+
+    private val adminId: UUID = UUID.fromString("10000000-0000-0000-0000-000000000001")
+
+    private fun ensureAdminExists() {
+        val count = (em.createNativeQuery("SELECT COUNT(*) FROM users WHERE id = :id")
+            .setParameter("id", adminId)
+            .singleResult as Number).toLong()
+        if (count == 0L) {
+            em.createNativeQuery(
+                """INSERT INTO users (id, email, nickname, provider, provider_id, role, is_active, created_at, updated_at)
+                   VALUES (:id, 'admin@test.com', 'AdminUser', 'GOOGLE', 'admin-provider-id', 'ADMIN', true, now(), now())"""
+            ).setParameter("id", adminId).executeUpdate()
+        }
+    }
+
+    // ── Tests ─────────────────────────────────────────────────────────────────
+
+    init {
+        beforeEach {
+            inTx { ensureAdminExists() }
+        }
+
+        // ─── Happy path: self-couple user with categories/transactions/refresh_token ───
+
+        test("happy path: deletes self-couple user and all related rows without FK violation") {
+            // Arrange: insert all related rows in a committed transaction
+            lateinit var userId: UUID
+            lateinit var coupleId: UUID
+            lateinit var categoryId: UUID
+            inTx {
+                userId = insertUser("victim@test.com", "Victim")
+                coupleId = insertSelfCouple(userId)
+                categoryId = insertCategory(coupleId)
+                insertPaymentMethod(coupleId)
+                insertTransaction(coupleId, userId, categoryId)
+                insertRefreshToken(userId)
+            }
+
+            // Act: service runs in its own @Transactional
+            val result = adminService.deleteUserByEmail(adminId, "victim@test.com", confirm = true)
+
+            // Assert result DTO
+            result.deletedUserId shouldBe userId
+            result.email shouldBe "victim@test.com"
+            result.deletedCoupleIds shouldBe listOf(coupleId)
+            result.deletedAt shouldNotBe null
+
+            // Assert: all rows gone (read in new tx)
+            inTx {
+                countRows("users", "id", userId) shouldBe 0
+                countRows("couples", "id", coupleId) shouldBe 0
+                countRows("categories", "couple_id", coupleId) shouldBe 0
+                countRows("payment_methods", "couple_id", coupleId) shouldBe 0
+                countRows("transactions", "couple_id", coupleId) shouldBe 0
+                countRows("refresh_tokens", "user_id", userId) shouldBe 0
+            }
+        }
+
+        // ─── email with leading/trailing whitespace is trimmed ───────────────
+
+        test("email with surrounding whitespace is trimmed before lookup") {
+            lateinit var userId: UUID
+            inTx {
+                userId = insertUser("trimmed@test.com", "TrimUser")
+                insertSelfCouple(userId)
+            }
+
+            val result = adminService.deleteUserByEmail(adminId, "  trimmed@test.com  ", confirm = true)
+            result.email shouldBe "trimmed@test.com"
+            inTx { countRows("users", "id", userId) shouldBe 0 }
+        }
+
+        // ─── Guard: confirm = false ────────────────────────────────────────────
+
+        test("guard: confirm=false throws DELETE_NOT_CONFIRMED") {
+            shouldThrow<BusinessException> {
+                adminService.deleteUserByEmail(adminId, "any@test.com", confirm = false)
+            }.code shouldBe "DELETE_NOT_CONFIRMED"
+        }
+
+        // ─── Guard: SYSTEM account ────────────────────────────────────────────
+
+        test("guard: SYSTEM account throws CANNOT_DELETE_SYSTEM_ACCOUNT") {
+            // system account is seeded by V35 migration
+            shouldThrow<BusinessException> {
+                adminService.deleteUserByEmail(adminId, "system@budgetbook.internal", confirm = true)
+            }.code shouldBe "CANNOT_DELETE_SYSTEM_ACCOUNT"
+        }
+
+        // ─── Guard: partner in ACTIVE couple ──────────────────────────────────
+
+        test("guard: user with active partner throws COUPLE_HAS_PARTNER") {
+            lateinit var u1: UUID
+            lateinit var u2: UUID
+            inTx {
+                u1 = insertUser("partner1@test.com", "P1")
+                u2 = insertUser("partner2@test.com", "P2")
+                insertRealCouple(u1, u2, status = "ACTIVE")
+            }
+
+            shouldThrow<BusinessException> {
+                adminService.deleteUserByEmail(adminId, "partner1@test.com", confirm = true)
+            }.code shouldBe "COUPLE_HAS_PARTNER"
+
+            // cleanup
+            inTx {
+                em.createNativeQuery("DELETE FROM couples WHERE user1_id = :u1 OR user2_id = :u1")
+                    .setParameter("u1", u1).executeUpdate()
+                em.createNativeQuery("DELETE FROM users WHERE id = :u1 OR id = :u2")
+                    .setParameter("u1", u1).setParameter("u2", u2).executeUpdate()
+            }
+        }
+
+        // ─── Guard: partner in DISSOLVED couple (shared-data safety) ──────────
+
+        test("guard: user with dissolved partner couple throws COUPLE_HAS_PARTNER") {
+            lateinit var u1: UUID
+            lateinit var u2: UUID
+            inTx {
+                u1 = insertUser("dissolved1@test.com", "D1")
+                u2 = insertUser("dissolved2@test.com", "D2")
+                insertRealCouple(u1, u2, status = "DISSOLVED")
+            }
+
+            shouldThrow<BusinessException> {
+                adminService.deleteUserByEmail(adminId, "dissolved1@test.com", confirm = true)
+            }.code shouldBe "COUPLE_HAS_PARTNER"
+
+            // cleanup
+            inTx {
+                em.createNativeQuery("DELETE FROM couples WHERE user1_id = :u1 OR user2_id = :u1")
+                    .setParameter("u1", u1).executeUpdate()
+                em.createNativeQuery("DELETE FROM users WHERE id = :u1 OR id = :u2")
+                    .setParameter("u1", u1).setParameter("u2", u2).executeUpdate()
+            }
+        }
+
+        // ─── Guard: user not found ────────────────────────────────────────────
+
+        test("guard: non-existent email throws USER_NOT_FOUND") {
+            shouldThrow<NotFoundException> {
+                adminService.deleteUserByEmail(adminId, "ghost@test.com", confirm = true)
+            }.code shouldBe "USER_NOT_FOUND"
+        }
+    }
+}

--- a/backend/src/test/kotlin/com/budgetbook/admin/integration/HighApiVersionDockerStrategy.kt
+++ b/backend/src/test/kotlin/com/budgetbook/admin/integration/HighApiVersionDockerStrategy.kt
@@ -1,0 +1,67 @@
+package com.budgetbook.admin.integration
+
+import org.testcontainers.dockerclient.DockerClientProviderStrategy
+import org.testcontainers.dockerclient.InvalidConfigurationException
+import org.testcontainers.dockerclient.TransportConfig
+import java.io.IOException
+import java.net.URI
+import java.net.UnixDomainSocketAddress
+import java.nio.channels.SocketChannel
+
+/**
+ * Custom Testcontainers Docker strategy for Docker Desktop on macOS.
+ *
+ * Docker Desktop 4.x proxy rejects API version-prefixed requests like /v1.32/info
+ * with empty 400 responses. docker-java defaults to v1.32, causing all built-in
+ * Testcontainers strategies to fail.
+ *
+ * This strategy:
+ * 1. Verifies the Docker socket exists.
+ * 2. Sends a raw /_ping HTTP request (no version prefix) directly over the Unix socket.
+ *    Docker Desktop accepts /[no version]/_ping and responds 200, confirming connectivity.
+ * 3. Returns a TransportConfig that Testcontainers uses to build its Docker client.
+ *    The client itself may still use v1.32 for subsequent calls, but those are
+ *    executed with a valid, connected socket and Docker Desktop handles them.
+ */
+class HighApiVersionDockerStrategy : DockerClientProviderStrategy() {
+
+    private val socketPath = "/var/run/docker.sock"
+
+    override fun getTransportConfig(): TransportConfig {
+        if (!java.io.File(socketPath).exists()) {
+            throw InvalidConfigurationException("Docker socket not found at $socketPath")
+        }
+        return TransportConfig.builder()
+            .dockerHost(URI.create("unix://$socketPath"))
+            .build()
+    }
+
+    override fun isApplicable(): Boolean = java.io.File(socketPath).exists()
+
+    override fun getDescription(): String = "HighApiVersionDockerStrategy (macOS Docker Desktop workaround)"
+
+    override fun getPriority(): Int = 100
+
+    /**
+     * Overrides the default test() which calls docker-java's infoCmd (uses /v1.32/info).
+     * Instead, sends a raw HTTP GET /_ping to the Unix socket.
+     * Docker Desktop responds 200 to /ping without a version prefix.
+     */
+    override fun test(): Boolean {
+        if (!java.io.File(socketPath).exists()) return false
+        return try {
+            val addr = UnixDomainSocketAddress.of(socketPath)
+            SocketChannel.open(addr).use { channel ->
+                val request = "GET /_ping HTTP/1.0\r\nHost: localhost\r\n\r\n"
+                val buf = java.nio.ByteBuffer.wrap(request.toByteArray())
+                channel.write(buf)
+                val response = java.nio.ByteBuffer.allocate(256)
+                channel.read(response)
+                val responseStr = String(response.array(), 0, response.position())
+                responseStr.contains("200 OK")
+            }
+        } catch (_: IOException) {
+            false
+        }
+    }
+}

--- a/backend/src/test/kotlin/com/budgetbook/admin/service/AdminServiceTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/admin/service/AdminServiceTest.kt
@@ -23,6 +23,8 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
+import jakarta.persistence.EntityManager
+import jakarta.persistence.Query
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.PageRequest
 import java.time.Instant
@@ -37,8 +39,9 @@ class AdminServiceTest : BehaviorSpec({
     val coupleRepository = mockk<CoupleRepository>()
     val transactionRepository = mockk<TransactionRepository>()
     val announcementRepository = mockk<AnnouncementRepository>()
+    val entityManager = mockk<EntityManager>(relaxed = true)
 
-    val adminService = AdminService(userRepository, coupleRepository, transactionRepository, announcementRepository)
+    val adminService = AdminService(userRepository, coupleRepository, transactionRepository, announcementRepository, entityManager)
 
     val adminUser = User(
         email = "admin@example.com",
@@ -353,6 +356,138 @@ class AdminServiceTest : BehaviorSpec({
                 shouldThrow<NotFoundException> {
                     adminService.getAnnouncement(unknownId)
                 }
+            }
+        }
+    }
+
+    // --- deleteUserByEmail ---
+
+    Given("admin requests hard delete of a user by email") {
+        val nativeQuery = mockk<jakarta.persistence.Query>(relaxed = true)
+        every { entityManager.createNativeQuery(any()) } returns nativeQuery
+        every { nativeQuery.setParameter(any<String>(), any()) } returns nativeQuery
+        every { nativeQuery.executeUpdate() } returns 0
+
+        When("confirm is false") {
+            Then("throws BusinessException DELETE_NOT_CONFIRMED") {
+                shouldThrow<BusinessException> {
+                    adminService.deleteUserByEmail(adminUser.id, "target@example.com", confirm = false)
+                }.code shouldBe "DELETE_NOT_CONFIRMED"
+            }
+        }
+
+        When("email does not exist") {
+            every { userRepository.findByEmail("notfound@example.com") } returns null
+
+            Then("throws NotFoundException USER_NOT_FOUND") {
+                shouldThrow<NotFoundException> {
+                    adminService.deleteUserByEmail(adminUser.id, "notfound@example.com", confirm = true)
+                }.code shouldBe "USER_NOT_FOUND"
+            }
+        }
+
+        When("target user has SYSTEM provider") {
+            val systemUser = User(
+                email = "system@internal",
+                nickname = "System",
+                provider = AuthProvider.SYSTEM,
+                providerId = "system"
+            )
+            every { userRepository.findByEmail(systemUser.email) } returns systemUser
+
+            Then("throws BusinessException CANNOT_DELETE_SYSTEM_ACCOUNT") {
+                shouldThrow<BusinessException> {
+                    adminService.deleteUserByEmail(adminUser.id, systemUser.email, confirm = true)
+                }.code shouldBe "CANNOT_DELETE_SYSTEM_ACCOUNT"
+            }
+        }
+
+        When("admin tries to delete their own account") {
+            every { userRepository.findByEmail(adminUser.email) } returns adminUser
+
+            Then("throws BusinessException CANNOT_DELETE_SELF") {
+                shouldThrow<BusinessException> {
+                    adminService.deleteUserByEmail(adminUser.id, adminUser.email, confirm = true)
+                }.code shouldBe "CANNOT_DELETE_SELF"
+            }
+        }
+
+        When("target user is another ADMIN account") {
+            val anotherAdmin = User(
+                email = "admin2@example.com",
+                nickname = "Admin2",
+                provider = AuthProvider.GOOGLE,
+                providerId = "google-admin2",
+                role = UserRole.ADMIN
+            )
+            every { userRepository.findByEmail(anotherAdmin.email) } returns anotherAdmin
+
+            Then("throws BusinessException CANNOT_DELETE_ADMIN") {
+                shouldThrow<BusinessException> {
+                    adminService.deleteUserByEmail(adminUser.id, anotherAdmin.email, confirm = true)
+                }.code shouldBe "CANNOT_DELETE_ADMIN"
+            }
+        }
+
+        When("target user has a real partner in a ACTIVE couple") {
+            val partner = User(
+                email = "partner@example.com",
+                nickname = "Partner",
+                provider = AuthProvider.GOOGLE,
+                providerId = "google-partner"
+            )
+            val realCouple = Couple(user1 = regularUser, user2 = partner, status = CoupleStatus.ACTIVE, isSelf = false)
+            every { userRepository.findByEmail(regularUser.email) } returns regularUser
+            every { coupleRepository.findAllByUserId(regularUser.id) } returns listOf(realCouple)
+
+            Then("throws BusinessException COUPLE_HAS_PARTNER") {
+                shouldThrow<BusinessException> {
+                    adminService.deleteUserByEmail(adminUser.id, regularUser.email, confirm = true)
+                }.code shouldBe "COUPLE_HAS_PARTNER"
+            }
+        }
+
+        When("target user has a DISSOLVED couple with a real partner") {
+            val partner = User(
+                email = "partner@example.com",
+                nickname = "Partner",
+                provider = AuthProvider.GOOGLE,
+                providerId = "google-partner"
+            )
+            val dissolvedCouple = Couple(
+                user1 = regularUser,
+                user2 = partner,
+                status = CoupleStatus.DISSOLVED,
+                isSelf = false
+            )
+            every { userRepository.findByEmail(regularUser.email) } returns regularUser
+            every { coupleRepository.findAllByUserId(regularUser.id) } returns listOf(dissolvedCouple)
+
+            Then("throws BusinessException COUPLE_HAS_PARTNER (shared-data safety guard)") {
+                shouldThrow<BusinessException> {
+                    adminService.deleteUserByEmail(adminUser.id, regularUser.email, confirm = true)
+                }.code shouldBe "COUPLE_HAS_PARTNER"
+            }
+        }
+
+        When("target user has only a self-couple (no partner)") {
+            val selfCouple = Couple(user1 = regularUser, user2 = null, status = CoupleStatus.ACTIVE, isSelf = true)
+            every { userRepository.findByEmail(regularUser.email) } returns regularUser
+            every { coupleRepository.findAllByUserId(regularUser.id) } returns listOf(selfCouple)
+
+            val result = adminService.deleteUserByEmail(adminUser.id, regularUser.email, confirm = true)
+
+            Then("returns DeleteUserResult with correct fields") {
+                result.deletedUserId shouldBe regularUser.id
+                result.email shouldBe regularUser.email
+                result.deletedCoupleIds shouldBe listOf(selfCouple.id)
+                result.deletedAt shouldNotBe null
+            }
+
+            Then("entityManager native queries are executed") {
+                verify(atLeast = 1) { entityManager.createNativeQuery(any()) }
+                verify { entityManager.flush() }
+                verify { entityManager.clear() }
             }
         }
     }

--- a/backend/src/test/kotlin/com/budgetbook/auth/domain/EmailPolicyTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/auth/domain/EmailPolicyTest.kt
@@ -1,0 +1,118 @@
+package com.budgetbook.auth.domain
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldEndWith
+
+class EmailPolicyTest : BehaviorSpec({
+
+    Given("EmailPolicy.buildPlaceholderEmail") {
+        When("called with KAKAO and a providerId") {
+            val result = EmailPolicy.buildPlaceholderEmail(AuthProvider.KAKAO, "12345678")
+
+            Then("generates lowercase provider_providerId@no-email.local") {
+                result shouldBe "kakao_12345678@no-email.local"
+                result shouldEndWith "@${EmailPolicy.PLACEHOLDER_EMAIL_DOMAIN}"
+            }
+        }
+
+        When("called with GOOGLE and a providerId") {
+            val result = EmailPolicy.buildPlaceholderEmail(AuthProvider.GOOGLE, "google-sub-999")
+
+            Then("generates google_ prefixed placeholder") {
+                result shouldBe "google_google-sub-999@no-email.local"
+            }
+        }
+
+        When("called with SYSTEM and a providerId") {
+            val result = EmailPolicy.buildPlaceholderEmail(AuthProvider.SYSTEM, "system-001")
+
+            Then("generates system_ prefixed placeholder") {
+                result shouldBe "system_system-001@no-email.local"
+            }
+        }
+    }
+
+    Given("EmailPolicy.isRealEmail") {
+        When("given a real email address") {
+            Then("returns true") {
+                EmailPolicy.isRealEmail("user@example.com") shouldBe true
+                EmailPolicy.isRealEmail("user@gmail.com") shouldBe true
+                EmailPolicy.isRealEmail("user@kakao.com") shouldBe true
+            }
+        }
+
+        When("given a placeholder email") {
+            Then("returns false") {
+                EmailPolicy.isRealEmail("kakao_12345678@no-email.local") shouldBe false
+                EmailPolicy.isRealEmail("google_abc@no-email.local") shouldBe false
+            }
+        }
+
+        When("given a blank string") {
+            Then("returns false") {
+                EmailPolicy.isRealEmail("") shouldBe false
+                EmailPolicy.isRealEmail("   ") shouldBe false
+            }
+        }
+    }
+
+    Given("EmailPolicy.isPlaceholderEmail") {
+        When("given a placeholder email") {
+            Then("returns true") {
+                EmailPolicy.isPlaceholderEmail("kakao_12345678@no-email.local") shouldBe true
+            }
+        }
+
+        When("given a real email") {
+            Then("returns false") {
+                EmailPolicy.isPlaceholderEmail("user@example.com") shouldBe false
+            }
+        }
+
+        When("given a blank string") {
+            Then("returns true (not a real email)") {
+                EmailPolicy.isPlaceholderEmail("") shouldBe true
+            }
+        }
+    }
+
+    Given("User.hasRealEmail extension function") {
+        When("user has a real email") {
+            val user = User(
+                email = "real@example.com",
+                nickname = "RealUser",
+                provider = AuthProvider.GOOGLE,
+                providerId = "google-1"
+            )
+            Then("returns true") {
+                user.hasRealEmail() shouldBe true
+            }
+        }
+
+        When("user has a placeholder email") {
+            val user = User(
+                email = "kakao_99999@no-email.local",
+                nickname = "PlaceholderUser",
+                provider = AuthProvider.KAKAO,
+                providerId = "99999"
+            )
+            Then("returns false") {
+                user.hasRealEmail() shouldBe false
+            }
+        }
+
+        When("user has a blank email (legacy)") {
+            val user = User(
+                email = "",
+                nickname = "LegacyUser",
+                provider = AuthProvider.KAKAO,
+                providerId = "legacy-1"
+            )
+            Then("returns false") {
+                user.hasRealEmail() shouldBe false
+            }
+        }
+    }
+})

--- a/backend/src/test/kotlin/com/budgetbook/auth/service/AuthServiceTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/auth/service/AuthServiceTest.kt
@@ -531,4 +531,107 @@ class AuthServiceTest : BehaviorSpec({
             }
         }
     }
+
+    // --- updateProfile email field ---
+
+    Given("a Kakao user with placeholder email updating to a real email") {
+        val kakaoUser = User(
+            email = "kakao_12345@no-email.local",
+            nickname = "KakaoUser",
+            provider = AuthProvider.KAKAO,
+            providerId = "12345"
+        )
+
+        every { userRepository.findById(kakaoUser.id) } returns Optional.of(kakaoUser)
+        every { userRepository.findByEmail("real@example.com") } returns null
+        every { userRepository.save(any()) } returnsArgument 0
+        every { coupleRepository.findByUserIdAndStatus(kakaoUser.id, CoupleStatus.ACTIVE) } returns null
+
+        When("updateProfile is called with a real email") {
+            val request = UpdateProfileRequest(email = "real@example.com")
+            val result = authService.updateProfile(kakaoUser.id, request)
+
+            Then("email is updated successfully") {
+                result.email shouldBe "real@example.com"
+            }
+
+            Then("evicts user cache") {
+                verify { userCacheService.evict(kakaoUser.id) }
+            }
+        }
+    }
+
+    Given("a user trying to update email to a placeholder domain value") {
+        val user = User(
+            email = "kakao_abc@no-email.local",
+            nickname = "KakaoUser2",
+            provider = AuthProvider.KAKAO,
+            providerId = "abc"
+        )
+
+        every { userRepository.findById(user.id) } returns Optional.of(user)
+
+        When("updateProfile is called with a placeholder-domain email") {
+            val request = UpdateProfileRequest(email = "attacker_xyz@no-email.local")
+
+            Then("throws BusinessException with INVALID_EMAIL") {
+                val exception = shouldThrow<BusinessException> {
+                    authService.updateProfile(user.id, request)
+                }
+                exception.code shouldBe "INVALID_EMAIL"
+            }
+        }
+    }
+
+    Given("a user trying to update email to one already used by another account") {
+        val existingUser = User(
+            email = "taken@example.com",
+            nickname = "ExistingUser",
+            provider = AuthProvider.GOOGLE,
+            providerId = "google-existing"
+        )
+        val user = User(
+            email = "kakao_dup@no-email.local",
+            nickname = "KakaoUser3",
+            provider = AuthProvider.KAKAO,
+            providerId = "dup"
+        )
+
+        every { userRepository.findById(user.id) } returns Optional.of(user)
+        every { userRepository.findByEmail("taken@example.com") } returns existingUser
+
+        When("updateProfile is called with the taken email") {
+            val request = UpdateProfileRequest(email = "taken@example.com")
+
+            Then("throws BusinessException with EMAIL_ALREADY_IN_USE") {
+                val exception = shouldThrow<BusinessException> {
+                    authService.updateProfile(user.id, request)
+                }
+                exception.code shouldBe "EMAIL_ALREADY_IN_USE"
+            }
+        }
+    }
+
+    Given("a user updating email to their own current email") {
+        val user = User(
+            email = "mine@example.com",
+            nickname = "SameEmailUser",
+            provider = AuthProvider.GOOGLE,
+            providerId = "google-same"
+        )
+
+        every { userRepository.findById(user.id) } returns Optional.of(user)
+        every { userRepository.findByEmail("mine@example.com") } returns user
+        every { userRepository.save(any()) } returnsArgument 0
+        every { coupleRepository.findByUserIdAndStatus(user.id, CoupleStatus.ACTIVE) } returns null
+
+        When("updateProfile is called with the same email") {
+            val request = UpdateProfileRequest(email = "mine@example.com")
+            val result = authService.updateProfile(user.id, request)
+
+            Then("succeeds (same-user idempotent update)") {
+                result.email shouldBe "mine@example.com"
+            }
+        }
+    }
 })

--- a/backend/src/test/kotlin/com/budgetbook/auth/service/CustomOAuth2UserServiceTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/auth/service/CustomOAuth2UserServiceTest.kt
@@ -7,6 +7,7 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldContain
 import io.mockk.every
 import io.mockk.mockk
@@ -163,6 +164,78 @@ class CustomOAuth2UserServiceTest : BehaviorSpec({
                 }
                 ex.error.errorCode shouldBe "account_exists"
                 ex.error.description shouldContain "KAKAO"
+            }
+        }
+    }
+
+    Given("a Kakao user who did not consent to email sharing") {
+        val providerId = "87654321"
+        val expectedPlaceholder = "kakao_87654321@no-email.local"
+
+        every { userRepository.findByProviderAndProviderId(AuthProvider.KAKAO, providerId) } returns null
+        // findByEmail must NOT be called for placeholder emails
+        val userSlot = slot<User>()
+        every { userRepository.save(capture(userSlot)) } answers { userSlot.captured }
+
+        val userInfo = CustomOAuth2UserService.OAuth2UserInfo(
+            providerId = providerId,
+            email = expectedPlaceholder,
+            name = "Kakao NoEmail",
+            profileImageUrl = null
+        )
+
+        When("findOrCreateUser is called") {
+            val result = service.findOrCreateUser(AuthProvider.KAKAO, userInfo)
+
+            Then("saves the user with the placeholder email") {
+                result.email shouldBe expectedPlaceholder
+                result.provider shouldBe AuthProvider.KAKAO
+            }
+
+            Then("does NOT call findByEmail (duplicate check skipped for placeholder)") {
+                io.mockk.verify(exactly = 0) { userRepository.findByEmail(any()) }
+            }
+        }
+    }
+
+    Given("two distinct Kakao users who both did not consent to email sharing") {
+        val providerId1 = "11111111"
+        val providerId2 = "22222222"
+        val placeholder1 = "kakao_11111111@no-email.local"
+        val placeholder2 = "kakao_22222222@no-email.local"
+
+        every { userRepository.findByProviderAndProviderId(AuthProvider.KAKAO, providerId1) } returns null
+        every { userRepository.findByProviderAndProviderId(AuthProvider.KAKAO, providerId2) } returns null
+        val slotA = slot<User>()
+        val slotB = slot<User>()
+        every { userRepository.save(capture(slotA)) } answers { slotA.captured }
+
+        val userInfo1 = CustomOAuth2UserService.OAuth2UserInfo(
+            providerId = providerId1,
+            email = placeholder1,
+            name = "Kakao User A",
+            profileImageUrl = null
+        )
+        val userInfo2 = CustomOAuth2UserService.OAuth2UserInfo(
+            providerId = providerId2,
+            email = placeholder2,
+            name = "Kakao User B",
+            profileImageUrl = null
+        )
+
+        When("both users sign up independently") {
+            val result1 = service.findOrCreateUser(AuthProvider.KAKAO, userInfo1)
+            every { userRepository.save(capture(slotB)) } answers { slotB.captured }
+            val result2 = service.findOrCreateUser(AuthProvider.KAKAO, userInfo2)
+
+            Then("each user gets their own unique placeholder email without UNIQUE conflict") {
+                result1.email shouldBe placeholder1
+                result2.email shouldBe placeholder2
+                result1.email shouldNotBe result2.email
+            }
+
+            Then("findByEmail is never called (skipped for both placeholders)") {
+                io.mockk.verify(exactly = 0) { userRepository.findByEmail(any()) }
             }
         }
     }

--- a/backend/src/test/kotlin/com/budgetbook/couple/service/CoupleServiceTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/couple/service/CoupleServiceTest.kt
@@ -474,4 +474,66 @@ class CoupleServiceTest : BehaviorSpec({
             }
         }
     }
+
+    // --- Email gate for couple linking ---
+
+    val placeholderUser = User(
+        email = "kakao_99999999@no-email.local",
+        nickname = "NoEmailUser",
+        provider = AuthProvider.KAKAO,
+        providerId = "99999999"
+    )
+
+    Given("a Kakao user with placeholder email (no real email) trying to create invitation") {
+        every { coupleRepository.findRealCoupleByUserIdAndStatus(placeholderUser.id, CoupleStatus.ACTIVE) } returns null
+        every { userRepository.findById(placeholderUser.id) } returns Optional.of(placeholderUser)
+
+        When("createInvitation is called") {
+            Then("throws BusinessException with EMAIL_REQUIRED_FOR_COUPLE") {
+                val ex = shouldThrow<BusinessException> {
+                    coupleService.createInvitation(placeholderUser.id)
+                }
+                ex.code shouldBe "EMAIL_REQUIRED_FOR_COUPLE"
+            }
+        }
+    }
+
+    Given("a Kakao user with placeholder email trying to accept an invitation") {
+        val invitation = CoupleInvitation(
+            inviter = user1,
+            invitationCode = "TESTCODE",
+            status = InvitationStatus.PENDING,
+            expiresAt = Instant.now().plusSeconds(3600)
+        )
+
+        every { coupleInvitationRepository.findByInvitationCode("TESTCODE") } returns invitation
+        every { userRepository.findById(placeholderUser.id) } returns Optional.of(placeholderUser)
+
+        When("acceptInvitation is called by placeholder user") {
+            Then("throws BusinessException with EMAIL_REQUIRED_FOR_COUPLE") {
+                val ex = shouldThrow<BusinessException> {
+                    coupleService.acceptInvitation(placeholderUser.id, "TESTCODE")
+                }
+                ex.code shouldBe "EMAIL_REQUIRED_FOR_COUPLE"
+            }
+        }
+    }
+
+    Given("a user with real email trying to create invitation") {
+        // user1 has email "user1@example.com" which is real
+        every { coupleRepository.findRealCoupleByUserIdAndStatus(user1.id, CoupleStatus.ACTIVE) } returns null
+        every { userRepository.findById(user1.id) } returns Optional.of(user1)
+        every { coupleInvitationRepository.updateStatusByInviterIdAndStatus(user1.id, InvitationStatus.PENDING, InvitationStatus.CANCELLED) } returns Unit
+
+        val invitationSlot = slot<CoupleInvitation>()
+        every { coupleInvitationRepository.save(capture(invitationSlot)) } answers { invitationSlot.captured }
+
+        When("createInvitation is called") {
+            val result = coupleService.createInvitation(user1.id)
+
+            Then("succeeds and returns invitation code") {
+                result.code shouldHaveLength 8
+            }
+        }
+    }
 })

--- a/backend/src/test/resources/application-integration-test.yml
+++ b/backend/src/test/resources/application-integration-test.yml
@@ -1,0 +1,52 @@
+spring:
+  jpa:
+    show-sql: false
+    hibernate:
+      ddl-auto: validate
+    properties:
+      hibernate:
+        format_sql: false
+
+  flyway:
+    enabled: true
+    baseline-on-migrate: true
+
+  data:
+    redis:
+      url: ""
+
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: test-google-client-id
+            client-secret: test-google-client-secret
+            scope: openid,profile,email
+          kakao:
+            client-id: test-kakao-client-id
+            client-secret: test-kakao-client-secret
+            client-authentication-method: client_secret_post
+            authorization-grant-type: authorization_code
+            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+            scope: profile,account_email
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+
+jwt:
+  secret: integration-test-secret-key-that-is-at-least-256-bits-long-for-hs256
+  access-token-expiry: 3600000
+  refresh-token-expiry: 604800000
+
+app:
+  frontend-url: http://localhost:5000
+
+logging:
+  level:
+    com.budgetbook: WARN
+    org.flywaydb: WARN
+    org.testcontainers: WARN

--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -182,6 +182,8 @@ The current backend accepts only the singular `type` query parameter (see §Tran
   - [Event Types](#event-types)
 - [Redis Cache Strategy](#redis-cache-strategy)
 - [Common Data Types](#common-data-types)
+- [Admin](#admin)
+  - [Hard Delete User by Email](#1-hard-delete-user-by-email)
 - [Error Codes](#error-codes)
 
 ---
@@ -406,7 +408,7 @@ Note: `coupleId` is omitted from the response when the user is not in an active 
 
 ### 4. Update Profile
 
-Updates the current user's profile information (nickname, profile image).
+Updates the current user's profile information (nickname, profile image, email).
 
 | Item        | Value                        |
 |:------------|:-----------------------------|
@@ -428,14 +430,23 @@ Updates the current user's profile information (nickname, profile image).
 | `nickname`          | `string`  | No       | New nickname (1-50 chars)          |
 | `profileImageUrl`   | `string`  | No       | New profile image URL              |
 | `clearProfileImage` | `boolean` | No       | Set true to remove profile image   |
+| `email`             | `string`  | No       | Register or update user email address. Constraints: (1) placeholder domain (`@no-email.local`) is not accepted, (2) must not be already in use by another account. |
 
 ```json
 {
   "nickname": "새닉네임",
   "profileImageUrl": null,
-  "clearProfileImage": false
+  "clearProfileImage": false,
+  "email": "user@example.com"
 }
 ```
+
+**Error Responses**
+
+| Status | Error Code | Description |
+|:-------|:-----------|:------------|
+| `400`  | `INVALID_EMAIL` | Placeholder domain (`@no-email.local`) supplied as email |
+| `400`  | `EMAIL_ALREADY_IN_USE` | Email is already used by another account |
 
 **Response `200 OK`**: `ApiResponse<UserResponse>`
 
@@ -560,6 +571,13 @@ Generates a new 8-character invitation code. The previous pending invitation for
 }
 ```
 
+**Error Responses**
+
+| Status | Error Code | Description |
+|:-------|:-----------|:------------|
+| `409`  | `COUPLE_ALREADY_EXISTS` | User is already in an active couple |
+| `400`  | `EMAIL_REQUIRED_FOR_COUPLE` | Caller has a placeholder or empty email; a real email must be registered before creating an invitation |
+
 ---
 
 ### 2. Get My Invitation Status
@@ -649,6 +667,7 @@ Accepts an invitation code and links the two users as a couple. Default categori
 | `410`  | `INVITATION_EXPIRED` | Invitation code has expired |
 | `409`  | `COUPLE_ALREADY_EXISTS` | Accepting user is already in a couple |
 | `400`  | `SELF_INVITATION` | User cannot accept their own invitation |
+| `400`  | `EMAIL_REQUIRED_FOR_COUPLE` | Caller has a placeholder or empty email; a real email must be registered before accepting an invitation |
 
 ---
 
@@ -4824,6 +4843,93 @@ spring:
 
 ---
 
+## Admin
+
+Admin-only endpoints. All requests require `Authorization: Bearer {accessToken}` and the authenticated user must have `role = ADMIN`. Non-admin requests receive `403 FORBIDDEN`.
+
+Base path: `/api/v1/admin`
+
+---
+
+### 1. Hard Delete User by Email
+
+Permanently removes a user and all data they own from the database. This operation is irreversible.
+
+**Constraints:**
+- Target user must not have a real partner in an active couple (self-couple or no couple only).
+- System account (`00000000-0000-0000-0000-000000000001`) cannot be deleted.
+- Admin cannot delete their own account.
+- `confirm` must be `true` as an explicit safety gate.
+
+| Item        | Value                              |
+|:------------|:-----------------------------------|
+| **Method**  | `DELETE`                           |
+| **Path**    | `/api/v1/admin/users`              |
+| **Auth**    | Required (`role = ADMIN`)          |
+
+**Request Headers**
+
+| Header          | Value                        |
+|:----------------|:-----------------------------|
+| `Authorization` | `Bearer {accessToken}`       |
+| `Content-Type`  | `application/json`           |
+
+**Request Body**: `AdminHardDeleteUserRequest`
+
+| Field     | Type      | Required | Description                                                  |
+|:----------|:----------|:--------:|:-------------------------------------------------------------|
+| `email`   | `string`  | Yes      | Email address of the user to delete (must be valid email format) |
+| `confirm` | `boolean` | Yes      | Must be `true` to execute deletion (safety gate)             |
+
+**Example Request**
+
+```json
+{
+  "email": "user@example.com",
+  "confirm": true
+}
+```
+
+**Response `200 OK`**: `ApiResponse<AdminDeleteUserResponse>`
+
+`AdminDeleteUserResponse`:
+
+| Field              | Type       | Description                                           |
+|:-------------------|:-----------|:------------------------------------------------------|
+| `deletedUserId`    | `UUID`     | ID of the deleted user                                |
+| `email`            | `string`   | Email of the deleted user                             |
+| `deletedCoupleIds` | `UUID[]`   | IDs of couple records that were deleted (may be empty)|
+| `deletedAt`        | `string`   | ISO 8601 datetime of when the deletion was performed  |
+
+**Example Response**
+
+```json
+{
+  "success": true,
+  "data": {
+    "deletedUserId": "550e8400-e29b-41d4-a716-446655440000",
+    "email": "user@example.com",
+    "deletedCoupleIds": ["a1b2c3d4-e5f6-7890-abcd-ef1234567890"],
+    "deletedAt": "2026-06-04T10:30:00Z"
+  },
+  "timestamp": "2026-06-04T10:30:00Z"
+}
+```
+
+**Error Responses**
+
+| Status | Error Code                       | Description                                              |
+|:------:|:---------------------------------|:---------------------------------------------------------|
+| `400`  | `DELETE_NOT_CONFIRMED`           | `confirm` field is absent or not `true`                  |
+| `400`  | `CANNOT_DELETE_SYSTEM_ACCOUNT`   | Target is the system account; hard-delete is not allowed |
+| `400`  | `CANNOT_DELETE_SELF`             | Admin cannot delete their own account                    |
+| `400`  | `COUPLE_HAS_PARTNER`             | Target user has a real partner; cannot delete shared data|
+| `400`  | `VALIDATION_ERROR`               | Email format is invalid or required fields are missing   |
+| `403`  | `FORBIDDEN`                      | Caller does not have `ADMIN` role                        |
+| `404`  | `USER_NOT_FOUND`                 | No user found with the given email                       |
+
+---
+
 ## Error Codes
 
 | Error Code                        | HTTP Status | Description                                          |
@@ -4862,3 +4968,11 @@ spring:
 | `SPENDING_PLAN_NOT_FOUND`         | `404`       | Requested spending plan does not exist or belongs to another couple |
 | `FEEDBACK_NOT_FOUND`              | `404`       | Requested feedback post does not exist                               |
 | `INVALID_STATUS`                  | `400`       | Operation not allowed for the resource's current status (e.g., editing a non-SUBMITTED feedback, completing an already-completed plan) |
+| `DELETE_NOT_CONFIRMED`            | `400`       | Deletion request must include `confirm=true`                         |
+| `CANNOT_DELETE_SYSTEM_ACCOUNT`    | `400`       | System account cannot be hard-deleted                                |
+| `CANNOT_DELETE_SELF`              | `400`       | Admin cannot delete their own account                                |
+| `COUPLE_HAS_PARTNER`              | `400`       | User has a real partner; cannot hard-delete shared data              |
+| `CANNOT_DELETE_ADMIN`             | `400`       | Admin accounts cannot be hard-deleted via this endpoint              |
+| `EMAIL_REQUIRED_FOR_COUPLE`       | `400`       | Email registration is required before linking a partner              |
+| `EMAIL_ALREADY_IN_USE`            | `400`       | Email is already used by another account                             |
+| `INVALID_EMAIL`                   | `400`       | Invalid email (placeholder domain not allowed)                       |

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -5,6 +5,17 @@
 
 ---
 
+## 🔴 KI-007: 카카오 OAuth 빈 email → 가입 실패 + 식별 불가 (2026-06-04)
+- **발견**: 카카오는 이메일이 선택 동의 → 미동의 시 `CustomOAuth2UserService.kt:64` `?: ""` 로 빈 문자열 저장 (예: 곽소영 `8358d6c8-...`, KAKAO, email='')
+- **버그**: `email`은 `NOT NULL UNIQUE`라 빈 문자열도 1명만 가능. 게다가 중복가입 체크 `findByEmail("")`(`:80`)가 기존 빈-email 유저를 반환 → **2번째 email-미동의 카카오 가입이 "이미 등록된 이메일"로 차단됨**
+- **사실 정정**: 파트너 연결은 email이 아니라 8자리 초대코드 방식(`CoupleService`). email 용도는 ① cross-provider 중복가입 방지 ② 어드민 식별뿐
+- **카카오 제약**: email 필수 동의는 비즈니스 앱 전환 + 검수 필요(즉시 불가). 통과해도 기존 가입자 소급 안 됨 + email 없는 카카오 계정은 여전히 불가
+- **조치 (결정 2026-06-04)**:
+  - Phase 1 (BE, 우선): email 없으면 `{provider}_{providerId}@no-email.local` placeholder 생성 + 중복체크 가드(placeholder skip) + V62 백필(곽소영 등 기존 '' row)
+  - Phase 3 (FE): placeholder/빈 email 유저에게 이메일 등록 유도 + BE email 업데이트 API
+  - Phase 2 (추후): 카카오 비즈니스 앱 전환 → 이메일 필수 동의 검수 신청 (안전 강화, placeholder가 본질 해결)
+- **상태**: Phase 1 착수 예정 (삭제 API 통합테스트 완료 직후, gradle 충돌 방지 순차)
+
 ## 🟡 KI-006: 완료 처리 시 거래 자동 등록 + 상태 변경
 - **요청**: 지출 계획 완료 처리 시 거래 자동 등록 + COMPLETED 상태 전환
 - **현재**: FE/BE 코드 정상. NAS에 최신 FE 재배포 후 확인 필요

--- a/frontend/lib/core/utils/email_policy.dart
+++ b/frontend/lib/core/utils/email_policy.dart
@@ -1,0 +1,15 @@
+/// Email policy helpers — mirrors BE EmailPolicy.
+///
+/// Kakao users who did not consent to email sharing receive a placeholder
+/// address in the form `{provider}_{providerId}@no-email.local`.
+/// An empty string is also treated as "not registered".
+///
+/// All screens must use [isPlaceholderEmail] / [User.hasRegisteredEmail]
+/// from this single location — never inline the check.
+const String _placeholderSuffix = '@no-email.local';
+
+/// Returns true when [email] is a placeholder or empty, meaning the user
+/// has not registered a real email address.
+bool isPlaceholderEmail(String email) {
+  return email.isEmpty || email.endsWith(_placeholderSuffix);
+}

--- a/frontend/lib/core/widgets/main_shell_page.dart
+++ b/frontend/lib/core/widgets/main_shell_page.dart
@@ -51,6 +51,7 @@ class _MainShellPageState extends State<MainShellPage> {
     _previousIndex = widget.navigationShell.currentIndex;
     _connectWebSocketIfAuthenticated();
     _preloadCommonData();
+    _promptEmailRegistrationIfNeeded();
   }
 
   @override
@@ -68,6 +69,41 @@ class _MainShellPageState extends State<MainShellPage> {
     getIt<PaymentMethodBloc>().add(const LoadPaymentMethods());
     getIt<FavoritesBloc>().add(const LoadFavorites());
     getIt<CoupleBloc>().add(const LoadCouple());
+  }
+
+  /// Kakao users who did not consent to email sharing are stored with a
+  /// placeholder email. Prompt them once per shell entry to register a real
+  /// email (required for partner linking + account recovery).
+  void _promptEmailRegistrationIfNeeded() {
+    final authState = getIt<AuthBloc>().state;
+    if (authState is AuthAuthenticated && !authState.user.hasRegisteredEmail) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        showDialog<void>(
+          context: context,
+          builder: (dialogContext) => AlertDialog(
+            title: const Text('이메일 등록 안내'),
+            content: const Text(
+              '계정에 이메일이 등록되어 있지 않습니다.\n'
+              '파트너 연결과 계정 보호를 위해 이메일을 등록해 주세요.',
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.of(dialogContext).pop(),
+                child: const Text('나중에'),
+              ),
+              FilledButton(
+                onPressed: () {
+                  Navigator.of(dialogContext).pop();
+                  context.push('/settings/profile-edit');
+                },
+                child: const Text('이메일 등록'),
+              ),
+            ],
+          ),
+        );
+      });
+    }
   }
 
   Future<void> _connectWebSocketIfAuthenticated() async {

--- a/frontend/lib/features/auth/data/datasources/auth_remote_datasource.dart
+++ b/frontend/lib/features/auth/data/datasources/auth_remote_datasource.dart
@@ -9,6 +9,7 @@ abstract class AuthRemoteDataSource {
   Future<UserModel> getCurrentUser();
   Future<UserModel> updateProfile({
     String? nickname,
+    String? email,
     String? profileImageUrl,
     bool clearProfileImage = false,
   });
@@ -44,11 +45,13 @@ class AuthRemoteDataSourceImpl implements AuthRemoteDataSource {
   @override
   Future<UserModel> updateProfile({
     String? nickname,
+    String? email,
     String? profileImageUrl,
     bool clearProfileImage = false,
   }) async {
     final data = <String, dynamic>{};
     if (nickname != null) data['nickname'] = nickname;
+    if (email != null) data['email'] = email;
     if (profileImageUrl != null) data['profileImageUrl'] = profileImageUrl;
     if (clearProfileImage) data['clearProfileImage'] = true;
 

--- a/frontend/lib/features/auth/data/repositories/auth_repository_impl.dart
+++ b/frontend/lib/features/auth/data/repositories/auth_repository_impl.dart
@@ -1,5 +1,6 @@
 import 'package:dartz/dartz.dart';
 import 'package:dio/dio.dart';
+import 'package:budget_book/core/error/dio_error_mapper.dart';
 import 'package:budget_book/core/error/failure.dart';
 import 'package:budget_book/features/auth/data/datasources/auth_remote_datasource.dart';
 import 'package:budget_book/features/auth/domain/entities/user.dart';
@@ -48,23 +49,21 @@ class AuthRepositoryImpl implements AuthRepository {
   @override
   Future<Either<Failure, User>> updateProfile({
     String? nickname,
+    String? email,
     String? profileImageUrl,
     bool clearProfileImage = false,
   }) async {
     try {
       final result = await remoteDataSource.updateProfile(
         nickname: nickname,
+        email: email,
         profileImageUrl: profileImageUrl,
         clearProfileImage: clearProfileImage,
       );
       return Right(result);
     } on DioException catch (e) {
-      return Left(
-        ServerFailure(
-          e.response?.data?['error']?['message'] as String? ??
-              'Failed to update profile',
-        ),
-      );
+      // Use mapDioError to preserve the server error code (e.g. EMAIL_ALREADY_IN_USE).
+      return Left(mapDioError(e, 'Failed to update profile'));
     } catch (e) {
       return const Left(ServerFailure('Failed to update profile'));
     }

--- a/frontend/lib/features/auth/domain/entities/user.dart
+++ b/frontend/lib/features/auth/domain/entities/user.dart
@@ -1,4 +1,5 @@
 import 'package:equatable/equatable.dart';
+import 'package:budget_book/core/utils/email_policy.dart';
 
 class User extends Equatable {
   final String id;
@@ -20,6 +21,9 @@ class User extends Equatable {
     this.coupleId,
     required this.createdAt,
   });
+
+  /// Returns true when this user has a verified, non-placeholder email.
+  bool get hasRegisteredEmail => !isPlaceholderEmail(email);
 
   @override
   List<Object?> get props => [

--- a/frontend/lib/features/auth/domain/repositories/auth_repository.dart
+++ b/frontend/lib/features/auth/domain/repositories/auth_repository.dart
@@ -8,6 +8,7 @@ abstract class AuthRepository {
   Future<Either<Failure, User>> getCurrentUser();
   Future<Either<Failure, User>> updateProfile({
     String? nickname,
+    String? email,
     String? profileImageUrl,
     bool clearProfileImage = false,
   });

--- a/frontend/lib/features/auth/presentation/bloc/auth_bloc.dart
+++ b/frontend/lib/features/auth/presentation/bloc/auth_bloc.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:budget_book/core/error/failure.dart';
 import 'package:budget_book/core/storage/secure_storage.dart';
 import 'package:budget_book/core/utils/error_reporter.dart';
 import 'package:budget_book/features/auth/domain/repositories/auth_repository.dart';
@@ -136,11 +137,15 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
     try {
       final result = await authRepository.updateProfile(
         nickname: event.nickname,
+        email: event.email,
         profileImageUrl: event.profileImageUrl,
         clearProfileImage: event.clearProfileImage,
       );
       result.fold(
-        (failure) => emit(AuthError(failure.message)),
+        (failure) => emit(AuthError(
+          failure.message,
+          errorCode: failure is ServerFailure ? failure.code : null,
+        )),
         (user) => emit(AuthAuthenticated(user)),
       );
     } catch (e) {

--- a/frontend/lib/features/auth/presentation/bloc/auth_event.dart
+++ b/frontend/lib/features/auth/presentation/bloc/auth_event.dart
@@ -42,20 +42,22 @@ class AuthSessionExpired extends AuthEvent {
   const AuthSessionExpired();
 }
 
-/// Updates the current user's profile (nickname, profile image).
+/// Updates the current user's profile (nickname, email, profile image).
 class UpdateProfile extends AuthEvent {
   final String? nickname;
+  final String? email;
   final String? profileImageUrl;
   final bool clearProfileImage;
 
   const UpdateProfile({
     this.nickname,
+    this.email,
     this.profileImageUrl,
     this.clearProfileImage = false,
   });
 
   @override
-  List<Object?> get props => [nickname, profileImageUrl, clearProfileImage];
+  List<Object?> get props => [nickname, email, profileImageUrl, clearProfileImage];
 }
 
 /// Uploads a profile image from the given file bytes.

--- a/frontend/lib/features/auth/presentation/bloc/auth_state.dart
+++ b/frontend/lib/features/auth/presentation/bloc/auth_state.dart
@@ -37,8 +37,12 @@ class AuthUnauthenticated extends AuthState {
 class AuthError extends AuthState {
   final String message;
 
-  const AuthError(this.message);
+  /// Optional server error code (e.g. EMAIL_ALREADY_IN_USE, INVALID_EMAIL).
+  /// Populated when the repository returns a [ServerFailure] with a code.
+  final String? errorCode;
+
+  const AuthError(this.message, {this.errorCode});
 
   @override
-  List<Object?> get props => [message];
+  List<Object?> get props => [message, errorCode];
 }

--- a/frontend/lib/features/couple/presentation/bloc/couple_bloc.dart
+++ b/frontend/lib/features/couple/presentation/bloc/couple_bloc.dart
@@ -47,7 +47,10 @@ class CoupleBloc extends Bloc<CoupleEvent, CoupleState> {
       emit(const CoupleLoading());
       final result = await coupleRepository.createInvitation();
       result.fold(
-        (failure) => emit(CoupleError(failure.message)),
+        (failure) => emit(CoupleError(
+          failure.message,
+          errorCode: failure is ServerFailure ? failure.code : null,
+        )),
         (invitation) => emit(CoupleInvitationPending(invitation)),
       );
     } catch (_) {
@@ -63,7 +66,10 @@ class CoupleBloc extends Bloc<CoupleEvent, CoupleState> {
       emit(const CoupleLoading());
       final result = await coupleRepository.acceptInvitation(event.code);
       result.fold(
-        (failure) => emit(CoupleError(failure.message)),
+        (failure) => emit(CoupleError(
+          failure.message,
+          errorCode: failure is ServerFailure ? failure.code : null,
+        )),
         (couple) => emit(CoupleLinked(couple)),
       );
     } catch (_) {
@@ -122,7 +128,10 @@ class CoupleBloc extends Bloc<CoupleEvent, CoupleState> {
       emit(const CoupleLoading());
       final result = await coupleRepository.dissolveCouple();
       result.fold(
-        (failure) => emit(CoupleError(failure.message)),
+        (failure) => emit(CoupleError(
+          failure.message,
+          errorCode: failure is ServerFailure ? failure.code : null,
+        )),
         (_) => emit(const CoupleNotLinked()),
       );
     } catch (_) {

--- a/frontend/lib/features/couple/presentation/bloc/couple_state.dart
+++ b/frontend/lib/features/couple/presentation/bloc/couple_state.dart
@@ -51,8 +51,12 @@ class CoupleLinked extends CoupleState {
 class CoupleError extends CoupleState {
   final String message;
 
-  const CoupleError(this.message);
+  /// Optional server error code (e.g. EMAIL_REQUIRED_FOR_COUPLE) so the UI
+  /// can branch on specific failures instead of showing a generic message.
+  final String? errorCode;
+
+  const CoupleError(this.message, {this.errorCode});
 
   @override
-  List<Object?> get props => [message];
+  List<Object?> get props => [message, errorCode];
 }

--- a/frontend/lib/features/couple/presentation/pages/couple_page.dart
+++ b/frontend/lib/features/couple/presentation/pages/couple_page.dart
@@ -25,17 +25,49 @@ class _CouplePageState extends State<CouplePage> {
     super.dispose();
   }
 
+  /// Shown when the partner-link API rejects a placeholder-email user
+  /// (BE returns EMAIL_REQUIRED_FOR_COUPLE). Guides the user to register
+  /// a real email in the profile-edit screen before linking a partner.
+  void _showEmailRequiredDialog(BuildContext context) {
+    showDialog<void>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('이메일 등록 필요'),
+        content: const Text(
+          '파트너 연결 전 이메일 등록이 필요합니다.\n정보 수정 화면에서 이메일을 등록해 주세요.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(),
+            child: const Text('닫기'),
+          ),
+          FilledButton(
+            onPressed: () {
+              Navigator.of(dialogContext).pop();
+              context.push('/settings/profile-edit');
+            },
+            child: const Text('이메일 등록'),
+          ),
+        ],
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return BlocListener<CoupleBloc, CoupleState>(
       listener: (context, state) {
         if (state is CoupleError) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(
-              content: Text(state.message),
-              backgroundColor: Theme.of(context).colorScheme.error,
-            ),
-          );
+          if (state.errorCode == 'EMAIL_REQUIRED_FOR_COUPLE') {
+            _showEmailRequiredDialog(context);
+          } else {
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(
+                content: Text(state.message),
+                backgroundColor: Theme.of(context).colorScheme.error,
+              ),
+            );
+          }
         } else if (state is CoupleLinked) {
           // Refresh auth state to update coupleId so router guard is aware
           context.read<AuthBloc>().add(const AuthRefreshUser());

--- a/frontend/lib/features/settings/presentation/pages/profile_edit_page.dart
+++ b/frontend/lib/features/settings/presentation/pages/profile_edit_page.dart
@@ -3,7 +3,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 import 'package:image_picker/image_picker.dart';
-import 'package:budget_book/core/utils/email_policy.dart';
 import 'package:budget_book/features/auth/presentation/bloc/auth_bloc.dart';
 import 'package:budget_book/features/auth/presentation/bloc/auth_event.dart';
 import 'package:budget_book/features/auth/presentation/bloc/auth_state.dart';

--- a/frontend/lib/features/settings/presentation/pages/profile_edit_page.dart
+++ b/frontend/lib/features/settings/presentation/pages/profile_edit_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 import 'package:image_picker/image_picker.dart';
+import 'package:budget_book/core/utils/email_policy.dart';
 import 'package:budget_book/features/auth/presentation/bloc/auth_bloc.dart';
 import 'package:budget_book/features/auth/presentation/bloc/auth_event.dart';
 import 'package:budget_book/features/auth/presentation/bloc/auth_state.dart';
@@ -17,6 +18,10 @@ class ProfileEditPage extends StatefulWidget {
 class _ProfileEditPageState extends State<ProfileEditPage> {
   final _formKey = GlobalKey<FormState>();
   late final TextEditingController _nicknameController;
+  late final TextEditingController _emailController;
+  // Holds a server-side email error (e.g. EMAIL_ALREADY_IN_USE) so the
+  // validator can surface it inline on the next rebuild.
+  String? _emailServerError;
   bool _isSubmitting = false;
   bool _isUploadingImage = false;
 
@@ -24,38 +29,66 @@ class _ProfileEditPageState extends State<ProfileEditPage> {
   void initState() {
     super.initState();
     final authState = context.read<AuthBloc>().state;
-    final currentNickname =
-        authState is AuthAuthenticated ? authState.user.nickname : '';
-    _nicknameController = TextEditingController(text: currentNickname);
+    final user = authState is AuthAuthenticated ? authState.user : null;
+    _nicknameController = TextEditingController(text: user?.nickname ?? '');
+    // Treat placeholder addresses as empty so the field appears blank.
+    final initialEmail =
+        (user != null && user.hasRegisteredEmail) ? user.email : '';
+    _emailController = TextEditingController(text: initialEmail);
   }
 
   @override
   void dispose() {
     _nicknameController.dispose();
+    _emailController.dispose();
     super.dispose();
   }
 
+  /// Maps a server error code from [AuthError] to a user-visible Korean string.
+  String? _mapEmailServerErrorCode(String? code) {
+    switch (code) {
+      case 'EMAIL_ALREADY_IN_USE':
+        return '이미 사용 중인 이메일입니다';
+      case 'INVALID_EMAIL':
+        return '올바른 이메일을 입력해 주세요';
+      default:
+        return null;
+    }
+  }
+
   void _onSubmit() {
+    // Clear any previous server-side email error before revalidating.
+    setState(() => _emailServerError = null);
     if (!_formKey.currentState!.validate()) return;
+
     final newNickname = _nicknameController.text.trim();
+    final newEmailRaw = _emailController.text.trim();
+    // Treat empty input as "no change" for email (don't send empty string).
+    final newEmail = newEmailRaw.isEmpty ? null : newEmailRaw;
+
     final authBloc = context.read<AuthBloc>();
     final currentState = authBloc.state;
 
     // Short-circuit when nothing changed: bypass the BLoC so we don't rely on
     // state-transition semantics (BLoC drops emits when the state is equal).
     // Avoids the historical "infinite spinner" + router-race-condition class.
-    if (currentState is AuthAuthenticated &&
-        currentState.user.nickname == newNickname) {
-      final messenger = ScaffoldMessenger.of(context);
-      context.pop();
-      messenger.showSnackBar(
-        const SnackBar(content: Text('변경된 사항이 없습니다')),
-      );
-      return;
+    if (currentState is AuthAuthenticated) {
+      final user = currentState.user;
+      final currentEmail = user.hasRegisteredEmail ? user.email : null;
+      final nicknameUnchanged = user.nickname == newNickname;
+      final emailUnchanged = currentEmail == newEmail;
+      if (nicknameUnchanged && emailUnchanged) {
+        final messenger = ScaffoldMessenger.of(context);
+        context.pop();
+        messenger.showSnackBar(
+          const SnackBar(content: Text('변경된 사항이 없습니다')),
+        );
+        return;
+      }
     }
 
     setState(() => _isSubmitting = true);
-    authBloc.add(UpdateProfile(nickname: newNickname));
+    authBloc.add(UpdateProfile(nickname: newNickname, email: newEmail));
   }
 
   Future<void> _showImageOptions() async {
@@ -156,9 +189,17 @@ class _ProfileEditPageState extends State<ProfileEditPage> {
         } else if (state is AuthError) {
           if (_isSubmitting) {
             setState(() => _isSubmitting = false);
-            ScaffoldMessenger.of(context).showSnackBar(
-              SnackBar(content: Text('프로필 수정 실패: ${state.message}')),
-            );
+            // Check whether the error is a known email-field error so we can
+            // surface it inline rather than as a generic snackbar.
+            final emailInlineError = _mapEmailServerErrorCode(state.errorCode);
+            if (emailInlineError != null) {
+              setState(() => _emailServerError = emailInlineError);
+              _formKey.currentState?.validate();
+            } else {
+              ScaffoldMessenger.of(context).showSnackBar(
+                SnackBar(content: Text('프로필 수정 실패: ${state.message}')),
+              );
+            }
           }
           if (_isUploadingImage) {
             setState(() => _isUploadingImage = false);
@@ -246,6 +287,43 @@ class _ProfileEditPageState extends State<ProfileEditPage> {
                         }
                         if (value.trim().length > 50) {
                           return '닉네임은 50자 이내로 입력해주세요';
+                        }
+                        return null;
+                      },
+                    ),
+                    const SizedBox(height: 16),
+                    // Email field — shown for all users; Kakao users without
+                    // a registered email see an empty field with a helper hint.
+                    TextFormField(
+                      controller: _emailController,
+                      keyboardType: TextInputType.emailAddress,
+                      decoration: InputDecoration(
+                        labelText: '이메일',
+                        hintText: 'example@email.com',
+                        border: const OutlineInputBorder(),
+                        prefixIcon: const Icon(Icons.email_outlined),
+                        helperText: (user != null && !user.hasRegisteredEmail)
+                            ? '이메일을 등록해 주세요'
+                            : null,
+                        helperStyle: TextStyle(
+                          color: Theme.of(context).colorScheme.primary,
+                        ),
+                      ),
+                      validator: (value) {
+                        // Return the server-side error if one was set.
+                        if (_emailServerError != null) {
+                          return _emailServerError;
+                        }
+                        // Empty is allowed — means "no change".
+                        if (value == null || value.trim().isEmpty) {
+                          return null;
+                        }
+                        // Basic RFC 5322 local-part@domain format check.
+                        final emailRegex = RegExp(
+                          r'^[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}$',
+                        );
+                        if (!emailRegex.hasMatch(value.trim())) {
+                          return '올바른 이메일을 입력해 주세요';
                         }
                         return null;
                       },


### PR DESCRIPTION
## 개요
어드민 유저 완전 삭제 API와 카카오 placeholder email 정책을 추가합니다. 두 작업은 모두 user/email 도메인에 속해 한 PR로 묶었습니다.

## 1. 유저 완전 삭제 API (admin)
- `DELETE /api/v1/admin/users` — `email` + `confirm`(안전장치), ADMIN 전용 (`/api/v1/admin/**` 인가)
- `couples` CASCADE + `users` CASCADE + NO ACTION 자식 선삭제 — `information_schema`로 실측한 FK 순서 기반
- 가드: SYSTEM 계정 / 본인 / 다른 ADMIN / 배우자 있는 real couple 거부
- **Testcontainers 실 PostgreSQL 통합테스트**로 FK CASCADE 실검증 (H2 mock 한계 보완)

## 2. 카카오 placeholder email 정책 (auth/couple)
- **버그**: 카카오 email 미동의 → 빈 문자열 저장 → `NOT NULL UNIQUE` 충돌 + `findByEmail("")` 중복가입 오차단 (2번째 email-없는 카카오 가입 실패)
- **해결**: `{provider}_{providerId}@no-email.local` placeholder fallback + 중복체크 skip
- `EmailPolicy` 단일 소스 (생성/판별), `User.hasRealEmail()`
- **커플 연결 게이트**: placeholder 유저 초대 생성/수락 거부 (`EMAIL_REQUIRED_FOR_COUPLE`)
- **email 업데이트**: `PATCH /auth/me` (placeholder 직접입력/중복 거부)
- `V62` 기존 빈 email row 백필

## 3. FE
- 정보수정 화면 email 필드 (서버 에러 한국어 inline)
- 홈 진입 시 placeholder 유저 email 등록 유도 팝업 (1회)
- 커플 연결 시 `EMAIL_REQUIRED_FOR_COUPLE` 안내 + 정보수정 유도

## 검증
- BE: **901 테스트 통과** (실 PostgreSQL Testcontainers 통합테스트 7건 포함)
- FE: `flutter analyze` 0 issue + `flutter test` 통과
- ⚠️ **CI 주목**: `build.gradle.kts`에 macOS Docker Desktop 우회 설정(`api.version=1.44` 등) 추가됨 — 이 PR CI(ubuntu-latest)가 통합테스트를 통과하는지가 핵심 검증 포인트

## 배포 후 확인
- `V62` 백필로 기존 빈 email 계정(예: 곽소영)이 placeholder로 전환되는지 라이브 확인

## 후속 (별도)
- 카카오 비즈니스 앱 전환 + 이메일 필수 동의 검수 (placeholder가 그 전까지/이후 소급 안전망)
- 개인정보처리방침/약관 페이지 (검수 시 필요)

🤖 Generated with [Claude Code](https://claude.com/claude-code)