### PR TITLE
fix(transaction): 새로고침/등록 후 달력·내역 월 불일치(이중 소스 drift) 해소

### DIFF
--- a/frontend/lib/core/router/app_router.dart
+++ b/frontend/lib/core/router/app_router.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
+import 'package:budget_book/core/bloc/month_cubit.dart';
 import 'package:budget_book/core/di/injection.dart';
 import 'package:budget_book/core/widgets/main_shell_page.dart';
 import 'package:budget_book/core/websocket/websocket_bloc.dart';
@@ -395,11 +396,21 @@ GoRouter createAppRouter(AuthBloc authBloc) => GoRouter(
                     visibility: f.visibility,
                   ));
                   transferBloc.add(LoadTransfers(year: year, month: month));
+                  // 이중 소스 동기화: 목록(TransactionBloc)을 URL year/month 로
+                  // 로드할 때 상단 월 네비게이터(MonthCubit)도 같은 달로 맞춘다.
+                  // 누락 시 "달력 6월 / 내역 5월" drift (새로고침·북마크·뒤로가기).
+                  // 같은 달이면 changeMonth 는 no-op (불필요한 reload 없음).
+                  getIt<MonthCubit>().changeMonth(year, month);
                 }
-                // Also load transfers if TransferBloc hasn't loaded yet
+                // Also load transfers if TransferBloc hasn't loaded yet.
+                // URL 에 year/month 가 있으면 그 달을 사용 (없을 때만 now).
+                // 누락 시 새로고침에서 transfers 만 now(현재 달) 로 빠져
+                // "내역 5월 / 이체 6월" drift 발생 (network trace 확인).
                 if (transferBloc.state is TransferInitial) {
                   final now = DateTime.now();
-                  transferBloc.add(LoadTransfers(year: now.year, month: now.month));
+                  final ty = int.tryParse(yearParam ?? '') ?? now.year;
+                  final tm = int.tryParse(monthParam ?? '') ?? now.month;
+                  transferBloc.add(LoadTransfers(year: ty, month: tm));
                 }
                 return MultiBlocProvider(
                   providers: [

--- a/frontend/lib/features/payment_method/presentation/bloc/payment_method_bloc.dart
+++ b/frontend/lib/features/payment_method/presentation/bloc/payment_method_bloc.dart
@@ -9,6 +9,15 @@ class PaymentMethodBloc
     extends Bloc<PaymentMethodEvent, PaymentMethodState> {
   final PaymentMethodRepository paymentMethodRepository;
 
+  /// 마지막으로 명시적으로 조회한 카드정산 요약의 달.
+  /// `LoadPaymentMethods` 의 auto-load 가 now() 하드코딩 대신 이 값을 재사용해,
+  /// 새로고침/파트너 동기화 시 선택한 달(예: 5월) 정산이 현재 달(6월) 로
+  /// 덮이는 wrong-month drift 를 방지 (network trace 확인, 2026-06-12).
+  /// MonthSyncHandler 가 changeMonth 직후 LoadCardSettlementSummary(선택달) 를
+  /// 큐잉하므로, 네트워크 왕복 뒤 발화하는 auto-load 시점엔 이 값이 갱신돼 있다.
+  int? _lastSettlementYear;
+  int? _lastSettlementMonth;
+
   PaymentMethodBloc({required this.paymentMethodRepository})
       : super(const PaymentMethodInitial()) {
     on<LoadPaymentMethods>(_onLoadPaymentMethods);
@@ -60,10 +69,15 @@ class PaymentMethodBloc
             cardPendings: currentLoaded?.cardPendings,
             cardSettlementSummary: currentLoaded?.cardSettlementSummary,
           ));
-          // Auto-load card settlement summary if credit cards exist
+          // Auto-load card settlement summary if credit cards exist.
+          // 선택한 달(마지막 조회 달) 기준으로 — now() 하드코딩 시 새로고침에서
+          // 선택 달 대신 현재 달 정산이 로드되는 drift 발생 (위 필드 주석 참고).
           if (methods.any((pm) => pm.isCredit)) {
             final now = DateTime.now();
-            add(LoadCardSettlementSummary(year: now.year, month: now.month));
+            add(LoadCardSettlementSummary(
+              year: _lastSettlementYear ?? now.year,
+              month: _lastSettlementMonth ?? now.month,
+            ));
           }
         },
       );
