### PR TITLE
fix(form): 지출/수입 탭 스왑 시 검은 화면 — FocusNode 소유권 충돌 fix

### DIFF
--- a/frontend/lib/features/transaction/presentation/pages/transaction_form_page.dart
+++ b/frontend/lib/features/transaction/presentation/pages/transaction_form_page.dart
@@ -144,10 +144,16 @@ class _TransactionFormPageState extends State<TransactionFormPage>
   /// 회차 5 — _onSubmit 후 spinner 무한 회귀 방지용 timeout 가드.
   Timer? _submitTimeoutTimer;
 
-  // FocusNodes for keyboard navigation on selector fields
+  // FocusNodes for keyboard navigation on selector fields.
+  // 지출/수입 탭이 TabBarView 에서 동시에 렌더링될 때 동일 FocusNode 를
+  // 두 Focus 위젯이 공유하면 소유권 충돌 → 지출 탭 검은 화면 회귀.
+  // 탭별 독립 인스턴스 사용.
   final FocusNode _categoryFocusNode = FocusNode();
   final FocusNode _paymentMethodFocusNode = FocusNode();
   final FocusNode _pocketFocusNode = FocusNode();
+  final FocusNode _incomeCategoryFocusNode = FocusNode();
+  final FocusNode _incomePmFocusNode = FocusNode();
+  final FocusNode _incomePocketFocusNode = FocusNode();
 
   // Tab controller for expense/income/transfer tabs
   late final TabController _tabController;
@@ -523,6 +529,9 @@ class _TransactionFormPageState extends State<TransactionFormPage>
     _categoryFocusNode.dispose();
     _paymentMethodFocusNode.dispose();
     _pocketFocusNode.dispose();
+    _incomeCategoryFocusNode.dispose();
+    _incomePmFocusNode.dispose();
+    _incomePocketFocusNode.dispose();
     super.dispose();
   }
 
@@ -704,7 +713,12 @@ class _TransactionFormPageState extends State<TransactionFormPage>
                   // Tab 0: Expense form
                   _buildTransactionFormBody(context, formKey: _expenseFormKey),
                   // Tab 1: Income form
-                  _buildTransactionFormBody(context, formKey: _incomeFormKey),
+                  _buildTransactionFormBody(context,
+                    formKey: _incomeFormKey,
+                    categoryFocusNode: _incomeCategoryFocusNode,
+                    pmFocusNode: _incomePmFocusNode,
+                    pocketFocusNode: _incomePocketFocusNode,
+                  ),
                   // Tab 2: Transfer form (embedded)
                   _buildTransferFormBody(context),
                 ],
@@ -714,7 +728,15 @@ class _TransactionFormPageState extends State<TransactionFormPage>
     );
   }
 
-  Widget _buildTransactionFormBody(BuildContext context, {GlobalKey<FormState>? formKey}) {
+  Widget _buildTransactionFormBody(BuildContext context, {
+    GlobalKey<FormState>? formKey,
+    FocusNode? categoryFocusNode,
+    FocusNode? pmFocusNode,
+    FocusNode? pocketFocusNode,
+  }) {
+    final catFn = categoryFocusNode ?? _categoryFocusNode;
+    final pmFn = pmFocusNode ?? _paymentMethodFocusNode;
+    final pocketFn = pocketFocusNode ?? _pocketFocusNode;
     // BlocListener is now in the top-level MultiBlocListener in build()
     return SingleChildScrollView(
         padding: const EdgeInsets.all(24),
@@ -796,7 +818,7 @@ class _TransactionFormPageState extends State<TransactionFormPage>
                   FocusTraversalOrder(
                     order: const NumericFocusOrder(3),
                     child: _buildKeyboardActivatableField(
-                      focusNode: _categoryFocusNode,
+                      focusNode: catFn,
                       onActivate: () => _activateCategoryPicker(context),
                       child: _buildCategoryPicker(context),
                     ),
@@ -811,7 +833,7 @@ class _TransactionFormPageState extends State<TransactionFormPage>
                   FocusTraversalOrder(
                     order: const NumericFocusOrder(4),
                     child: _buildKeyboardActivatableField(
-                      focusNode: _paymentMethodFocusNode,
+                      focusNode: pmFn,
                       onActivate: () => _activatePaymentMethodPicker(context),
                       child: _buildPaymentMethodPicker(context),
                     ),
@@ -821,7 +843,7 @@ class _TransactionFormPageState extends State<TransactionFormPage>
                   FocusTraversalOrder(
                     order: const NumericFocusOrder(5),
                     child: _buildKeyboardActivatableField(
-                      focusNode: _pocketFocusNode,
+                      focusNode: pocketFn,
                       onActivate: () => _activatePocketPicker(context),
                       child: _buildPocketPicker(context),
                     ),


### PR DESCRIPTION
## 문제
`transaction_form_page.dart`에서 지출(Tab 0)·수입(Tab 1) 폼이 `_buildTransactionFormBody`를 공유하며 동일 FocusNode 3개(`_categoryFocusNode`/`_paymentMethodFocusNode`/`_pocketFocusNode`)를 함께 사용. TabBarView가 탭 스왑 중 두 탭을 동시 렌더링할 때 같은 FocusNode를 두 Focus 위젯이 소유 → 소유권 충돌 → 지출/수입 탭 스왑 시 검은 화면 회귀.

## 수정
- 수입 탭 전용 FocusNode 3개 추가 (`_incomeCategoryFocusNode`/`_incomePmFocusNode`/`_incomePocketFocusNode`) + dispose
- `_buildTransactionFormBody`에 선택적 focusNode 파라미터 추가 (미지정 시 지출용 기본값)
- 수입 탭 호출부에서 전용 FocusNode 전달 → 탭별 독립 인스턴스

## 검증
- `flutter analyze --no-fatal-infos --no-congratulate`: 통과 (info 3건은 무관 테스트 파일)
- `flutter test test/features/transaction/`: 68 테스트 전부 통과
- 구조: 지출/수입 탭이 더 이상 FocusNode 공유하지 않음

## 비고
기존 PR #234(브랜치 33커밋 뒤처짐)를 현재 main 위로 재적용한 것. #234는 이 PR로 대체·종료.

🤖 Generated with [Claude Code](https://claude.com/claude-code)