### PR TITLE
fix(infra): postgres autovacuum 임계치 하향 — 소형 테이블 죽은 튜플 자동 청소

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -2,6 +2,20 @@ services:
   postgres:
     image: postgres:16-alpine
     container_name: db_postgres_bb
+    # 소형·고빈도 UPDATE 테이블(users 등)이 글로벌 autovacuum 임계치(50 + 0.2*N)에
+    # 도달하지 못해 죽은 튜플/TOAST 블로트가 누적되던 문제(2026-06-05) 대응.
+    # 임계치를 낮춰 작은 테이블도 자동으로 vacuum/analyze 되도록 함.
+    # (프로덕션에는 ALTER SYSTEM 으로 이미 적용됨 — 본 설정은 재생성/신규 환경 대비 source of truth)
+    command:
+      - "postgres"
+      - "-c"
+      - "autovacuum_vacuum_threshold=10"
+      - "-c"
+      - "autovacuum_vacuum_scale_factor=0.05"
+      - "-c"
+      - "autovacuum_analyze_threshold=10"
+      - "-c"
+      - "autovacuum_analyze_scale_factor=0.05"
     ports:
       - "5433:5432"
     environment:


### PR DESCRIPTION
## 문제
`users` 테이블이 11행인데 432KB(TOAST 264KB) 차지. 원인 조사 결과 **소형·고빈도 UPDATE 테이블의 죽은 튜플(dead tuple)이 자동 청소되지 않고 누적**.

## 근본 원인
- 글로벌 autovacuum 트리거 = `50 + 0.2 × 행수`. 행이 적은 테이블(수십 행)은 이 임계치에 영원히 도달하지 못함
- 매 OAuth 로그인마다 `users` 를 UPDATE (특히 Kakao 프로필 썸네일 URL 회전) → TOAST 죽은 튜플 누적
- 전수 스캔 결과 공통 증상: `users`, `refresh_tokens`(dead 157%), `monthly_budgets`(133%), `transactions`(88 dead), `categories`(28) 등 — 대부분 `last_autovacuum` 비어있음

## 변경
글로벌 autovacuum 임계치 하향 → 모든 테이블(현재+미래, TOAST 포함) 자동 청소:
- `autovacuum_vacuum_threshold`: 50 → 10
- `autovacuum_vacuum_scale_factor`: 0.2 → 0.05
- `autovacuum_analyze_threshold`: 50 → 10
- `autovacuum_analyze_scale_factor`: 0.1 → 0.05

`infra/docker-compose.yml` postgres `command` 에 `-c` 옵션으로 박제 (재생성/신규 환경/로컬 dev 대비 source of truth).

## 적용 상태 (이미 라이브)
- **프로덕션**: `ALTER SYSTEM SET ... + pg_reload_conf()` 로 적용 완료 (무중단, `postgresql.auto.conf` 볼륨 영속). `pg_settings` source=`configuration file`, `pending_restart=f` 확인
- **기존 블로트 회수**: `users` 432KB→128KB (TOAST 264KB→0), 나머지 소형 테이블 `VACUUM (ANALYZE)` 로 죽은 튜플 전량 0
- 이 PR(infra compose)은 deploy-nas 가 DB 컨테이너를 재생성하지 않으므로 프로덕션 자동 반영 대상 아님 — 버전관리/재현용

## 코드(OAuth) 미변경 사유
`CustomOAuth2UserService` 의 로그인 시 save 는 Hibernate dirty checking 이 무변경 시 UPDATE 를 생략하고, 실제 변경(프로필 URL 회전)은 영속이 필요하므로 hot path 수정은 실익 없음. autovacuum 이 올바른 해결 메커니즘.

🤖 Generated with [Claude Code](https://claude.com/claude-code)