### PR TITLE
fix(transaction): 달력뷰 상세 라우팅 + 이체/공유·개인 필터 + 잔액 오염 & 자산 잔액 기능

### DIFF
--- a/backend/src/main/kotlin/com/budgetbook/paymentmethod/controller/PaymentMethodController.kt
+++ b/backend/src/main/kotlin/com/budgetbook/paymentmethod/controller/PaymentMethodController.kt
@@ -2,6 +2,7 @@ package com.budgetbook.paymentmethod.controller
 
 import com.budgetbook.common.dto.ApiResponse
 import com.budgetbook.common.security.AuthUser
+import com.budgetbook.paymentmethod.dto.AssetBalanceResponse
 import com.budgetbook.paymentmethod.dto.CardPendingResponse
 import com.budgetbook.paymentmethod.dto.CardSettlementSummaryResponse
 import com.budgetbook.paymentmethod.dto.CreatePaymentMethodRequest
@@ -10,6 +11,7 @@ import com.budgetbook.paymentmethod.dto.ReorderPaymentMethodRequest
 import com.budgetbook.paymentmethod.dto.UpdatePaymentMethodRequest
 import com.budgetbook.paymentmethod.service.PaymentMethodService
 import jakarta.validation.Valid
+import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.DeleteMapping
@@ -21,6 +23,7 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
+import java.time.LocalDate
 import java.util.UUID
 
 @RestController
@@ -68,6 +71,15 @@ class PaymentMethodController(
     ): ResponseEntity<Void> {
         paymentMethodService.deletePaymentMethod(userId, id)
         return ResponseEntity.noContent().build()
+    }
+
+    @GetMapping("/{id}/balance")
+    fun getAssetBalance(
+        @AuthUser userId: UUID,
+        @PathVariable id: UUID,
+        @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) asOf: LocalDate
+    ): ApiResponse<AssetBalanceResponse> {
+        return ApiResponse.ok(paymentMethodService.getAssetBalance(userId, id, asOf))
     }
 
     @GetMapping("/card-settlement-summary")

--- a/backend/src/main/kotlin/com/budgetbook/paymentmethod/dto/PaymentMethodDtos.kt
+++ b/backend/src/main/kotlin/com/budgetbook/paymentmethod/dto/PaymentMethodDtos.kt
@@ -56,6 +56,12 @@ data class ReorderPaymentMethodRequest(
     val orderedIds: List<UUID>
 )
 
