### PR TITLE
feat(transaction): 자동완성 제안 최근 3개월 빈도 기준 + 패턴 최대 3개

### DIFF
--- a/backend/src/main/kotlin/com/budgetbook/transaction/repository/TransactionRepository.kt
+++ b/backend/src/main/kotlin/com/budgetbook/transaction/repository/TransactionRepository.kt
@@ -256,6 +256,7 @@ interface TransactionRepository : JpaRepository<Transaction, UUID>, JpaSpecifica
     ): List<Array<Any>>
 
     // 회차 12 follow-up (2026-05-04) — categoryGroupName 추가 (FE 카테고리 표시 통일).
+    // 2026-06-29 — :since (최근 3개월) 필터 추가. COUNT/정렬을 최근 사용 빈도 기준으로 한정.
     @Query("""
         SELECT t.description,
                t.category.id, t.category.name, t.category.icon, t.category.color,
@@ -264,6 +265,7 @@ interface TransactionRepository : JpaRepository<Transaction, UUID>, JpaSpecifica
                COUNT(t)
         FROM Transaction t
         WHERE t.couple.id = :coupleId
+        AND t.transactionDate >= :since
         AND LOWER(t.description) LIKE LOWER(CONCAT(:query, '%'))
         GROUP BY t.description,
                  t.category.id, t.category.name, t.category.icon, t.category.color,
@@ -273,7 +275,8 @@ interface TransactionRepository : JpaRepository<Transaction, UUID>, JpaSpecifica
     """)
     fun findSuggestionPatterns(
         @Param("coupleId") coupleId: UUID,
-        @Param("query") query: String
+        @Param("query") query: String,
+        @Param("since") since: LocalDate
     ): List<Array<Any?>>
 
     @Query("""

--- a/backend/src/main/kotlin/com/budgetbook/transaction/service/TransactionService.kt
+++ b/backend/src/main/kotlin/com/budgetbook/transaction/service/TransactionService.kt
@@ -423,8 +423,10 @@ class TransactionService(
         if (query.length < 2) return emptyList()
         val couple = getActiveCouple(userId)
         val safeLimit = limit.coerceIn(1, 20)
+        // 최근 3개월 내 사용 빈도만 집계 (그 이전 거래는 제안에서 제외).
+        val since = LocalDate.now().minusMonths(3)
 
-        val rows = transactionRepository.findSuggestionPatterns(couple.id, query)
+        val rows = transactionRepository.findSuggestionPatterns(couple.id, query, since)
 
         // Group by description, then collect patterns per description
         val grouped = linkedMapOf<String, MutableList<com.budgetbook.transaction.dto.SuggestionPattern>>()
@@ -450,7 +452,7 @@ class TransactionService(
             .map { (desc, patterns) ->
                 com.budgetbook.transaction.dto.SuggestionResponse(
                     description = desc,
-                    patterns = patterns.take(5)
+                    patterns = patterns.take(3)
                 )
             }
     }

--- a/backend/src/test/kotlin/com/budgetbook/transaction/service/TransactionServiceTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/transaction/service/TransactionServiceTest.kt
@@ -440,7 +440,7 @@ class TransactionServiceTest : BehaviorSpec({
         every { coupleResolver.getActiveCouple(user1.id) } returns couple
 
         When("matching descriptions exist") {
-            every { transactionRepository.findSuggestionPatterns(couple.id, "점심") } returns listOf(
+            every { transactionRepository.findSuggestionPatterns(couple.id, "점심", any()) } returns listOf(
                 arrayOf<Any?>("점심 식사", null, null, null, null, null, null, null, 3L),
                 arrayOf<Any?>("점심 도시락", null, null, null, null, null, null, null, 1L)
             )
@@ -455,7 +455,7 @@ class TransactionServiceTest : BehaviorSpec({
         }
 
         When("no matching descriptions exist") {
-            every { transactionRepository.findSuggestionPatterns(couple.id, "없는것") } returns emptyList()
+            every { transactionRepository.findSuggestionPatterns(couple.id, "없는것", any()) } returns emptyList()
 
             val result = service.getSuggestions(user1.id, "없는것", 10)
 
@@ -465,7 +465,7 @@ class TransactionServiceTest : BehaviorSpec({
         }
 
         When("limit exceeds max") {
-            every { transactionRepository.findSuggestionPatterns(couple.id, "점심") } returns listOf(
+            every { transactionRepository.findSuggestionPatterns(couple.id, "점심", any()) } returns listOf(
                 arrayOf<Any?>("점심", null, null, null, null, null, null, null, 1L)
             )
 
@@ -478,7 +478,7 @@ class TransactionServiceTest : BehaviorSpec({
         }
 
         When("limit is zero or negative") {
-            every { transactionRepository.findSuggestionPatterns(couple.id, "점심") } returns listOf(
+            every { transactionRepository.findSuggestionPatterns(couple.id, "점심", any()) } returns listOf(
                 arrayOf<Any?>("점심 식사", null, null, null, null, null, null, null, 5L),
                 arrayOf<Any?>("점심 도시락", null, null, null, null, null, null, null, 2L)
             )
@@ -496,6 +496,23 @@ class TransactionServiceTest : BehaviorSpec({
 
             Then("returns empty list without querying") {
                 result shouldBe emptyList()
+            }
+        }
+
+        When("one description has more than 3 patterns") {
+            every { transactionRepository.findSuggestionPatterns(couple.id, "점심", any()) } returns listOf(
+                arrayOf<Any?>("점심", null, null, null, null, null, null, null, 5L),
+                arrayOf<Any?>("점심", null, null, null, null, null, null, null, 4L),
+                arrayOf<Any?>("점심", null, null, null, null, null, null, null, 3L),
+                arrayOf<Any?>("점심", null, null, null, null, null, null, null, 2L),
+                arrayOf<Any?>("점심", null, null, null, null, null, null, null, 1L)
+            )
+
+            val result = service.getSuggestions(user1.id, "점심", 10)
+
+            Then("caps patterns at 3 per description") {
+                result.size shouldBe 1
+                result[0].patterns.size shouldBe 3
             }
         }
     }

--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -87,6 +87,7 @@ The current backend accepts only the singular `type` query parameter (see §Tran
   - [Delete Transaction](#5-delete-transaction)
   - [Export CSV](#6-export-csv)
   - [List Settlement Candidates](#7-list-settlement-candidates)
+  - [Description Suggestions](#8-description-suggestions)
 - [Budgets](#budgets)
   - [Create Budget](#1-create-budget)
   - [List Budgets](#2-list-budgets)
@@ -1346,6 +1347,57 @@ Each item in the list represents one transaction. Items that already belong to t
 | `400`  | `VALIDATION_ERROR`           | `paymentMethodId` is missing or not a valid UUID         |
 | `404`  | `PAYMENT_METHOD_NOT_FOUND`   | Payment method does not exist or belongs to another couple |
 | `400`  | `VALIDATION_ERROR`           | Referenced payment method is not of type `CREDIT`        |
+
+---
+
+### 8. Description Suggestions
+
+Returns autocomplete suggestions for the transaction description field, grouped by description. Each group carries the category/payment-method patterns most frequently paired with that description, with a usage `count` for each pattern.
+
+| Attribute   | Value                                |
+|:------------|:-------------------------------------|
+| **Method**  | `GET`                                |
+| **Path**    | `/api/v1/transactions/suggestions`   |
+| **Auth**    | Required                             |
+
+**Query Parameters**
+
+| Parameter | Type     | Required | Description                                                              |
+|:----------|:---------|:---------|:-------------------------------------------------------------------------|
+| `q`       | `string` | Yes      | Description prefix. Queries shorter than 2 characters return an empty list. |
+| `limit`   | `int`    | No       | Max number of description groups (default `5`, clamped to `1`–`20`).      |
+
+**Behavior**
+
+- Counting window: only transactions from the **last 3 months** (`transactionDate >= today − 3 months`) are aggregated. Descriptions not used within this window are excluded.
+- Groups are sorted by total usage count (descending) within the window.
+- Each group returns at most **3 patterns** (category + payment-method combinations), ordered by `count` descending.
+
+**Response** (`200 OK`)
+
+```json
+{
+  "success": true,
+  "data": [
+    {
+      "description": "스타벅스",
+      "patterns": [
+        {
+          "categoryId": "…",
+          "categoryName": "카페",
+          "categoryGroupName": "식비",
+          "categoryIcon": "coffee",
+          "categoryColor": "#6F4E37",
+          "paymentMethodId": "…",
+          "paymentMethodName": "신한카드",
+          "count": 12
+        }
+      ]
+    }
+  ],
+  "error": null
+}
+```
 
 ---
 


### PR DESCRIPTION
## 요청
거래 기록 입력 시 뜨는 자동완성 제안(이전 입력 내용, 우측에 횟수)을:
1. **3개월 이내 횟수 기준으로 정렬**
2. **개수 최대 3개만 노출** (패턴 기준)

## 변경
**BE only** (FE 변경 불필요 — 칩은 5개 유지, 패턴은 BE 반환분 그대로 렌더)

- `TransactionRepository.findSuggestionPatterns`: `AND t.transactionDate >= :since` 필터 추가
- `TransactionService.getSuggestions`: `since = LocalDate.now().minusMonths(3)` 전달, `patterns.take(5)` → `take(3)`
- `TransactionServiceTest`: 스텁 `since` 인자 반영 + 패턴 3개 캡 검증 테스트 추가
- `docs/api-spec.md`: 미문서화였던 `/transactions/suggestions` 명세 추가

## 동작 변화
- 최근 3개월 내 사용한 내용만 집계·정렬, 그 이전에만 쓴 내용은 제안에서 제외
- 한 내용당 카테고리·결제수단 조합(우측 N회)이 상위 3개까지만 표시
- 부수효과: `AiClassificationService` 자동분류도 최근 3개월 패턴만 참고(의도상 개선)

## 검증
- 자동완성 단위 테스트 전부 통과 (TransactionService/Controller, AiClassification)
- 로컬 통합 테스트 1건은 Docker 미설치 환경 이슈(코드 무관) → CI에서 통과 예상

🤖 Generated with [Claude Code](https://claude.com/claude-code)