### PR TITLE
fix(transaction): 자동완성 제안 수입/지출 타입별 분리 + 월 이동 시 필터 드롭 방지

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -1,5 +1,9 @@
 # Backend - Kotlin Spring Boot API
 
+## Efficiency Rules
+- **grep → Read 순서**: 200줄+ 파일은 `grep -n "symbol"` 위치 확인 후 `Read(offset, limit)` 해당 범위만. 전체 Read 금지.
+- **명령 예산**: 하나의 가설 검증 최대 5개 명령. 초과 전 파악 내용 먼저 보고.
+
 ## Stack
 - Kotlin 1.9+, Spring Boot 3.2+, Java 21
 - Spring Data JPA (PostgreSQL via Supabase)

--- a/backend/src/main/kotlin/com/budgetbook/ai/service/AiClassificationService.kt
+++ b/backend/src/main/kotlin/com/budgetbook/ai/service/AiClassificationService.kt
@@ -7,6 +7,7 @@ import com.budgetbook.category.service.CategoryService
 import com.budgetbook.common.cache.RedisCacheService
 import com.budgetbook.common.service.CoupleAwareService
 import com.budgetbook.couple.service.CoupleResolver
+import com.budgetbook.transaction.domain.TransactionType
 import com.budgetbook.transaction.service.TransactionService
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.slf4j.LoggerFactory
@@ -60,8 +61,9 @@ class AiClassificationService(
         type: String,
         cacheKey: String
     ): ClassifyResponse {
-        // 2. Try pattern matching from existing transactions
-        val suggestions = transactionService.getSuggestions(userId, description, 1)
+        // 2. Try pattern matching from existing transactions (수입/지출 타입 일치 패턴만).
+        val txType = if (type.uppercase() == "INCOME") TransactionType.INCOME else TransactionType.EXPENSE
+        val suggestions = transactionService.getSuggestions(userId, description, 1, txType)
         if (suggestions.isNotEmpty()) {
             val topPattern = suggestions.first().patterns.first()
             if (topPattern.categoryId != null) {

--- a/backend/src/main/kotlin/com/budgetbook/transaction/controller/TransactionController.kt
+++ b/backend/src/main/kotlin/com/budgetbook/transaction/controller/TransactionController.kt
@@ -4,6 +4,7 @@ import com.budgetbook.common.dto.ApiResponse
 import com.budgetbook.common.dto.CommonFilterParams
 import com.budgetbook.common.ratelimit.RateLimit
 import com.budgetbook.common.security.AuthUser
+import com.budgetbook.transaction.domain.TransactionType
 import com.budgetbook.transaction.dto.CreateTransactionRequest
 import com.budgetbook.transaction.dto.CsvImportResponse
 import com.budgetbook.transaction.dto.PageResponse
@@ -129,9 +130,10 @@ class TransactionController(
     fun getSuggestions(
         @AuthUser userId: UUID,
         @RequestParam q: String,
-        @RequestParam(defaultValue = "5") limit: Int
+        @RequestParam(defaultValue = "5") limit: Int,
+        @RequestParam(required = false) type: TransactionType? = null
     ): ApiResponse<List<com.budgetbook.transaction.dto.SuggestionResponse>> {
-        return ApiResponse.ok(transactionService.getSuggestions(userId, q, limit))
+        return ApiResponse.ok(transactionService.getSuggestions(userId, q, limit, type))
     }
 
     @RateLimit(maxRequests = 5, windowSeconds = 60)

--- a/backend/src/main/kotlin/com/budgetbook/transaction/repository/TransactionRepository.kt
+++ b/backend/src/main/kotlin/com/budgetbook/transaction/repository/TransactionRepository.kt
@@ -266,6 +266,7 @@ interface TransactionRepository : JpaRepository<Transaction, UUID>, JpaSpecifica
         FROM Transaction t
         WHERE t.couple.id = :coupleId
         AND t.transactionDate >= :since
+        AND (:type IS NULL OR t.type = :type)
         AND LOWER(t.description) LIKE LOWER(CONCAT(:query, '%'))
         GROUP BY t.description,
                  t.category.id, t.category.name, t.category.icon, t.category.color,
@@ -276,7 +277,8 @@ interface TransactionRepository : JpaRepository<Transaction, UUID>, JpaSpecifica
     fun findSuggestionPatterns(
         @Param("coupleId") coupleId: UUID,
         @Param("query") query: String,
-        @Param("since") since: LocalDate
+        @Param("since") since: LocalDate,
+        @Param("type") type: TransactionType?
     ): List<Array<Any?>>
 
     @Query("""

--- a/backend/src/main/kotlin/com/budgetbook/transaction/service/TransactionService.kt
+++ b/backend/src/main/kotlin/com/budgetbook/transaction/service/TransactionService.kt
@@ -419,14 +419,20 @@ class TransactionService(
     }
 
     @Transactional(readOnly = true)
-    fun getSuggestions(userId: UUID, query: String, limit: Int = 5): List<com.budgetbook.transaction.dto.SuggestionResponse> {
+    fun getSuggestions(
+        userId: UUID,
+        query: String,
+        limit: Int = 5,
+        type: TransactionType? = null
+    ): List<com.budgetbook.transaction.dto.SuggestionResponse> {
         if (query.length < 2) return emptyList()
         val couple = getActiveCouple(userId)
         val safeLimit = limit.coerceIn(1, 20)
         // 최근 3개월 내 사용 빈도만 집계 (그 이전 거래는 제안에서 제외).
         val since = LocalDate.now().minusMonths(3)
 
-        val rows = transactionRepository.findSuggestionPatterns(couple.id, query, since)
+        // 수입/지출 타입별 제안 분리 (type=null 이면 전체 — 구버전 클라이언트 호환).
+        val rows = transactionRepository.findSuggestionPatterns(couple.id, query, since, type)
 
         // Group by description, then collect patterns per description
         val grouped = linkedMapOf<String, MutableList<com.budgetbook.transaction.dto.SuggestionPattern>>()

--- a/backend/src/test/kotlin/com/budgetbook/ai/service/AiClassificationServiceTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/ai/service/AiClassificationServiceTest.kt
@@ -11,6 +11,7 @@ import com.budgetbook.common.cache.RedisCacheService
 import com.budgetbook.couple.domain.Couple
 import com.budgetbook.couple.domain.CoupleStatus
 import com.budgetbook.couple.service.CoupleResolver
+import com.budgetbook.transaction.domain.TransactionType
 import com.budgetbook.transaction.dto.SuggestionPattern
 import com.budgetbook.transaction.dto.SuggestionResponse
 import com.budgetbook.transaction.service.TransactionService
@@ -65,7 +66,7 @@ class AiClassificationServiceTest : BehaviorSpec({
                 result.categoryId shouldBe cachedResponse.categoryId
                 result.categoryName shouldBe "식비"
                 result.source shouldBe "CACHE"
-                verify(exactly = 0) { transactionService.getSuggestions(any(), any(), any()) }
+                verify(exactly = 0) { transactionService.getSuggestions(any(), any(), any(), any()) }
                 verify(exactly = 0) { claudeApiClient.sendMessage(any(), any(), any(), any()) }
             }
         }
@@ -91,7 +92,7 @@ class AiClassificationServiceTest : BehaviorSpec({
                 )
             )
         )
-        every { transactionService.getSuggestions(user1.id, "스타벅스 커피", 1) } returns suggestions
+        every { transactionService.getSuggestions(user1.id, "스타벅스 커피", 1, TransactionType.EXPENSE) } returns suggestions
 
         When("classify is called") {
             val result = service.classify(user1.id, "스타벅스 커피", "EXPENSE")
@@ -108,7 +109,7 @@ class AiClassificationServiceTest : BehaviorSpec({
 
     Given("no cache, no pattern match, AI is enabled") {
         every { redisCacheService.get(any()) } returns null
-        every { transactionService.getSuggestions(user1.id, "새로운 가게", 1) } returns emptyList()
+        every { transactionService.getSuggestions(user1.id, "새로운 가게", 1, TransactionType.EXPENSE) } returns emptyList()
 
         val catId = UUID.randomUUID()
         val categories = listOf(
@@ -143,7 +144,7 @@ class AiClassificationServiceTest : BehaviorSpec({
         )
 
         every { redisCacheService.get(any()) } returns null
-        every { transactionService.getSuggestions(user1.id, "새로운 가게", 1) } returns emptyList()
+        every { transactionService.getSuggestions(user1.id, "새로운 가게", 1, TransactionType.EXPENSE) } returns emptyList()
 
         When("classify is called with no pattern match") {
             val result = disabledService.classify(user1.id, "새로운 가게", "EXPENSE")
@@ -158,7 +159,7 @@ class AiClassificationServiceTest : BehaviorSpec({
 
     Given("AI call fails") {
         every { redisCacheService.get(any()) } returns null
-        every { transactionService.getSuggestions(user1.id, "실패 테스트", 1) } returns emptyList()
+        every { transactionService.getSuggestions(user1.id, "실패 테스트", 1, TransactionType.EXPENSE) } returns emptyList()
 
         val categories = listOf(
             CategoryResponse(

--- a/backend/src/test/kotlin/com/budgetbook/transaction/controller/TransactionControllerTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/transaction/controller/TransactionControllerTest.kt
@@ -251,7 +251,7 @@ class TransactionControllerTest : FunSpec({
             SuggestionResponse("점심 식사", emptyList()),
             SuggestionResponse("점심 도시락", emptyList())
         )
-        every { transactionService.getSuggestions(testUserId, "점", 10) } returns suggestions
+        every { transactionService.getSuggestions(testUserId, "점", 10, null) } returns suggestions
 
         val result = controller.getSuggestions(testUserId, "점", 10)
 
@@ -263,7 +263,7 @@ class TransactionControllerTest : FunSpec({
     test("getSuggestions with custom limit") {
 
         val suggestions = listOf(SuggestionResponse("커피", emptyList()))
-        every { transactionService.getSuggestions(testUserId, "커", 5) } returns suggestions
+        every { transactionService.getSuggestions(testUserId, "커", 5, null) } returns suggestions
 
         val result = controller.getSuggestions(testUserId, "커", 5)
 
@@ -273,7 +273,7 @@ class TransactionControllerTest : FunSpec({
 
     test("getSuggestions returns empty list when no matches") {
 
-        every { transactionService.getSuggestions(testUserId, "없는내용", 10) } returns emptyList()
+        every { transactionService.getSuggestions(testUserId, "없는내용", 10, null) } returns emptyList()
 
         val result = controller.getSuggestions(testUserId, "없는내용", 10)
 

--- a/backend/src/test/kotlin/com/budgetbook/transaction/service/TransactionServiceTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/transaction/service/TransactionServiceTest.kt
@@ -440,7 +440,7 @@ class TransactionServiceTest : BehaviorSpec({
         every { coupleResolver.getActiveCouple(user1.id) } returns couple
 
         When("matching descriptions exist") {
-            every { transactionRepository.findSuggestionPatterns(couple.id, "점심", any()) } returns listOf(
+            every { transactionRepository.findSuggestionPatterns(couple.id, "점심", any(), any()) } returns listOf(
                 arrayOf<Any?>("점심 식사", null, null, null, null, null, null, null, 3L),
                 arrayOf<Any?>("점심 도시락", null, null, null, null, null, null, null, 1L)
             )
@@ -455,7 +455,7 @@ class TransactionServiceTest : BehaviorSpec({
         }
 
         When("no matching descriptions exist") {
-            every { transactionRepository.findSuggestionPatterns(couple.id, "없는것", any()) } returns emptyList()
+            every { transactionRepository.findSuggestionPatterns(couple.id, "없는것", any(), any()) } returns emptyList()
 
             val result = service.getSuggestions(user1.id, "없는것", 10)
 
@@ -465,7 +465,7 @@ class TransactionServiceTest : BehaviorSpec({
         }
 
         When("limit exceeds max") {
-            every { transactionRepository.findSuggestionPatterns(couple.id, "점심", any()) } returns listOf(
+            every { transactionRepository.findSuggestionPatterns(couple.id, "점심", any(), any()) } returns listOf(
                 arrayOf<Any?>("점심", null, null, null, null, null, null, null, 1L)
             )
 
@@ -478,7 +478,7 @@ class TransactionServiceTest : BehaviorSpec({
         }
 
         When("limit is zero or negative") {
-            every { transactionRepository.findSuggestionPatterns(couple.id, "점심", any()) } returns listOf(
+            every { transactionRepository.findSuggestionPatterns(couple.id, "점심", any(), any()) } returns listOf(
                 arrayOf<Any?>("점심 식사", null, null, null, null, null, null, null, 5L),
                 arrayOf<Any?>("점심 도시락", null, null, null, null, null, null, null, 2L)
             )
@@ -500,7 +500,7 @@ class TransactionServiceTest : BehaviorSpec({
         }
 
         When("one description has more than 3 patterns") {
-            every { transactionRepository.findSuggestionPatterns(couple.id, "점심", any()) } returns listOf(
+            every { transactionRepository.findSuggestionPatterns(couple.id, "점심", any(), any()) } returns listOf(
                 arrayOf<Any?>("점심", null, null, null, null, null, null, null, 5L),
                 arrayOf<Any?>("점심", null, null, null, null, null, null, null, 4L),
                 arrayOf<Any?>("점심", null, null, null, null, null, null, null, 3L),
@@ -513,6 +513,20 @@ class TransactionServiceTest : BehaviorSpec({
             Then("caps patterns at 3 per description") {
                 result.size shouldBe 1
                 result[0].patterns.size shouldBe 3
+            }
+        }
+
+        When("a transaction type is given") {
+            every { transactionRepository.findSuggestionPatterns(couple.id, "점심", any(), TransactionType.INCOME) } returns listOf(
+                arrayOf<Any?>("점심 정산", null, null, null, null, null, null, null, 2L)
+            )
+
+            val result = service.getSuggestions(user1.id, "점심", 10, TransactionType.INCOME)
+
+            Then("forwards the type filter to the repository") {
+                result.size shouldBe 1
+                result[0].description shouldBe "점심 정산"
+                verify { transactionRepository.findSuggestionPatterns(couple.id, "점심", any(), TransactionType.INCOME) }
             }
         }
     }

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -1,5 +1,9 @@
 # Frontend - Flutter (Web + Mobile Unified)
 
+## Efficiency Rules
+- **grep → Read 순서**: `grep -n "ClassName\|methodName" file.dart` 먼저 → 해당 범위만 `Read(offset, limit)`. 2100줄 파일 전체 Read 절대 금지.
+- **명령 예산**: 하나의 가설 검증 최대 5개 명령. 초과 전 파악 내용 먼저 보고.
+
 ## Stack
 - Flutter 3.x, Dart 3.x
 - flutter_bloc for state management

--- a/frontend/lib/core/bloc/month_sync_handler.dart
+++ b/frontend/lib/core/bloc/month_sync_handler.dart
@@ -69,29 +69,17 @@ class MonthSyncHandler extends StatelessWidget {
     } catch (_) {}
 
     // Transaction list — 전체 필터(currentFilter) 유지.
-    // 과거 인시던트(2026-04-15 월 이동 시 dateFrom/To/keyword/pocket/amount/type drop)
-    // 재발 방지를 위해 currentCategoryId/currentPaymentMethodId 만 꺼내던 것을
-    // TransactionFilter value object 전체로 교체.
+    // 과거 인시던트(2026-04-15 월 이동 시 필터 drop) 재발 방지: 개별 필드를 수동
+    // 나열하면 새 필터(transactionTypes·needsReviewOnly)를 빠뜨려 재발하므로,
+    // LoadTransactions.fromFilter 팩토리로 TransactionFilter 전체를 드롭 없이 전달한다.
+    // 월 이동 시 특정 월 종속 기간 필터는 해제(clearDateRange).
     try {
       final txnBloc = getIt<TransactionBloc>();
-      final f = txnBloc.currentFilter;
-      txnBloc.add(LoadTransactions(
-        year: year,
-        month: month,
-        keyword: f.keyword,
-        categoryId: f.categoryId,
-        categoryIds: f.categoryIds,
-        categoryGroupIds: f.categoryGroupIds,
-        paymentMethodId: f.paymentMethodId,
-        paymentMethodIds: f.paymentMethodIds,
-        pocketId: f.pocketId,
-        pocketIds: f.pocketIds,
-        amountMin: f.amountMin,
-        amountMax: f.amountMax,
-        dateFrom: f.dateFrom,
-        dateTo: f.dateTo,
-        type: f.type,
-        visibility: f.visibility,
+      txnBloc.add(LoadTransactions.fromFilter(
+        year,
+        month,
+        txnBloc.currentFilter,
+        clearDateRange: true,
       ));
     } catch (_) {}
 

--- a/frontend/lib/features/transaction/data/datasources/transaction_remote_datasource.dart
+++ b/frontend/lib/features/transaction/data/datasources/transaction_remote_datasource.dart
@@ -33,7 +33,7 @@ abstract class TransactionRemoteDataSource {
   Future<TransactionModel> updateTransaction(
       String id, Map<String, dynamic> data);
   Future<void> deleteTransaction(String id);
-  Future<List<SuggestionGroup>> getSuggestions(String query);
+  Future<List<SuggestionGroup>> getSuggestions(String query, {String? type});
 }
 
 class TransactionRemoteDataSourceImpl implements TransactionRemoteDataSource {
@@ -154,10 +154,14 @@ class TransactionRemoteDataSourceImpl implements TransactionRemoteDataSource {
   }
 
   @override
-  Future<List<SuggestionGroup>> getSuggestions(String query) async {
+  Future<List<SuggestionGroup>> getSuggestions(String query, {String? type}) async {
     final response = await apiClient.dio.get(
       '${ApiEndpoints.transactions}/suggestions',
-      queryParameters: {'q': query, 'limit': 5},
+      queryParameters: {
+        'q': query,
+        'limit': 5,
+        if (type != null) 'type': type,
+      },
     );
     final list = response.data['data'] as List<dynamic>;
     return list.map((item) {

--- a/frontend/lib/features/transaction/data/repositories/transaction_repository_impl.dart
+++ b/frontend/lib/features/transaction/data/repositories/transaction_repository_impl.dart
@@ -159,9 +159,12 @@ class TransactionRepositoryImpl implements TransactionRepository {
   }
 
   @override
-  Future<Either<Failure, List<SuggestionGroup>>> getSuggestions(String query) async {
+  Future<Either<Failure, List<SuggestionGroup>>> getSuggestions(
+    String query, {
+    String? type,
+  }) async {
     try {
-      final data = await remoteDataSource.getSuggestions(query);
+      final data = await remoteDataSource.getSuggestions(query, type: type);
       return Right(data);
     } on DioException catch (e) {
       return Left(mapDioError(e, 'Failed to load suggestions'));

--- a/frontend/lib/features/transaction/domain/repositories/transaction_repository.dart
+++ b/frontend/lib/features/transaction/domain/repositories/transaction_repository.dart
@@ -56,7 +56,10 @@ abstract class TransactionRepository {
 
   Future<Either<Failure, void>> deleteTransaction(String id);
 
-  Future<Either<Failure, List<SuggestionGroup>>> getSuggestions(String query);
+  Future<Either<Failure, List<SuggestionGroup>>> getSuggestions(
+    String query, {
+    String? type,
+  });
 }
 
 /// Suggestion group from /transactions/suggestions endpoint.

--- a/frontend/lib/features/transaction/presentation/bloc/transaction_event.dart
+++ b/frontend/lib/features/transaction/presentation/bloc/transaction_event.dart
@@ -1,4 +1,5 @@
 import 'package:equatable/equatable.dart';
+import 'package:budget_book/features/transaction/domain/entities/transaction_filter.dart';
 
 sealed class TransactionEvent extends Equatable {
   const TransactionEvent();
@@ -50,6 +51,42 @@ class LoadTransactions extends TransactionEvent {
     this.visibility,
     this.needsReviewOnly,
   });
+
+  /// 필터 VO 전체를 드롭 없이 전파하는 단일 진입점.
+  /// MonthSyncHandler 등 외부 consumer 가 개별 필드를 수동 나열하다 한 필드를
+  /// 빠뜨리는 사고(2026-04-15 "월 이동 후 필터 drop" 인시던트, transactionTypes·
+  /// needsReviewOnly 누락으로 재발)를 원천 차단한다. 새 필터 추가 시 TransactionFilter
+  /// 와 LoadTransactions 생성자만 고치면 이 팩토리는 자동으로 전체를 전달한다.
+  factory LoadTransactions.fromFilter(
+    int year,
+    int month,
+    TransactionFilter f, {
+    String? scrollToDate,
+    bool clearDateRange = false,
+  }) {
+    return LoadTransactions(
+      year: year,
+      month: month,
+      keyword: f.keyword,
+      categoryId: f.categoryId,
+      categoryIds: f.categoryIds,
+      categoryGroupIds: f.categoryGroupIds,
+      paymentMethodId: f.paymentMethodId,
+      paymentMethodIds: f.paymentMethodIds,
+      pocketId: f.pocketId,
+      pocketIds: f.pocketIds,
+      amountMin: f.amountMin,
+      amountMax: f.amountMax,
+      // 월 이동 시 특정 월에 종속된 명시적 기간 필터는 해제(페이지 내비게이터와 동일 규칙).
+      dateFrom: clearDateRange ? null : f.dateFrom,
+      dateTo: clearDateRange ? null : f.dateTo,
+      type: f.type,
+      transactionTypes: f.transactionTypes,
+      visibility: f.visibility,
+      needsReviewOnly: f.needsReviewOnly,
+      scrollToDate: scrollToDate,
+    );
+  }
 
   @override
   List<Object?> get props => [

--- a/frontend/lib/features/transaction/presentation/pages/transaction_form_page.dart
+++ b/frontend/lib/features/transaction/presentation/pages/transaction_form_page.dart
@@ -414,7 +414,9 @@ class _TransactionFormPageState extends State<TransactionFormPage>
 
   Future<void> _fetchSuggestions(String query) async {
     final repo = context.read<TransactionBloc>().transactionRepository;
-    final result = await repo.getSuggestions(query);
+    // 수입/지출 타입별 제안 분리 — ADJUSTMENT 는 EXPENSE 로 취급(카테고리 필터와 동일 규칙).
+    final suggestionType = _selectedType == 'INCOME' ? 'INCOME' : 'EXPENSE';
+    final result = await repo.getSuggestions(query, type: suggestionType);
     if (!mounted) return;
     result.fold(
       (_) => setState(() {

--- a/frontend/lib/features/transaction/presentation/pages/transaction_list_page.dart
+++ b/frontend/lib/features/transaction/presentation/pages/transaction_list_page.dart
@@ -636,6 +636,8 @@ class _TransactionListPageState extends State<TransactionListPage> {
                     scrollToDate: _pendingScrollToDate,
                     transactionTypes: _filterState.transactionTypes,
                     visibility: _filterState.visibility,
+                    needsReviewOnly:
+                        _filterState.needsReviewOnly ? true : null,
                   ),
                 );
           },

--- a/frontend/test/features/transaction/data/repositories/transaction_repository_impl_test.dart
+++ b/frontend/test/features/transaction/data/repositories/transaction_repository_impl_test.dart
@@ -101,9 +101,9 @@ class MockTransactionRemoteDataSource extends Mock
       ) as Future<void>;
 
   @override
-  Future<List<SuggestionGroup>> getSuggestions(String query) =>
+  Future<List<SuggestionGroup>> getSuggestions(String query, {String? type}) =>
       super.noSuchMethod(
-        Invocation.method(#getSuggestions, [query]),
+        Invocation.method(#getSuggestions, [query], {#type: type}),
         returnValue: Future.value(<SuggestionGroup>[]),
       ) as Future<List<SuggestionGroup>>;
 


### PR DESCRIPTION
## 배경
1. **수입인데 지출 카테고리 제안이 뜸** — 거래 입력 자동완성이 수입/지출 구분 없이 섞여 나옴
2. **필터 적용 후 월 이동 시 필터 미적용** — 필터를 걸고 월을 넘기면 필터가 사라짐

## 근본 원인
**버그 1**: `TransactionRepository.findSuggestionPatterns` 쿼리에 `t.type` 필터가 없어 수입/지출 거래 패턴이 무구분 집계됨. `getSuggestions`/controller/FE 모두 type 미전달.

**버그 2**: 월 이동 시 `LoadTransactions` 가 두 곳(리스트 페이지 `onMonthChanged` + `MonthSyncHandler`)에서 이중 dispatch 되고, BLoC 핸들러는 기본 concurrent transformer라 경쟁. `MonthCubit.changeMonth` 는 stream microtask로 전파되어 **MonthSyncHandler 이벤트가 나중에 큐잉 → 최종 emit을 이김(authoritative)**. 그런데 MonthSyncHandler 가 `currentFilter` VO를 안 쓰고 필드를 수동 나열하다 `transactionTypes`(Phase 22)·`needsReviewOnly`(V61)를 누락 → drop. (2026-04-15 "월 이동 필터 drop" 인시던트 재발)

## 변경
### 버그 1 — 제안 타입 분리
- `findSuggestionPatterns(coupleId, query, since, type)` + `AND (:type IS NULL OR t.type = :type)` (type=null → 구버전 FE 무필터 호환)
- `TransactionService.getSuggestions(userId, query, limit, type)`
- Controller `@RequestParam(required=false) type: TransactionType?`
- `AiClassificationService` 는 자기 type 을 INCOME/EXPENSE 로 매핑해 패턴매칭에 전달
- FE `getSuggestions(query, type:)` — `_selectedType`(ADJUSTMENT→EXPENSE) 전송

### 버그 2 — 필터 드롭 구조적 방지
- **`LoadTransactions.fromFilter(year, month, TransactionFilter, {scrollToDate, clearDateRange})`** 팩토리 추가: VO 전체를 드롭 없이 매핑하는 단일 진입점 (신규 필터 추가 시 VO+생성자만 고치면 자동 전파)
- `MonthSyncHandler` 는 이 팩토리 + `clearDateRange:true` 사용
- 리스트 페이지 `onMonthChanged` 에 누락됐던 `needsReviewOnly` 추가

## 검증
- BE 유닛 테스트: transaction/ai/category/budget/statistics 패키지 BUILD SUCCESSFUL (getSuggestions type 전달 검증 케이스 추가)
- FE `flutter analyze` 에러 0, `flutter test` 748개 전체 통과, `flutter build web` 성공
- ⚠️ `DeleteUserByEmailIntegrationTest` 는 Testcontainers Docker 필요 — 로컬 샌드박스에 Docker 부재로 스킵(CI에서 실행). 본 변경과 무관.

🤖 Generated with [Claude Code](https://claude.com/claude-code)