### PR TITLE
fix(transfer): 카드 정산 등록 FK 위반 + 달력뷰 이체 표시/월 drift

### DIFF
--- a/backend/src/main/kotlin/com/budgetbook/transfer/service/TransferService.kt
+++ b/backend/src/main/kotlin/com/budgetbook/transfer/service/TransferService.kt
@@ -286,7 +286,11 @@ class TransferService(
             kind = TransferKind.CARD_SETTLEMENT,
             isCardSettlement = true
         )
-        val saved = transferRepository.save(transfer)
+        // saveAndFlush: 아래 markAsPaidForSettlement 는 transactions 테이블 대상 @Modifying 벌크
+        // UPDATE 로, Hibernate auto-flush 가 다른 테이블(transfers) 의 pending INSERT 를 함께
+        // 내보내지 않는다. flush 하지 않으면 settlement_transfer_id FK 가 아직 존재하지 않는
+        // transfer 를 가리켜 transactions_settlement_transfer_id_fkey 위반이 발생한다.
+        val saved = transferRepository.saveAndFlush(transfer)
 
         // 2. 선택된 거래들의 paid_at 업데이트 + 정산 이체 링크 저장 (미결제 목록에서 제외).
         //    V63: 링크를 저장해야 정산 수정/삭제 시 paid_at 을 양방향 재조정할 수 있다.
