### PR TITLE
fix(assets,category): 카드결제 후 거래내역 미반영 + 자산 금액/은행그룹/수입카테고리 4건

### DIFF
--- a/frontend/lib/features/card_settlement/presentation/pages/card_settlement_page.dart
+++ b/frontend/lib/features/card_settlement/presentation/pages/card_settlement_page.dart
@@ -19,6 +19,8 @@ import 'package:budget_book/features/payment_method/presentation/bloc/payment_me
 import 'package:budget_book/features/payment_method/presentation/bloc/payment_method_state.dart';
 import 'package:budget_book/features/transaction/presentation/bloc/transaction_bloc.dart';
 import 'package:budget_book/features/transaction/presentation/bloc/transaction_event.dart';
+import 'package:budget_book/features/transfer/presentation/bloc/transfer_bloc.dart';
+import 'package:budget_book/features/transfer/presentation/bloc/transfer_event.dart';
 
 class CardSettlementPage extends StatefulWidget {
   final String? initialCardId;
@@ -192,12 +194,20 @@ class _CardSettlementPageState extends State<CardSettlementPage> {
             year: _selectedYear,
             month: _selectedMonth,
           ));
-          // 거래내역 갱신 — 결제 대상 거래들의 paid_at 이 업데이트되어
-          // 미결제 목록에서 제외되어야 하므로 셀프 경로에서도 즉시 갱신.
+          // 거래내역 갱신 — 결제 대상 거래들의 paid_at 업데이트 + 신규 정산
+          // 이체(Transfer, 결제일 _selectedDate 기준 생성) 가 거래 목록(거래+이체
+          // 병합 뷰)에 즉시 보이도록 셀프 경로에서 직접 갱신.
           // (WebSocket 경로는 authorId 체크로 본인 이벤트 스킵)
+          // 정산 이체가 사는 결제일의 달로 거래/이체 BLoC 을 함께 로드해 두
+          // BLoC 의 월을 일치시킨다 (과거: TransferBloc 미갱신 → 탭 재진입 전까지
+          // 정산 이체 미노출).
           getIt<TransactionBloc>().add(LoadTransactions(
-            year: _selectedYear,
-            month: _selectedMonth,
+            year: _selectedDate.year,
+            month: _selectedDate.month,
+          ));
+          getIt<TransferBloc>().add(LoadTransfers(
+            year: _selectedDate.year,
+            month: _selectedDate.month,
           ));
           final dashState = getIt<DashboardBloc>().state;
           final year = dashState is DashboardLoaded

--- a/frontend/lib/features/payment_method/presentation/bloc/payment_method_bloc.dart
+++ b/frontend/lib/features/payment_method/presentation/bloc/payment_method_bloc.dart
@@ -97,6 +97,9 @@ class PaymentMethodBloc
       final currentPendings = state is PaymentMethodLoaded
           ? (state as PaymentMethodLoaded).cardPendings
           : null;
+      final currentSummary = state is PaymentMethodLoaded
+          ? (state as PaymentMethodLoaded).cardSettlementSummary
+          : null;
 
       final result = await paymentMethodRepository.createPaymentMethod(
         name: event.name,
@@ -109,11 +112,13 @@ class PaymentMethodBloc
         (failure) => emit(PaymentMethodLoaded(
           currentMethods,
           cardPendings: currentPendings,
+          cardSettlementSummary: currentSummary,
           operationError: failure.message,
         )),
         (method) => emit(PaymentMethodLoaded(
           [...currentMethods, method],
           cardPendings: currentPendings,
+          cardSettlementSummary: currentSummary,
         )),
       );
     } catch (_) {
@@ -122,6 +127,7 @@ class PaymentMethodBloc
         emit(PaymentMethodLoaded(
           loaded.paymentMethods,
           cardPendings: loaded.cardPendings,
+          cardSettlementSummary: loaded.cardSettlementSummary,
           operationError: '예기치 않은 오류가 발생했습니다',
         ));
       } else {
@@ -141,6 +147,9 @@ class PaymentMethodBloc
       final currentPendings = state is PaymentMethodLoaded
           ? (state as PaymentMethodLoaded).cardPendings
           : null;
+      final currentSummary = state is PaymentMethodLoaded
+          ? (state as PaymentMethodLoaded).cardSettlementSummary
+          : null;
 
       final result = await paymentMethodRepository.updatePaymentMethod(
         id: event.id,
@@ -156,6 +165,7 @@ class PaymentMethodBloc
         (failure) => emit(PaymentMethodLoaded(
           currentMethods,
           cardPendings: currentPendings,
+          cardSettlementSummary: currentSummary,
           operationError: failure.message,
         )),
         (updated) {
@@ -165,6 +175,7 @@ class PaymentMethodBloc
           emit(PaymentMethodLoaded(
             updatedList,
             cardPendings: currentPendings,
+            cardSettlementSummary: currentSummary,
           ));
         },
       );
@@ -174,6 +185,7 @@ class PaymentMethodBloc
         emit(PaymentMethodLoaded(
           loaded.paymentMethods,
           cardPendings: loaded.cardPendings,
+          cardSettlementSummary: loaded.cardSettlementSummary,
           operationError: '예기치 않은 오류가 발생했습니다',
         ));
       } else {
@@ -193,6 +205,9 @@ class PaymentMethodBloc
       final currentPendings = state is PaymentMethodLoaded
           ? (state as PaymentMethodLoaded).cardPendings
           : null;
+      final currentSummary = state is PaymentMethodLoaded
+          ? (state as PaymentMethodLoaded).cardSettlementSummary
+          : null;
 
       final result =
           await paymentMethodRepository.deletePaymentMethod(event.id);
@@ -200,6 +215,7 @@ class PaymentMethodBloc
         (failure) => emit(PaymentMethodLoaded(
           currentMethods,
           cardPendings: currentPendings,
+          cardSettlementSummary: currentSummary,
           operationError: failure.message,
         )),
         (_) {
@@ -208,6 +224,7 @@ class PaymentMethodBloc
           emit(PaymentMethodLoaded(
             updatedList,
             cardPendings: currentPendings,
+            cardSettlementSummary: currentSummary,
           ));
         },
       );
