### PR TITLE
fix(category): 수입 입력 중 그룹/카테고리가 지출로 생성되는 버그 + FAB 라벨/순서 정리

### DIFF
--- a/frontend/lib/core/widgets/category_group_selector_sheet.dart
+++ b/frontend/lib/core/widgets/category_group_selector_sheet.dart
@@ -897,6 +897,9 @@ class _CategoryGroupSelectorSheetState
       getIt<CategoryGroupBloc>().add(CreateCategoryGroup(
         name: name,
         visibility: visibility,
+        // 거래 폼의 현재 type(INCOME/EXPENSE) 으로 그룹 생성.
+        // 누락 시 기본값 EXPENSE 로 떨어져 수입 입력 중 만든 그룹이 지출로 생성됨.
+        categoryType: widget.categoryType,
       ));
     }
   }

--- a/frontend/lib/features/settings/presentation/pages/asset_management_page.dart
+++ b/frontend/lib/features/settings/presentation/pages/asset_management_page.dart
@@ -243,20 +243,11 @@ class AssetManagementPage extends StatelessWidget {
                   ],
                 ),
               ),
+              // 순서: 공유 그룹 / 하위 카테고리 / 개인 그룹.
+              // '카테고리' 는 그룹 아래에 들어가는 항목이므로 페이지 내 다른
+              // 표현('하위 카테고리 없음' 등)과 통일해 '하위 카테고리' 로 표기.
               Row(
                 children: [
-                  Expanded(
-                    child: _AddOptionCard(
-                      icon: Icons.label_outline,
-                      label: '카테고리',
-                      color: typeColor,
-                      onTap: () {
-                        Navigator.of(sheetCtx).pop();
-                        _showAddCategory(context);
-                      },
-                    ),
-                  ),
-                  const SizedBox(width: 8),
                   Expanded(
                     child: _AddOptionCard(
                       icon: Icons.create_new_folder_outlined,
@@ -268,6 +259,18 @@ class AssetManagementPage extends StatelessWidget {
                           context,
                           categoryType: _lastSelectedCategoryType,
                         );
+                      },
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: _AddOptionCard(
+                      icon: Icons.label_outline,
+                      label: '하위 카테고리',
+                      color: typeColor,
+                      onTap: () {
+                        Navigator.of(sheetCtx).pop();
+                        _showAddCategory(context);
                       },
                     ),
                   ),


### PR DESCRIPTION
## 이슈
1. **버그** — 수입 거래 입력 중 카테고리 선택 시트에서 그룹을 추가하면 지출 카테고리로 생성됨
2. **UX** — 자산관리 > 카테고리 + 버튼 시트의 "카테고리" 라벨이 그룹 하위 항목임을 드러내지 못해 혼동

## 원인
- `category_group_selector_sheet.dart`의 `_showAddGroupDialog`가 `CreateCategoryGroup` 호출 시 `categoryType`를 누락 → 기본값 `EXPENSE`로 생성. 거래 폼이 INCOME 컨텍스트여도 지출 그룹이 만들어지고, 그 안의 하위 카테고리도 지출 쪽에 남음.
- 같은 시트의 카테고리 추가 경로(`_showAddCategoryDialog`)는 이미 `type: widget.categoryType`로 정상 전파 중이었음 → 그룹 경로만 누락.

## 변경
- `category_group_selector_sheet.dart`: 그룹 생성에 `categoryType: widget.categoryType` 전파
- `asset_management_page.dart`: FAB 시트 "카테고리" → "하위 카테고리" 표기 통일, 순서를 `공유 그룹 / 하위 카테고리 / 개인 그룹`으로 재배치

## 전수 조사
- 다른 `CreateCategoryGroup` 호출: `asset_management_page:70`(정상), `budget_form_page:492`(지출 전용 컨텍스트), `category_group_page:252`(라우트 미연결 고아 페이지) → 추가 수정 불필요

## 검증
- `flutter analyze --no-fatal-infos`: 통과 (info 3건은 기존 test 파일, 변경 무관)
- `flutter test`: 742/742 통과
- `flutter build web --release`: 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)