@@ -362,7 +366,10 @@ class TransferService(
         transfer.amount = amount
         transfer.transferDate = transferDate
         transfer.description = description ?: "카드 결제"
-        val saved = transferRepository.save(transfer)
+        // saveAndFlush: create 경로와 동일 이유로 flush 를 강제한다(defense-in-depth). 편집 대상
+        // transfer 는 이미 DB 에 존재하지만, unmark→save→mark 순서에서 pending 변경을 확정해
+        // 벌크 UPDATE 와의 순서 의존성을 제거한다.
+        val saved = transferRepository.saveAndFlush(transfer)
 
         // 3. 새로 선택된 거래 마킹 + 링크 저장.
         if (transactionIds.isNotEmpty()) {

--- a/backend/src/test/kotlin/com/budgetbook/transfer/integration/CardSettlementIntegrationTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/transfer/integration/CardSettlementIntegrationTest.kt
@@ -1,0 +1,225 @@
+package com.budgetbook.transfer.integration
+
+import com.budgetbook.admin.integration.HighApiVersionDockerStrategy
+import com.budgetbook.transfer.domain.TransferKind
+import com.budgetbook.transfer.service.TransferService
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.extensions.spring.SpringExtension
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import jakarta.persistence.EntityManager
+import jakarta.persistence.PersistenceContext
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.ApplicationContextInitializer
+import org.springframework.context.ConfigurableApplicationContext
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.support.TestPropertySourceUtils
+import org.springframework.transaction.PlatformTransactionManager
+import org.springframework.transaction.support.TransactionTemplate
+import org.testcontainers.containers.PostgreSQLContainer
+import java.time.LocalDate
+import java.util.UUID
+
+/**
+ * Integration test for [TransferService.createCardSettlement] / [TransferService.updateCardSettlement]
+ * against a real PostgreSQL container (Testcontainers) with Flyway migrations applied.
+ *
+ * Regression guard for the FK ordering bug (prod, 2026-07-22):
+ * `createCardSettlement` did `transferRepository.save(transfer)` (application-assigned UUID → INSERT
+ * merely scheduled, not flushed) and then ran the `markAsPaidForSettlement` bulk `@Modifying` UPDATE
+ * on the `transactions` table. Hibernate auto-flush before a bulk update only flushes changes whose
+ * query-spaces intersect the update's table, so the pending `transfers` INSERT was NOT flushed →
+ * `transactions.settlement_transfer_id` referenced a transfer row that did not yet exist →
+ * `transactions_settlement_transfer_id_fkey` violation (DataIntegrityViolationException).
+ *
+ * Mock-based [com.budgetbook.transfer.service.TransferServiceTest] cannot catch this: mocks never
+ * exercise the real FK. Only a real DB reproduces it. The fix is `saveAndFlush`.
+ */
+@SpringBootTest
+@ActiveProfiles("integration-test")
+@ContextConfiguration(initializers = [CardSettlementIntegrationTest.DataSourceInitializer::class])
+class CardSettlementIntegrationTest(
+    private val transferService: TransferService,
+    @PersistenceContext private val em: EntityManager,
+    private val txManager: PlatformTransactionManager,
+) : FunSpec() {
+
+    override fun extensions() = listOf(SpringExtension)
+
+    companion object {
+        val postgres: PostgreSQLContainer<*> = PostgreSQLContainer("postgres:16-alpine")
+            .withDatabaseName("budgetbook_test")
+            .withUsername("test")
+            .withPassword("test")
+
+        init {
+            System.setProperty(
+                "testcontainers.docker.client.strategy",
+                HighApiVersionDockerStrategy::class.java.name
+            )
+            postgres.start()
+        }
+    }
+
+    class DataSourceInitializer : ApplicationContextInitializer<ConfigurableApplicationContext> {
+        override fun initialize(ctx: ConfigurableApplicationContext) {
+            TestPropertySourceUtils.addInlinedPropertiesToEnvironment(
+                ctx,
+                "spring.datasource.url=${postgres.jdbcUrl}",
+                "spring.datasource.username=${postgres.username}",
+                "spring.datasource.password=${postgres.password}",
+                "spring.datasource.driver-class-name=org.postgresql.Driver",
+                "spring.jpa.hibernate.ddl-auto=validate",
+                "spring.flyway.enabled=true",
+                "spring.flyway.baseline-on-migrate=true"
+            )
+        }
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────────────
+
+    private fun <T> inTx(action: () -> T): T =
+        TransactionTemplate(txManager).execute { action() }!!
+
+    private fun insertUser(email: String): UUID {
+        val id = UUID.randomUUID()
+        em.createNativeQuery(
+            """INSERT INTO users (id, email, nickname, provider, provider_id, role, is_active, created_at, updated_at)
+               VALUES (:id, :email, 'Settler', 'GOOGLE', :pid, 'USER', true, now(), now())"""
+        ).setParameter("id", id).setParameter("email", email)
+            .setParameter("pid", UUID.randomUUID().toString()).executeUpdate()
+        return id
+    }
+
+    private fun insertSelfCouple(userId: UUID): UUID {
+        val id = UUID.randomUUID()
+        em.createNativeQuery(
+            """INSERT INTO couples (id, user1_id, user2_id, status, is_self, created_at, updated_at)
+               VALUES (:id, :userId, null, 'ACTIVE', true, now(), now())"""
+        ).setParameter("id", id).setParameter("userId", userId).executeUpdate()
+        return id
+    }
+
+    private fun insertCategory(coupleId: UUID): UUID {
+        val id = UUID.randomUUID()
+        em.createNativeQuery(
+            """INSERT INTO categories (id, couple_id, name, type, is_default, display_order, created_at, updated_at)
+               VALUES (:id, :coupleId, '식비', 'EXPENSE', false, 0, now(), now())"""
+        ).setParameter("id", id).setParameter("coupleId", coupleId).executeUpdate()
+        return id
+    }
+
+    private fun insertPaymentMethod(coupleId: UUID, name: String, type: String): UUID {
+        val id = UUID.randomUUID()
+        em.createNativeQuery(
+            """INSERT INTO payment_methods (id, couple_id, name, type, is_active, is_default, display_order, created_at, updated_at)
+               VALUES (:id, :coupleId, :name, :type, true, false, 0, now(), now())"""
+        ).setParameter("id", id).setParameter("coupleId", coupleId)
+            .setParameter("name", name).setParameter("type", type).executeUpdate()
+        return id
+    }
+
+    private fun insertExpenseTxn(coupleId: UUID, authorId: UUID, categoryId: UUID, cardId: UUID): UUID {
+        val id = UUID.randomUUID()
+        em.createNativeQuery(
+            """INSERT INTO transactions
+               (id, couple_id, author_id, category_id, payment_method_id, type, amount, description, transaction_date, created_at, updated_at)
+               VALUES (:id, :coupleId, :authorId, :categoryId, :cardId, 'EXPENSE', 10000, '카드 지출', :txDate, now(), now())"""
+        ).setParameter("id", id).setParameter("coupleId", coupleId).setParameter("authorId", authorId)
+            .setParameter("categoryId", categoryId).setParameter("cardId", cardId)
+            .setParameter("txDate", LocalDate.of(2026, 6, 15)).executeUpdate()
+        return id
+    }
+
+    private fun settlementTransferIdOf(txnId: UUID): UUID? =
+        em.createNativeQuery("SELECT settlement_transfer_id FROM transactions WHERE id = :id")
+            .setParameter("id", txnId).singleResult as UUID?
+
+    private fun paidAtOf(txnId: UUID): Any? =
+        em.createNativeQuery("SELECT paid_at FROM transactions WHERE id = :id")
+            .setParameter("id", txnId).singleResult
+
+    // ── Tests ─────────────────────────────────────────────────────────────────
+
+    init {
+        test("createCardSettlement with linked transactions persists transfer before marking (no FK violation)") {
+            lateinit var userId: UUID
+            lateinit var bankId: UUID
+            lateinit var cardId: UUID
+            val txnIds = mutableListOf<UUID>()
+            inTx {
+                userId = insertUser("settle-${UUID.randomUUID()}@test.com")
+                val coupleId = insertSelfCouple(userId)
+                val categoryId = insertCategory(coupleId)
+                bankId = insertPaymentMethod(coupleId, "신한은행", "BANK")
+                cardId = insertPaymentMethod(coupleId, "현대카드", "CREDIT")
+                repeat(3) { txnIds.add(insertExpenseTxn(coupleId, userId, categoryId, cardId)) }
+            }
+
+            // Act — before the fix this threw DataIntegrityViolationException on the FK.
+            val result = transferService.createCardSettlement(
+                userId = userId,
+                sourcePaymentMethodId = bankId,
+                destinationPaymentMethodId = cardId,
+                amount = 30000,
+                transferDate = LocalDate.of(2026, 7, 1),
+                description = "현대카드 7월 결제",
+                transactionIds = txnIds,
+            )
+
+            // Assert — transfer row exists and every linked transaction points to it.
+            result.kind shouldBe TransferKind.CARD_SETTLEMENT
+            inTx {
+                txnIds.forEach { txnId ->
+                    settlementTransferIdOf(txnId) shouldBe result.id
+                    paidAtOf(txnId).shouldNotBeNull()
+                }
+            }
+        }
+
+        test("updateCardSettlement re-links a new transaction selection (no FK violation)") {
+            lateinit var userId: UUID
+            lateinit var bankId: UUID
+            lateinit var cardId: UUID
+            lateinit var firstTxn: UUID
+            lateinit var secondTxn: UUID
+            inTx {
+                userId = insertUser("update-${UUID.randomUUID()}@test.com")
+                val coupleId = insertSelfCouple(userId)
+                val categoryId = insertCategory(coupleId)
+                bankId = insertPaymentMethod(coupleId, "국민은행", "BANK")
+                cardId = insertPaymentMethod(coupleId, "삼성카드", "CREDIT")
+                firstTxn = insertExpenseTxn(coupleId, userId, categoryId, cardId)
+                secondTxn = insertExpenseTxn(coupleId, userId, categoryId, cardId)
+            }
+
+            val created = transferService.createCardSettlement(
+                userId = userId,
+                sourcePaymentMethodId = bankId,
+                destinationPaymentMethodId = cardId,
+                amount = 10000,
+                transferDate = LocalDate.of(2026, 7, 1),
+                description = "삼성카드 결제",
+                transactionIds = listOf(firstTxn),
+            )
+
+            // Act — swap the linked selection to the second transaction.
+            transferService.updateCardSettlement(
+                userId = userId,
+                transferId = created.id,
+                sourcePaymentMethodId = bankId,
+                destinationPaymentMethodId = cardId,
+                amount = 10000,
+                transferDate = LocalDate.of(2026, 7, 1),
+                description = "삼성카드 결제 (수정)",
+                transactionIds = listOf(secondTxn),
+            )
+
+            inTx {
+                settlementTransferIdOf(firstTxn) shouldBe null
+                settlementTransferIdOf(secondTxn) shouldBe created.id
+            }
+        }
+    }
+}

--- a/backend/src/test/kotlin/com/budgetbook/transfer/service/TransferServiceTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/transfer/service/TransferServiceTest.kt
@@ -510,7 +510,7 @@ class TransferServiceTest : BehaviorSpec({
             every { paymentMethodRepository.findById(bankPm.id) } returns Optional.of(bankPm)
             every { paymentMethodRepository.findById(creditPm.id) } returns Optional.of(creditPm)
             val transferSlot = slot<Transfer>()
-            every { transferRepository.save(capture(transferSlot)) } answers { transferSlot.captured }
+            every { transferRepository.saveAndFlush(capture(transferSlot)) } answers { transferSlot.captured }
 
             val result = service.createCardSettlement(
                 userId = user1.id,
@@ -576,7 +576,7 @@ class TransferServiceTest : BehaviorSpec({
                 amount = 500000, transferDate = LocalDate.of(2026, 4, 15),
                 kind = TransferKind.CARD_SETTLEMENT, isCardSettlement = true
             )
-            every { transferRepository.save(any()) } returns savedTransfer
+            every { transferRepository.saveAndFlush(any()) } returns savedTransfer
             every {
                 transactionRepository.markAsPaidForSettlement(txnIds, LocalDate.of(2026, 4, 15), savedTransfer.id)
             } returns txnIds.size
@@ -619,7 +619,7 @@ class TransferServiceTest : BehaviorSpec({
             every { transferRepository.findByIdAndCoupleId(settlement.id, couple.id) } returns settlement
             every { paymentMethodRepository.findById(bankPm.id) } returns Optional.of(bankPm)
             every { paymentMethodRepository.findById(creditPm.id) } returns Optional.of(creditPm)
-            every { transferRepository.save(any()) } answers { firstArg() }
+            every { transferRepository.saveAndFlush(any()) } answers { firstArg() }
             every { transactionRepository.unmarkBySettlementTransfer(settlement.id) } returns 2
             every {
                 transactionRepository.markAsPaidForSettlement(newTxnIds, LocalDate.of(2026, 4, 20), settlement.id)

--- a/frontend/lib/features/transaction/presentation/widgets/transaction_calendar_view.dart
+++ b/frontend/lib/features/transaction/presentation/widgets/transaction_calendar_view.dart
@@ -55,8 +55,21 @@ class _TransactionCalendarViewState extends State<TransactionCalendarView> {
       final key = _parseDateKey(tr.transferDate);
       final entry = map.putIfAbsent(key, () => _DaySummary());
       entry.transfers.add(tr);
+      entry.transferTotal += tr.amount;
     }
     return map;
+  }
+
+  /// 부모(list page)가 새 year/month 를 전달하면 달력 본문을 해당 월로 재동기화.
+  /// State 는 위젯 재빌드 시 재사용되므로 didUpdateWidget 없이는 _focusedDay 가
+  /// 최초 월에 고정되어, 월 이동(MonthNavigator/MonthCubit) 후에도 달력이 옛 월을
+  /// 계속 렌더하는 drift 가 발생한다.
+  @override
+  void didUpdateWidget(covariant TransactionCalendarView oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.year != widget.year || oldWidget.month != widget.month) {
+      _focusedDay = DateTime(widget.year, widget.month, 1);
+    }
   }
 
   static DateTime _parseDateKey(String yyyymmdd) {
@@ -84,6 +97,10 @@ class _TransactionCalendarViewState extends State<TransactionCalendarView> {
             focusedDay: _focusedDay,
             currentDay: DateTime.now(),
             availableCalendarFormats: const {CalendarFormat.month: 'Month'},
+            // 월 이동은 MonthNavigator(MonthCubit) 단일 소스로 일원화. 달력 자체 가로
+            // 스와이프를 허용하면 페이지 월과 MonthCubit/데이터 월이 어긋나 drift 가
+            // 재발하므로 스와이프 제스처를 비활성화한다.
+            availableGestures: AvailableGestures.none,
             headerVisible: false,
             startingDayOfWeek: StartingDayOfWeek.sunday,
             daysOfWeekHeight: 24,
@@ -141,6 +158,17 @@ class _TransactionCalendarViewState extends State<TransactionCalendarView> {
                           style: TextStyle(
                             fontSize: 9,
                             color: Colors.red.shade700,
+                            fontWeight: FontWeight.w600,
+                          ),
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      if (summary.transfers.isNotEmpty)
+                        Text(
+                          '⇄${CurrencyFormatter.format(summary.transferTotal)}',
+                          style: TextStyle(
+                            fontSize: 9,
+                            color: Colors.grey.shade600,
                             fontWeight: FontWeight.w600,
                           ),
                           maxLines: 1,
@@ -284,6 +312,7 @@ class _TransactionCalendarViewState extends State<TransactionCalendarView> {
 class _DaySummary {
   int income = 0;
   int expense = 0;
+  int transferTotal = 0;
   final List<Transaction> transactions = [];
   final List<Transfer> transfers = [];
 }


### PR DESCRIPTION
## 이슈 1 — 카드 정산 등록 시 \`Data integrity constraint violated\` (BE)
- prod 로그: \`POST /transfers/card-settlement\` → \`transactions_settlement_transfer_id_fkey\` 위반 (\`Key (settlement_transfer_id)=... is not present in table transfers\`)
- 원인: \`createCardSettlement\`가 \`save(transfer)\`(앱 생성 UUID → INSERT 예약만, flush 안 함) 직후 \`markAsPaidForSettlement\`(transactions 대상 \`@Modifying\` 벌크 UPDATE) 실행. Hibernate auto-flush는 벌크 UPDATE 대상 테이블과 교차하는 변경만 flush하므로 다른 테이블(transfers)의 pending INSERT를 내보내지 않음 → FK가 미존재 transfer를 가리켜 위반. 링크거래 포함 create는 상시 실패(7/1 포함 여부 무관).
- 수정: create/update 경로 \`save\` → \`saveAndFlush\`

## 이슈 2 — 달력뷰에 이체 미표시 (FE)
- \`markerBuilder\`가 income/expense만 렌더 → 이체만 있는 날 셀 마커 없음
- 수정: \`summary.transfers\` 존재 시 회색 \`⇄{합계}\` 마커 추가

## 이슈 3 — 필터+달력+월이동 후 옛 월(6월) 잔존 (FE)
- \`_focusedDay\`가 최초 1회만 초기화(didUpdateWidget/onPageChanged 부재) → 부모가 새 월(MonthCubit 반영) 전달해도 달력 본문이 옛 월 고정
- 수정: \`didUpdateWidget\`으로 year/month 변경 시 \`_focusedDay\` 재동기화 + \`availableGestures=none\`으로 달력 자체 스와이프 비활성화 → 월 이동을 MonthNavigator(MonthCubit) 단일 소스로 일원화

## 재발 방지
- \`CardSettlementIntegrationTest\`(Testcontainers 실 PostgreSQL) 추가. fix를 되돌리면 prod와 동일한 \`DataIntegrityViolationException\`으로 red 확인(red-green 증명). mock 테스트로는 실 FK를 못 잡음.

## 검증
- BE: \`./gradlew test build\` 통과 (통합테스트 포함)
- FE: \`flutter analyze\` / \`test\`(755) / \`build web\` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)