@@ -217,6 +234,7 @@ class PaymentMethodBloc
         emit(PaymentMethodLoaded(
           loaded.paymentMethods,
           cardPendings: loaded.cardPendings,
+          cardSettlementSummary: loaded.cardSettlementSummary,
           operationError: '예기치 않은 오류가 발생했습니다',
         ));
       } else {

--- a/frontend/lib/features/settings/presentation/pages/asset_management_page.dart
+++ b/frontend/lib/features/settings/presentation/pages/asset_management_page.dart
@@ -823,7 +823,11 @@ class _CategoryTabState extends State<_CategoryTab> {
                 Navigator.of(dialogContext).pop();
                 getIt<CategoryBloc>().add(CreateCategory(
                   name: name,
-                  type: 'EXPENSE',
+                  // 그룹의 실제 타입(INCOME/EXPENSE)으로 생성.
+                  // 과거 'EXPENSE' 하드코딩 → 수입 그룹에 하위 카테고리 추가 시
+                  // EXPENSE 로 생성되어 수입 거래 폼 필터(c.type=='INCOME')에서
+                  // 탈락 → 노출 안 됨.
+                  type: group.categoryType,
                   groupId: group.id,
                   visibility: group.visibility,
                 ));
@@ -896,10 +900,26 @@ class _PaymentMethodTab extends StatefulWidget {
 class _PaymentMethodTabState extends State<_PaymentMethodTab> {
   List<PaymentMethod>? _localMethods;
 
-  /// bloc state 의 paymentMethods 를 displayOrder ASC 로 정렬하여 반환.
+  /// 타입 그룹 표시 우선순위 (현금→은행→체크→신용).
+  /// paymentMethodGroupLabels 키 순서와 일치.
+  static const List<String> _typeOrder = ['CASH', 'BANK', 'DEBIT', 'CREDIT'];
+
+  /// bloc state 의 paymentMethods 를 **타입 그룹 → displayOrder** 순으로 정렬.
+  /// displayOrder 만으로 정렬하면 같은 타입이 흩어져 헤더가 쪼개지는 버그
+  /// (은행 항목이 은행 그룹에 안 모임) 가 있어, 타입을 1차 키로 둔다.
+  /// reorder 는 동일 타입 내로 제한되므로 충돌 없음.
   List<PaymentMethod> _sortedFromState(PaymentMethodLoaded state) {
+    int typeRank(String t) {
+      final i = _typeOrder.indexOf(t);
+      return i < 0 ? _typeOrder.length : i;
+    }
+
     return List<PaymentMethod>.from(state.paymentMethods)
-      ..sort((a, b) => a.displayOrder.compareTo(b.displayOrder));
+      ..sort((a, b) {
+        final byType = typeRank(a.type).compareTo(typeRank(b.type));
+        if (byType != 0) return byType;
+        return a.displayOrder.compareTo(b.displayOrder);
+      });
   }
 
   @override

--- a/frontend/test/features/payment_method/presentation/bloc/payment_method_bloc_test.dart
+++ b/frontend/test/features/payment_method/presentation/bloc/payment_method_bloc_test.dart
@@ -325,6 +325,46 @@ void main() {
         ],
       );
 
+      // 회귀 (2026-06-17) — 결제수단 생성 시 기존 cardSettlementSummary 가
+      // 유지돼야 함. 과거 emit 누락 → 자산 탭 전월/미결제/이번달 금액 사라짐.
+      blocTest<PaymentMethodBloc, PaymentMethodState>(
+        'preserves cardSettlementSummary when creating a payment method',
+        build: () {
+          when(mockRepository.createPaymentMethod(
+            name: '국민체크',
+            type: 'DEBIT',
+            settlementDay: null,
+            closingDay: null,
+            linkedBankId: null,
+          )).thenAnswer((_) async => Right(tNewDebitMethod));
+          return bloc;
+        },
+        seed: () => PaymentMethodLoaded(
+          tMethods,
+          cardSettlementSummary: const CardSettlementSummary(
+            previousMonth: CardSettlementMonth(
+                year: 2026, month: 5, totalAmount: 1000, cards: []),
+            currentMonth: CardSettlementMonth(
+                year: 2026, month: 6, totalAmount: 2000, cards: []),
+          ),
+        ),
+        act: (bloc) => bloc.add(const CreatePaymentMethod(
+          name: '국민체크',
+          type: 'DEBIT',
+        )),
+        expect: () => [
+          PaymentMethodLoaded(
+            [...tMethods, tNewDebitMethod],
+            cardSettlementSummary: const CardSettlementSummary(
+              previousMonth: CardSettlementMonth(
+                  year: 2026, month: 5, totalAmount: 1000, cards: []),
+              currentMonth: CardSettlementMonth(
+                  year: 2026, month: 6, totalAmount: 2000, cards: []),
+            ),
+          ),
+        ],
+      );
+
       blocTest<PaymentMethodBloc, PaymentMethodState>(
         'creates credit card with settlement and closing days',
         build: () {


### PR DESCRIPTION
라이브 테스트 중 발견된 자산/카테고리/정산 영역 4건 수정. 모두 FE, 근본 원인 코드 확정.

## #1 카드결제 후 거래내역 미반영
카드결제는 Transfer(is_card_settlement, 결제일 기준)를 생성하는데, 성공 핸들러가 `TransferBloc`을 리로드하지 않음. 거래 목록은 거래+이체 병합 뷰라, 정산 이체가 탭 재진입 전까지 안 보임.
→ 결제일(`_selectedDate`)의 달로 `TransactionBloc`+`TransferBloc` 함께 리로드.

## #2 자산 전월/미결제/이번달 금액 미노출
`payment_method_bloc`의 Create/Update/Delete가 재emit 시 `cardSettlementSummary`를 누락 → null로 덮여 자산 정산 금액이 사라짐 (Reorder는 이미 올바르게 보존).
→ `cardPendings`처럼 `cardSettlementSummary` 보존. 회귀 테스트 추가.

## #3 은행 항목(토스증권/카카오페이) 은행 그룹에 안 모임
`asset_management_page._sortedFromState`가 `displayOrder`로만 정렬 → 같은 타입이 흩어지면 헤더가 쪼개지고 신규 BANK는 별도 헤더가 됨.
→ 타입 그룹(CASH→BANK→DEBIT→CREDIT) → displayOrder 순 정렬. reorder는 동일 타입 내 제한이라 무충돌.

## #4 수입 그룹 하위 카테고리 거래 폼 미노출
자산관리 그룹의 "카테고리 추가" 다이얼로그가 `type:'EXPENSE'` 하드코딩 → 수입 그룹에 추가해도 EXPENSE로 생성돼 수입 거래 폼의 `c.type=='INCOME'` 필터에서 탈락.
→ `group.categoryType` 사용.

## 검증 (로컬 CI 전체)
- `flutter analyze --no-fatal-infos`: clean
- 전체 테스트 **742개 통과** (#2 회귀 테스트 추가)
- `flutter build web --release`: 성공

## 배포 후 라이브 확인
1. 카드결제 후 거래 내역에 정산 이체 즉시 노출
2. 자산 추가/수정/삭제 후 전월/미결제/이번달 금액 유지
3. 토스증권/카카오페이 등 은행 항목이 은행 그룹에 모임 + 신규 은행 항목도 은행 그룹에 생성
4. 수입 그룹 하위 카테고리가 수입 거래 폼에 노출

🤖 Generated with [Claude Code](https://claude.com/claude-code)