### PR TITLE
fix(nginx,fe): 모바일 main.dart.js stale 캐시로 계산기 아이콘 미노출 수정

### DIFF
--- a/frontend/test/core/widgets/calculator_amount_field_test.dart
+++ b/frontend/test/core/widgets/calculator_amount_field_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:budget_book/core/widgets/calculator_amount_field.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -61,6 +62,69 @@ void main() {
 
     test('negative result is allowed by evaluator (caller decides reject)', () {
       expect(eval('5-10'), -5);
+    });
+  });
+
+  // 2026-06-05 — 모바일(좁은 폭) 브라우저에서 계산기 아이콘 미노출 회귀 재현.
+  // 거래 폼은 suffixText '원' + prefixIcon payments 와 함께 CalculatorAmountField 를
+  // 쓴다. 좁은 폭에서 suffixIcon(계산기 Row)이 clip/offscreen 되는지 검증.
+  group('CalculatorAmountField widget — 계산기 아이콘 노출 (mobile width)', () {
+    Future<void> pumpField(WidgetTester tester, {String initial = ''}) async {
+      final controller = TextEditingController(text: initial);
+      addTearDown(controller.dispose);
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Padding(
+              padding: const EdgeInsets.all(16),
+              child: CalculatorAmountField(
+                controller: controller,
+                decoration: const InputDecoration(
+                  labelText: '금액',
+                  suffixText: '원',
+                  prefixIcon: Icon(Icons.payments),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('360px 폭 — 빈 금액(생성)에서 계산기 아이콘이 화면 안에 보인다',
+        (tester) async {
+      tester.view.physicalSize = const Size(360, 690);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      await pumpField(tester);
+
+      final icon = find.byIcon(Icons.calculate_outlined);
+      expect(icon, findsOneWidget);
+      final rect = tester.getRect(icon);
+      expect(rect.left, greaterThanOrEqualTo(0.0),
+          reason: '계산기 아이콘 왼쪽이 화면 밖(clip): $rect');
+      expect(rect.right, lessThanOrEqualTo(360.0),
+          reason: '계산기 아이콘 오른쪽이 화면 밖(clip): $rect');
+      expect(rect.width, greaterThan(0.0), reason: '아이콘 폭 0(collapse)');
+    });
+
+    testWidgets('360px 폭 — 금액 입력됨(수정)에서도 계산기 아이콘이 화면 안에 보인다',
+        (tester) async {
+      tester.view.physicalSize = const Size(360, 690);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      await pumpField(tester, initial: '1,000,000');
+
+      final icon = find.byIcon(Icons.calculate_outlined);
+      expect(icon, findsOneWidget);
+      final rect = tester.getRect(icon);
+      expect(rect.left, greaterThanOrEqualTo(0.0),
+          reason: '계산기 아이콘 왼쪽이 화면 밖(clip): $rect');
+      expect(rect.right, lessThanOrEqualTo(360.0),
+          reason: '계산기 아이콘 오른쪽이 화면 밖(clip): $rect');
     });
   });
 }

--- a/infra/nginx/aiva-bb.conf
+++ b/infra/nginx/aiva-bb.conf
@@ -1,0 +1,169 @@
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+
+    server_name aiva-bb.duckdns.org;
+
+    ssl_certificate /usr/syno/etc/certificate/_archive/AIVABB/fullchain.pem;
+    ssl_certificate_key /usr/syno/etc/certificate/_archive/AIVABB/privkey.pem;
+
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers HIGH:!aNULL:!MD5;
+
+    root /var/services/web_bb;
+    index index.html;
+
+    # API proxy
+    location ^~ /api/ {
+        proxy_connect_timeout 60;
+        proxy_read_timeout 60;
+        proxy_send_timeout 60;
+        proxy_intercept_errors off;
+        proxy_http_version 1.1;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_pass http://localhost:8081;
+    }
+
+    # OAuth2 proxy
+    location ^~ /oauth2/ {
+        proxy_connect_timeout 60;
+        proxy_read_timeout 60;
+        proxy_send_timeout 60;
+        proxy_intercept_errors off;
+        proxy_http_version 1.1;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_pass http://localhost:8081;
+    }
+
+    # Login OAuth2 callback
+    location ^~ /login/ {
+        proxy_connect_timeout 60;
+        proxy_read_timeout 60;
+        proxy_send_timeout 60;
+        proxy_intercept_errors off;
+        proxy_http_version 1.1;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_pass http://localhost:8081;
+    }
+
+    # Actuator
+    location ^~ /actuator/ {
+        proxy_pass http://localhost:8081;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+
+    # WebSocket
+    location ^~ /ws {
+        proxy_pass http://localhost:8081;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection upgrade;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+    # ── Override global gzip off (ssl.compress.conf) for static assets ──
+    # 관리: repo ops/nas-nginx/aiva-bb.conf (Phase 25 성능 회복)
+    # comp_level 4: NAS CPU 저사양에서 실시간 인코딩 부담 경감 (크기 차이 미미).
+    gzip on;
+    gzip_vary on;
+    gzip_min_length 1000;
+    gzip_comp_level 4;
+    gzip_proxied any;
+    gzip_types
+        text/plain
+        text/css
+        text/xml
+        text/javascript
+        application/javascript
+        application/x-javascript
+        application/json
+        application/xml
+        application/xml+rss
+        image/svg+xml
+        font/ttf
+        font/otf
+        font/woff
+        font/woff2
+        application/font-sfnt
+        application/vnd.ms-fontobject;
+
+    # ── Cache policy (Phase 25 Step 0.6) ──
+    # Flutter web 은 main.dart.js 파일명이 고정이라 브라우저가 stale 번들을
+    # 계속 서빙하는 문제가 있음. 엔트리 포인트만 no-cache 로 설정해 배포 즉시
+    # 새 버전 감지. ETag 기반 304 응답으로 실제 전송량은 최소화.
+    #
+    # location = /index.html 은 try_files 가 SPA fallback 으로 넘길 때
+    # 내부 재매칭되어 deep link 도 no-cache 헤더가 붙음.
+
+    location = /index.html {
+        add_header Cache-Control "no-cache, must-revalidate" always;
+        add_header Pragma "no-cache" always;
+    }
+
+    location ~ ^/(flutter_bootstrap\.js|flutter_service_worker\.js|version\.json)$ {
+        add_header Cache-Control "no-cache, must-revalidate" always;
+        add_header Pragma "no-cache" always;
+    }
+
+    # /assets 라우트 충돌 해소 (Phase 25 Step 2 — Flutter 라우트 vs 빌드 산출물 디렉터리)
+    # Flutter 빌드의 /assets/ 디렉터리는 정적 리소스 (이미지/폰트). 그대로 두면
+    # /assets → 301 → /assets/ → 403 디렉터리 접근 차단됨. exact match 로 override.
+    # /assets/<file> 는 `location /` try_files 로 기존대로 서빙 (변화 없음).
+    location = /assets {
+        add_header Cache-Control "no-cache, must-revalidate" always;
+        add_header Pragma "no-cache" always;
+        try_files /index.html =404;
+    }
+
+    # ── Static fonts — long-term cache + MIME override (P-6 재시도) ──
+    # 1차 시도(PR #153) 실패 원인:
+    #   - Flutter web asset URL 이 /assets/assets/fonts/ (중복 /assets/) 인데
+    #     location prefix 를 /assets/fonts/ 로 작성 → 매칭 실패
+    #   - nginx 가 .ttf 를 application/octet-stream 으로 서빙 → gzip_types
+    #     매칭 실패 → gzip 미적용 (10MB 원본 그대로 전송)
+    #
+    # 해결: 확장자 정규식으로 경로 독립 매칭 + MIME 강제 override 로 gzip 적용.
+    # immutable 캐시는 빌드 산출물이 변경 시 새 URL 이라 안전.
+    location ~* \.(ttf|otf|woff|woff2)$ {
+        types {
+            font/ttf ttf;
+            font/otf otf;
+            font/woff woff;
+            font/woff2 woff2;
+        }
+        add_header Cache-Control "public, max-age=31536000, immutable" always;
+        access_log off;
+        try_files $uri =404;
+    }
+
+    # SPA fallback
+    location / {
+        # 2026-06-05 — main.dart.js 등 content-hash 없는 번들이 위 no-cache
+        # 정규식(flutter_bootstrap/service_worker/version.json)에 빠져 stale
+        # 캐시되던 문제. 모바일 브라우저가 구버전 main.dart.js 를 잡고 있어 신규
+        # UI(계산기 아이콘 등)가 노출되지 않았음. hashless 산출물 전체를 no-cache
+        # 로 커버한다. 폰트(~* ttf/otf/woff)는 location 정규식 우선이라 immutable 유지.
+        add_header Cache-Control "no-cache, must-revalidate" always;
+        add_header Pragma "no-cache" always;
+        try_files $uri $uri/ /index.html;
+    }
+}
+
+server {
+    listen 80;
+    listen [::]:80;
+    server_name aiva-bb.duckdns.org;
+    return 301 https://$host$request_uri;
+}


### PR DESCRIPTION
## 증상
모바일(브라우저)에서 거래 생성/수정 시 금액 옆 **계산기 아이콘이 안 보임**. 웹(데스크탑)은 정상. 이전에도 아이콘 문제로 반복 발생.

## 근본 원인 (분석 확정)
- 코드/배포는 정상: 위젯 테스트 통과(360px에서 아이콘 화면 내 위치) + `main.dart.js` last-modified 최신
- nginx `aiva-bb.conf`의 no-cache 정규식(`flutter_bootstrap.js`/`flutter_service_worker.js`/`version.json`)에 **`main.dart.js`가 누락** → `location /`로 fallback되며 Cache-Control 헤더 부재 (curl 확인)
- → 모바일 브라우저가 구버전 `main.dart.js`를 heuristic 캐시 → 신규 UI(계산기 아이콘, V61) 미노출. 데스크탑은 캐시 갱신돼 정상. **배포마다 반복된 이유.**

## 수정
- `location /`에 `Cache-Control: no-cache, must-revalidate` 추가 — hashless 산출물 전체 커버, 폰트는 정규식 우선이라 immutable 유지
- **프로덕션 nginx 적용 완료** (reload 후 `main.dart.js` no-cache 확인). 이후 모든 배포가 모바일에 즉시 반영
- nginx conf가 git 미추적이었어 `infra/nginx/aiva-bb.conf`로 박제(source of truth)

## 회귀 방지
- `calculator_amount_field_test`에 모바일 폭(360px) 위젯 렌더 테스트 추가 — 기존엔 evaluator 단위 테스트만 있어 위젯 렌더 회귀를 못 잡았음

## 사용자 확인
이미 캐시된 모바일은 1회 강력 새로고침/시크릿 탭 필요. 이후 자동 반영.

🤖 Generated with [Claude Code](https://claude.com/claude-code)