### PR TITLE
fix(transaction): 거래 내역 일부만 표시·스피너 정지 + 과거 날짜 포커싱 실패

### DIFF
--- a/frontend/lib/features/transaction/presentation/bloc/transaction_bloc.dart
+++ b/frontend/lib/features/transaction/presentation/bloc/transaction_bloc.dart
@@ -86,7 +86,11 @@ class TransactionBloc extends Bloc<TransactionEvent, TransactionState> {
     on<DeleteTransaction>(_onDeleteTransaction);
   }
 
-  static const int _pageSize = 30;
+  // 회차 (2026-06-23) — 포커싱-구동 점진 로드 개편.
+  // pageSize 상향으로 라운드트립 최소화: 대부분의 달은 1요청으로 전부 로드되고,
+  // 500건 규모의 달에서 가장 과거 항목으로 포커싱할 때도 2~3요청이면 대상 페이지에
+  // 도달. (이전 30 → 첫 페이지가 최근 3일치만 덮어 포커싱 실패 + 스피너 정지.)
+  static const int _pageSize = 200;
 
   Future<void> _onLoadTransactions(
     LoadTransactions event,
@@ -240,6 +244,9 @@ class TransactionBloc extends Bloc<TransactionEvent, TransactionState> {
         isLoadingMore: true,
         serverTotalIncome: currentState.serverTotalIncome,
         serverTotalExpense: currentState.serverTotalExpense,
+        // 포커싱 의도 보존: 추가 페이지를 붙이는 동안에도 scrollToDate 가 살아 있어야
+        // UI 가 대상 날짜 등장 시 포커싱하고, 부재 시 다음 페이지를 계속 요청한다.
+        scrollToDate: currentState.scrollToDate,
         dateFrom: currentState.dateFrom,
         dateTo: currentState.dateTo,
       ));
@@ -281,6 +288,7 @@ class TransactionBloc extends Bloc<TransactionEvent, TransactionState> {
             operationError: failure.message,
             serverTotalIncome: currentState.serverTotalIncome,
             serverTotalExpense: currentState.serverTotalExpense,
+            scrollToDate: currentState.scrollToDate,
             dateFrom: currentState.dateFrom,
             dateTo: currentState.dateTo,
           ));
@@ -299,6 +307,7 @@ class TransactionBloc extends Bloc<TransactionEvent, TransactionState> {
             currentPage: nextPage,
             serverTotalIncome: currentState.serverTotalIncome,
             serverTotalExpense: currentState.serverTotalExpense,
+            scrollToDate: currentState.scrollToDate,
             dateFrom: currentState.dateFrom,
             dateTo: currentState.dateTo,
           ));
@@ -316,6 +325,7 @@ class TransactionBloc extends Bloc<TransactionEvent, TransactionState> {
         operationError: '예기치 않은 오류가 발생했습니다',
         serverTotalIncome: currentState.serverTotalIncome,
         serverTotalExpense: currentState.serverTotalExpense,
+        scrollToDate: currentState.scrollToDate,
         dateFrom: currentState.dateFrom,
         dateTo: currentState.dateTo,
       ));

