### PR TITLE
fix(budget): 예산 사용률에서 지출계획(planned) 제외 → 표시 숫자와 % 일치

### DIFF
--- a/backend/src/main/kotlin/com/budgetbook/budget/service/BudgetService.kt
+++ b/backend/src/main/kotlin/com/budgetbook/budget/service/BudgetService.kt
@@ -679,8 +679,12 @@ class BudgetService(
             }
 
             val remainingAmount = effectiveBudgetAmount - spentAmount - plannedAmount
+            // usageRate reflects ACTUAL spending only (spent / budget), matching the
+            // budget list / alert display which shows "spent / budget" (회차 12 P4 removed
+            // the planned segment from this view) and BudgetAlertService's percentage.
+            // plannedAmount stays in remainingAmount as a separate reservation concept.
             val usageRate = if (effectiveBudgetAmount > 0) {
-                Math.round((spentAmount + plannedAmount).toDouble() / effectiveBudgetAmount * 1000.0) / 10.0
+                Math.round(spentAmount.toDouble() / effectiveBudgetAmount * 1000.0) / 10.0
             } else {
                 0.0
             }

--- a/backend/src/test/kotlin/com/budgetbook/budget/service/BudgetServiceTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/budget/service/BudgetServiceTest.kt
@@ -852,6 +852,16 @@ class BudgetServiceTest : BehaviorSpec({
                 catItem.remainingAmount shouldBe 70000 // 150000 - 50000 - 30000
             }
 
+            // Regression (2026-07-01): usageRate reflects ACTUAL spending only, NOT planned.
+            // Previously (spent + planned) / budget inflated the % beyond the displayed
+            // "spent / budget" numbers (e.g. June weekly budget showed 100.4% for 740,504 / 857,142).
+            Then("usageRate excludes planned amount") {
+                val catItem = result.items.first { it.category != null }
+                catItem.usageRate shouldBe 33.3 // 50000 / 150000, NOT (50000 + 30000) / 150000
+                val totalItem = result.items.first { it.category == null }
+                totalItem.usageRate shouldBe 2.7 // 80000 / 3000000, NOT (80000 + 50000) / 3000000
+            }
+
             Then("includes planned amount in total budget item") {
                 val totalItem = result.items.first { it.category == null }
                 totalItem.plannedAmount shouldBe 50000


### PR DESCRIPTION
## 증상
- 6월 주간 예산 **857,142원 / 사용 740,504원**인데 사용률 **100.4%** 표시 (4·5월은 정상)
- 예산 목록·알림 위젯은 `spent / budget` 숫자만 보여주는데 % 만 어긋남 (막대는 86% 채움, 텍스트는 100.4% — 자기모순)

## 근본 원인
`BudgetService.getBudgetSummary` 의 `usageRate` 분자에 `plannedAmount`(지출계획)가 포함:
- `usageRate = round((spent + planned) / budget × 100)`
- 회차 12 P4에서 이 화면의 지출계획 표시 세그먼트를 제거했는데 사용률 계산은 planned 를 계속 포함
- 지출계획이 있는 달만 % 가 튐: `(740,504 + 약 120,066) / 857,142 = 100.4%`
- 4·5월은 planned=0 이라 `spent/budget` 과 동일해 정상으로 보였음
- ⚠️ PR #262(주간↔월 환산)와 무관 — 환산은 정상(`857,142 = 200,000 × 30/7`)

## 수정
- `usageRate = spent / budget` 로 통일
- 표시 숫자 · progress bar · `BudgetAlertService.percentage`(이미 spent 기준)와 일치
- `plannedAmount` 는 `remainingAmount` 의 예약 개념으로 유지(별도 분석 영역)
- 영향 범위: 예산 목록 페이지 + 예산 알림 위젯 (둘 다 BE `usageRate` 소비) — 대시보드 총합 카드는 이미 FE `totalSpent/totalBudget` 로 spent 기준

## 검증
- `BudgetServiceTest` + report 패키지 테스트 통과
- usageRate planned 제외 회귀 테스트 추가 (33.3% = 50000/150000, planned 30000 무시)

🤖 Generated with [Claude Code](https://claude.com/claude-code)