+data class AssetBalanceResponse(
+    val paymentMethodId: UUID,
+    val asOf: LocalDate,
+    val balance: Long?
+)
+
 data class CardPendingResponse(
     val paymentMethod: PaymentMethodResponse,
     val pendingAmount: Long,

--- a/backend/src/main/kotlin/com/budgetbook/paymentmethod/service/PaymentMethodService.kt
+++ b/backend/src/main/kotlin/com/budgetbook/paymentmethod/service/PaymentMethodService.kt
@@ -8,6 +8,7 @@ import com.budgetbook.couple.service.CoupleResolver
 import com.budgetbook.common.service.CoupleAwareService
 import com.budgetbook.paymentmethod.domain.PaymentMethod
 import com.budgetbook.paymentmethod.domain.PaymentMethodType
+import com.budgetbook.paymentmethod.dto.AssetBalanceResponse
 import com.budgetbook.paymentmethod.dto.CardPendingResponse
 import com.budgetbook.paymentmethod.dto.CardSettlementMonth
 import com.budgetbook.paymentmethod.dto.CardSettlementSummaryResponse
@@ -62,6 +63,44 @@ class PaymentMethodService(
         return allIds.associateWith { id ->
             (txNet[id] ?: 0L) + (transferIn[id] ?: 0L) - (transferOut[id] ?: 0L)
         }
+    }
+
+    /**
+     * asOf(배타 상한) 시점의 단일 결제수단 잔액 조회.
+     * userId 로 활성 커플을 해석한 뒤 calculateBalanceAsOf 에 위임한다.
+     */
+    @Transactional(readOnly = true)
+    fun getAssetBalance(userId: UUID, paymentMethodId: UUID, asOf: LocalDate): AssetBalanceResponse {
+        val couple = getActiveCouple(userId)
+        return calculateBalanceAsOf(couple.id, paymentMethodId, asOf)
+    }
+
+    /**
+     * 단일 결제수단의 asOf 미만 시점 잔액을 계산한다.
+     * - PM 이 커플 소유가 아니면 NotFoundException(404).
+     * - CREDIT 타입은 balance = null.
+     * - 그 외: txNet(asOf) + transferIn(asOf) - transferOut(asOf).
+     */
+    @Transactional(readOnly = true)
+    fun calculateBalanceAsOf(coupleId: UUID, paymentMethodId: UUID, asOf: LocalDate): AssetBalanceResponse {
+        val pm = paymentMethodRepository.findByIdAndCoupleId(paymentMethodId, coupleId)
+            ?: throw NotFoundException("PAYMENT_METHOD_NOT_FOUND", "Payment method does not exist.")
+
+        if (pm.type == PaymentMethodType.CREDIT) {
+            return AssetBalanceResponse(paymentMethodId = pm.id, asOf = asOf, balance = null)
+        }
+
+        val txNet = transactionRepository.netAmountByPaymentMethodForCoupleUpTo(coupleId, asOf)
+            .associate { row -> row[0] as UUID to (row[1] as Number).toLong() }
+
+        val transferIn = transferRepository.sumAmountByDestinationForCoupleUpTo(coupleId, asOf)
+            .associate { row -> row[0] as UUID to (row[1] as Number).toLong() }
+
+        val transferOut = transferRepository.sumAmountBySourceForCoupleUpTo(coupleId, asOf)
+            .associate { row -> row[0] as UUID to (row[1] as Number).toLong() }
+
+        val balance = (txNet[pm.id] ?: 0L) + (transferIn[pm.id] ?: 0L) - (transferOut[pm.id] ?: 0L)
+        return AssetBalanceResponse(paymentMethodId = pm.id, asOf = asOf, balance = balance)
     }
 
     @Transactional

--- a/backend/src/main/kotlin/com/budgetbook/transaction/repository/TransactionRepository.kt
+++ b/backend/src/main/kotlin/com/budgetbook/transaction/repository/TransactionRepository.kt
@@ -410,6 +410,26 @@ interface TransactionRepository : JpaRepository<Transaction, UUID>, JpaSpecifica
     """)
     fun netAmountByPaymentMethodForCouple(@Param("coupleId") coupleId: UUID): List<Array<Any>>
 
+    /**
+     * 결제수단 별 순잔액 (asOf 미만 시점 기준):
+     * netAmountByPaymentMethodForCouple 와 동일하되 transactionDate < :asOf 조건 추가.
+     * asOf 는 상한 배타(exclusive) — asOf 당일 거래는 제외된다.
+     */
+    @Query("""
+        SELECT t.paymentMethod.id,
+            COALESCE(SUM(CASE WHEN t.type = com.budgetbook.transaction.domain.TransactionType.INCOME THEN t.amount ELSE 0L END), 0L) -
+            COALESCE(SUM(CASE WHEN t.type = com.budgetbook.transaction.domain.TransactionType.EXPENSE THEN t.amount ELSE 0L END), 0L) +
+            COALESCE(SUM(CASE WHEN t.type = com.budgetbook.transaction.domain.TransactionType.ADJUSTMENT THEN t.amount ELSE 0L END), 0L)
+        FROM Transaction t
+        WHERE t.couple.id = :coupleId AND t.paymentMethod IS NOT NULL
+        AND t.transactionDate < :asOf
+        GROUP BY t.paymentMethod.id
+    """)
+    fun netAmountByPaymentMethodForCoupleUpTo(
+        @Param("coupleId") coupleId: UUID,
+        @Param("asOf") asOf: LocalDate
+    ): List<Array<Any>>
+
     @Query("""
         SELECT t FROM Transaction t
         LEFT JOIN FETCH t.category

--- a/backend/src/main/kotlin/com/budgetbook/transfer/repository/TransferRepository.kt
+++ b/backend/src/main/kotlin/com/budgetbook/transfer/repository/TransferRepository.kt
@@ -32,6 +32,36 @@ interface TransferRepository : JpaRepository<Transfer, UUID> {
     """)
     fun sumAmountBySourceForCouple(@Param("coupleId") coupleId: UUID): List<Array<Any>>
 
+    /**
+     * destination PM 별 이체 유입 합계 (asOf 미만 시점 기준).
+     * asOf 는 상한 배타(exclusive) — asOf 당일 이체는 제외된다.
+     */
+    @Query("""
+        SELECT tr.destinationPaymentMethod.id, COALESCE(SUM(tr.amount), 0)
+        FROM Transfer tr WHERE tr.couple.id = :coupleId
+        AND tr.transferDate < :asOf
+        GROUP BY tr.destinationPaymentMethod.id
+    """)
+    fun sumAmountByDestinationForCoupleUpTo(
+        @Param("coupleId") coupleId: UUID,
+        @Param("asOf") asOf: LocalDate
+    ): List<Array<Any>>
+
+    /**
+     * source PM 별 이체 유출 합계 (asOf 미만 시점 기준).
+     * asOf 는 상한 배타(exclusive) — asOf 당일 이체는 제외된다.
+     */
+    @Query("""
+        SELECT tr.sourcePaymentMethod.id, COALESCE(SUM(tr.amount), 0)
+        FROM Transfer tr WHERE tr.couple.id = :coupleId
+        AND tr.transferDate < :asOf
+        GROUP BY tr.sourcePaymentMethod.id
+    """)
+    fun sumAmountBySourceForCoupleUpTo(
+        @Param("coupleId") coupleId: UUID,
+        @Param("asOf") asOf: LocalDate
+    ): List<Array<Any>>
+
     @Query("""
         SELECT tr.sourcePaymentMethod.id, COALESCE(SUM(tr.amount), 0)
         FROM Transfer tr

--- a/backend/src/test/kotlin/com/budgetbook/paymentmethod/controller/PaymentMethodControllerTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/paymentmethod/controller/PaymentMethodControllerTest.kt
@@ -1,5 +1,6 @@
 package com.budgetbook.paymentmethod.controller
 
+import com.budgetbook.paymentmethod.dto.AssetBalanceResponse
 import com.budgetbook.paymentmethod.dto.CardPendingResponse
 import com.budgetbook.paymentmethod.dto.CreatePaymentMethodRequest
 import com.budgetbook.paymentmethod.dto.PaymentMethodResponse
@@ -91,6 +92,34 @@ class PaymentMethodControllerTest : FunSpec({
 
         result.statusCode shouldBe HttpStatus.NO_CONTENT
         verify(exactly = 1) { paymentMethodService.deletePaymentMethod(testUserId, methodId) }
+    }
+
+    test("getAssetBalance returns date-bounded balance") {
+
+        val pmId = UUID.randomUUID()
+        val asOf = LocalDate.of(2024, 5, 1)
+        val response = AssetBalanceResponse(paymentMethodId = pmId, asOf = asOf, balance = 480000L)
+        every { paymentMethodService.getAssetBalance(testUserId, pmId, asOf) } returns response
+
+        val result = controller.getAssetBalance(testUserId, pmId, asOf)
+
+        result.success shouldBe true
+        result.data!!.paymentMethodId shouldBe pmId
+        result.data!!.asOf shouldBe asOf
+        result.data!!.balance shouldBe 480000L
+    }
+
+    test("getAssetBalance returns null balance for CREDIT payment method") {
+
+        val pmId = UUID.randomUUID()
+        val asOf = LocalDate.of(2024, 5, 1)
+        val response = AssetBalanceResponse(paymentMethodId = pmId, asOf = asOf, balance = null)
+        every { paymentMethodService.getAssetBalance(testUserId, pmId, asOf) } returns response
+
+        val result = controller.getAssetBalance(testUserId, pmId, asOf)
+
+        result.success shouldBe true
+        result.data!!.balance shouldBe null
     }
 
     test("getCardPendingSummary returns card pending data") {

--- a/backend/src/test/kotlin/com/budgetbook/paymentmethod/repository/AssetBalanceQueryTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/paymentmethod/repository/AssetBalanceQueryTest.kt
@@ -1,0 +1,142 @@
+package com.budgetbook.paymentmethod.repository
+
+import com.budgetbook.auth.domain.AuthProvider
+import com.budgetbook.auth.domain.User
+import com.budgetbook.couple.domain.Couple
+import com.budgetbook.couple.domain.CoupleStatus
+import com.budgetbook.paymentmethod.domain.PaymentMethod
+import com.budgetbook.paymentmethod.domain.PaymentMethodType
+import com.budgetbook.transaction.domain.Transaction
+import com.budgetbook.transaction.domain.TransactionType
+import com.budgetbook.transaction.repository.TransactionRepository
+import com.budgetbook.transfer.domain.Transfer
+import com.budgetbook.transfer.repository.TransferRepository
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.extensions.spring.SpringExtension
+import io.kotest.matchers.shouldBe
+import jakarta.persistence.EntityManager
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.TestPropertySource
+import org.springframework.transaction.PlatformTransactionManager
+import org.springframework.transaction.support.TransactionTemplate
+import java.time.LocalDate
+import java.util.UUID
+
+/**
+ * Repository-level test for the date-bounded (`< asOf`) asset-balance queries.
+ *
+ * Runs against H2 (PostgreSQL mode) via @DataJpaTest so the JPQL `AND ... < :asOf`
+ * boundary is actually executed — proving exclusivity of the upper bound, which a
+ * MockK service test cannot verify.
+ */
+@DataJpaTest
+@ActiveProfiles("test")
+@TestPropertySource(properties = [
+    "spring.datasource.url=jdbc:h2:mem:asset-balance;DB_CLOSE_DELAY=-1;MODE=PostgreSQL",
+    "spring.jpa.hibernate.ddl-auto=create-drop",
+    "spring.flyway.enabled=false",
+    "spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect"
+])
+class AssetBalanceQueryTest(
+    @Autowired private val transactionRepository: TransactionRepository,
+    @Autowired private val transferRepository: TransferRepository,
+    @Autowired private val em: EntityManager,
+    @Autowired private val txManager: PlatformTransactionManager,
+) : FunSpec() {
+
+    override fun extensions() = listOf(SpringExtension)
+
+    init {
+        lateinit var coupleId: UUID
+        lateinit var bankId: UUID
+        lateinit var cashId: UUID
+
+        val asOf = LocalDate.of(2024, 5, 1)
+
+        beforeSpec {
+            TransactionTemplate(txManager).execute {
+            val user1 = User(email = "u1@test.com", nickname = "U1", provider = AuthProvider.GOOGLE, providerId = "g1")
+            val user2 = User(email = "u2@test.com", nickname = "U2", provider = AuthProvider.KAKAO, providerId = "k2")
+            em.persist(user1)
+            em.persist(user2)
+            val couple = Couple(user1 = user1, user2 = user2, status = CoupleStatus.ACTIVE)
+            em.persist(couple)
+            coupleId = couple.id
+
+            val bank = PaymentMethod(couple = couple, name = "신한은행", type = PaymentMethodType.BANK, displayOrder = 0)
+            val cash = PaymentMethod(couple = couple, name = "현금", type = PaymentMethodType.CASH, displayOrder = 1)
+            em.persist(bank)
+            em.persist(cash)
+            bankId = bank.id
+            cashId = cash.id
+
+            fun tx(type: TransactionType, amount: Long, date: LocalDate, pm: PaymentMethod) {
+                em.persist(
+                    Transaction(
+                        couple = couple, author = user1, type = type, amount = amount,
+                        description = "t", transactionDate = date, paymentMethod = pm
+                    )
+                )
+            }
+
+            fun transfer(amount: Long, date: LocalDate, src: PaymentMethod, dest: PaymentMethod) {
+                em.persist(
+                    Transfer(
+                        couple = couple, author = user1, sourcePaymentMethod = src,
+                        destinationPaymentMethod = dest, amount = amount, transferDate = date
+                    )
+                )
+            }
+
+            // --- bank transactions ---
+            tx(TransactionType.INCOME, 500_000L, LocalDate.of(2024, 4, 20), bank)   // before asOf: counts
+            tx(TransactionType.EXPENSE, 100_000L, LocalDate.of(2024, 4, 25), bank)  // before asOf: counts
+            tx(TransactionType.ADJUSTMENT, -20_000L, LocalDate.of(2024, 4, 30), bank) // signed delta, counts
+            tx(TransactionType.INCOME, 999_999L, asOf, bank)                         // ON asOf: EXCLUDED
+            tx(TransactionType.INCOME, 999_999L, LocalDate.of(2024, 6, 1), bank)     // after asOf: EXCLUDED
+
+            // --- transfers: cash -> bank (bank is dest = inflow, cash is source = outflow) ---
+            transfer(100_000L, LocalDate.of(2024, 4, 28), cash, bank)               // before asOf: counts
+            transfer(70_000L, asOf, cash, bank)                                     // ON asOf: EXCLUDED
+
+            em.flush()
+            em.clear()
+            }
+        }
+
+        test("netAmountByPaymentMethodForCoupleUpTo: excludes tx on/after asOf, includes ADJUSTMENT as signed delta") {
+            val net = transactionRepository.netAmountByPaymentMethodForCoupleUpTo(coupleId, asOf)
+                .associate { it[0] as UUID to (it[1] as Number).toLong() }
+
+            // 500000 (INCOME) - 100000 (EXPENSE) + (-20000) (ADJUSTMENT) = 380000
+            // the 999999 income ON asOf and the one AFTER asOf are excluded
+            net[bankId] shouldBe 380_000L
+        }
+
+        test("transfer sums up to asOf: dest inflow counted before asOf, on-asOf transfer excluded") {
+            val inflow = transferRepository.sumAmountByDestinationForCoupleUpTo(coupleId, asOf)
+                .associate { it[0] as UUID to (it[1] as Number).toLong() }
+            val outflow = transferRepository.sumAmountBySourceForCoupleUpTo(coupleId, asOf)
+                .associate { it[0] as UUID to (it[1] as Number).toLong() }
+
+            // only the 100000 transfer (2024-04-28) is < asOf; the 70000 ON asOf is excluded
+            inflow[bankId] shouldBe 100_000L      // bank as destination
+            outflow[cashId] shouldBe 100_000L     // cash as source
+        }
+
+        test("full asOf balance: bank = txNet + transferIn - transferOut") {
+            val net = transactionRepository.netAmountByPaymentMethodForCoupleUpTo(coupleId, asOf)
+                .associate { it[0] as UUID to (it[1] as Number).toLong() }
+            val inflow = transferRepository.sumAmountByDestinationForCoupleUpTo(coupleId, asOf)
+                .associate { it[0] as UUID to (it[1] as Number).toLong() }
+            val outflow = transferRepository.sumAmountBySourceForCoupleUpTo(coupleId, asOf)
+                .associate { it[0] as UUID to (it[1] as Number).toLong() }
+
+            val bankBalance = (net[bankId] ?: 0L) + (inflow[bankId] ?: 0L) - (outflow[bankId] ?: 0L)
+            // 380000 + 100000 - 0 = 480000
+            bankBalance shouldBe 480_000L
+        }
+    }
+}

--- a/backend/src/test/kotlin/com/budgetbook/paymentmethod/service/PaymentMethodServiceTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/paymentmethod/service/PaymentMethodServiceTest.kt
@@ -323,6 +323,107 @@ class PaymentMethodServiceTest : BehaviorSpec({
         }
     }
 
+    // --- calculateBalanceAsOf (date-bounded balance) ---
+
+    Given("a bank payment method for asOf balance calculation") {
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
+
+        val bank = PaymentMethod(couple = couple, name = "신한은행", type = PaymentMethodType.BANK, displayOrder = 0)
+        every { paymentMethodRepository.findByIdAndCoupleId(bank.id, couple.id) } returns bank
+
+        val asOf = java.time.LocalDate.of(2024, 5, 1)
+
+        When("getAssetBalance is called and net includes INCOME/EXPENSE/ADJUSTMENT before asOf") {
+            // net = INCOME - EXPENSE + ADJUSTMENT already collapsed by query;
+            // e.g. income 500000 - expense 100000 + adjustment (-20000 signed) = 380000
+            every { transactionRepository.netAmountByPaymentMethodForCoupleUpTo(couple.id, asOf) } returns listOf(
+                arrayOf<Any>(bank.id, 380000L)
+            )
+            every { transferRepository.sumAmountByDestinationForCoupleUpTo(couple.id, asOf) } returns listOf(
+                arrayOf<Any>(bank.id, 100000L)
+            )
+            every { transferRepository.sumAmountBySourceForCoupleUpTo(couple.id, asOf) } returns listOf(
+                arrayOf<Any>(bank.id, 200000L)
+            )
+
+            val result = service.getAssetBalance(user1.id, bank.id, asOf)
+
+            Then("balance = txNet + transferIn - transferOut, and ADJUSTMENT delta is included via net") {
+                result.paymentMethodId shouldBe bank.id
+                result.asOf shouldBe asOf
+                // 380000 + 100000 - 200000 = 280000
+                result.balance shouldBe 280000L
+            }
+        }
+
+        When("PM has transfer inflow as destination and outflow as source") {
+            every { transactionRepository.netAmountByPaymentMethodForCoupleUpTo(couple.id, asOf) } returns emptyList()
+            every { transferRepository.sumAmountByDestinationForCoupleUpTo(couple.id, asOf) } returns listOf(
+                arrayOf<Any>(bank.id, 70000L)
+            )
+            every { transferRepository.sumAmountBySourceForCoupleUpTo(couple.id, asOf) } returns listOf(
+                arrayOf<Any>(bank.id, 30000L)
+            )
+
+            val result = service.getAssetBalance(user1.id, bank.id, asOf)
+
+            Then("dest adds and source subtracts") {
+                // 0 + 70000 - 30000 = 40000
+                result.balance shouldBe 40000L
+            }
+        }
+
+        When("no rows returned (all transactions dated on/after asOf are excluded by query)") {
+            every { transactionRepository.netAmountByPaymentMethodForCoupleUpTo(couple.id, asOf) } returns emptyList()
+            every { transferRepository.sumAmountByDestinationForCoupleUpTo(couple.id, asOf) } returns emptyList()
+            every { transferRepository.sumAmountBySourceForCoupleUpTo(couple.id, asOf) } returns emptyList()
+
+            val result = service.getAssetBalance(user1.id, bank.id, asOf)
+
+            Then("balance is zero — the < asOf bound excludes same-day and later entries") {
+                result.balance shouldBe 0L
+            }
+        }
+    }
+
+    Given("a CREDIT payment method for asOf balance calculation") {
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
+
+        val credit = PaymentMethod(couple = couple, name = "신한카드", type = PaymentMethodType.CREDIT, settlementDay = 15, closingDay = 10)
+        every { paymentMethodRepository.findByIdAndCoupleId(credit.id, couple.id) } returns credit
+
+        val asOf = java.time.LocalDate.of(2024, 5, 1)
+
+        When("getAssetBalance is called for a CREDIT card") {
+            val result = service.getAssetBalance(user1.id, credit.id, asOf)
+
+            Then("balance is null and no balance queries are executed") {
+                result.paymentMethodId shouldBe credit.id
+                result.asOf shouldBe asOf
+                result.balance shouldBe null
+                verify(exactly = 0) { transactionRepository.netAmountByPaymentMethodForCoupleUpTo(any(), any()) }
+                verify(exactly = 0) { transferRepository.sumAmountByDestinationForCoupleUpTo(any(), any()) }
+                verify(exactly = 0) { transferRepository.sumAmountBySourceForCoupleUpTo(any(), any()) }
+            }
+        }
+    }
+
+    Given("a payment method belonging to another couple") {
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
+        val otherPmId = UUID.randomUUID()
+        val asOf = java.time.LocalDate.of(2024, 5, 1)
+        every { paymentMethodRepository.findByIdAndCoupleId(otherPmId, couple.id) } returns null
+
+        When("getAssetBalance is called") {
+            Then("throws NotFoundException (404)") {
+                val ex = shouldThrow<NotFoundException> {
+                    service.getAssetBalance(user1.id, otherPmId, asOf)
+                }
+                ex.code shouldBe "PAYMENT_METHOD_NOT_FOUND"
+            }
+        }
+    }
+
     // --- linkedBank validation ---
 
     Given("a user creating a CREDIT card with linkedBank") {

--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -112,6 +112,7 @@ The current backend accepts only the singular `type` query parameter (see §Tran
   - [Delete Payment Method](#4-delete-payment-method)
   - [Card Pending Summary](#5-card-pending-summary)
   - [Card Settlement Summary](#6-card-settlement-summary)
+  - [Balance As Of Date](#7-balance-as-of-date)
 - [Weekly Budgets](#weekly-budgets)
   - [Weekly Overview](#1-weekly-overview)
   - [Current Week Summary](#2-current-week-summary)
@@ -2239,6 +2240,56 @@ Returns credit card spending grouped by settlement month for the previous and cu
 
 ---
 
+### 7. Balance As Of Date
+
+Returns a payment method's balance considering all transactions and transfers **strictly before** the given `asOf` date. Used by the transaction list to show an asset's running balance and an "as-of-month" balance header. To get the end-of-month balance, callers pass the first day of the *next* month as `asOf`.
+
+**Balance formula**: `balance = txNet + transferIn − transferOut`, where:
+- `txNet` = Σ(`INCOME`) − Σ(`EXPENSE`) + Σ(`ADJUSTMENT` signed delta), for transactions of this payment method with `transactionDate < asOf`
+- `transferIn` = Σ transfers where this payment method is the destination and `transferDate < asOf`
+- `transferOut` = Σ transfers where this payment method is the source and `transferDate < asOf`
+
+| Item        | Value                                          |
+|:------------|:------------------------------------------------|
+| **Method**  | `GET`                                            |
+| **Path**    | `/api/v1/payment-methods/{id}/balance`           |
+| **Auth**    | Required                                         |
+
+**Path Parameters**
+
+| Parameter | Type   | Required | Description        |
+|:----------|:-------|:--------:|:--------------------|
+| `id`      | `UUID` | Yes      | Payment method ID   |
+
+**Query Parameters**
+
+| Parameter | Type        | Required | Description                                                                              |
+|:----------|:------------|:--------:|:------------------------------------------------------------------------------------------|
+| `asOf`    | `LocalDate` | Yes      | Exclusive upper bound, `YYYY-MM-DD`. Balance includes only entries dated strictly before this date. |
+
+**Response `200 OK`**: `ApiResponse<AssetBalanceResponse>`
+
+```json
+{
+  "success": true,
+  "data": {
+    "paymentMethodId": "550e8400-e29b-41d4-a716-446655440030",
+    "asOf": "2026-04-01",
+    "balance": 150000
+  }
+}
+```
+
+**Error Responses**
+
+| Status | Error Code                 | Description                                                    |
+|:-------|:----------------------------|:----------------------------------------------------------------|
+| `404`  | `PAYMENT_METHOD_NOT_FOUND`  | Payment method does not exist or belongs to another couple      |
+
+> **Note**: `balance` is `null` for `CREDIT`-type payment methods (mirrors `PaymentMethodResponse.balance`).
+
+---
+
 ## Weekly Budgets
 
 Extends the existing Budget endpoints with weekly tracking capabilities.
@@ -2581,6 +2632,14 @@ Semantic classification of a transfer. See Phase 22 Changes › TransferKind for
 | `linkedBankId`   | `UUID`    | Yes      | ID of the linked BANK-type payment method (only for `CREDIT` type)                       |
 | `linkedBankName` | `string`  | Yes      | Display name of the linked bank (only for `CREDIT` type)                                 |
 | `createdAt`      | `string`  | No       | ISO 8601 timestamp                                                                        |
+
+### AssetBalanceResponse
+
+| Field             | Type        | Nullable | Description                                                        |
+|:------------------|:------------|:--------:|:---------------------------------------------------------------------|
+| `paymentMethodId` | `UUID`      | No       | Payment method unique identifier                                    |
+| `asOf`            | `string`    | No       | Echo of the requested `asOf` date (`YYYY-MM-DD`)                     |
+| `balance`         | `long`      | Yes      | Balance as of the exclusive `asOf` date (null for `CREDIT` type)     |
 
 ### CardPendingResponse
 

--- a/frontend/lib/core/constants/api_endpoints.dart
+++ b/frontend/lib/core/constants/api_endpoints.dart
@@ -47,6 +47,10 @@ class ApiEndpoints {
       '/api/v1/payment-methods/card-pending';
   static const String paymentMethodsCardSettlementSummary =
       '/api/v1/payment-methods/card-settlement-summary';
+  /// Balance-as-of-date for a single payment method (asOf = exclusive upper
+  /// bound, YYYY-MM-DD). See api-spec §7 "Balance As Of Date".
+  static String paymentMethodBalance(String id) =>
+      '/api/v1/payment-methods/$id/balance';
 
   // Weekly Budget
   static const String weeklyBudgets = '/api/v1/budgets/weekly';

--- a/frontend/lib/features/payment_method/data/datasources/payment_method_remote_datasource.dart
+++ b/frontend/lib/features/payment_method/data/datasources/payment_method_remote_datasource.dart
@@ -13,6 +13,11 @@ abstract class PaymentMethodRemoteDataSource {
   Future<List<CardPendingModel>> getCardPending(int year, int month);
   Future<CardSettlementSummaryModel> getCardSettlementSummary({int? year, int? month});
   Future<void> reorderPaymentMethods(List<String> orderedIds);
+
+  /// Fetch a single payment method's balance considering all transactions and
+  /// transfers strictly before [asOf] (YYYY-MM-DD). Returns null for CREDIT
+  /// cards (balance is not tracked). See api-spec §7.
+  Future<int?> getBalanceAsOf(String paymentMethodId, String asOf);
 }
 
 class PaymentMethodRemoteDataSourceImpl
@@ -91,5 +96,15 @@ class PaymentMethodRemoteDataSourceImpl
       ApiEndpoints.paymentMethodsReorder,
       data: {'orderedIds': orderedIds},
     );
+  }
+
+  @override
+  Future<int?> getBalanceAsOf(String paymentMethodId, String asOf) async {
+    final response = await apiClient.dio.get(
+      ApiEndpoints.paymentMethodBalance(paymentMethodId),
+      queryParameters: {'asOf': asOf},
+    );
+    final data = response.data['data'] as Map<String, dynamic>;
+    return (data['balance'] as num?)?.toInt();
   }
 }

--- a/frontend/lib/features/payment_method/data/repositories/payment_method_repository_impl.dart
+++ b/frontend/lib/features/payment_method/data/repositories/payment_method_repository_impl.dart
@@ -131,4 +131,16 @@ class PaymentMethodRepositoryImpl implements PaymentMethodRepository {
       return const Left(ServerFailure('Failed to reorder payment methods'));
     }
   }
+
+  @override
+  Future<Either<Failure, int?>> getBalanceAsOf(String id, String asOf) async {
+    try {
+      final result = await remoteDataSource.getBalanceAsOf(id, asOf);
+      return Right(result);
+    } on DioException catch (e) {
+      return Left(mapDioError(e, 'Failed to load asset balance'));
+    } catch (e) {
+      return const Left(ServerFailure('Failed to load asset balance'));
+    }
+  }
 }

--- a/frontend/lib/features/payment_method/domain/repositories/payment_method_repository.dart
+++ b/frontend/lib/features/payment_method/domain/repositories/payment_method_repository.dart
@@ -28,4 +28,8 @@ abstract class PaymentMethodRepository {
       int year, int month);
   Future<Either<Failure, CardSettlementSummary>> getCardSettlementSummary({int? year, int? month});
   Future<Either<Failure, void>> reorderPaymentMethods(List<String> orderedIds);
+
+  /// Balance of [id] considering everything strictly before [asOf]
+  /// (YYYY-MM-DD). Right(null) for CREDIT cards. See api-spec §7.
+  Future<Either<Failure, int?>> getBalanceAsOf(String id, String asOf);
 }

--- a/frontend/lib/features/transaction/presentation/pages/transaction_list_page.dart
+++ b/frontend/lib/features/transaction/presentation/pages/transaction_list_page.dart
@@ -37,9 +37,11 @@ import 'package:budget_book/core/models/unified_filter_state.dart';
 import 'package:budget_book/core/widgets/filters/unified_filter_bar.dart';
 import 'package:budget_book/core/widgets/filters/payment_method_filter.dart';
 import 'package:budget_book/features/transaction/presentation/widgets/transaction_calendar_view.dart';
+import 'package:budget_book/features/transaction/presentation/utils/running_balance.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:budget_book/features/payment_method/presentation/bloc/payment_method_bloc.dart';
 import 'package:budget_book/features/payment_method/presentation/bloc/payment_method_state.dart';
+import 'package:budget_book/features/payment_method/domain/repositories/payment_method_repository.dart';
 
 class TransactionListPage extends StatefulWidget {
   final String? initialPaymentMethodId;
@@ -76,6 +78,12 @@ class _TransactionListPageState extends State<TransactionListPage> {
   bool _isSearching = false;
   String? _pendingScrollToDate;
   _TxViewMode _viewMode = _TxViewMode.list;
+
+  // MODE B (single non-credit asset filter) — memoized end-of-month balance.
+  // Keyed by "$pmId|$year|$month" so it is fetched once per rebuild cycle and
+  // not re-requested on every build.
+  Future<int?>? _monthEndBalanceFuture;
+  String? _monthEndBalanceKey;
 
   // Unified filter state
   late UnifiedFilterState _filterState = UnifiedFilterState(
@@ -524,6 +532,32 @@ class _TransactionListPageState extends State<TransactionListPage> {
     return false;
   }
 
+  /// CHANGE 3 — the single asset (BANK/CASH/DEBIT) currently filtered, if any.
+  /// Returns null when zero/multiple payment methods are selected OR the single
+  /// selection is a CREDIT card (credit balance is null → MODE A applies).
+  String? get _singleAssetPmId {
+    if (_filterState.paymentMethodIds.length != 1) return null;
+    if (_isFilteredByCreditCard) return null;
+    return _filterState.paymentMethodIds.first;
+  }
+
+  /// CHANGE 4 — memoized end-of-month balance for MODE B. `asOf` = first day of
+  /// the month AFTER [year]/[month] (exclusive upper bound), so the result is
+  /// the asset's balance at the end of the viewed month.
+  Future<int?> _monthEndBalanceFor(String pmId, int year, int month) {
+    final nextMonthFirst =
+        month == 12 ? DateTime(year + 1, 1, 1) : DateTime(year, month + 1, 1);
+    final asOf = DateFormat('yyyy-MM-dd').format(nextMonthFirst);
+    final key = '$pmId|$year|$month';
+    if (_monthEndBalanceKey != key || _monthEndBalanceFuture == null) {
+      _monthEndBalanceKey = key;
+      _monthEndBalanceFuture = getIt<PaymentMethodRepository>()
+          .getBalanceAsOf(pmId, asOf)
+          .then((either) => either.fold((_) => null, (b) => b));
+    }
+    return _monthEndBalanceFuture!;
+  }
+
   /// 회차 1 (2026-05-10) — 이슈 Z1: 거래 탭에서 잔액 수정 진입점 추가.
   /// 단일 BANK 결제수단 필터 활성 시에만 노출.
   Widget _buildBalanceAdjustAction(BuildContext context) {
@@ -737,34 +771,66 @@ class _TransactionListPageState extends State<TransactionListPage> {
                           dst.contains(keyword);
                     }).toList();
 
+              // CHANGE 2 — SINGLE gating step shared by calendar + list +
+              // running-balance so all three consume the SAME lists.
+              //
+              // visibleTransactions: client-side type gating. TRANSFER is not a
+              // transaction type, so a TRANSFER-only selection yields zero
+              // transactions (fixes "이체 필터 무효"). Empty set keeps all. BE
+              // already narrows for EXPENSE/INCOME; this is correct + robust.
+              final types = _filterState.transactionTypes;
+              final visibleTransactions = types.isEmpty
+                  ? state.filteredTransactions
+                  : state.filteredTransactions
+                      .where((t) => types.contains(t.type))
+                      .toList();
+
+              // visibleTransfers: hide unless the filter includes transfers
+              // (preserves prior showTransfers), AND hide under the PRIVATE
+              // (개인) visibility filter — transfers are treated as SHARED for
+              // now (all current assets are shared).
+              final includeTransfers =
+                  types.isEmpty || types.contains('TRANSFER');
+              final showTransfers =
+                  includeTransfers && _filterState.visibility != 'PRIVATE';
+              final visibleTransfers =
+                  showTransfers ? searchedTransfers : const <Transfer>[];
+
               // S2: single aggregation entry point via LedgerSummary.from
               // kind/type branching lives inside the factory, including
               // CARD_SETTLEMENT exclusion (supersedes PR-A heuristic).
+              // Fed the SAME gated lists so the summary matches the rows.
               final summary = LedgerSummary.from(
-                txs: state.filteredTransactions,
-                tfs: searchedTransfers,
+                txs: visibleTransactions,
+                tfs: visibleTransfers,
                 pmFilter: filterPmId,
               );
 
               // 회차 8 — BE getSummary 가 모든 필터 지원하도록 확장됨.
-              // FE client-side fold (page 단위 부정확) 제거.
               // 모든 케이스에서 BE 가 계산한 정확한 합계(state.totalIncome/Expense) 사용.
-              // server total 미수신 시 (statisticsRepository 미주입) 만 client summary fallback.
+              // server total 미수신 시 (statisticsRepository 미주입) 만 client fallback.
+              //
+              // Gate income/expense display by type: for a TRANSFER-only
+              // selection the BE strips TRANSFER → no type filter is sent → the
+              // server totals still contain all income/expense. Zero them so
+              // the summary matches the (empty) transaction rows.
               final hasServerTotals = state.serverTotalIncome != null;
-              final displayIncome = hasServerTotals
-                  ? state.totalIncome
-                  : summary.totalIncome;
-              final displayExpense = hasServerTotals
-                  ? state.totalExpense
-                  : summary.totalExpense;
+              final gateIncome = types.isEmpty || types.contains('INCOME');
+              final gateExpense = types.isEmpty || types.contains('EXPENSE');
+              final displayIncome = !gateIncome
+                  ? 0
+                  : (hasServerTotals ? state.totalIncome : summary.totalIncome);
+              final displayExpense = !gateExpense
+                  ? 0
+                  : (hasServerTotals
+                      ? state.totalExpense
+                      : summary.totalExpense);
               final displayTransfer = summary.totalTransfer;
 
-              // Gate transfer display by filter: if user picked EXPENSE/INCOME
-              // without TRANSFER, hide transfers from the merged list.
-              final types = _filterState.transactionTypes;
-              final showTransfers =
-                  types.isEmpty || types.contains('TRANSFER');
-              final listTransfers = showTransfers ? searchedTransfers : const <Transfer>[];
+              // CHANGE 3/4 — MODE B when exactly one non-credit asset is
+              // filtered. singleAssetPmId is null otherwise (→ MODE A).
+              final singleAssetPmId = _singleAssetPmId;
+              final isModeB = singleAssetPmId != null;
 
               return Column(
                 children: [
@@ -774,23 +840,45 @@ class _TransactionListPageState extends State<TransactionListPage> {
                     balance: displayIncome - displayExpense,
                     totalTransfer: displayTransfer > 0 ? displayTransfer : null,
                   ),
+                  if (isModeB)
+                    _buildMonthEndBalanceHeader(
+                        context, singleAssetPmId, state.year, state.month),
                   if (_viewMode == _TxViewMode.calendar)
                     Expanded(
                       child: TransactionCalendarView(
                         year: state.year,
                         month: state.month,
-                        transactions: state.filteredTransactions,
-                        transfers: searchedTransfers,
+                        transactions: visibleTransactions,
+                        transfers: visibleTransfers,
                         onTransactionTap: (tx) =>
-                            context.push('/transactions/${tx.id}'),
+                            context.push('/transactions/detail/${tx.id}'),
                         onTransferTap: (tr) =>
                             context.push('/transfers/${tr.id}'),
                       ),
                     )
-                  else if (state.filteredTransactions.isEmpty && listTransfers.isEmpty)
+                  else if (visibleTransactions.isEmpty &&
+                      visibleTransfers.isEmpty)
                     Expanded(child: _buildEmpty(context))
+                  else if (isModeB)
+                    Expanded(
+                      child: FutureBuilder<int?>(
+                        future: _monthEndBalanceFor(
+                            singleAssetPmId, state.year, state.month),
+                        builder: (context, snap) => _buildGroupedList(
+                          context,
+                          state,
+                          visibleTransactions,
+                          visibleTransfers,
+                          assetPmId: singleAssetPmId,
+                          assetAnchor: snap.data,
+                        ),
+                      ),
+                    )
                   else
-                    Expanded(child: _buildGroupedList(context, state, listTransfers)),
+                    Expanded(
+                      child: _buildGroupedList(
+                          context, state, visibleTransactions, visibleTransfers),
+                    ),
                 ],
               );
             },
@@ -800,18 +888,57 @@ class _TransactionListPageState extends State<TransactionListPage> {
     );
   }
 
-  Widget _buildGroupedList(BuildContext context, TransactionLoaded state, List<Transfer> transfers) {
-    // Merge transactions and transfers into LedgerItems, grouped by date
-    // Use filteredGroupedByDate when date filter is active
+  /// CHANGE 4 — "○월 말 잔액" header, MODE B only. Hidden while the balance is
+  /// loading or null (e.g. credit — but credit never reaches MODE B).
+  Widget _buildMonthEndBalanceHeader(
+      BuildContext context, String pmId, int year, int month) {
+    return FutureBuilder<int?>(
+      future: _monthEndBalanceFor(pmId, year, month),
+      builder: (context, snap) {
+        final bal = snap.data;
+        if (bal == null) return const SizedBox.shrink();
+        return Container(
+          width: double.infinity,
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
+          color: Theme.of(context)
+              .colorScheme
+              .primaryContainer
+              .withValues(alpha: 0.3),
+          child: Text(
+            '$month월 말 잔액: ${CurrencyFormatter.format(bal)}원',
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  fontWeight: FontWeight.w600,
+                  color: Theme.of(context)
+                      .colorScheme
+                      .onSurface
+                      .withValues(alpha: 0.75),
+                ),
+          ),
+        );
+      },
+    );
+  }
+
+  /// [transactions] / [transfers] are the already-gated (CHANGE 2) lists.
+  /// MODE B (asset running balance) is active when [assetPmId] != null;
+  /// [assetAnchor] is the asset's end-of-month balance (null while the async
+  /// fetch is in flight → show no running number). MODE A otherwise.
+  Widget _buildGroupedList(
+    BuildContext context,
+    TransactionLoaded state,
+    List<Transaction> transactions,
+    List<Transfer> transfers, {
+    String? assetPmId,
+    int? assetAnchor,
+  }) {
+    // Merge transactions and transfers into LedgerItems, grouped by date.
+    // (Server already filters transactions by dateFrom/dateTo.)
     final groupedItems = <String, List<LedgerItem>>{};
 
-    // Add transactions (filtered by date if applicable)
-    final txnGrouped = state.filteredGroupedByDate;
-    for (final entry in txnGrouped.entries) {
-      groupedItems.putIfAbsent(entry.key, () => []);
-      for (final t in entry.value) {
-        groupedItems[entry.key]!.add(LedgerItem.fromTransaction(t));
-      }
+    // Add transactions
+    for (final t in transactions) {
+      groupedItems.putIfAbsent(t.transactionDate, () => []);
+      groupedItems[t.transactionDate]!.add(LedgerItem.fromTransaction(t));
     }
 
     // Add transfers
@@ -820,6 +947,9 @@ class _TransactionListPageState extends State<TransactionListPage> {
       groupedItems[transfer.transferDate]!.add(LedgerItem.fromTransfer(transfer));
     }
 
+    // NEWEST-FIRST: dates sorted descending. Within a day, transactions are
+    // inserted before transfers (matches iteration order below). The running
+    // balance / total is accumulated in this exact newest-first order.
     final sortedDates = groupedItems.keys.toList()..sort((a, b) => b.compareTo(a));
 
     // 회차 (2026-06-23) — 포커싱-구동 점진 로드.
@@ -861,31 +991,29 @@ class _TransactionListPageState extends State<TransactionListPage> {
       });
     }
 
-    // Calculate running totals for transactions only (transfers are not income/expense)
-    final flatTransactions = <Transaction>[];
+    // CHANGE 3 — running totals. Flatten to display order (newest-first).
+    final orderedItems = <LedgerItem>[];
     for (final date in sortedDates) {
-      for (final item in groupedItems[date]!) {
-        if (item.isTransaction) {
-          flatTransactions.add(item.transaction!);
-        }
-      }
+      orderedItems.addAll(groupedItems[date]!);
     }
-    final runningTotals = <String, int>{};
-    int cumulative = 0;
-    for (int i = flatTransactions.length - 1; i >= 0; i--) {
-      final t = flatTransactions[i];
-      cumulative += t.isExpense ? -t.amount : t.amount;
-      runningTotals[t.id] = cumulative;
-    }
-    // Offset running totals to account for unloaded older transactions
-    if (state.serverTotalIncome != null && state.serverTotalExpense != null) {
-      final serverBalance = state.serverTotalIncome! - state.serverTotalExpense!;
-      final offset = serverBalance - cumulative;
-      if (offset != 0) {
-        for (final key in runningTotals.keys.toList()) {
-          runningTotals[key] = runningTotals[key]! + offset;
-        }
-      }
+
+    // runningTotals keyed by ledgerRowKey (tx:<id> / tf:<id>).
+    Map<String, int> runningTotals;
+    if (assetPmId != null) {
+      // MODE B — asset balance backward-accumulated from end-of-month anchor.
+      // While the anchor is still loading (null), emit nothing so we never
+      // show a wrong number.
+      runningTotals = assetAnchor == null
+          ? const <String, int>{}
+          : computeAssetBalance(orderedItems, assetAnchor, assetPmId);
+    } else {
+      // MODE A — cumulative EXPENSE only (negative), anchored on the month's
+      // total expense (pagination-safe). Local fallback when no server total.
+      final localExpense = transactions
+          .where((t) => t.isExpense)
+          .fold(0, (s, t) => s + t.amount);
+      final anchorExpense = state.serverTotalExpense ?? localExpense;
+      runningTotals = computeExpenseCumulative(orderedItems, anchorExpense);
     }
 
     // Add 1 extra item for the loading indicator when loading more
@@ -950,6 +1078,7 @@ class _TransactionListPageState extends State<TransactionListPage> {
                 if (item.isTransfer) {
                   return TransferListTile(
                     transfer: item.transfer!,
+                    runningTotal: runningTotals[ledgerRowKey(item)],
                     onTap: () =>
                         context.push(transferEditRoute(item.transfer!)),
                   );
@@ -957,7 +1086,7 @@ class _TransactionListPageState extends State<TransactionListPage> {
                 final t = item.transaction!;
                 return TransactionListTile(
                   transaction: t,
-                  runningTotal: runningTotals[t.id],
+                  runningTotal: runningTotals[ledgerRowKey(item)],
                   onTap: () => context.push('/transactions/detail/${t.id}'),
                   onLongPress: () => _showTransactionActions(context, t),
                   onDelete: () {

--- a/frontend/lib/features/transaction/presentation/utils/running_balance.dart
+++ b/frontend/lib/features/transaction/presentation/utils/running_balance.dart
@@ -1,0 +1,81 @@
+// Running-balance / running-total computation for the transaction list.
+//
+// Two display modes (see transaction_list_page CHANGE 3):
+//
+// - MODE A (computeExpenseCumulative) — no single-asset filter (default).
+//   Running value = cumulative EXPENSE only (negative). Anchored on the
+//   month's total expense so it is pagination-safe: the newest expense row
+//   shows -totalExpense, older rows show less accumulated expense. Income /
+//   adjustment rows carry the current cumulative but do NOT change it;
+//   transfers get no value at all.
+//
+// - MODE B (computeAssetBalance) — single non-credit asset filter.
+//   Running value = that asset's balance right after each row. Anchored on the
+//   asset's end-of-month balance (asOf = first day of next month) and
+//   accumulated NEWEST-FIRST by subtracting each row's net effect. Shown on
+//   both transaction and transfer rows.
+//
+// All inputs are expected in display order (newest-first) — the exact order
+// the grouped list renders (sortedDates descending, transactions then
+// transfers within a day).
+import 'package:budget_book/features/transaction/domain/entities/ledger_item.dart';
+
+/// Stable per-row key that never collides between a transaction and a transfer
+/// even if they happen to share an id.
+String ledgerRowKey(LedgerItem item) =>
+    item.isTransfer ? 'tf:${item.transfer!.id}' : 'tx:${item.transaction!.id}';
+
+/// MODE A — cumulative expense (negative). [anchorExpense] is the month's total
+/// expense (server total preferred; caller may pass a local fallback sum).
+/// Only transaction rows receive a value; transfers are skipped.
+Map<String, int> computeExpenseCumulative(
+  List<LedgerItem> orderedNewestFirst,
+  int anchorExpense,
+) {
+  final map = <String, int>{};
+  int running = anchorExpense;
+  for (final item in orderedNewestFirst) {
+    if (!item.isTransaction) continue; // transfers: no running total in MODE A
+    final t = item.transaction!;
+    map[ledgerRowKey(item)] = -running;
+    if (t.isExpense) running -= t.amount;
+  }
+  return map;
+}
+
+/// Signed effect of a row on [pmId]'s balance.
+/// - transaction: income +amount, expense -amount, adjustment +amount (signed),
+///   else 0.
+/// - transfer: destination is [pmId] → +amount, source is [pmId] → -amount,
+///   else 0.
+int netEffectOnAsset(LedgerItem item, String pmId) {
+  if (item.isTransaction) {
+    final t = item.transaction!;
+    if (t.isIncome) return t.amount;
+    if (t.isExpense) return -t.amount;
+    if (t.isAdjustment) return t.amount; // ADJUSTMENT amount is a signed delta
+    return 0;
+  }
+  final tr = item.transfer!;
+  if (tr.destinationPaymentMethod.id == pmId) return tr.amount;
+  if (tr.sourcePaymentMethod.id == pmId) return -tr.amount;
+  return 0;
+}
+
+/// MODE B — asset balance backward-accumulation. [anchorBalance] is the asset's
+/// balance at end of the viewed month (balance considering everything with
+/// date < firstDayOfNextMonth). Every row (transaction AND transfer) receives
+/// the balance right after it.
+Map<String, int> computeAssetBalance(
+  List<LedgerItem> orderedNewestFirst,
+  int anchorBalance,
+  String pmId,
+) {
+  final map = <String, int>{};
+  int running = anchorBalance;
+  for (final item in orderedNewestFirst) {
+    map[ledgerRowKey(item)] = running;
+    running -= netEffectOnAsset(item, pmId);
+  }
+  return map;
+}

--- a/frontend/lib/features/transaction/presentation/widgets/transfer_list_tile.dart
+++ b/frontend/lib/features/transaction/presentation/widgets/transfer_list_tile.dart
@@ -7,11 +7,15 @@ import 'package:budget_book/features/transfer/domain/entities/transfer.dart';
 class TransferListTile extends StatelessWidget {
   final Transfer transfer;
   final VoidCallback? onTap;
+  /// Asset running balance (MODE B, single-asset filter). When non-null it
+  /// replaces the author nickname in the trailing column.
+  final int? runningTotal;
 
   const TransferListTile({
     super.key,
     required this.transfer,
     this.onTap,
+    this.runningTotal,
   });
 
   @override
@@ -82,15 +86,27 @@ class TransferListTile extends StatelessWidget {
                   fontWeight: FontWeight.w600,
                 ),
           ),
-          Text(
-            transfer.author.nickname,
-            style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                  color: Theme.of(context)
-                      .colorScheme
-                      .onSurface
-                      .withValues(alpha: 0.4),
-                ),
-          ),
+          if (runningTotal != null)
+            Text(
+              '${CurrencyFormatter.format(runningTotal!)}원',
+              style: TextStyle(
+                fontSize: 10,
+                color: Theme.of(context)
+                    .colorScheme
+                    .onSurface
+                    .withValues(alpha: 0.35),
+              ),
+            )
+          else
+            Text(
+              transfer.author.nickname,
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: Theme.of(context)
+                        .colorScheme
+                        .onSurface
+                        .withValues(alpha: 0.4),
+                  ),
+            ),
         ],
       ),
     );

--- a/frontend/test/features/transaction/presentation/utils/running_balance_test.dart
+++ b/frontend/test/features/transaction/presentation/utils/running_balance_test.dart
@@ -1,0 +1,161 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:budget_book/features/transaction/domain/entities/transaction.dart';
+import 'package:budget_book/features/transaction/domain/entities/transaction_author.dart';
+import 'package:budget_book/features/transaction/domain/entities/ledger_item.dart';
+import 'package:budget_book/features/transfer/domain/entities/transfer.dart';
+import 'package:budget_book/features/transaction/presentation/utils/running_balance.dart';
+
+// Test helpers --------------------------------------------------------------
+
+TransactionAuthor _author() => const TransactionAuthor(id: 'u1', nickname: 't');
+
+Transaction _tx({
+  required String type,
+  required int amount,
+  required String id,
+  String date = '2026-04-10',
+}) {
+  return Transaction(
+    id: id,
+    coupleId: 'c1',
+    author: _author(),
+    type: type,
+    amount: amount,
+    description: 'desc',
+    transactionDate: date,
+    createdAt: DateTime.parse('2026-04-10T00:00:00Z'),
+    updatedAt: DateTime.parse('2026-04-10T00:00:00Z'),
+  );
+}
+
+Transfer _tf({
+  required int amount,
+  required String id,
+  String sourceId = 'pmSrc',
+  String destId = 'pmDst',
+  String date = '2026-04-10',
+}) {
+  return Transfer(
+    id: id,
+    coupleId: 'c1',
+    author: _author(),
+    sourcePaymentMethod:
+        PaymentMethodRef(id: sourceId, name: 'src', type: 'BANK'),
+    destinationPaymentMethod:
+        PaymentMethodRef(id: destId, name: 'dst', type: 'BANK'),
+    amount: amount,
+    transferDate: date,
+    createdAt: DateTime.parse('2026-04-10T00:00:00Z'),
+  );
+}
+
+void main() {
+  group('MODE A — computeExpenseCumulative (cumulative expense, negative)', () {
+    test('newest expense shows -totalExpense, older rows show less', () {
+      // Display order is NEWEST-FIRST.
+      final e1 = LedgerItem.fromTransaction(
+          _tx(type: 'EXPENSE', amount: 3000, id: 'e1')); // newest
+      final e2 = LedgerItem.fromTransaction(
+          _tx(type: 'EXPENSE', amount: 2000, id: 'e2'));
+      final e3 = LedgerItem.fromTransaction(
+          _tx(type: 'EXPENSE', amount: 1000, id: 'e3')); // oldest
+
+      // Anchor = total expense = 3000+2000+1000 = 6000.
+      final map = computeExpenseCumulative([e1, e2, e3], 6000);
+
+      expect(map['tx:e1'], -6000, reason: 'newest = -totalExpense');
+      expect(map['tx:e2'], -3000, reason: '6000 - 3000');
+      expect(map['tx:e3'], -1000, reason: 'only its own expense remains');
+    });
+
+    test('income and adjustment do NOT change the running value', () {
+      final inc = LedgerItem.fromTransaction(
+          _tx(type: 'INCOME', amount: 9999, id: 'i1')); // newest
+      final exp = LedgerItem.fromTransaction(
+          _tx(type: 'EXPENSE', amount: 4000, id: 'e1'));
+      final adj = LedgerItem.fromTransaction(
+          _tx(type: 'ADJUSTMENT', amount: 500, id: 'a1')); // oldest
+
+      final map = computeExpenseCumulative([inc, exp, adj], 4000);
+
+      // Only the single expense contributes to the anchor.
+      expect(map['tx:i1'], -4000, reason: 'income carries cumulative, unchanged');
+      expect(map['tx:e1'], -4000);
+      expect(map['tx:a1'], 0, reason: 'after the expense is consumed, 0 remains');
+    });
+
+    test('transfers get NO running total in MODE A', () {
+      final exp = LedgerItem.fromTransaction(
+          _tx(type: 'EXPENSE', amount: 1000, id: 'e1'));
+      final tf = LedgerItem.fromTransfer(_tf(amount: 5000, id: 'tf1'));
+
+      final map = computeExpenseCumulative([exp, tf], 1000);
+
+      expect(map.containsKey('tf:tf1'), isFalse);
+      expect(map['tx:e1'], -1000);
+    });
+  });
+
+  group('MODE B — computeAssetBalance (asset balance, backward-accumulated)', () {
+    const pmId = 'pmMine';
+
+    test('income/expense/adjustment net effect, newest shows end anchor', () {
+      // Newest-first display order. End-of-month anchor balance = 10000.
+      final inc = LedgerItem.fromTransaction(
+          _tx(type: 'INCOME', amount: 2000, id: 'i1')); // newest
+      final exp = LedgerItem.fromTransaction(
+          _tx(type: 'EXPENSE', amount: 3000, id: 'e1'));
+      final adj = LedgerItem.fromTransaction(
+          _tx(type: 'ADJUSTMENT', amount: 500, id: 'a1')); // oldest
+
+      final map = computeAssetBalance([inc, exp, adj], 10000, pmId);
+
+      expect(map['tx:i1'], 10000, reason: 'balance right after newest row');
+      // running -= (+2000) → 8000 shown on next row
+      expect(map['tx:e1'], 8000);
+      // running -= (-3000) → 11000 shown on next row
+      expect(map['tx:a1'], 11000);
+      // sanity: balance BEFORE the oldest row would be 11000 - 500 = 10500.
+    });
+
+    test('transfer in (destination == pm) adds, transfer out subtracts', () {
+      final tin = LedgerItem.fromTransfer(
+          _tf(amount: 1000, id: 'in1', destId: pmId, sourceId: 'other'));
+      final tout = LedgerItem.fromTransfer(
+          _tf(amount: 400, id: 'out1', sourceId: pmId, destId: 'other'));
+      final unrelated = LedgerItem.fromTransfer(
+          _tf(amount: 999, id: 'x1', sourceId: 'o1', destId: 'o2'));
+
+      // Order newest-first: [tin, tout, unrelated]; anchor = 5000.
+      final map = computeAssetBalance([tin, tout, unrelated], 5000, pmId);
+
+      expect(map['tf:in1'], 5000);
+      // running -= (+1000 in) → 4000
+      expect(map['tf:out1'], 4000);
+      // running -= (-400 out) → 4400
+      expect(map['tf:x1'], 4400);
+      // unrelated netEffect 0 → running stays 4400 for anything older.
+    });
+
+    test('both transactions and transfers receive a running balance', () {
+      final tf = LedgerItem.fromTransfer(
+          _tf(amount: 1000, id: 'in1', destId: pmId, sourceId: 'other'));
+      final exp = LedgerItem.fromTransaction(
+          _tx(type: 'EXPENSE', amount: 2000, id: 'e1'));
+
+      final map = computeAssetBalance([tf, exp], 7000, pmId);
+
+      expect(map['tf:in1'], 7000);
+      expect(map['tx:e1'], 6000, reason: '7000 - (+1000 transfer in)');
+    });
+  });
+
+  group('netEffectOnAsset', () {
+    const pmId = 'pm1';
+    test('adjustment uses signed amount', () {
+      final neg = LedgerItem.fromTransaction(
+          _tx(type: 'ADJUSTMENT', amount: -300, id: 'a1'));
+      expect(netEffectOnAsset(neg, pmId), -300);
+    });
+  });
+}


### PR DESCRIPTION
## 배경
거래 목록 3버그 + 자산 잔액 기능 요청. 각 버그는 hard-evidence 진단 후 근본 원인 확정.

> Base = `fix/suggestion-type-and-month-filter-drop` (#264). #264 머지 후 main 으로 retarget 예정 — 스택 PR.

## 수정 내역

### 1) 달력뷰 상세보기 GoException
- `transaction_list_page.dart` 달력뷰 탭이 `/transactions/{id}`(라우트 없음)로 이동 → 목록뷰와 동일하게 `/transactions/detail/{id}`로 수정.

### 2) 필터 장애 (이체 / 공유·개인)
근본: 목록이 `/transfers` 스트림을 클라이언트에서 합치는데, 거래 행은 타입으로 안 걸러지고(이체 필터 무효) 이체 행은 visibility 무필터(공유·개인 무효).
- 이체 필터: `TRANSFER`는 FE 전용 pseudo-type이라 BE 미전송 → BE 전체 반환. `visibleTransactions` 클라이언트 타입 게이팅 추가 → 이체만 선택 시 거래 0건.
- 공유·개인: 이체는 현재 모두 **공유**로 간주 → `PRIVATE`(개인) 필터 시 숨김. (개인 자산 도입은 추후 고도화; 그때 source/dest 자산 visibility로 이체 분류)
- 합계바도 동일 게이팅으로 목록과 일치.

### 3) 잔액(runningTotal) 오염
근본: (a) ADJUSTMENT를 +수입으로 오합산, (b) offset이 서버합계(이체 포함·조정 제외) vs 로컬(이체 제외·조정 포함) 정의 불일치로 전 행 오염.
- 재설계 (`running_balance.dart` 순수 헬퍼 + 7 테스트):
  - **자산필터 없음** → 누적 **지출액만**(음수). 이체·조정·수입 제외.
  - **결제수단 1개 필터(비신용)** → 그 자산 **잔액**(월말 앵커에서 newest-first 역누적, 이체 in/out·ADJUSTMENT signed 반영). 이체 행에도 표시.
  - 두 모드 모두 BE 앵커 기준이라 페이지네이션에 안전.

### 4) 자산 잔액 기능 (요청)
- **BE**: `GET /api/v1/payment-methods/{id}/balance?asOf=YYYY-MM-DD` — date-bounded (`transactionDate`/`transferDate < asOf`), `balance = txNet + transferIn − transferOut`, CREDIT은 null. api-spec §7.
- **FE**: 결제수단 1개 필터 시 "○월 말 잔액" 헤더 + 거래별 자산 잔액 컬럼 → "5월 시점 자산 얼마였는지" 해결.

## 검증
- BE: paymentmethod/transaction/transfer 스펙 통과 + `AssetBalanceQueryTest`로 `< asOf` 경계·ADJUSTMENT signed·이체 in/out 실증(@DataJpaTest). compile 통과.
- FE: `flutter analyze` 0 errors, `flutter test` 755/755, `flutter build web` 성공.
- (참고) `./gradlew build`는 기존 `DeleteUserByEmailIntegrationTest`(Testcontainers/Docker 필요)만 실패 — 본 변경과 무관, Docker 없는 환경 게이트.

## 라이브 검증 필요 (배포 후)
- [ ] 달력뷰 → 날짜 → 리스트 탭 → 상세 진입
- [ ] 이체 / 공유 / 개인 필터 각각 적용
- [ ] 결제수단 1개 필터: 거래별 자산 잔액 + "○월 말 잔액" 헤더 (과거월 포함)
- [ ] 필터 없을 때 누적 지출액(음수) 표시, 이체·잔액수정 미오염

🤖 Generated with [Claude Code](https://claude.com/claude-code)