--- a/frontend/lib/features/transaction/presentation/pages/transaction_list_page.dart
+++ b/frontend/lib/features/transaction/presentation/pages/transaction_list_page.dart
@@ -819,21 +819,42 @@ class _TransactionListPageState extends State<TransactionListPage> {
 
     final sortedDates = groupedItems.keys.toList()..sort((a, b) => b.compareTo(a));
 
-    // Handle scroll-to-date (one-shot: consume and clear immediately)
-    final targetDate = _pendingScrollToDate;
+    // 회차 (2026-06-23) — 포커싱-구동 점진 로드.
+    // 포커싱 대상: MonthNavigator 날짜 선택(_pendingScrollToDate, 명시적)이
+    // BLoC scrollToDate(등록/수정 후, 수동적)보다 우선.
+    //
+    // 대상이 로드된 페이지에 없으면 (예: 500건 중 가장 과거 항목 수정) hasMore 인
+    // 동안 다음 페이지를 자동 요청 → 등장할 때 포커싱. 마지막 페이지까지 부재면
+    // 대상 거래 자체가 없는 것(날짜 이동 등)으로 보고 조용히 종료(무한루프 방지).
+    final targetDate = _pendingScrollToDate ?? state.scrollToDate;
     if (targetDate != null) {
-      _pendingScrollToDate = null; // always consume to prevent infinite loops
       if (sortedDates.contains(targetDate)) {
+        // 대상 로드됨 → 포커싱. 명시적 선택(_pending)은 1회성 소비.
+        // (ensureVisible 는 이미 보이는 항목에 대해선 no-op 이라 rebuild 반복 안전.)
+        _pendingScrollToDate = null;
         WidgetsBinding.instance.addPostFrameCallback((_) {
-          _scrollToDate(targetDate, sortedDates);
+          if (mounted) _scrollToDate(targetDate, sortedDates);
         });
+      } else if (state.hasMore && !state.isLoadingMore) {
+        // 대상 미로드 → 등장할 때까지 다음 페이지 자동 요청.
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (mounted) {
+            context.read<TransactionBloc>().add(const LoadMoreTransactions());
+          }
+        });
+      } else {
+        // 마지막 페이지까지 로드했는데도 부재 → 조용히 종료.
+        _pendingScrollToDate = null;
       }
-      // If target date not loaded, user can scroll manually — no auto-load
-    } else if (state.scrollToDate != null && sortedDates.contains(state.scrollToDate!)) {
-      // One-shot scroll from BLoC (e.g., after create/update)
-      final scrollDate = state.scrollToDate!;
+    } else if (state.hasMore && !state.isLoadingMore) {
+      // 뷰포트 자동 채움(증상 1): 콘텐츠가 화면을 못 채우면 스크롤이 불가능해
+      // 하단 스피너만 떠 멈춘다. 스크롤 여지가 없으면(maxScrollExtent <= 0) 자동으로
+      // 다음 페이지를 요청해 화면을 채우고, 채워지면 기존 70% 무한스크롤로 이어진다.
       WidgetsBinding.instance.addPostFrameCallback((_) {
-        _scrollToDate(scrollDate, sortedDates);
+        if (!mounted || !_scrollController.hasClients) return;
+        if (_scrollController.position.maxScrollExtent <= 0) {
+          context.read<TransactionBloc>().add(const LoadMoreTransactions());
+        }
       });
     }
 

--- a/frontend/test/features/transaction/presentation/bloc/transaction_bloc_test.dart
+++ b/frontend/test/features/transaction/presentation/bloc/transaction_bloc_test.dart
@@ -213,7 +213,7 @@ void main() {
   final tPageResponse = PageResponse<Transaction>(
     content: tTransactions,
     page: 0,
-    size: 30,
+    size: 200,
     totalElements: 2,
     totalPages: 1,
     first: true,
@@ -242,7 +242,7 @@ void main() {
           when(mockRepository.getTransactions(
             year: 2024,
             month: 1,
-            size: 30,
+            size: 200,
           )).thenAnswer((_) async => Right(tPageResponse));
           return transactionBloc;
         },
@@ -269,7 +269,7 @@ void main() {
             keyword: 'lunch',
             amountMin: 5000,
             amountMax: 20000,
-            size: 30,
+            size: 200,
           )).thenAnswer((_) async => Right(tPageResponse));
           return transactionBloc;
         },
@@ -298,7 +298,7 @@ void main() {
           when(mockRepository.getTransactions(
             year: 2024,
             month: 1,
-            size: 30,
+            size: 200,
           )).thenAnswer((_) async =>
               const Left(ServerFailure('Failed to load transactions')));
           return transactionBloc;
@@ -353,7 +353,7 @@ void main() {
           when(mockRepository.getTransactions(
             year: 2024,
             month: 1,
-            size: 30,
+            size: 200,
           )).thenAnswer((_) async => Right(tPageResponse));
           return transactionBloc;
         },
@@ -374,7 +374,7 @@ void main() {
           verify(mockRepository.getTransactions(
             year: 2024,
             month: 1,
-            size: 30,
+            size: 200,
           )).called(1);
         },
       );
@@ -396,7 +396,7 @@ void main() {
           when(mockRepository.getTransactions(
             year: anyNamed('year'),
             month: anyNamed('month'),
-            size: 30,
+            size: 200,
           )).thenAnswer((_) async => Right(tPageResponse));
           return transactionBloc;
         },
