### PR TITLE
fix(transaction): 달력 셀 금액 전체 숫자 표시(폭 초과 시 축소)

### DIFF
--- a/frontend/lib/features/transaction/presentation/widgets/transaction_calendar_view.dart
+++ b/frontend/lib/features/transaction/presentation/widgets/transaction_calendar_view.dart
@@ -142,30 +142,26 @@ class _TransactionCalendarViewState extends State<TransactionCalendarView> {
   }
 
   Widget _amountLine(String prefix, int amount, Color color) {
-    return Text(
-      '$prefix${_compactAmount(amount)}',
-      maxLines: 1,
-      overflow: TextOverflow.ellipsis,
-      style: TextStyle(
-        fontSize: 9,
-        height: 1.2,
-        color: color,
-        fontWeight: FontWeight.w600,
+    // 전체 금액(쉼표 포맷)을 그대로 노출하되, 좁은 셀 폭을 넘으면 잘림(ellipsis) 대신
+    // FittedBox 로 글자를 축소해 정확한 숫자를 항상 읽을 수 있게 한다.
+    return SizedBox(
+      width: double.infinity,
+      child: FittedBox(
+        fit: BoxFit.scaleDown,
+        alignment: Alignment.center,
+        child: Text(
+          '$prefix${CurrencyFormatter.format(amount)}',
+          maxLines: 1,
+          softWrap: false,
+          style: TextStyle(
+            fontSize: 9,
+            height: 1.2,
+            color: color,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
       ),
     );
-  }
-
-  /// 좁은 셀 폭에 맞춘 축약 포맷(만/억). 정확한 금액은 일자 탭 시 바텀시트에서 확인.
-  static String _compactAmount(int amount) {
-    final abs = amount.abs();
-    if (abs >= 100000000) {
-      final eok = abs / 100000000;
-      return '${eok.toStringAsFixed(eok >= 10 ? 0 : 1)}억';
-    }
-    if (abs >= 10000) {
-      return '${abs ~/ 10000}만';
-    }
-    return CurrencyFormatter.format(abs);
   }
 
   @override


### PR DESCRIPTION
## 문제
직전 PR #271에서 달력 셀 금액을 만/억으로 축약했으나, 정확한 금액을 읽을 수 없다는 피드백.

## 수정
- 전체 쉼표 포맷 금액(예: \`+1,234,567\`)을 그대로 노출
- 좁은 셀 폭 초과 시 잘림(ellipsis) 대신 \`FittedBox(scaleDown)\`로 글자를 축소 → 숫자 전체를 항상 읽을 수 있음
- 3줄(수입/지출/이체) 세로 스택 레이아웃은 유지

## 검증
- \`flutter analyze\` / \`test\`(transaction 68) / \`build web\` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)