### PR TITLE
fix(transaction): 다른 달 거래 등록 시 해당 달 포커싱 + 중복 등록 차단

### DIFF
--- a/frontend/lib/features/transaction/presentation/bloc/transaction_bloc.dart
+++ b/frontend/lib/features/transaction/presentation/bloc/transaction_bloc.dart
@@ -61,6 +61,22 @@ class TransactionBloc extends Bloc<TransactionEvent, TransactionState> {
   int get currentYear => _currentYear;
   int get currentMonth => _currentMonth;
 
+  /// 생성/수정 in-flight 가드.
+  /// 응답 지연 중 사용자가 등록 버튼을 다시 눌러도(폼 15초 타임아웃이 버튼을
+  /// 재활성화) 같은 요청이 진행 중이면 중복 이벤트를 drop → 중복 거래 생성 방지.
+  /// flutter_bloc 기본 concurrent 처리에서 두 번째 핸들러가 이 플래그를 보고 멈춘다.
+  bool _isMutating = false;
+
+  /// 거래 날짜('yyyy-MM-dd')의 연/월. 등록/수정 후 해당 거래의 달로 포커싱하기
+  /// 위해 사용. 파싱 실패/미지정 시 현재 포커스 월 유지.
+  ({int year, int month}) _focusMonthFor(String? transactionDate) {
+    if (transactionDate != null) {
+      final d = DateTime.tryParse(transactionDate);
+      if (d != null) return (year: d.year, month: d.month);
+    }
+    return (year: _currentYear, month: _currentMonth);
+  }
+
   TransactionBloc({required this.transactionRepository, this.statisticsRepository})
       : super(const TransactionInitial()) {
     on<LoadTransactions>(_onLoadTransactions);
@@ -310,6 +326,9 @@ class TransactionBloc extends Bloc<TransactionEvent, TransactionState> {
     CreateTransaction event,
     Emitter<TransactionState> emit,
   ) async {
+    // 중복 등록 방지: 같은 생성/수정이 진행 중이면 즉시 drop.
+    if (_isMutating) return;
+    _isMutating = true;
     try {
       final result = await transactionRepository.createTransaction(
         type: event.type,
@@ -322,11 +341,15 @@ class TransactionBloc extends Bloc<TransactionEvent, TransactionState> {
         pocketId: event.pocketId,
         needsReview: event.needsReview,
       );
+      // 등록 성공 후에는 **방금 등록한 거래의 달**로 재조회해야 한다.
+      // (이전: _currentYear/_currentMonth = 보고 있던 달 → 다른 달 거래 등록 시
+      //  목록은 이전 달만 보이고 신규 거래가 사라지던 버그)
+      final focus = _focusMonthFor(event.transactionDate);
       result.fold(
         (failure) => emit(TransactionError(failure.message)),
         (_) => add(LoadTransactions(
-              year: _currentYear,
-              month: _currentMonth,
+              year: focus.year,
+              month: focus.month,
               keyword: _currentKeyword,
               categoryId: _currentCategoryId,
               categoryIds: _currentCategoryIds,
@@ -361,6 +384,8 @@ class TransactionBloc extends Bloc<TransactionEvent, TransactionState> {
       } else {
         emit(const TransactionError('예기치 않은 오류가 발생했습니다'));
       }
+    } finally {
+      _isMutating = false;
     }
   }
 
@@ -368,6 +393,9 @@ class TransactionBloc extends Bloc<TransactionEvent, TransactionState> {
     UpdateTransaction event,
     Emitter<TransactionState> emit,
   ) async {
+    // 중복 수정 방지: 같은 생성/수정이 진행 중이면 즉시 drop.
+    if (_isMutating) return;
+    _isMutating = true;
     try {
       final result = await transactionRepository.updateTransaction(
         id: event.id,
@@ -381,11 +409,15 @@ class TransactionBloc extends Bloc<TransactionEvent, TransactionState> {
         pocketId: event.pocketId,
         needsReview: event.needsReview,
       );
+      // 수정 성공 후에는 **수정된 거래의 달**로 재조회 (날짜를 다른 달로 옮긴
+      // 경우 목록/네비게이터가 그 달을 가리키도록). transactionDate 미변경
+      // (null) 이면 현재 포커스 월 유지.
+      final focus = _focusMonthFor(event.transactionDate);
       result.fold(
         (failure) => emit(TransactionError(failure.message)),
         (_) => add(LoadTransactions(
-              year: _currentYear,
-              month: _currentMonth,
+              year: focus.year,
+              month: focus.month,
               keyword: _currentKeyword,
               categoryId: _currentCategoryId,
               categoryIds: _currentCategoryIds,
@@ -420,6 +452,8 @@ class TransactionBloc extends Bloc<TransactionEvent, TransactionState> {
       } else {
         emit(const TransactionError('예기치 않은 오류가 발생했습니다'));
       }
+    } finally {
+      _isMutating = false;
     }
   }
 

--- a/frontend/lib/features/transaction/presentation/pages/transaction_form_page.dart
+++ b/frontend/lib/features/transaction/presentation/pages/transaction_form_page.dart
@@ -556,11 +556,14 @@ class _TransactionFormPageState extends State<TransactionFormPage>
             } else if (state is TransactionLoaded) {
               _submitTimeoutTimer?.cancel();
               _isSubmitting = false;
-              // 회차 12 P2 Phase A — 거래 등록 후 dashboard reload 시 사용자가 보던
-              // month 유지 (MonthCubit). 이전: now 강제로 다른 월 보던 사용자에게
-              // 현재월 dashboard 가 표시되어 sync 깨짐.
-              final monthState = getIt<MonthCubit>().state;
-              getIt<DashboardBloc>().add(LoadDashboard(year: monthState.year, month: monthState.month));
+              // 등록/수정한 거래의 달로 전역 포커스 이동.
+              // state.year/month = 방금 등록/수정한 거래의 달 (TransactionBloc 가
+              // 거래 날짜 기준으로 재조회). MonthCubit 을 맞춰 네비게이터 + 모든
+              // 월 의존 뷰를 동기화 → "다른 달 등록 시 이전 달만 보임"(버그1) 및
+              // "달력 6월 / 내역 5월" 불일치(버그2)를 함께 해소.
+              // 같은 달이면 changeMonth 는 no-op 이므로 아래 명시 reload 유지.
+              getIt<MonthCubit>().changeMonth(state.year, state.month);
+              getIt<DashboardBloc>().add(LoadDashboard(year: state.year, month: state.month));
               getIt<PaymentMethodBloc>().add(const LoadPaymentMethods());
               if (_continueMode) {
                 _resetFormForContinue();

--- a/frontend/lib/features/transfer/presentation/bloc/transfer_bloc.dart
+++ b/frontend/lib/features/transfer/presentation/bloc/transfer_bloc.dart
@@ -10,6 +10,10 @@ class TransferBloc extends Bloc<TransferEvent, TransferState> {
   int _currentYear = DateTime.now().year;
   int _currentMonth = DateTime.now().month;
 
+  /// 생성/수정 in-flight 가드 — 응답 지연 중 연타로 인한 중복 이체 생성 방지.
+  /// (거래 등록 중복 방지와 동일 패턴: TransactionBloc._isMutating)
+  bool _isMutating = false;
+
   TransferBloc({required this.transferRepository})
       : super(const TransferInitial()) {
     on<LoadTransfers>(_onLoadTransfers);
@@ -65,6 +69,9 @@ class TransferBloc extends Bloc<TransferEvent, TransferState> {
     Emitter<TransferState> emit,
   ) async {
     debugPrint('[TransferBloc] createTransfer: source=${event.sourcePaymentMethodId}, dest=${event.destinationPaymentMethodId}, amount=${event.amount}, date=${event.transferDate}');
+    // 중복 이체 방지: 같은 생성/수정이 진행 중이면 즉시 drop.
+    if (_isMutating) return;
+    _isMutating = true;
     try {
       final result = await transferRepository.createTransfer(
         sourcePaymentMethodId: event.sourcePaymentMethodId,
@@ -98,6 +105,8 @@ class TransferBloc extends Bloc<TransferEvent, TransferState> {
     } catch (e) {
       debugPrint('[TransferBloc] createTransfer EXCEPTION: $e');
       emit(const TransferError('예기치 않은 오류가 발생했습니다'));
+    } finally {
+      _isMutating = false;
     }
   }
 
@@ -105,6 +114,9 @@ class TransferBloc extends Bloc<TransferEvent, TransferState> {
     UpdateTransfer event,
     Emitter<TransferState> emit,
   ) async {
+    // 중복 수정 방지: 같은 생성/수정이 진행 중이면 즉시 drop.
+    if (_isMutating) return;
+    _isMutating = true;
     try {
       final result = await transferRepository.updateTransfer(
         id: event.id,
@@ -136,6 +148,8 @@ class TransferBloc extends Bloc<TransferEvent, TransferState> {
       );
     } catch (e) {
       emit(const TransferError('예기치 않은 오류가 발생했습니다'));
+    } finally {
+      _isMutating = false;
     }
   }
 

--- a/frontend/test/features/transaction/presentation/bloc/transaction_bloc_test.dart
+++ b/frontend/test/features/transaction/presentation/bloc/transaction_bloc_test.dart
@@ -378,6 +378,96 @@ void main() {
           )).called(1);
         },
       );
+
+      // 버그1 회귀: 보고 있던 달과 다른 달의 거래를 등록하면, 재조회는
+      // **등록한 거래의 달**로 이뤄져야 한다 (이전: 보고 있던 달로 재조회 →
+      // 신규 거래가 목록에 안 보임).
+      blocTest<TransactionBloc, TransactionState>(
+        'reloads the created transaction\'s month, not the viewed month',
+        build: () {
+          when(mockRepository.createTransaction(
+            type: 'EXPENSE',
+            amount: 15000,
+            description: '점심 식사',
+            categoryId: 'cat-1',
+            transactionDate: '2024-06-10',
+            memo: null,
+          )).thenAnswer((_) async => Right(tTransaction1));
+          when(mockRepository.getTransactions(
+            year: anyNamed('year'),
+            month: anyNamed('month'),
+            size: 30,
+          )).thenAnswer((_) async => Right(tPageResponse));
+          return transactionBloc;
+        },
+        act: (bloc) {
+          // 5월을 보던 중 (currentYear/Month = 2024/5)
+          bloc.add(const LoadTransactions(year: 2024, month: 5));
+          // 6월 거래 등록
+          bloc.add(const CreateTransaction(
+            type: 'EXPENSE',
+            amount: 15000,
+            description: '점심 식사',
+            categoryId: 'cat-1',
+            transactionDate: '2024-06-10',
+          ));
+        },
+        verify: (_) {
+          // 재조회가 6월로 이뤄졌는지 (5월 아님)
+          verify(mockRepository.getTransactions(
+            year: 2024,
+            month: 6,
+            size: 30,
+          )).called(1);
+        },
+      );
+
+      // 버그3 회귀: 응답 지연 중 중복 등록 이벤트가 들어와도 1건만 생성.
+      blocTest<TransactionBloc, TransactionState>(
+        'drops duplicate create events while one is in-flight',
+        build: () {
+          when(mockRepository.createTransaction(
+            type: 'EXPENSE',
+            amount: 15000,
+            description: '점심 식사',
+            categoryId: 'cat-1',
+            transactionDate: '2024-01-15',
+            memo: null,
+          )).thenAnswer((_) async {
+            // 응답 지연 시뮬레이션 — 두 번째 이벤트가 in-flight 중 도착하도록.
+            await Future<void>.delayed(const Duration(milliseconds: 50));
+            return Right(tTransaction1);
+          });
+          when(mockRepository.getTransactions(
+            year: anyNamed('year'),
+            month: anyNamed('month'),
+            size: 30,
+          )).thenAnswer((_) async => Right(tPageResponse));
+          return transactionBloc;
+        },
+        act: (bloc) {
+          const event = CreateTransaction(
+            type: 'EXPENSE',
+            amount: 15000,
+            description: '점심 식사',
+            categoryId: 'cat-1',
+            transactionDate: '2024-01-15',
+          );
+          bloc.add(event);
+          bloc.add(event); // 연타 — in-flight 중이면 drop 되어야 함
+        },
+        wait: const Duration(milliseconds: 100),
+        verify: (_) {
+          verify(mockRepository.createTransaction(
+            type: 'EXPENSE',
+            amount: 15000,
+            description: '점심 식사',
+            categoryId: 'cat-1',
+            transactionDate: '2024-01-15',
+            memo: null,
+          )).called(1); // 2번이 아니라 1번만 호출
+        },
+      );
     });
 
     group('DeleteTransaction', () {


### PR DESCRIPTION
## 문제 (사용자 보고)

1. **다른 달 거래 등록 시 이전 달만 보임** — 5월로 이동 후 6월 거래를 등록하면 5월 거래만 보이고 방금 등록한 6월 거래가 사라짐. (입력 거래로 자동 포커싱되어야 함)
2. **네비게이터/목록 월 불일치** — 어떤 플로우에서 상단 달력(월 네비게이터)은 6월인데 거래 내역은 5월로 나옴.
3. **응답 지연 시 중복 등록** — 등록 응답이 지연될 때 버튼을 누른 횟수만큼 거래가 중복 생성됨.

## 근본 원인

- **버그1**: `_onCreateTransaction`/`_onUpdateTransaction`이 등록 성공 후 재조회를 `_currentYear/_currentMonth`(보고 있던 달)로 하면서 `scrollToDate`만 신규 거래 날짜로 지정 → 다른 달이면 목록에 없어 안 보임.
- **버그2**: 월 네비게이터는 `MonthCubit`, 목록/달력은 `TransactionLoaded.month`를 각각 따르는데 등록/수정·라우터 재조회가 BLoC만 갱신하고 `MonthCubit`은 안 건드려 두 소스가 drift.
- **버그3**: 폼의 15초 타임아웃이 요청 in-flight 중 등록 버튼을 재활성화 → 재클릭 시 중복 `CreateTransaction`. BLoC에 in-flight 중복 차단 장치 없음.

## 수정

- `transaction_bloc.dart` — 등록/수정 재조회를 **거래 날짜의 달**(`event.transactionDate` 파싱)로 변경. `_isMutating` in-flight 가드 추가로 진행 중 중복 이벤트 drop.
- `transaction_form_page.dart` — 성공 리스너에서 `MonthCubit.changeMonth(거래의 달)`로 전역 월 포커스 동기화 (네비게이터 + 모든 월 의존 뷰가 함께 이동).
- `transfer_bloc.dart` — 동일 in-flight 가드를 이체 생성/수정에도 적용 (공통 적용 범위 원칙).

## 검증

- ✅ `flutter analyze --no-fatal-infos --no-congratulate` (전체) — 신규 이슈 0
- ✅ `flutter test` — 740/740 통과 (회귀 테스트 2건 추가: 등록 달 포커싱, 중복 drop)
- ✅ `flutter build web --release` 성공
- 영향 범위 전수 확인: `CreateTransaction`/`UpdateTransaction` 전 dispatch 사이트(폼·잔액조정 시트·날짜이동 다이얼로그) 모두 단건/모달 순차 → 가드 안전. 일괄 CSV 임포트는 Dio 직접 호출이라 미영향.

라이브 검증(다른 달 등록→해당 달 표시·네비 일치, 수정 시 날짜 이동, 지연 중 연타→1건)은 배포 후 확인 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