@@ -417,7 +417,7 @@ void main() {
           verify(mockRepository.getTransactions(
             year: 2024,
             month: 6,
-            size: 30,
+            size: 200,
           )).called(1);
         },
       );
@@ -441,7 +441,7 @@ void main() {
           when(mockRepository.getTransactions(
             year: anyNamed('year'),
             month: anyNamed('month'),
-            size: 30,
+            size: 200,
           )).thenAnswer((_) async => Right(tPageResponse));
           return transactionBloc;
         },
@@ -531,7 +531,7 @@ void main() {
       final tPage1Response = PageResponse<Transaction>(
         content: [tTransaction1],
         page: 0,
-        size: 30,
+        size: 200,
         totalElements: 2,
         totalPages: 2,
         first: true,
@@ -541,7 +541,7 @@ void main() {
       final tPage2Response = PageResponse<Transaction>(
         content: [tTransaction2],
         page: 1,
-        size: 30,
+        size: 200,
         totalElements: 2,
         totalPages: 2,
         first: false,
@@ -555,13 +555,13 @@ void main() {
             year: 2024,
             month: 1,
             page: 0,
-            size: 30,
+            size: 200,
           )).thenAnswer((_) async => Right(tPage1Response));
           when(mockRepository.getTransactions(
             year: 2024,
             month: 1,
             page: 1,
-            size: 30,
+            size: 200,
           )).thenAnswer((_) async => Right(tPage2Response));
           return transactionBloc;
         },


### PR DESCRIPTION
## 증상
- 거래 내역에 최근 3일치(6/13·14·15) 일부만 보이고 하단 스피너가 멈춘 채 무한 반복 — 스크롤해야만 다음 데이터 노출
- 위 영향으로 이전 날짜 거래 등록/수정 시 해당 항목으로 포커싱 안됨

## 근본 원인 (hard evidence)
- 월 장부를 30건/페이지 오프셋 페이지네이션(`transactionDate DESC`, `TransactionRepository.kt:24`)으로 로드 → `page 0` = 그 달 최신 30건 = 최근 며칠치만
- 다음 페이지는 실제 스크롤 제스처(`ScrollUpdateNotification`)에서만 로드 → 뷰포트 미충족 시 자동 로드가 없어 **스피너만 멈춤**
- 등록/수정 후 `scrollToDate` 대상이 미로드 페이지(과거)면 `sortedDates.contains` 매칭 실패 → **포커싱 조용히 skip** (`transaction_list_page.dart:832`)
- `_onLoadMoreTransactions` 4개 emit 이 `scrollToDate` 누락 → 추가 로드 중 포커싱 의도 소실

## 해결 — 포커싱-구동 점진 로드 (focus-driven auto-load)
- **pageSize 30 → 200**: 라운드트립 최소화(대부분 월 1요청, 500건도 2~3요청)
- **`scrollToDate` 보존**: `_onLoadMoreTransactions` 4개 emit 전부
- **포커싱 대상 미로드 시 자동 추가 로드**: 대상이 로드된 페이지에 없으면 `hasMore` 인 동안 `LoadMore` 자동 dispatch → 등장 시 포커싱. 마지막 페이지까지 부재면 조용히 종료(무한루프 방지) → **500건 중 가장 과거 항목도 포커싱 보장**
- **뷰포트 자동 채움**: `maxScrollExtent <= 0 && hasMore` 시 자동 `LoadMore` → 멈춘 스피너 해소. 화면 채워지면 기존 70% 무한스크롤로 연결
- 부수 개선: 달력 뷰·러닝 잔액이 대부분 월 전체 로드로 정확해짐

## 검증
- `flutter analyze --no-fatal-infos --no-congratulate` 통과 (기존 test 파일 info 3건만)
- `flutter test` — **742개 전체 통과** (`transaction_bloc_test` size 30→200 갱신)
- `flutter build web` 성공

## 라이브 검증 요청 (배포 후)
- [ ] 거래량 많은 달에서 가장 과거 항목 수정 → 해당 항목으로 자동 포커싱
- [ ] 짧은 목록에서 스피너만 떠 멈추는 현상 미발생
- [ ] 달력 뷰 전체 날짜 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)