### PR TITLE
feat(infra): 변경 감지(change-gated) DB 백업 스크립트

### DIFF
--- a/infra/scripts/db-backup.README.md
+++ b/infra/scripts/db-backup.README.md
@@ -1,0 +1,30 @@
+# DB 백업 — `db-backup.sh`
+
+aiva-bb 프로덕션 PostgreSQL(`db_postgres_bb`)의 **변경 감지(change-gated) 백업** 스크립트.
+
+## 동작
+매일 NAS cron 으로 실행. `pg_dump` 내용의 "지문"(fingerprint)이 직전 백업과 다를 때만 새 백업을 저장하고, 동일하면 기존 백업을 그대로 둔다 → **변경이 없으면 공간 낭비 0**.
+
+- **지문 계산**: plain SQL 덤프에서 `\restrict`/`\unrestrict` 줄(pg_dump 16.x 가 매 실행 삽입하는 랜덤 보안 토큰)을 제외하고 전체를 정렬한 뒤 `sha256`. 정렬이 COPY 행 순서 noise(heap 상태에 따라 변함)를 제거하므로, **논리적 데이터가 같으면 항상 같은 지문**이 된다. 스키마(마이그레이션) 변경 시에는 DDL 줄이 달라져 지문이 바뀌므로 자동으로 백업이 트리거된다.
+- **저장 위치**: `/volume2/bb-backups` — live 데이터(`/volume1`)와 물리 디스크 분리.
+- **보관**: 최근 30개 변경분(`RETENTION`). 초과분 자동 삭제.
+- **안전장치**: 덤프 실패/불완전(끝맺음 마커 없음) 시 기존 백업을 보존하고 종료(손상 덤프로 덮어쓰지 않음).
+- 오프사이트(클라우드) 복사는 미적용 — 추후 필요 시 rclone/Hyper Backup 추가.
+
+## 스케줄 (NAS cron)
+DSM 7 `/etc/crontab` 에 TAB 구분으로 등록(매일 04:00, root):
+```
+0	4	*	*	*	root	/volume1/docker/budget-book/infra/scripts/db-backup.sh >/dev/null 2>&1
+```
+편집 후 반영: `sudo synosystemctl restart crond`
+
+> NAS 의 `/etc/crontab` 은 repo 가 자동 동기화하지 않는다. 신규 NAS 셋업 시 위 줄을 직접 추가하거나 DSM Task Scheduler 로 등록할 것.
+
+## 복구
+```bash
+gunzip -c /volume2/bb-backups/budgetbook_YYYYMMDD_HHMMSS.sql.gz \
+  | sudo /usr/local/bin/docker exec -i db_postgres_bb psql -U budgetbook -d budgetbook
+```
+덤프는 `--clean --if-exists` 라 기존 객체를 drop 후 재생성한다. 빈 DB 로의 전체 복구도 안전(검증 완료: 11 users / 339 transactions / 122 categories 정확 복구).
+
+> 인덱스 생성 fsync 때문에 NAS 디스크에서 복구가 수십 초~분 단위로 걸릴 수 있다(정상).

