### PR TITLE
fix(budget): 주간 예산 환산 단일화 + TEMPLATE 조회월 투영

### DIFF
--- a/backend/src/main/kotlin/com/budgetbook/budget/service/BudgetService.kt
+++ b/backend/src/main/kotlin/com/budgetbook/budget/service/BudgetService.kt
@@ -118,13 +118,10 @@ class BudgetService(
             }
         }
 
-        val weeklyAmount = if (budgetPeriod == BudgetPeriod.WEEKLY) {
-            // Use client-provided weeklyAmount (the per-week budget the user intended),
-            // falling back to amount / numberOfWeeks for backward compat
-            request.weeklyAmount ?: (request.amount / calculateNumberOfWeeks(request.yearMonth))
-        } else {
-            null
-        }
+        // weeklyAmount = source of truth for WEEKLY; monthly `amount` derived consistently.
+        val (resolvedAmount, weeklyAmount) = resolveBudgetAmounts(
+            budgetPeriod, request.amount, request.weeklyAmount, request.yearMonth
+        )
 
         val (startDate, endDate) = resolveStartEndDates(periodType, request.yearMonth, request.startDate, request.endDate)
 
@@ -162,7 +159,7 @@ class BudgetService(
             yearMonth = request.yearMonth,
             endYearMonth = effectiveEndYearMonth,
             rowKind = rowKind,
-            amount = request.amount,
+            amount = resolvedAmount,
             budgetPeriod = budgetPeriod,
             weeklyAmount = weeklyAmount,
             periodType = periodType,
@@ -195,7 +192,9 @@ class BudgetService(
         val couple = getActiveCouple(userId)
         val yearMonth = formatYearMonth(year, month)
         val rows = budgetRepository.findByCoupleIdAndYearMonthAndUserId(couple.id, yearMonth, userId)
-        return MonthlyBudgetResolver.resolveForMonth(rows).map { it.toResponse() }
+        // Project TEMPLATE rows onto the viewing month so the edit form opens on the
+        // correct month (not the template's stale creation month).
+        return MonthlyBudgetResolver.resolveForMonth(rows).map { projectToMonth(it, yearMonth) }
     }
 
     @Transactional
@@ -250,28 +249,22 @@ class BudgetService(
             budget.category = null  // Mutual exclusivity
         }
 
-        budget.amount = request.amount
-
-        request.budgetPeriod?.let { periodStr ->
-            val newPeriod = try {
+        val effectivePeriod = request.budgetPeriod?.let { periodStr ->
+            try {
                 BudgetPeriod.valueOf(periodStr)
             } catch (e: IllegalArgumentException) {
                 throw com.budgetbook.common.exception.BusinessException(
                     "VALIDATION_ERROR", "Invalid budget period: $periodStr"
                 )
             }
-            budget.budgetPeriod = newPeriod
-            budget.weeklyAmount = if (newPeriod == BudgetPeriod.WEEKLY) {
-                request.weeklyAmount ?: (request.amount / calculateNumberOfWeeks(budget.yearMonth))
-            } else {
-                null
-            }
-        } ?: run {
-            if (budget.budgetPeriod == BudgetPeriod.WEEKLY) {
-                budget.weeklyAmount = request.weeklyAmount
-                    ?: (request.amount / calculateNumberOfWeeks(budget.yearMonth))
-            }
-        }
+        } ?: budget.budgetPeriod
+        budget.budgetPeriod = effectivePeriod
+        // weeklyAmount = source of truth for WEEKLY; monthly `amount` derived consistently.
+        val (resolvedAmount, weeklyAmount) = resolveBudgetAmounts(
+            effectivePeriod, request.amount, request.weeklyAmount, budget.yearMonth
+        )
+        budget.amount = resolvedAmount
+        budget.weeklyAmount = weeklyAmount
 
         // Update periodType and date range if provided
         request.periodType?.let { ptStr ->
@@ -435,9 +428,10 @@ class BudgetService(
                 .orElseThrow { NotFoundException("USER_NOT_FOUND", "User not found.") }
         } else null
 
-        val weeklyAmount = if (resolvedBudgetPeriod == BudgetPeriod.WEEKLY) {
-            request.weeklyAmount ?: (request.amount / calculateNumberOfWeeks(viewingMonth))
-        } else null
+        // weeklyAmount = source of truth for WEEKLY; monthly `amount` derived consistently.
+        val (resolvedAmount, weeklyAmount) = resolveBudgetAmounts(
+            resolvedBudgetPeriod, request.amount, request.weeklyAmount, viewingMonth
+        )
 
         // V57 OVERRIDE partial unique 충돌 체크 (E-3 fix: rowKind=OVERRIDE 만 검사 —
         // 기존 existsByCoupleIdAndCategoryGroupAndYearMonth 는 TEMPLATE 행도 포함하여
@@ -462,7 +456,7 @@ class BudgetService(
             yearMonth = viewingMonth,
             endYearMonth = viewingMonth,
             rowKind = BudgetRowKind.OVERRIDE,
-            amount = request.amount,
+            amount = resolvedAmount,
             budgetPeriod = resolvedBudgetPeriod,
             weeklyAmount = weeklyAmount,
             periodType = resolvedPeriodType,
@@ -538,9 +532,10 @@ class BudgetService(
                 .orElseThrow { NotFoundException("USER_NOT_FOUND", "User not found.") }
         } else null
 
-        val weeklyAmount = if (resolvedBudgetPeriod == BudgetPeriod.WEEKLY) {
-            request.weeklyAmount ?: (request.amount / calculateNumberOfWeeks(viewingMonth))
-        } else null
+        // weeklyAmount = source of truth for WEEKLY; monthly `amount` derived consistently.
+        val (resolvedAmount, weeklyAmount) = resolveBudgetAmounts(
+            resolvedBudgetPeriod, request.amount, request.weeklyAmount, viewingMonth
+        )
 
         // 1) 원본 TEMPLATE 종료
         val prev = previousYearMonth(viewingMonth)
@@ -555,7 +550,7 @@ class BudgetService(
             yearMonth = viewingMonth,
             endYearMonth = null,
             rowKind = BudgetRowKind.TEMPLATE,
-            amount = request.amount,
+            amount = resolvedAmount,
             budgetPeriod = resolvedBudgetPeriod,
             weeklyAmount = weeklyAmount,
             periodType = resolvedPeriodType,
@@ -677,8 +672,8 @@ class BudgetService(
             }
 
             val effectiveBudgetAmount = if (budget.budgetPeriod == BudgetPeriod.WEEKLY) {
-                val weeklyAmt = budget.weeklyAmount ?: (budget.amount * 7 / ym.lengthOfMonth())
-                weeklyAmt * ym.lengthOfMonth().toLong() / 7
+                val weeklyAmt = budget.weeklyAmount ?: WeeklyBudgetService.monthlyToWeekly(budget.amount, ym)
+                WeeklyBudgetService.weeklyToMonthly(weeklyAmt, ym)
             } else {
                 budget.amount
             }
@@ -775,23 +770,21 @@ class BudgetService(
         )
         val existingKeys = existingTargetBudgets.map { Pair(it.category?.id, it.group?.id) }.toSet()
 
-        val numberOfWeeks = calculateNumberOfWeeks(targetYearMonth)
-
         val newBudgets = sourceBudgets
             .filter { Pair(it.category?.id, it.group?.id) !in existingKeys }
             .map { source ->
-                val weeklyAmount = if (source.budgetPeriod == BudgetPeriod.WEEKLY) {
-                    source.amount / numberOfWeeks
-                } else {
-                    null
-                }
+                // Preserve the source per-week amount; re-derive monthly `amount` for the
+                // target month's day count (weeklyAmount = source of truth).
+                val (resolvedAmount, weeklyAmount) = resolveBudgetAmounts(
+                    source.budgetPeriod, source.amount, source.weeklyAmount, targetYearMonth
+                )
                 val (sd, ed) = resolveStartEndDates(source.periodType, targetYearMonth, null, null)
                 MonthlyBudget(
                     couple = couple,
                     category = source.category,
                     group = source.group,
                     yearMonth = targetYearMonth,
-                    amount = source.amount,
+                    amount = resolvedAmount,
                     budgetPeriod = source.budgetPeriod,
                     weeklyAmount = weeklyAmount,
                     periodType = source.periodType,
@@ -829,6 +822,53 @@ class BudgetService(
     private fun formatYearMonth(year: Int, month: Int): String =
         "%04d-%02d".format(year, month)
 
+    /**
+     * Resolve the stored (amount, weeklyAmount) pair for a budget.
+     *
+     * For WEEKLY budgets, `weeklyAmount` is the source of truth and the monthly
+     * `amount` is DERIVED via [WeeklyBudgetService.weeklyToMonthly] so it equals the
+     * effective budget every display path computes (summary / weekly overview / FE),
+     * making the usage % consistent. Legacy callers that send only `amount` get a
+     * back-derived weeklyAmount. Non-WEEKLY budgets keep `amount` as-is, weeklyAmount null.
+     */
+    private fun resolveBudgetAmounts(
+        period: BudgetPeriod,
+        requestAmount: Long,
+        requestWeeklyAmount: Long?,
+        yearMonth: String
+    ): Pair<Long, Long?> {
+        if (period != BudgetPeriod.WEEKLY) return Pair(requestAmount, null)
+        val ym = YearMonth.parse(yearMonth)
+        val weekly = requestWeeklyAmount
+            ?: WeeklyBudgetService.monthlyToWeekly(requestAmount, ym)
+        return Pair(WeeklyBudgetService.weeklyToMonthly(weekly, ym), weekly)
+    }
+
+    /**
+     * Project a resolved budget row onto the month being viewed.
+     *
+     * A TEMPLATE row keeps its original creation month in `yearMonth`/`startDate`/
+     * `endDate`; returned as-is, the client (edit form) derives the period month from
+     * the stale `startDate` and jumps to the wrong month. This rewrites those fields to
+     * the viewing month (WEEKLY/MONTHLY only — DAILY/NONE keep their custom range), and
+     * recomputes the WEEKLY monthly `amount` for the viewing month's day count.
+     */
+    private fun projectToMonth(budget: MonthlyBudget, viewingYearMonth: String): BudgetResponse {
+        val base = budget.toResponse()
+        if (budget.yearMonth == viewingYearMonth) return base
+        val ym = YearMonth.parse(viewingYearMonth)
+        val (sd, ed) = when (budget.periodType) {
+            PeriodType.WEEKLY, PeriodType.MONTHLY ->
+                Pair(ym.atDay(1).toString(), ym.atEndOfMonth().toString())
+            else -> Pair(base.startDate, base.endDate)
+        }
+        val amount = budget.weeklyAmount
+            ?.takeIf { budget.budgetPeriod == BudgetPeriod.WEEKLY }
+            ?.let { WeeklyBudgetService.weeklyToMonthly(it, ym) }
+            ?: base.amount
+        return base.copy(yearMonth = viewingYearMonth, amount = amount, startDate = sd, endDate = ed)
+    }
+
     private fun resolveStartEndDates(
         periodType: PeriodType,
         yearMonth: String,
@@ -848,12 +888,5 @@ class BudgetService(
                 }
             }
         }
-    }
-
-    private fun calculateNumberOfWeeks(yearMonth: String): Int {
-        val parts = yearMonth.split("-")
-        val ym = YearMonth.of(parts[0].toInt(), parts[1].toInt())
-        val lastDay = ym.lengthOfMonth()
-        return if (lastDay > 28) 5 else 4
     }
 }

--- a/backend/src/main/kotlin/com/budgetbook/budget/service/WeeklyBudgetService.kt
+++ b/backend/src/main/kotlin/com/budgetbook/budget/service/WeeklyBudgetService.kt
@@ -79,7 +79,7 @@ class WeeklyBudgetService(
         // Pre-compute per-budget pro-rata amounts for each week,
         // with the last week receiving the remainder to eliminate rounding errors.
         val proRataByBudgetAndWeek: Map<UUID, List<Long>> = weeklyBudgets.associate { budget ->
-            val perWeekAmount = budget.weeklyAmount ?: (budget.amount * 7L / ym.lengthOfMonth())
+            val perWeekAmount = budget.weeklyAmount ?: monthlyToWeekly(budget.amount, ym)
             val monthlyTotal = perWeekAmount * ym.lengthOfMonth().toLong() / 7
             val amounts = weekRanges.mapIndexed { index, (weekStart, weekEnd) ->
                 if (index == weekRanges.size - 1) {
@@ -255,7 +255,7 @@ class WeeklyBudgetService(
         val isLastWeek = currentWeekIndex == weekRanges.size - 1
 
         val items = weeklyBudgets.map { budget ->
-            val perWeekAmount = budget.weeklyAmount ?: (budget.amount * 7L / ym.lengthOfMonth())
+            val perWeekAmount = budget.weeklyAmount ?: monthlyToWeekly(budget.amount, ym)
             val proRataBudget = if (isLastWeek) {
                 // Last week gets the remainder to eliminate rounding errors
                 val monthlyTotal = perWeekAmount * ym.lengthOfMonth().toLong() / 7
@@ -385,10 +385,9 @@ class WeeklyBudgetService(
         // Sum weekly contributions: use weeklyAmount if set, otherwise derive from monthly
         val parts = yearMonth.split("-")
         val ym = YearMonth.of(parts[0].toInt(), parts[1].toInt())
-        val daysInMonth = ym.lengthOfMonth()
 
         return weeklyBudgets.sumOf { budget ->
-            budget.weeklyAmount ?: ((budget.amount * 7) / daysInMonth)
+            budget.weeklyAmount ?: monthlyToWeekly(budget.amount, ym)
         }
     }
 
@@ -430,5 +429,24 @@ class WeeklyBudgetService(
             val days = ChronoUnit.DAYS.between(start, end) + 1
             return (weeklyAmount * days) / 7
         }
+
+        /**
+         * Canonical weekly↔monthly conversion for WEEKLY budgets.
+         *
+         * `weeklyAmount` (the per-week budget the user enters) is the source of truth.
+         * The monthly-equivalent is the per-week amount scaled by the month's actual
+         * day count (`daysInMonth / 7`) — the SAME formula every display path uses
+         * (budget summary, weekly overview, FE `effectiveMonthlyAmount`). Storing the
+         * derived monthly `amount` with this formula keeps the usage % consistent.
+         *
+         * [weeklyToMonthly] and [monthlyToWeekly] are inverse pairs (up to integer
+         * rounding); they replace the old `amount / numberOfWeeks` (4 or 5) divisor,
+         * which was NOT the inverse of `* daysInMonth / 7` and caused the % drift.
+         */
+        fun weeklyToMonthly(weeklyAmount: Long, yearMonth: YearMonth): Long =
+            weeklyAmount * yearMonth.lengthOfMonth().toLong() / 7
+
+        fun monthlyToWeekly(monthlyAmount: Long, yearMonth: YearMonth): Long =
+            Math.round(monthlyAmount.toDouble() * 7.0 / yearMonth.lengthOfMonth())
     }
 }

--- a/backend/src/main/resources/db/migration/V64__unify_weekly_budget_conversion.sql
+++ b/backend/src/main/resources/db/migration/V64__unify_weekly_budget_conversion.sql
@@ -1,0 +1,39 @@
+-- V64: Unify weekly↔monthly budget conversion (fix usage-% drift)
+--
+-- Background: WEEKLY budgets stored `amount` as an approximation — the client sent
+-- weeklyAmount*4, and the BE fallback used amount / numberOfWeeks (4 or 5). Every
+-- display path, however, computes the monthly-equivalent as `weekly_amount * daysInMonth / 7`
+-- (≈ 4.28–4.43 weeks). Those two conventions are NOT inverse, so the displayed monthly
+-- total and usage % drifted from what the user set — worsened by the prorated partial
+-- first/last weeks.
+--
+-- New model: `weekly_amount` is the source of truth; `amount` is DERIVED as
+-- ROUND(weekly_amount * daysInMonth / 7), the exact inverse of the display formula.
+-- This migration re-derives `amount` for all existing WEEKLY budgets so the stored
+-- value and every displayed value agree (the usage % then matches across views).
+--
+-- Constraints checked: ck_monthly_budgets_amount CHECK (amount >= 0) — recomputed
+-- amount is always >= 0. weekly_amount has no CHECK constraint.
+
+-- 1) Defensive backfill: any WEEKLY row still missing weekly_amount (legacy) gets a
+--    per-week value back-derived from the stored monthly amount with the canonical inverse.
+UPDATE monthly_budgets
+SET weekly_amount = ROUND(
+        amount * 7.0
+        / EXTRACT(DAY FROM (date_trunc('month', to_date(year_month, 'YYYY-MM'))
+                            + interval '1 month' - interval '1 day'))
+    )
+WHERE budget_period = 'WEEKLY'
+  AND weekly_amount IS NULL;
+
+-- 2) Re-derive monthly `amount` = ROUND(weekly_amount * daysInMonth / 7) for every WEEKLY
+--    row so stored amount == the effective budget every display path computes.
+UPDATE monthly_budgets
+SET amount = ROUND(
+        weekly_amount
+        * EXTRACT(DAY FROM (date_trunc('month', to_date(year_month, 'YYYY-MM'))
+                            + interval '1 month' - interval '1 day'))
+        / 7.0
+    )
+WHERE budget_period = 'WEEKLY'
+  AND weekly_amount IS NOT NULL;

--- a/backend/src/test/kotlin/com/budgetbook/budget/service/BudgetServiceTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/budget/service/BudgetServiceTest.kt
@@ -36,6 +36,7 @@ import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
 import java.time.LocalDate
+import java.time.YearMonth
 import java.util.Optional
 import java.util.UUID
 
@@ -141,6 +142,71 @@ class BudgetServiceTest : BehaviorSpec({
                     service.createBudget(user1.id, request)
                 }
                 ex.code shouldBe "CATEGORY_NOT_FOUND"
+            }
+        }
+    }
+
+    // --- WEEKLY budget conversion (bug 1: usage-% drift) ---
+
+    Given("a WEEKLY budget created with a per-week amount (June 2026, 30 days)") {
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
+        every { categoryRepository.findById(category.id) } returns Optional.of(category)
+        every { budgetRepository.existsByCoupleIdAndCategoryGroupAndYearMonth(couple.id, category.id, null, "2026-06") } returns false
+        val slotB = slot<MonthlyBudget>()
+        every { budgetRepository.save(capture(slotB)) } answers { slotB.captured }
+
+        When("creating with weeklyAmount=100000 and an approximate amount") {
+            // FE may send amount = weekly*4 (400000); BE must ignore it and derive from weekly.
+            val request = BudgetRequest(
+                categoryId = category.id, yearMonth = "2026-06", amount = 400000,
+                budgetPeriod = "WEEKLY", weeklyAmount = 100000, periodType = "WEEKLY"
+            )
+            val result = service.createBudget(user1.id, request)
+
+            Then("weeklyAmount is preserved and monthly amount = weekly * daysInMonth / 7") {
+                result.weeklyAmount shouldBe 100000
+                result.amount shouldBe 428571 // 100000 * 30 / 7, NOT 400000
+            }
+        }
+
+        When("creating with only a monthly amount (legacy, no weeklyAmount)") {
+            val request = BudgetRequest(
+                categoryId = category.id, yearMonth = "2026-06", amount = 428571,
+                budgetPeriod = "WEEKLY", weeklyAmount = null, periodType = "WEEKLY"
+            )
+            val result = service.createBudget(user1.id, request)
+
+            Then("weeklyAmount is back-derived and amount stays consistent") {
+                result.weeklyAmount shouldBe 100000 // round(428571 * 7 / 30)
+                result.amount shouldBe 428571
+            }
+        }
+    }
+
+    // --- getBudgetsByMonth: TEMPLATE projection (bug 2: edit jumps to wrong month) ---
+
+    Given("a WEEKLY TEMPLATE created in May, viewed in June") {
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
+        val template = MonthlyBudget(
+            couple = couple, category = category, yearMonth = "2026-05",
+            endYearMonth = null, rowKind = com.budgetbook.budget.domain.BudgetRowKind.TEMPLATE,
+            amount = 442580, budgetPeriod = BudgetPeriod.WEEKLY, weeklyAmount = 100000,
+            periodType = com.budgetbook.budget.domain.PeriodType.WEEKLY,
+            startDate = LocalDate.of(2026, 5, 1), endDate = LocalDate.of(2026, 5, 31)
+        )
+        every { budgetRepository.findByCoupleIdAndYearMonthAndUserId(couple.id, "2026-06", user1.id) } returns listOf(template)
+
+        When("getBudgetsByMonth(2026, 6) is called") {
+            val result = service.getBudgetsByMonth(user1.id, 2026, 6)
+
+            Then("the response is projected onto June, not the template's May") {
+                result.size shouldBe 1
+                result[0].yearMonth shouldBe "2026-06"
+                result[0].startDate shouldBe "2026-06-01"
+                result[0].endDate shouldBe "2026-06-30"
+                // weeklyAmount preserved; monthly amount re-derived for June's 30 days
+                result[0].weeklyAmount shouldBe 100000
+                result[0].amount shouldBe 428571
             }
         }
     }
@@ -270,11 +336,11 @@ class BudgetServiceTest : BehaviorSpec({
             val request = BudgetUpdateRequest(amount = 200000, budgetPeriod = "WEEKLY")
             val result = service.updateBudget(user1.id, budget.id, request)
 
-            Then("updates amount, budgetPeriod, and calculates weeklyAmount") {
-                result.amount shouldBe 200000
+            Then("derives weeklyAmount via daysInMonth/7 and a consistent monthly amount") {
                 result.budgetPeriod shouldBe "WEEKLY"
-                // 2026-03 has 31 days -> 5 weeks, so 200000 / 5 = 40000
-                result.weeklyAmount shouldBe 40000
+                // Canonical inverse, NOT the old flat 200000/5 = 40000.
+                result.weeklyAmount shouldBe WeeklyBudgetService.monthlyToWeekly(200000, YearMonth.of(2026, 3))
+                result.amount shouldBe WeeklyBudgetService.weeklyToMonthly(result.weeklyAmount!!, YearMonth.of(2026, 3))
             }
         }
     }
@@ -292,11 +358,10 @@ class BudgetServiceTest : BehaviorSpec({
             val request = BudgetUpdateRequest(amount = 250000)
             val result = service.updateBudget(user1.id, budget.id, request)
 
-            Then("recalculates weeklyAmount from new amount") {
-                result.amount shouldBe 250000
+            Then("recalculates weeklyAmount from the new amount, amount stays consistent") {
                 result.budgetPeriod shouldBe "WEEKLY"
-                // 250000 / 5 = 50000
-                result.weeklyAmount shouldBe 50000
+                result.weeklyAmount shouldBe WeeklyBudgetService.monthlyToWeekly(250000, YearMonth.of(2026, 3))
+                result.amount shouldBe WeeklyBudgetService.weeklyToMonthly(result.weeklyAmount!!, YearMonth.of(2026, 3))
             }
         }
     }
@@ -314,9 +379,10 @@ class BudgetServiceTest : BehaviorSpec({
             val request = BudgetUpdateRequest(amount = 200000, weeklyAmount = 45000)
             val result = service.updateBudget(user1.id, budget.id, request)
 
-            Then("uses the explicit weeklyAmount") {
-                result.amount shouldBe 200000
+            Then("uses the explicit weeklyAmount and derives the monthly amount from it") {
                 result.weeklyAmount shouldBe 45000
+                // amount is derived from weeklyAmount (source of truth), not the sent 200000.
+                result.amount shouldBe WeeklyBudgetService.weeklyToMonthly(45000, YearMonth.of(2026, 3))
             }
         }
     }

--- a/backend/src/test/kotlin/com/budgetbook/budget/service/WeeklyBudgetServiceTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/budget/service/WeeklyBudgetServiceTest.kt
@@ -149,6 +149,62 @@ class WeeklyBudgetServiceTest : BehaviorSpec({
         }
     }
 
+    // --- weeklyToMonthly / monthlyToWeekly (canonical conversion) ---
+
+    Given("canonical weekly↔monthly conversion") {
+        When("converting a per-week amount to monthly for a 30-day month (June 2026)") {
+            val monthly = WeeklyBudgetService.weeklyToMonthly(100_000, YearMonth.of(2026, 6))
+            Then("scales by daysInMonth/7, NOT by a flat 4 or 5 weeks") {
+                // 100000 * 30 / 7 = 428571 (≈4.28 weeks), not 400000 (×4) or 500000 (×5)
+                monthly shouldBe 428_571
+            }
+        }
+
+        When("converting a 31-day month (March 2026)") {
+            val monthly = WeeklyBudgetService.weeklyToMonthly(70_000, YearMonth.of(2026, 3))
+            Then("uses 31 days") {
+                monthly shouldBe (70_000L * 31 / 7) // 310000
+            }
+        }
+
+        When("deriving a per-week amount from a monthly total (June 2026)") {
+            val weekly = WeeklyBudgetService.monthlyToWeekly(428_571, YearMonth.of(2026, 6))
+            Then("inverts weeklyToMonthly within rounding") {
+                weekly shouldBe 100_000
+            }
+        }
+
+        When("round-tripping weekly → monthly → weekly across months") {
+            Then("returns the original per-week value for representative inputs") {
+                listOf(YearMonth.of(2026, 2), YearMonth.of(2026, 6), YearMonth.of(2026, 3)).forEach { ym ->
+                    listOf(50_000L, 100_000L, 123_456L).forEach { weekly ->
+                        val monthly = WeeklyBudgetService.weeklyToMonthly(weekly, ym)
+                        WeeklyBudgetService.monthlyToWeekly(monthly, ym) shouldBe weekly
+                    }
+                }
+            }
+        }
+
+        When("weeklyToMonthly equals the sum of per-week pro-rata (with last-week remainder)") {
+            Then("the stored monthly amount matches the weekly overview's total exactly") {
+                val ym = YearMonth.of(2026, 6)
+                val weekly = 100_000L
+                val monthly = WeeklyBudgetService.weeklyToMonthly(weekly, ym)
+                val ranges = WeeklyBudgetService.calculateWeekRanges(ym)
+                val summed = ranges.mapIndexed { index, (s, e) ->
+                    if (index == ranges.size - 1) {
+                        val prev = ranges.take(index)
+                            .sumOf { (ps, pe) -> WeeklyBudgetService.calculateProRataBudget(weekly, ps, pe) }
+                        monthly - prev
+                    } else {
+                        WeeklyBudgetService.calculateProRataBudget(weekly, s, e)
+                    }
+                }.sum()
+                summed shouldBe monthly
+            }
+        }
+    }
+
     // --- getWeeklyOverview ---
 
     Given("only MONTHLY budgets exist (no WEEKLY)") {

--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -1438,9 +1438,14 @@ Creates a monthly budget for the couple. At most one of `categoryId` or `groupId
 | `categoryId`   | `UUID`   | No       | Category ID. Mutually exclusive with `groupId`. Both `null` = total budget for the month.            |
 | `groupId`      | `UUID`   | No       | Category group ID. Mutually exclusive with `categoryId`. Both `null` = total budget for the month.   |
 | `yearMonth`    | `string` | Yes      | Target month in `YYYY-MM` format (e.g., `2026-03`)                                                  |
-| `amount`       | `long`   | Yes      | Budget amount in KRW (must be > 0)                                                                   |
+| `amount`       | `long`   | Yes      | Budget amount in KRW (must be > 0). For `WEEKLY` budgets this is ignored when `weeklyAmount` is sent — see note below. |
 | `budgetPeriod` | `string` | No       | Budget period type: `MONTHLY` (default) or `WEEKLY`                                                  |
+| `weeklyAmount` | `long`   | No       | Per-week amount in KRW. Source of truth for `WEEKLY` budgets. If omitted for a `WEEKLY` budget, it is back-derived from `amount`. |
 | `visibility`   | `string` | No       | `SHARED` (default) or `PRIVATE`. Private budgets are only visible to the creator. Shared and private budgets can coexist for the same category/month (unique constraint applies per visibility scope). |
+
+> **WEEKLY budget conversion.** For `WEEKLY` budgets `weeklyAmount` (per-week) is the source of truth; the stored/returned monthly `amount` is **derived** as `round(weeklyAmount × daysInMonth ÷ 7)` — the same formula every view uses to compute the effective monthly budget, so the usage % is consistent. (Earlier versions stored `amount ≈ weeklyAmount × 4`, which drifted from the displayed value.)
+>
+> **TEMPLATE projection.** When a multi-month budget (TEMPLATE) is listed for a month later than its creation month, the response's `yearMonth`/`startDate`/`endDate` are projected onto the **viewing month**, and a `WEEKLY` budget's `amount` is re-derived for that month's day count.
 
 **Response `201 Created`**: `ApiResponse<BudgetResponse>`
 

--- a/frontend/lib/features/budget/presentation/pages/budget_form_page.dart
+++ b/frontend/lib/features/budget/presentation/pages/budget_form_page.dart
@@ -641,10 +641,12 @@ class _BudgetFormPageState extends State<BudgetFormPage> {
       if (_budgetPeriod == 'WEEKLY') {
         final weekly = CurrencyFormatter.parse(_weeklyAmountController.text.trim())!;
         weeklyAmount = weekly;
-        // Monthly amount = weekly * 4 (approximate)
+        // Monthly amount = weekly * daysInMonth / 7 — the canonical inverse the BE/display
+        // use (NOT weekly * 4). Keeps the optimistic local value in sync with the server.
+        final daysInMonth = DateTime(_selectedYear, _selectedMonth + 1, 0).day;
         amount = _amountController.text.trim().isNotEmpty
             ? CurrencyFormatter.parse(_amountController.text.trim())!
-            : weekly * 4;
+            : (weekly * daysInMonth / 7).round();
       } else {
         amount = CurrencyFormatter.parse(_amountController.text.trim())!;
         weeklyAmount = null;


### PR DESCRIPTION
## 배경
주간 예산에서 두 가지 버그가 보고됨.

### 버그 1 — 주간 예산 % 불일치
- weekly↔monthly 환산이 **저장 경로**(`amount / numberOfWeeks` = 4 또는 5)와 **표시 경로**(`weeklyAmount * daysInMonth / 7` ≈ 4.28~4.43주)로 비대칭.
- 두 식이 역함수가 아니라, 첫째/마지막 부분 주(partial week) 일할 계산 시 표시 금액·사용률(%)이 사용자가 입력한 값과 어긋남.

### 버그 2 — 6월 주간 예산 클릭 시 5월로 이동
- `getBudgetsByMonth` 가 TEMPLATE 원본 엔티티(생성월의 stale `yearMonth`/`startDate`)를 그대로 반환.
- 편집 폼(`PeriodSelection.fromApiValues`)이 `startDate` 에서 달을 파생 → 6월 조회인데 5월로 점프.

## 변경
**BE — 환산 단일화 (weeklyAmount = source of truth)**
- `WeeklyBudgetService.weeklyToMonthly` / `monthlyToWeekly` 공용 헬퍼 추가 (역함수 쌍).
- create/update/template-split/late-split/copy + summary fallback 전 경로를 헬퍼로 통일. `amount = round(weeklyAmount * daysInMonth / 7)` 로 파생 저장.
- `calculateNumberOfWeeks`(4/5 divisor) 제거.

**BE — TEMPLATE 조회월 투영**
- `projectToMonth` 로 `getBudgetsByMonth` 응답의 `yearMonth`/`startDate`/`endDate` 를 조회월로 투영, WEEKLY `amount` 는 조회월 일수로 재산출 (엔티티 불변).

**DB**
- `V64__unify_weekly_budget_conversion.sql`: 기존 WEEKLY 행 `amount` 를 `weekly_amount` 기준 재계산 (사용자 입력 주간액 보존).

**FE**
- 예산 폼의 월액 근사 `weekly*4` → `round(weekly * daysInMonth / 7)` 로 BE/표시와 일치.

**Docs**
- api-spec: WEEKLY amount 파생 규칙 + TEMPLATE 투영 명시.

## 검증
- BE: `./gradlew test --tests "com.budgetbook.budget.*"` 통과. 신규 회귀테스트 — 환산 round-trip, partial-week 합 일치, WEEKLY create amount 파생, TEMPLATE 5월→6월 투영.
- FE: `flutter analyze`(에러 0) + budget/weekly 테스트 83건 통과.
- ⚠️ admin `DeleteUserByEmailIntegrationTest`(Testcontainers)는 로컬 Docker 부재로 미실행 — GitHub Actions CI에서 실행. 예산과 무관.
- ⏳ **라이브 검증 필요**: NAS 배포 후 V64 마이그레이션 실행 + (1) 6월 주간 예산 편집 시 6월 표시, (2) 주간/월간 % 일치 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)