### PR TITLE
chore(infra): DB 백업 오프사이트 업로드 (rclone gcrypt 암호화)

### DIFF
--- a/infra/scripts/db-backup.sh
+++ b/infra/scripts/db-backup.sh
@@ -79,4 +79,20 @@ ls -1t "${BACKUP_DIR}"/budgetbook_*.sql.gz 2>/dev/null | tail -n +$((RETENTION +
   rm -f "$old" && log "보관초과 삭제: $(basename "$old")"
 done
 
+# ── 5) 오프사이트 업로드 (rclone gcrypt remote 설정 시에만) ──
+# gcrypt = crypt remote (gdrive:bb-backups 를 클라이언트측 암호화 래핑). 업로드 전에
+# 파일명·내용이 암호화되어 PII 가 클라우드에 평문으로 올라가지 않는다. 미설정이면 스킵.
+# sync --include 로 로컬(최근 RETENTION 개)을 그대로 미러 → 원격에도 동일 보관정책 적용.
+RCLONE="/usr/local/bin/rclone"
+RCLONE_CONF="/root/.config/rclone/rclone.conf"   # cron(root) HOME 모호성 회피 위해 명시
+if [ -x "$RCLONE" ] && "$RCLONE" --config "$RCLONE_CONF" listremotes 2>/dev/null | grep -q '^gcrypt:'; then
+  if "$RCLONE" --config "$RCLONE_CONF" sync "${BACKUP_DIR}/" "gcrypt:" --include 'budgetbook_*.sql.gz' 2>>"$LOG"; then
+    log "오프사이트 동기화 → gcrypt (암호화, 최근 ${RETENTION}개 미러)"
+  else
+    log "WARN: 오프사이트 업로드 실패 — 로컬 백업은 정상"
+  fi
+else
+  log "오프사이트(gcrypt) 미설정 — 업로드 스킵"
+fi
+
 exit 0


### PR DESCRIPTION
## 요약
일일 DB 백업(`infra/scripts/db-backup.sh`)에 오프사이트 미러 단계를 추가합니다. rclone `gcrypt`(crypt) remote가 설정된 경우에만 동작하며, 클라이언트측 암호화 후 업로드하여 PII가 클라우드에 평문으로 저장되지 않습니다.

## 변경
- 백업 사이클 5단계로 오프사이트 sync 추가
- `gcrypt` remote 미설정 시 스킵 → 기존 로컬 백업 동작 불변
- `sync --include 'budgetbook_*.sql.gz'` 로 로컬 보관정책(최근 `RETENTION`개)을 원격에 동일 적용
- 업로드 실패해도 로컬 백업은 정상 (WARN 로그만 남김)
- cron(root) HOME 모호성 회피를 위해 `--config` 경로 명시

## 검증
- `bash -n` 문법 검사 통과
- 조건 가드로 remote 미설정 환경(현 NAS)에서는 no-op

## 후속 (NAS 설정 필요, 별도)
실제 오프사이트 활성화하려면 NAS에서 `rclone config`로 `gcrypt:` crypt remote 생성 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)