@@ -252,6 +266,13 @@ class PaymentMethodBloc
     LoadCardSettlementSummary event,
     Emitter<PaymentMethodState> emit,
   ) async {
+    // 명시적으로 달을 지정해 조회하면 기억 → 이후 auto-load 가 재사용.
+    // await 이전(핸들러 진입)에 세팅해야 동시 처리되는 LoadPaymentMethods 의
+    // auto-load 가 올바른 달을 읽는다.
+    if (event.year != null && event.month != null) {
+      _lastSettlementYear = event.year;
+      _lastSettlementMonth = event.month;
+    }
     try {
       final currentMethods = state is PaymentMethodLoaded
           ? (state as PaymentMethodLoaded).paymentMethods

--- a/frontend/lib/features/transaction/presentation/pages/transaction_form_page.dart
+++ b/frontend/lib/features/transaction/presentation/pages/transaction_form_page.dart
@@ -120,6 +120,11 @@ class _TransactionFormPageState extends State<TransactionFormPage>
   bool _isSubmitting = false;
   bool _continueMode = false;
   bool _keepSameItems = false;
+  /// 이 폼 세션에서 마지막으로 저장 성공한 거래의 달.
+  /// continue 모드로 등록 후 뒤로가기로 폼을 나갈 때, stale URL 로 복귀해
+  /// 목록이 이전 달로 돌아가는 drift 를 막기 위해 등록한 달로 이동한다.
+  int? _savedYear;
+  int? _savedMonth;
   /// V61 (2026-05-06) — 사용자가 "확인/입력 필요" 로 마킹한 거래 여부.
   bool _needsReview = false;
   String? _categoryError;
@@ -565,6 +570,9 @@ class _TransactionFormPageState extends State<TransactionFormPage>
               getIt<MonthCubit>().changeMonth(state.year, state.month);
               getIt<DashboardBloc>().add(LoadDashboard(year: state.year, month: state.month));
               getIt<PaymentMethodBloc>().add(const LoadPaymentMethods());
+              // 등록/수정한 거래의 달을 기록 → continue 모드 뒤로가기 시 이 달로 복귀.
+              _savedYear = state.year;
+              _savedMonth = state.month;
               if (_continueMode) {
                 _resetFormForContinue();
               } else if (isEditing) {
@@ -572,7 +580,9 @@ class _TransactionFormPageState extends State<TransactionFormPage>
                 // to avoid stale edit page in browser history
                 context.go('/transactions?year=${state.year}&month=${state.month}');
               } else {
-                context.pop();
+                // 등록 월을 URL 에 실어 복귀 → 라우터가 목록/달력을 모두 그 달로
+                // 동기화 (pop 으로 stale URL 복귀 시 발생하던 drift 방지).
+                context.go('/transactions?year=${state.year}&month=${state.month}');
               }
             } else if (state is TransactionError) {
               _submitTimeoutTimer?.cancel();
@@ -623,9 +633,18 @@ class _TransactionFormPageState extends State<TransactionFormPage>
           },
         ),
       ],
-      child: Scaffold(
-        appBar: AppBar(
-          title: Text(isEditing ? '거래 수정' : '거래 추가'),
+      // continue 모드로 거래를 등록한 뒤 뒤로가기로 폼을 나가면, 진입 전의
+      // stale URL (이전 달) 로 복귀해 목록이 이전 달로 돌아가는 drift 가 발생.
+      // 저장 이력이 있으면 pop 을 가로채 등록한 달의 목록 URL 로 이동한다.
+      child: PopScope(
+        canPop: _savedYear == null,
+        onPopInvokedWithResult: (didPop, _) {
+          if (didPop || _savedYear == null) return;
+          context.go('/transactions?year=$_savedYear&month=$_savedMonth');
+        },
+        child: Scaffold(
+          appBar: AppBar(
+            title: Text(isEditing ? '거래 수정' : '거래 추가'),
           actions: [
             if (isEditing)
               IconButton(
@@ -688,6 +707,7 @@ class _TransactionFormPageState extends State<TransactionFormPage>
                   _buildTransferFormBody(context),
                 ],
               ),
+      ),
       ),
     );
   }

--- a/frontend/test/features/payment_method/presentation/bloc/payment_method_bloc_test.dart
+++ b/frontend/test/features/payment_method/presentation/bloc/payment_method_bloc_test.dart
@@ -230,6 +230,38 @@ void main() {
         ],
       );
 