--- a/infra/scripts/db-backup.sh
+++ b/infra/scripts/db-backup.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# db-backup.sh — change-gated PostgreSQL backup for budget-book (aiva-bb)
+#
+# 매일 NAS cron 으로 실행. pg_dump 내용 "지문"(전체 정렬 후 sha256)이 직전 백업과
+# 다를 때만 새 백업을 저장한다. 동일하면 기존 백업을 그대로 두어 공간 낭비를 막는다.
+#
+# 지문 원리: pg_dump plain 출력은 타임스탬프가 없어 거의 결정적이지만 두 가지 noise 가
+# 있다 — (1) COPY 데이터 행 순서가 heap 상태(UPDATE/autovacuum)에 따라 달라지고,
+# (2) pg_dump 16.x 는 보안용 \restrict / \unrestrict 메타커맨드를 매 실행 랜덤 토큰으로
+# 삽입한다. → restrict 줄을 제외하고 전체를 정렬하면, 논리적 데이터가 같으면 항상 같은
+# 지문이 된다. 스키마(마이그레이션) 변경 시 DDL 줄이 달라져 지문이 바뀌므로 자동 백업.
+# (\restrict 줄은 지문에서만 제외하고, 저장되는 백업 파일에는 그대로 보존한다.)
+#
+# 저장 위치: /volume2/bb-backups (live 데이터는 /volume1 → 디스크 분리)
+# 보관: 최근 N개 변경분만 (RETENTION)
+#
+# 복구:
+#   gunzip -c budgetbook_YYYYMMDD_HHMMSS.sql.gz \
+#     | sudo /usr/local/bin/docker exec -i db_postgres_bb psql -U budgetbook -d budgetbook
+#   (덤프는 --clean --if-exists 라 기존 객체를 drop 후 재생성. 빈 DB 복구도 안전.)
+
+set -euo pipefail
+
+# ── config ──
+CONTAINER="db_postgres_bb"
+DOCKER="/usr/local/bin/docker"
+DB="budgetbook"
+DB_USER="budgetbook"
+BACKUP_DIR="/volume2/bb-backups"
+RETENTION=30
+
+# root 면 docker 직접, 아니면 sudo -n (cron 이 admin 으로 돌 때 대비)
+if [ "$(id -u)" = "0" ]; then
+  DEXEC="$DOCKER"
+else
+  DEXEC="sudo -n $DOCKER"
+fi
+
+LOG="${BACKUP_DIR}/backup.log"
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*" >> "$LOG"; }
+
+mkdir -p "$BACKUP_DIR"
+
+TMP="$(mktemp /tmp/bb_dump.XXXXXX.sql)"
+trap 'rm -f "$TMP"' EXIT
+
+# ── 1) dump (plain SQL) ──
+if ! $DEXEC exec "$CONTAINER" pg_dump -U "$DB_USER" \
+      --clean --if-exists --no-owner --no-privileges "$DB" > "$TMP" 2>>"$LOG"; then
+  log "ERROR: pg_dump 실패 — 기존 백업 보존, 종료"
+  exit 1
+fi
+
+# 덤프 완결성 가드: 끝맺음 마커 없으면 손상/중단으로 보고 기존 백업 보존
+if [ ! -s "$TMP" ] || ! grep -q "PostgreSQL database dump complete" "$TMP"; then
+  log "ERROR: 덤프 불완전(빈 파일/미완료) — 기존 백업 보존, 종료"
+  exit 1
+fi
+
+# ── 2) 내용 지문 (\restrict 제외 + 전체 정렬 sha256 → 행순서·랜덤토큰 noise 제거) ──
+FP="$(grep -vE '^\\(un)?restrict ' "$TMP" | LC_ALL=C sort | sha256sum | awk '{print $1}')"
+LAST_FILE="${BACKUP_DIR}/latest.sha256"
+LAST="$(cat "$LAST_FILE" 2>/dev/null || echo '')"
+
+if [ "$FP" = "$LAST" ]; then
+  log "no change (fp=${FP:0:12}) — 백업 스킵"
+  exit 0
+fi
+
+# ── 3) 변경 감지 → gzip 저장 + 지문 갱신 ──
+TS="$(date '+%Y%m%d_%H%M%S')"
+OUT="${BACKUP_DIR}/budgetbook_${TS}.sql.gz"
+gzip -c "$TMP" > "$OUT"
+echo "$FP" > "$LAST_FILE"
+log "backup 생성: $(basename "$OUT") ($(du -h "$OUT" | awk '{print $1}'), fp=${FP:0:12})"
+
+# ── 4) 보관: 최근 RETENTION 개 변경분만 유지 ──
+ls -1t "${BACKUP_DIR}"/budgetbook_*.sql.gz 2>/dev/null | tail -n +$((RETENTION + 1)) | while read -r old; do
+  rm -f "$old" && log "보관초과 삭제: $(basename "$old")"
+done
+
+exit 0


### PR DESCRIPTION
## 문제
프로덕션 DB(aiva-bb)에 **백업이 전무**. 데이터 디렉토리(`/volume1/docker/postgres_bb`) 소실 시 복구 수단 0.

## 변경
변경 감지(change-gated) 백업 — `pg_dump` 지문이 직전 백업과 다를 때만 새 백업 저장(변경 없으면 공간 낭비 0).

- `infra/scripts/db-backup.sh` — 매일 04:00 NAS cron
  - **지문** = pg_dump plain 에서 `\restrict` 줄(pg_dump 16.x 매 실행 랜덤 보안토큰) 제외 + 전체 정렬 `sha256`. COPY 행순서 noise 제거 → 동일 데이터면 동일 지문. 스키마 변경 시 자동 트리거.
  - `/volume2/bb-backups` 저장 (live `/volume1` 과 디스크 분리), 최근 30개 보관
  - 덤프 실패/불완전 시 기존 백업 보존(손상 덮어쓰기 방지)
- `infra/scripts/db-backup.README.md` — 동작·스케줄·복구 문서

## 설계 노트
- "dump 해시 비교"의 함정: pg_dump 출력은 동일 데이터라도 (1) COPY 행순서, (2) pg_dump 16.x `\restrict` 랜덤토큰 때문에 매번 달라짐 → 두 덤프 sort 후 diff 로 원인 측정 후 해결
- restic/borg 대신 무설치 해시 게이트 선택(이 규모엔 적정). 오프사이트는 추후.

## 검증 (프로덕션 라이브)
- ✅ 생성 → 재실행 시 "no change 스킵", 파일 1개 유지(지문 안정)
- ✅ scratch DB 전체 복구 실증: **11 users / 339 transactions / 122 categories** 프로덕션과 정확 일치
- ✅ `/etc/crontab` 등록(TAB, root, 04:00) + `synosystemctl restart crond`, crond active

## 비고
NAS `/etc/crontab` 은 deploy 가 자동 동기화하지 않음 — 본 PR 은 스크립트/문서의 버전관리. 프로덕션 스크립트·cron 은 이미 배포·등록 완료.

🤖 Generated with [Claude Code](https://claude.com/claude-code)