+      // 회귀 (2026-06-12) — auto-load 가 now() 가 아닌 마지막으로 명시 조회한
+      // 달을 재사용해야 새로고침/동기화 시 선택 달 정산이 현재 달로 덮이지 않음.
+      blocTest<PaymentMethodBloc, PaymentMethodState>(
+        'auto-load reuses last explicitly-requested settlement month '
+        '(not now)',
+        build: () {
+          when(mockRepository.getPaymentMethods())
+              .thenAnswer((_) async => Right(tMethods));
+          when(mockRepository.getCardSettlementSummary(
+                  year: anyNamed('year'), month: anyNamed('month')))
+              .thenAnswer(
+            (_) async => const Right(CardSettlementSummary(
+              previousMonth: CardSettlementMonth(
+                  year: 2026, month: 4, totalAmount: 0, cards: []),
+              currentMonth: CardSettlementMonth(
+                  year: 2026, month: 5, totalAmount: 0, cards: []),
+            )),
+          );
+          return bloc;
+        },
+        // 먼저 5월 정산을 명시 조회 → 이후 LoadPaymentMethods 의 auto-load.
+        act: (bloc) => bloc
+          ..add(const LoadCardSettlementSummary(year: 2026, month: 5))
+          ..add(const LoadPaymentMethods()),
+        verify: (_) {
+          // auto-load 는 now() 가 아닌 기억된 5월로 호출되어야 한다.
+          verify(mockRepository.getCardSettlementSummary(
+                  year: 2026, month: 5))
+              .called(greaterThanOrEqualTo(2));
+        },
+      );
+
       blocTest<PaymentMethodBloc, PaymentMethodState>(
         'emits [PaymentMethodLoading, PaymentMethodError] on failure',
         build: () {


### PR DESCRIPTION
## 문제
새로고침 `https://aiva-bb.duckdns.org/transactions?year=2026&month=5` 시 **달력은 6월, 내역은 5월**로 어긋남. 또한 6/12 거래 2건 등록 후 목록이 5월로 돌아가고 달력은 6월로 표시되는 drift 재발 (PR #253 이후).

## 근본 원인 (network trace 로 런타임 확증)
새로고침 시 두 월이 섞여 호출됨:
- 5월(URL): `transactions`, `statistics/summary`, `transfers`
- 6월(now 기본값): `transfers`(2번째), `card-settlement-summary`

거래 화면 "현재 월"이 이중 소스 — 달력=`MonthCubit`(now 기본값=6월), 목록=`TransactionBloc`(URL=5월). 라우터가 URL을 BLoC에만 넣고 MonthCubit은 안 건드렸고, `MonthSyncHandler`는 초기 로드엔 fire 안 함.

## 수정
- **app_router `/transactions`**: `MonthCubit.changeMonth(year, month)` 동기화 → 네비게이터가 항상 목록과 일치 (sync fan-out으로 월 의존 BLoC 전체 수렴). no-op 가드로 drift 때만 동작.
- **app_router transfers fallback**: `TransferInitial` 시 now() 대신 URL year/month → `transfers?month=6` wrong-call 제거.
- **transaction_form**: create 저장도 `context.go(?year&month)` (pop 금지) + continue 모드 뒤로가기용 `PopScope` → 등록 월로 복귀.
- **payment_method_bloc**: card settlement auto-load가 now() 대신 마지막 명시 조회 달 재사용 → 자산 탭 정산이 선택 달로 유지 (새로고침/동기화 시 현재 달로 덮이던 drift 방지).

## 검증
- `flutter analyze --no-fatal-infos`: clean
- 전체 테스트 **741개 통과** (auto-load 월 재사용 회귀 테스트 추가)
- `flutter build web --release`: 성공

## 배포 후 라이브 확인 항목
1. `?year=2026&month=5` 새로고침 → 달력·내역 모두 5월
2. 6/12 거래 등록 → 둘 다 6월
3. 자산 탭 카드정산이 선택한 달 기준 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)