### PR TITLE
refactor(filter): 거래 필터 전파 VO 단일화 + 합계/문서/테스트 환경 정합성 (정산 기능 선행)

### DIFF
--- a/.claude/domains/commands.md
+++ b/.claude/domains/commands.md
@@ -5,6 +5,22 @@
 | Backend 빌드 | `cd backend && ./gradlew build` |
 | Backend 테스트 | `cd backend && ./gradlew test` |
 | Frontend 의존성 | `cd frontend && flutter pub get` |
+| Frontend 분석 | `cd frontend && flutter analyze --no-fatal-infos --no-congratulate` (부분 경로 금지 — CI 와 동일하게 전체) |
 | Frontend 테스트 | `cd frontend && flutter test` |
 | Frontend 빌드 | `cd frontend && flutter build web` |
 | 로컬 인프라 | `cd infra && docker-compose up -d` |
+
+## Backend 테스트와 Docker (Testcontainers)
+
+`./gradlew test` 에는 Testcontainers 통합테스트(`*IntegrationTest`)가 포함되므로 **Docker 데몬이
+떠 있어야 한다**. 안 떠 있으면 `Kotest > initializationError` /
+`Could not find a valid Docker environment` 로 **테스트 1건도 못 돌고** task 전체가 실패한다.
+
+- 소켓 경로는 `build.gradle.kts` 의 `tasks.withType<Test>` 가 후보 목록에서 **실제 존재하는**
+  것을 골라 `DOCKER_HOST` 로 주입한다: `$DOCKER_HOST` → `/var/run/docker.sock` →
+  `~/.colima/default/docker.sock` → `~/.docker/run/docker.sock` → `~/.rd/docker.sock`.
+- 즉 colima / Docker Desktop / Rancher 어느 쪽이든 데몬만 켜져 있으면 추가 설정이 필요 없다.
+  (2026-07-27 이전에는 `/var/run/docker.sock` 하드코딩 → Docker Desktop 미실행 + colima 사용 시
+  끊긴 심볼릭 링크를 잡아 로컬 CI 게이트를 통과할 수 없었다.)
+- 확인: `docker info --format '{{.ServerVersion}}'` → 값이 나오면 OK.
+- 특수 런타임을 강제하려면 `DOCKER_HOST=unix:///path/to/docker.sock ./gradlew test`.

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -100,8 +100,29 @@ tasks.withType<Test> {
     // Docker Desktop 4.x proxy rejects /v1.32/info (docker-java default) with empty 400.
     // Testcontainers uses its own shaded docker-java which reads API version from "api.version"
     // environment variable (not DOCKER_API_VERSION). Setting this to "1.44" bypasses the v1.32 issue.
+    //
+    // 2026-07-27 — 소켓 경로를 /var/run/docker.sock 로 고정하면, 활성 런타임이 colima/
+    // Rancher 인 머신에서 그 심볼릭 링크가 끊겨 있어(Docker Desktop 미실행) 전체 test
+    // task 가 Kotest initializationError("Could not find a valid Docker environment") 로
+    // 죽는다. `docker info` 는 정상인데 로컬 CI 게이트를 통과할 수 없는 상태가 된다.
+    // → 실제로 **존재하는** 소켓을 후보 목록에서 골라 주입한다. (끊긴 심볼릭 링크는
+    //   File.exists() == false 로 자동 탈락.)
     val varRunSock = "/var/run/docker.sock"
-    val dockerHost = System.getenv("DOCKER_HOST") ?: "unix://$varRunSock"
+    val home = System.getProperty("user.home")
+    val socketCandidates = listOfNotNull(
+        System.getenv("DOCKER_HOST")
+            ?.takeIf { it.startsWith("unix://") }
+            ?.removePrefix("unix://"),
+        varRunSock,
+        "$home/.colima/default/docker.sock",
+        "$home/.docker/run/docker.sock",
+        "$home/.rd/docker.sock",
+    )
+    // `java.io.File` 은 Kotlin DSL 에서 `java` 확장과 충돌 → 기본 import 된 File 사용.
+    val resolvedSocket = socketCandidates.firstOrNull { File(it).exists() }
+    val dockerHost = System.getenv("DOCKER_HOST")
+        ?: resolvedSocket?.let { "unix://$it" }
+        ?: "unix://$varRunSock"
     environment("DOCKER_HOST", dockerHost)
     environment("api.version", "1.44")          // Testcontainers shaded docker-java reads this key
     environment("TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE", varRunSock)

--- a/backend/src/main/kotlin/com/budgetbook/statistics/controller/StatisticsController.kt
+++ b/backend/src/main/kotlin/com/budgetbook/statistics/controller/StatisticsController.kt
@@ -52,7 +52,9 @@ class StatisticsController(
             amountMin = filter.amountMin,
             amountMax = filter.amountMax,
             keyword = filter.keyword,
-            transactionTypes = filter.transactionTypes ?: emptyList()
+            transactionTypes = filter.transactionTypes ?: emptyList(),
+            // 2026-07-27 — 목록과 동일 필터로 합계 계산 (합계 ≠ 행 불일치 fix).
+            needsReviewOnly = filter.needsReviewOnly
         ))
     }
 

--- a/backend/src/main/kotlin/com/budgetbook/statistics/service/StatisticsService.kt
+++ b/backend/src/main/kotlin/com/budgetbook/statistics/service/StatisticsService.kt
@@ -67,7 +67,10 @@ class StatisticsService(
         amountMin: Long? = null,
         amountMax: Long? = null,
         keyword: String? = null,
-        transactionTypes: List<String> = emptyList()
+        transactionTypes: List<String> = emptyList(),
+        // 2026-07-27 — 거래 목록에만 적용되고 summary 에는 누락돼 있던 필터.
+        // 목록은 needs_review 만 보여주는데 합계는 전체였다 → "합계 ≠ 보이는 행".
+        needsReviewOnly: Boolean? = null
     ): StatisticsSummaryResponse {
         val couple = getActiveCouple(userId)
         val visFilter = validateVisibility(visibility)
@@ -98,7 +101,8 @@ class StatisticsService(
             amountMin != null ||
             amountMax != null ||
             !keyword.isNullOrBlank() ||
-            effectiveTypes.isNotEmpty()
+            effectiveTypes.isNotEmpty() ||
+            needsReviewOnly == true
 
         val totalIncome: Long
         val totalExpense: Long
@@ -115,7 +119,8 @@ class StatisticsService(
                 visibility = visFilter,
                 categoryIds = effectiveCategoryIds,
                 paymentMethodIds = effectivePaymentMethodIds,
-                pocketIds = effectivePocketIds
+                pocketIds = effectivePocketIds,
+                needsReviewOnly = needsReviewOnly
             )
             val expenseSpec = TransactionSpecifications.withFilters(
                 coupleId = couple.id, startDate = startDate, endDate = endDate,
@@ -125,7 +130,8 @@ class StatisticsService(
                 visibility = visFilter,
                 categoryIds = effectiveCategoryIds,
                 paymentMethodIds = effectivePaymentMethodIds,
-                pocketIds = effectivePocketIds
+                pocketIds = effectivePocketIds,
+                needsReviewOnly = needsReviewOnly
             )
 
             val incomeTransactions = transactionRepository.findAll(incomeSpec)

--- a/backend/src/main/kotlin/com/budgetbook/transaction/service/TransactionService.kt
+++ b/backend/src/main/kotlin/com/budgetbook/transaction/service/TransactionService.kt
@@ -140,7 +140,11 @@ class TransactionService(
             pocketId?.let { set.add(it) }
         }
 
-        val pageSize = size.coerceIn(1, 100)
+        // 상한 200 — FE(`TransactionBloc._pageSize = 200`) 와 일치시킨다.
+        // 이전 상한 100 은 FE 의 200 요청을 조용히 반토막 내 왕복을 2배로 만들었고
+        // (포커싱-구동 자동 LoadMore 가 보완해 표면화되지 않았다), mock 기대값(200)과도
+        // 어긋났다. 값 변경 시 FE `_pageSize` 와 함께 바꿀 것.
+        val pageSize = size.coerceIn(1, MAX_PAGE_SIZE)
         val sort = Sort.by(Sort.Order.desc("transactionDate"), Sort.Order.desc("createdAt"))
         val pageable = PageRequest.of(page, pageSize, sort)
 
@@ -632,6 +636,11 @@ class TransactionService(
     }
 
     companion object {
+        /**
+         * 거래 목록 페이지 크기 상한. FE `TransactionBloc._pageSize` 와 동일해야 한다.
+         */
+        const val MAX_PAGE_SIZE = 200
+
         fun parseVisibility(visibilityStr: String?): Visibility {
             return when (visibilityStr?.uppercase()) {
                 "PRIVATE" -> Visibility.PRIVATE

--- a/backend/src/test/kotlin/com/budgetbook/admin/integration/HighApiVersionDockerStrategy.kt
+++ b/backend/src/test/kotlin/com/budgetbook/admin/integration/HighApiVersionDockerStrategy.kt
@@ -9,58 +9,92 @@ import java.net.UnixDomainSocketAddress
 import java.nio.channels.SocketChannel
 
 /**
- * Custom Testcontainers Docker strategy for Docker Desktop on macOS.
+ * Custom Testcontainers Docker strategy for Unix-socket Docker runtimes on macOS.
  *
  * Docker Desktop 4.x proxy rejects API version-prefixed requests like /v1.32/info
  * with empty 400 responses. docker-java defaults to v1.32, causing all built-in
  * Testcontainers strategies to fail.
  *
  * This strategy:
- * 1. Verifies the Docker socket exists.
- * 2. Sends a raw /_ping HTTP request (no version prefix) directly over the Unix socket.
- *    Docker Desktop accepts /[no version]/_ping and responds 200, confirming connectivity.
+ * 1. Resolves the first *reachable* Docker socket among several candidates.
+ * 2. Sends a raw /_ping HTTP request (no version prefix) directly over the Unix socket
+ *    to confirm connectivity (the daemon answers /_ping without a version prefix).
  * 3. Returns a TransportConfig that Testcontainers uses to build its Docker client.
- *    The client itself may still use v1.32 for subsequent calls, but those are
- *    executed with a valid, connected socket and Docker Desktop handles them.
+ *
+ * 2026-07-27 — socket path was hardcoded to `/var/run/docker.sock` (Docker Desktop).
+ * On machines whose active runtime is colima/Rancher/podman that symlink is dangling,
+ * so the whole test task failed at Kotest initialization with
+ * "Could not find a valid Docker environment" even though `docker info` worked.
+ * Candidates are now probed in order, with DOCKER_HOST winning when set.
  */
 class HighApiVersionDockerStrategy : DockerClientProviderStrategy() {
 
-    private val socketPath = "/var/run/docker.sock"
+    /**
+     * Socket candidates, highest priority first:
+     * 1. `DOCKER_HOST` when it points at a unix socket (explicit developer intent / CI)
+     * 2. `/var/run/docker.sock` — Docker Desktop, Linux CI, colima with default symlink
+     * 3. colima default socket
+     * 4. Docker Desktop per-user socket
+     * 5. Rancher Desktop per-user socket
+     */
+    private val candidateSocketPaths: List<String> = buildList {
+        System.getenv("DOCKER_HOST")
+            ?.takeIf { it.startsWith("unix://") }
+            ?.removePrefix("unix://")
+            ?.let { add(it) }
+        add("/var/run/docker.sock")
+        val home = System.getProperty("user.home")
+        add("$home/.colima/default/docker.sock")
+        add("$home/.docker/run/docker.sock")
+        add("$home/.rd/docker.sock")
+    }
+
+    /** First candidate that answers /_ping, or null when Docker is unavailable. */
+    private val resolvedSocketPath: String? by lazy {
+        candidateSocketPaths.firstOrNull { ping(it) }
+    }
 
     override fun getTransportConfig(): TransportConfig {
-        if (!java.io.File(socketPath).exists()) {
-            throw InvalidConfigurationException("Docker socket not found at $socketPath")
-        }
+        val socketPath = resolvedSocketPath
+            ?: throw InvalidConfigurationException(
+                "No reachable Docker socket. Tried: ${candidateSocketPaths.joinToString()}"
+            )
         return TransportConfig.builder()
             .dockerHost(URI.create("unix://$socketPath"))
             .build()
     }
 
-    override fun isApplicable(): Boolean = java.io.File(socketPath).exists()
+    override fun isApplicable(): Boolean = resolvedSocketPath != null
 
-    override fun getDescription(): String = "HighApiVersionDockerStrategy (macOS Docker Desktop workaround)"
+    override fun getDescription(): String =
+        "HighApiVersionDockerStrategy (unix socket ${resolvedSocketPath ?: "unresolved"})"
 
     override fun getPriority(): Int = 100
 
     /**
      * Overrides the default test() which calls docker-java's infoCmd (uses /v1.32/info).
      * Instead, sends a raw HTTP GET /_ping to the Unix socket.
-     * Docker Desktop responds 200 to /ping without a version prefix.
      */
-    override fun test(): Boolean {
-        if (!java.io.File(socketPath).exists()) return false
+    override fun test(): Boolean = resolvedSocketPath != null
+
+    private fun ping(socketPath: String): Boolean {
+        val file = java.io.File(socketPath)
+        // Dangling symlink (e.g. Docker Desktop socket while colima is the active
+        // runtime) reports exists() == false, which is exactly what we want to skip.
+        if (!file.exists()) return false
         return try {
             val addr = UnixDomainSocketAddress.of(socketPath)
             SocketChannel.open(addr).use { channel ->
                 val request = "GET /_ping HTTP/1.0\r\nHost: localhost\r\n\r\n"
-                val buf = java.nio.ByteBuffer.wrap(request.toByteArray())
-                channel.write(buf)
+                channel.write(java.nio.ByteBuffer.wrap(request.toByteArray()))
                 val response = java.nio.ByteBuffer.allocate(256)
                 channel.read(response)
-                val responseStr = String(response.array(), 0, response.position())
-                responseStr.contains("200 OK")
+                String(response.array(), 0, response.position()).contains("200 OK")
             }
         } catch (_: IOException) {
+            false
+        } catch (_: UnsupportedOperationException) {
+            // Platform without unix-domain socket support.
             false
         }
     }

--- a/backend/src/test/kotlin/com/budgetbook/statistics/controller/StatisticsControllerTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/statistics/controller/StatisticsControllerTest.kt
@@ -59,6 +59,32 @@ class StatisticsControllerTest : FunSpec({
         verify { statisticsService.getMonthlySummary(testUserId, 2026, 3, "SHARED", null, null) }
     }
 
+    // 2026-07-27 회귀 가드 — 거래 목록에는 needsReviewOnly 가 적용되는데 summary 에는
+    // 전달되지 않아 "확인/입력 필요만 보기" 상태에서 월 합계가 전체 금액을 보여줬다
+    // (합계 ≠ 보이는 행). 컨트롤러가 이 필터를 서비스로 넘기는지 고정한다.
+    test("getMonthlySummary passes needsReviewOnly to service") {
+
+        val summary = StatisticsSummaryResponse("2026-03", 0, 30000, 0, -30000, 2)
+        every {
+            statisticsService.getMonthlySummary(
+                userId = testUserId, year = 2026, month = 3, visibility = "ALL",
+                dateFrom = null, dateTo = null, needsReviewOnly = true
+            )
+        } returns summary
+
+        val filter = CommonFilterParams(needsReviewOnly = true)
+        val result = controller.getMonthlySummary(testUserId, 2026, 3, filter)
+
+        result.success shouldBe true
+        result.data!!.totalExpense shouldBe 30000
+        verify {
+            statisticsService.getMonthlySummary(
+                userId = testUserId, year = 2026, month = 3, visibility = "ALL",
+                dateFrom = null, dateTo = null, needsReviewOnly = true
+            )
+        }
+    }
+
     test("getMonthlySummary passes visibility PRIVATE to service") {
 
         val summary = StatisticsSummaryResponse("2026-03", 200000, 100000, 0, 100000, 5)

--- a/backend/src/test/kotlin/com/budgetbook/statistics/service/StatisticsServiceTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/statistics/service/StatisticsServiceTest.kt
@@ -719,6 +719,38 @@ class StatisticsServiceTest : BehaviorSpec({
         }
     }
 
+    // --- getMonthlySummary: needsReviewOnly (2026-07-27 회귀 가드) ---
+
+    Given("a user filtering the ledger by needs_review") {
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
+
+        When("needsReviewOnly=true is passed") {
+            // needsReviewOnly 는 content 필터 → sumByTypeForCouple(전체 합계) 대신
+            // Specification 경로로 가야 한다. sumByTypeForCouple 을 mock 하지 않았으므로
+            // 그 경로를 타면 mockk 가 예외를 던져 테스트가 실패한다 (= 가드).
+            every {
+                transactionRepository.findAll(
+                    any<org.springframework.data.jpa.domain.Specification<com.budgetbook.transaction.domain.Transaction>>()
+                )
+            } returns emptyList()
+
+            val result = service.getMonthlySummary(
+                userId = user1.id, year = 2026, month = 3, needsReviewOnly = true
+            )
+
+            Then("uses the filtered Specification path so totals match the visible rows") {
+                result.totalIncome shouldBe 0L
+                result.totalExpense shouldBe 0L
+                result.transactionCount shouldBe 0
+                verify(exactly = 2) {
+                    transactionRepository.findAll(
+                        any<org.springframework.data.jpa.domain.Specification<com.budgetbook.transaction.domain.Transaction>>()
+                    )
+                }
+            }
+        }
+    }
+
     // --- getPeriodSummary: filters applied ---
 
     Given("a user for period summary with filters") {

--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -1252,7 +1252,9 @@ Permanently deletes a transaction. Only the author or the partner can delete it.
 
 ### 7. List Settlement Candidates
 
-Returns unpaid (unsettled) EXPENSE transactions that are eligible to be included in a card settlement, optionally together with transactions already bound to a specific existing settlement transfer (for the edit-mode use case).
+Returns the items that make up a card settlement (카드 결제) for a given month: unpaid EXPENSE
+transactions charged to the card **plus** transfers whose source is that card. Optionally also
+returns items already bound to a specific settlement transfer (edit-mode use case).
 
 | Item        | Value                                      |
 |:------------|:-------------------------------------------|
@@ -1264,82 +1266,78 @@ Returns unpaid (unsettled) EXPENSE transactions that are eligible to be included
 
 | Parameter               | Type      | Required | Description                                                                                                                    |
 |:------------------------|:----------|:--------:|:-------------------------------------------------------------------------------------------------------------------------------|
-| `paymentMethodId`       | `UUID`    | Yes      | CREDIT payment method whose unsettled transactions are fetched                                                                 |
-| `settlementTransferId`  | `UUID`    | No       | When supplied, the response includes **both** unpaid transactions and transactions already bound to this settlement transfer. Used to pre-populate the candidate list when editing an existing card settlement. |
+| `paymentMethodId`       | `UUID`    | Yes      | CREDIT payment method whose unsettled items are fetched                                                                        |
+| `year`                  | `integer` | Yes      | Settlement month (year part). Items are matched by `settlementDate` within this month; when none match, the previous month's unsettled transactions are returned as a fallback. |
+| `month`                 | `integer` | Yes      | Settlement month (1-12)                                                                                                        |
+| `settlementTransferId`  | `UUID`    | No       | When supplied, the response includes **both** unpaid items and items already bound to this settlement transfer. Used to pre-populate the candidate list when editing an existing card settlement. |
 
-**Response `200 OK`**: `ApiResponse<List<SettlementTransactionResponse>>`
+**Response `200 OK`**: `ApiResponse<SettlementTransactionsResponse>`
 
-Each item in the list represents one transaction. Items that already belong to the referenced `settlementTransferId` carry a non-null `settlementTransferId` field so the client can distinguish pre-selected vs. newly selectable candidates.
+> The payload is an **object with a running total**, not a bare array — the client shows
+> `totalAmount` as the settlement amount without re-summing rows.
+
+| Field              | Type                            | Description                                        |
+|:-------------------|:--------------------------------|:---------------------------------------------------|
+| `totalAmount`      | `integer`                       | Sum of every item's `amount` (transactions + transfers) |
+| `transactionCount` | `integer`                       | Number of items                                    |
+| `transactions`     | `SettlementTransactionItem[]`   | Items, ascending by date                           |
+
+`SettlementTransactionItem` is a **narrow projection** — not the full `TransactionResponse`:
+
+| Field                  | Type            | Description                                                              |
+|:-----------------------|:----------------|:-------------------------------------------------------------------------|
+| `id`                   | `UUID`          | Transaction id (`type=TRANSACTION`) or transfer id (`type=TRANSFER`)     |
+| `transactionDate`      | `date`          | Transaction date, or the transfer date for transfers                     |
+| `settlementDate`       | `date` / `null` | Card settlement date. Always `null` for transfers                        |
+| `description`          | `string`        | Description (transfers without one fall back to `"이체"`)                 |
+| `amount`               | `integer`       | Amount                                                                   |
+| `categoryName`         | `string` / `null` | Category name. `null` for transfers                                    |
+| `categoryIcon`         | `string` / `null` | Category icon. `null` for transfers                                    |
+| `type`                 | `string`        | `TRANSACTION` or `TRANSFER`                                              |
+| `settlementTransferId` | `UUID` / `null` | Non-null when the item is already bound to a card-settlement transfer     |
 
 ```json
 {
   "success": true,
-  "data": [
-    {
-      "id": "550e8400-e29b-41d4-a716-446655440030",
-      "coupleId": "550e8400-e29b-41d4-a716-446655440001",
-      "author": {
-        "id": "550e8400-e29b-41d4-a716-446655440000",
-        "nickname": "홍길동",
-        "profileImageUrl": "https://lh3.googleusercontent.com/..."
+  "data": {
+    "totalAmount": 23000,
+    "transactionCount": 2,
+    "transactions": [
+      {
+        "id": "550e8400-e29b-41d4-a716-446655440031",
+        "transactionDate": "2026-05-10",
+        "settlementDate": "2026-06-15",
+        "description": "지하철 충전",
+        "amount": 8000,
+        "categoryName": "교통",
+        "categoryIcon": "directions_bus",
+        "type": "TRANSACTION",
+        "settlementTransferId": "550e8400-e29b-41d4-a716-446655440200"
       },
-      "category": {
-        "id": "550e8400-e29b-41d4-a716-446655440010",
-        "name": "식비",
-        "type": "EXPENSE",
-        "icon": "restaurant",
-        "color": "#FF5733"
-      },
-      "type": "EXPENSE",
-      "amount": 15000,
-      "description": "점심 식사",
-      "transactionDate": "2026-05-15",
-      "paymentMethodId": "550e8400-e29b-41d4-a716-446655440031",
-      "paymentMethodName": "신한카드",
-      "paymentMethodType": "CREDIT",
-      "settlementDate": "2026-06-15",
-      "settlementTransferId": null,
-      "visibility": "SHARED",
-      "createdAt": "2026-05-15T12:30:00Z",
-      "updatedAt": "2026-05-15T12:30:00Z"
-    },
-    {
-      "id": "550e8400-e29b-41d4-a716-446655440031",
-      "coupleId": "550e8400-e29b-41d4-a716-446655440001",
-      "author": {
-        "id": "550e8400-e29b-41d4-a716-446655440000",
-        "nickname": "홍길동",
-        "profileImageUrl": "https://lh3.googleusercontent.com/..."
-      },
-      "category": {
-        "id": "550e8400-e29b-41d4-a716-446655440011",
-        "name": "교통",
-        "type": "EXPENSE",
-        "icon": "directions_bus",
-        "color": "#3399FF"
-      },
-      "type": "EXPENSE",
-      "amount": 8000,
-      "description": "지하철 충전",
-      "transactionDate": "2026-05-10",
-      "paymentMethodId": "550e8400-e29b-41d4-a716-446655440031",
-      "paymentMethodName": "신한카드",
-      "paymentMethodType": "CREDIT",
-      "settlementDate": "2026-06-15",
-      "settlementTransferId": "550e8400-e29b-41d4-a716-446655440200",
-      "visibility": "SHARED",
-      "createdAt": "2026-05-10T09:00:00Z",
-      "updatedAt": "2026-05-10T09:00:00Z"
-    }
-  ],
+      {
+        "id": "550e8400-e29b-41d4-a716-446655440030",
+        "transactionDate": "2026-05-15",
+        "settlementDate": "2026-06-15",
+        "description": "점심 식사",
+        "amount": 15000,
+        "categoryName": "식비",
+        "categoryIcon": "restaurant",
+        "type": "TRANSACTION",
+        "settlementTransferId": null
+      }
+    ]
+  },
   "timestamp": "2026-06-24T10:00:00Z"
 }
 ```
 
 **Response field notes**
 
-- `settlementTransferId` — `UUID` or `null`. Non-null only when the transaction is already marked as paid via a card settlement transfer. When the `settlementTransferId` query parameter is supplied, already-bound transactions for that transfer are included and carry the matching UUID here.
-- All other fields follow the standard `TransactionResponse` schema.
+- `settlementTransferId` — non-null only when the transaction is already marked paid via a card
+  settlement transfer. When the `settlementTransferId` query parameter is supplied, already-bound
+  transactions for that transfer are included and carry the matching UUID here.
+- Transfers are included because a card settlement must cover card-sourced transfers as well;
+  omitting them under-reports the settlement amount (2026-04-15 인시던트).
 
 **Error Responses**
 

--- a/docs/current-tasks.md
+++ b/docs/current-tasks.md
@@ -1,5 +1,9 @@
 # Current Tasks - Budget Book
 
+> 최종 갱신: 2026-07-27. 이 파일은 **지금 진행 중인 작업**만 담는다.
+> 완료된 Phase 목록은 `docs/project-audit.md §1.1`, 미해결 이슈는 `docs/known-issues.md`,
+> 세션별 기획/결과는 `docs/sessions/` 를 본다.
+
 ## How to Use (Team Coordination)
 - Each agent reads this file at session start
 - Claim a task by writing your name in the `Owner` field
@@ -7,24 +11,36 @@
 - Pull before editing, commit after updating
 - Only edit files in YOUR ownership scope
 
-## Completed
-- [x] Phase 1: OAuth2 Auth (Google/Kakao) - Backend + Frontend + Deploy
-- [x] Phase 1 Cleanup: JWT secret fix, @Transactional, email-first linking, missing tests, refresh token scheduler
-- [x] Phase 2a: Couple linking, Category management, Transaction CRUD - Backend + Frontend
+## Completed (요약 — 상세는 project-audit.md)
+- [x] Phase 1: OAuth2 인증(Google/Kakao) + JWT
+- [x] Phase 2a: 커플 연결, 카테고리, 거래 CRUD
+- [x] Phase 2b: 월 예산, 통계/분석
+- [x] Phase 3: 카테고리 그룹, 결제수단, 주간 예산, 리포트, 반복 거래
+- [x] Phase 11~13: 보험, 즐겨찾기, 지출 계획, 위시리스트(주차 배정)
+- [x] Phase 22: 이체(`transfers.kind`) + 잔액 조정(ADJUSTMENT) + 자산 잔액
+- [x] 홈 대시보드 위젯 커스터마이징, 공지사항, 피드백/릴리스노트
+- [x] WebSocket 실시간 동기화(STOMP + Caffeine/Redis 2단계 캐시)
+- [x] NAS 이전(Render/Supabase/Pages → Synology NAS), PWA 아이콘, DB 백업(오프사이트 암호화)
 
-## Active Sprint (Phase 2b)
+## Active Sprint (정산 스냅샷 기능 — 기획서 `docs/sessions/2026-07-27_1_plan.md`)
 
 | ID | Task | Owner | Status | Scope |
 |----|------|-------|--------|-------|
-| CT-P2b-spec | API spec for budget + statistics endpoints | contract-teammate | DONE | docs/api-spec.md |
-| CT-P2b-db | DB migration V6 (monthly_budgets) | contract-teammate | DONE | db/migration |
-| BE-P2-4 | Backend: Budget domain (entity, CRUD, summary) | backend-teammate | TODO | budget feature |
-| BE-P2-5 | Backend: Statistics domain (summary, by-category, trend) | backend-teammate | TODO | statistics feature |
-| FE-P2-4 | Frontend: Budget UI (plan screen, per-category budgets) | frontend-teammate | TODO | budget feature |
-| FE-P2-5 | Frontend: Statistics UI (charts, trend) | frontend-teammate | TODO | statistics feature |
+| PR1-FE | 필터 전파 구조적 수정 (`LoadTransactions` 생성자 봉인 + VO 단일화) | frontend | DONE | transaction/statistics bloc·repo·datasource |
+| PR1-FE2 | `needsReviewOnly` 드롭 3곳 fix (sync/탭복귀/URL진입) | frontend | DONE | core/websocket, core/widgets, core/router |
+| PR1-BE | `/statistics/summary` 에 `needsReviewOnly` 반영 (합계 ≠ 행 fix) | backend | DONE | statistics controller/service |
+| PR1-BE2 | 거래 목록 페이지 상한 100 → 200 (FE `_pageSize` 와 일치) | backend | DONE | TransactionService |
+| PR1-INFRA | Testcontainers Docker 소켓 후보 탐색 (colima/Desktop) | devops | DONE | build.gradle.kts, 통합테스트 전략 |
+| PR1-DOC | api-spec settlement 응답 정정 / erd.md V13~V64 / KI-007·audit 상태 | contract | DONE | docs/ |
+| PR2-BE | 정산 스냅샷 BE (V65 + 6 엔드포인트 + `reconciled` 필터 + 집계) | backend | TODO | reconciliation feature |
+| PR3-FE | 정산 뷰(상단 미기록 / 하단 스냅샷별) + 배지 5곳 + sync | frontend | TODO | reconciliation feature |
 
-## Backlog (Phase 2c+)
-| ID | Task | Owner | Scope |
-|----|------|-------|-------|
-| P2-6 | Real-time sync (WebSocket) | backend + frontend | websocket |
-| P2-7 | Redis integration (Upstash) | backend | cache/session |
+## Backlog
+
+| ID | Task | Scope |
+|----|------|-------|
+| RECON-P4 | 월말 "미기록 N건" 인앱 알림 | notification |
+| RECON-P6 | 홈 대시보드 "미정산 N건" 위젯 | home |
+| KI-007-P2 | 카카오 비즈니스 앱 전환(이메일 필수 동의) — 선택 | auth |
+| REL-ANDROID | Android 스토어 배포 | infra |
+| ASSET-PRIVATE | 개인 자산(PaymentMethod visibility/owner) + 이체 visibility 파생 | payment_method, transfer |

--- a/docs/erd.md
+++ b/docs/erd.md
@@ -1,8 +1,17 @@
 # Budget Book - Entity Relationship Diagram
 
 > Database schema definition for Budget Book.
-> All tables use PostgreSQL (hosted on Supabase).
+> PostgreSQL 16, self-hosted on the Synology NAS (`db_postgres_bb`, internal port 5433).
+> (Supabase 는 2026 상반기에 NAS 로 이전 완료 — 더 이상 사용하지 않는다.)
 > Migrations are managed via Flyway with `V{N}__` naming convention.
+>
+> **문서 범위 주의 (2026-07-27 감사)**: 아래 `## Table Details` 의 상세 표는 V12 까지만
+> 작성되어 있었고 V13~V64 에서 추가된 테이블·컬럼이 빠져 있었다. 그 공백은
+> [§ V13~V64 스키마 증분](#v13v64-스키마-증분) 에 정리했다. 신규 마이그레이션을 작성할 때는
+> **반드시 두 절을 함께** 확인할 것 (누락된 CHECK/UNIQUE 제약을 모른 채 작성하면
+> prod 에서 제약 위반이 난다 — 과거 실제 사고).
+>
+> 마지막 검증: 2026-07-27, 라이브 DB `flyway_schema_history` 최신 = V64 (전건 success).
 
 ---
 
@@ -599,6 +608,130 @@ Records transfers of funds between pockets. Affects balance calculation for both
 
 ---
 
+## V13~V64 스키마 증분
+
+> 위 `## Table Details` 는 V12 시점 스냅샷이다. 이 절은 그 이후 추가/변경분을 정리한다.
+> 컬럼 목록은 2026-07-27 라이브 DB(`information_schema.columns`) 기준으로 검증했다.
+
+### 기존 테이블에 추가된 컬럼
+
+| 테이블 | 컬럼 | 타입 | 비고 |
+|:---|:---|:---|:---|
+| `transactions` | `pocket_id` | UUID | V13. 머니 포켓 FK (nullable) |
+| `transactions` | `visibility` | VARCHAR(10) NOT NULL `'SHARED'` | V26. `SHARED`/`PRIVATE` |
+| `transactions` | `owner_id` | UUID | V26. PRIVATE 소유자 |
+| `transactions` | `paid_at` | DATE | V51. 카드 결제 완료일. null = 미결제(결제 대상) |
+| `transactions` | `needs_review` | BOOLEAN NOT NULL `false` | V61. "확인/입력 필요" 플래그. 통계 합계에 영향 없음 |
+| `transactions` | `settlement_transfer_id` | UUID | V63. 이 거래를 결제 완료로 마킹한 카드 정산 이체 ID |
+| `transactions` | `type` CHECK 확장 | — | V54. `INCOME`/`EXPENSE`/`ADJUSTMENT` |
+| `transactions` | `amount` CHECK 완화 | — | V46 (0 허용), V54 (ADJUSTMENT 는 음수 허용) |
+| `categories` | `group_id`, `visibility`, `owner_id`, `display_order` | — | V7 / V26 |
+| `category_groups` | `visibility`, `owner_id` | — | V26 |
+| `category_groups` | `category_type` | VARCHAR NOT NULL | V58. 그룹이 속한 카테고리 타입(수입/지출). 하드코딩 EXPENSE 금지 |
+| `payment_methods` | `closing_day` | INT | 카드 마감일 |
+| `payment_methods` | `linked_bank_id` | UUID | V34. CREDIT 카드의 결제 은행(BANK 타입 결제수단) |
+| `payment_methods` | `type` CHECK 확장 | — | V30. `CASH`/`DEBIT`/`CREDIT`/`BANK` |
+| `monthly_budgets` | `pocket_id` | UUID | V23 |
+| `monthly_budgets` | `period_type`, `start_date`, `end_date` | — | V24. `NONE`/`DAILY`/`WEEKLY`/`MONTHLY` |
+| `monthly_budgets` | `group_id` | UUID | V25. 그룹 단위 예산 |
+| `monthly_budgets` | `visibility`, `owner_id` | — | V26 |
+| `monthly_budgets` | `weekly_amount` | BIGINT | 주간 예산 source of truth. `amount = round(weekly*days/7)` (V64) |
+| `monthly_budgets` | `end_year_month`, `row_kind` | — | V57/V60. `TEMPLATE`(다월 반복) / `OVERRIDE`(단월) |
+| `money_pockets` | `goal_amount`, `target_date` | — | V17 |
+| `money_pockets` | `visibility`, `owner_id` | — | V26 |
+| `couples` | `dissolved_at` | TIMESTAMPTZ | V16 |
+| `users` | `is_active` | BOOLEAN NOT NULL `true` | V21 |
+| `users` | `provider` CHECK 확장 | — | V35. `GOOGLE`/`KAKAO`/`SYSTEM` (시스템 계정 UUID `0000…0001`) |
+| `users` | `email` | — | V62. 미동의 카카오 계정은 `{provider}_{providerId}@no-email.local` placeholder |
+
+### V13~V64 에서 추가된 테이블
+
+#### `transfers` (V33, V52·V54 확장)
+
+자산 간 이동 + 카드 결제. **거래 목록은 `transactions` + `transfers` 를 FE 에서 병합**해
+표시하므로, 목록/집계/필터를 건드릴 때 두 스트림을 함께 다뤄야 한다.
+
+| 컬럼 | 타입 | 비고 |
+|:---|:---|:---|
+| `id` | UUID PK | |
+| `couple_id` | UUID NOT NULL | FK `couples` |
+| `author_id` | UUID NOT NULL | FK `users` |
+| `source_payment_method_id` | UUID NOT NULL | 출금 자산 |
+| `destination_payment_method_id` | UUID NOT NULL | 입금 자산 |
+| `amount` | BIGINT NOT NULL | |
+| `description` / `memo` | VARCHAR(255) / TEXT | nullable |
+| `transfer_date` | DATE NOT NULL | |
+| `auto_settlement_key` | VARCHAR(100) UNIQUE | V35. 자동 정산 중복 방지 키 (partial unique) |
+| `is_card_settlement` | BOOLEAN NOT NULL `false` | V52. **deprecated** — `kind` 로 대체됨 |
+| `kind` | VARCHAR NOT NULL `'GENERIC'` | V54. CHECK `CARD_SETTLEMENT`/`EXPENSE_TRANSFER`/`INCOME_TRANSFER`/`GENERIC` |
+
+집계 규칙: `CARD_SETTLEMENT` 는 모든 통계에서 제외(원본 지출이 이미 집계됨),
+`EXPENSE_TRANSFER`→지출, `INCOME_TRANSFER`→수입, `GENERIC`→이체 합계.
+인덱스: `idx_transfers_couple_date_kind (couple_id, transfer_date, kind)` (V54/V56).
+
+#### `insurances` (V37)
+
+`id`, `couple_id`, `user_id`, `name`, `insurer?`, `insurance_type`, `premium_amount`,
+`payment_day?`, `payment_cycle`(`MONTHLY` 기본), `payment_method_id?`, `category_id?`,
+`start_date?`, `end_date?`, `memo?`, `is_active`, `visibility`, `owner_id?`, `created_at`, `updated_at`.
+
+#### `spending_plans` (V39, V40 확장)
+
+지출 계획 / 위시리스트. `id`, `couple_id`, `author_id`, `name`, `amount`, `target_date?`,
+`memo?`, `category_id?`, `payment_method_id?`, `budget_id?`, `linked_transaction_id?`,
+`status`(`PLANNED`/`COMPLETED`/`SKIPPED`/`OVERDUE`), `actual_amount?`, `completed_date?`,
+`is_recurring`, `frequency?`(`WEEKLY`/`MONTHLY`), `recurring_source_id?`, `visibility`,
+`owner_id?`, `priority`(`MEDIUM` 기본), `estimated_min?`, `estimated_max?`, `tags?`,
+`week_number?`(V40 주차 배정).
+
+#### `spending_plan_status_history` (V41)
+
+`id`, `spending_plan_id`, `from_status?`, `to_status`, `changed_by`, `actual_amount?`,
+`linked_transaction_id?`, `note?`, `created_at`.
+
+#### `weekly_budget_settlements` (V47)
+
+주간 예산 마감(정산). `id`, `couple_id`, `budget_id`, `year_month`, `week_number`,
+`week_start`, `week_end`, `category_id?`, `settled_amount`, `status`(`PENDING`/`SETTLED`),
+`settled_at?`, `settled_by?`, `created_at`, `updated_at`.
+
+> 이름이 비슷한 세 개념을 구분할 것: **카드 정산**(`transfers.kind=CARD_SETTLEMENT`),
+> **주간 예산 정산**(이 테이블), 그리고 장부 **정산 스냅샷**(별도 기능).
+
+#### `distribution_ratios` (V18)
+
+`id`, `couple_id`, `pocket_id`, `ratio`(NUMERIC), `created_at`, `updated_at`.
+
+#### `couple_preferences` (V38)
+
+`id`, `couple_id` (UNIQUE), `favorite_category_ids` UUID[], `favorite_payment_method_ids` UUID[],
+`created_at`, `updated_at`.
+
+#### `category_patterns` (V50)
+
+자동 카테고리 추천용 학습 데이터. `id`, `couple_id`, `keyword`, `category_id`,
+`frequency`(기본 1), `last_used_at`, `created_at`.
+
+#### `announcements` (V22)
+
+`id`, `title`, `content`, `is_active`, `created_by?`, `created_at`, `updated_at`.
+
+#### `feedback_posts` (V42) / `feedback_comments` (V43) / `feedback_votes` (V49)
+
+- `feedback_posts`: `id`, `user_id`, `category`, `title`, `content`,
+  `status`(`SUBMITTED` 기본), `admin_note?`, `resolved_release_id?`, `vote_count`(V49 캐시),
+  `created_at`, `updated_at`
+- `feedback_comments`: `id`, `post_id`, `author_id`, `content`, `is_admin_reply`, `created_at`
+- `feedback_votes`: `id`, `post_id`, `user_id`, `created_at`
+
+#### `release_notes` (V44) / `release_note_feedbacks` (V45)
+
+- `release_notes`: `id`, `version`(UNIQUE), `title`, `content`, `is_published`,
+  `published_at?`, `created_by`, `created_at`, `updated_at`
+- `release_note_feedbacks`: `release_note_id`, `feedback_post_id` (조인 테이블)
+
+---
+
 ## Relationships
 
 | From                      | To                          | Cardinality | Description                                                |
@@ -648,3 +781,56 @@ Records transfers of funds between pockets. Affects balance calculation for both
 | V11     | `V11__create_money_pockets_table.sql`            | Money pockets (budget envelopes) per couple              |
 | V12     | `V12__create_pocket_transfers_table.sql`         | Pocket transfers between money pockets                   |
 | V13     | `V13__add_pocket_id_to_transactions.sql`         | `transactions.pocket_id` FK to money pockets             |
+| V14     | `V14__add_budget_unique_constraint.sql`           | 예산 중복 방지 UNIQUE                                     |
+| V15     | `V15__add_pocket_transfer_indexes.sql`           | 포켓 이체 인덱스 3종                                      |
+| V16     | `V16__add_dissolved_at_to_couples.sql`           | `couples.dissolved_at`                                    |
+| V17     | `V17__add_pocket_goals.sql`                      | 포켓 목표 금액/기한                                       |
+| V18     | `V18__add_distribution_ratios.sql`               | `distribution_ratios` 테이블                              |
+| V19     | `V19__add_constraints.sql`                       | 전역 CHECK/UNIQUE 정비 (카테고리·결제수단·예산)            |
+| V20     | `V20__add_performance_indexes.sql`               | 조회 성능 인덱스                                          |
+| V21     | `V21__add_admin_fields.sql`                      | `users.is_active` + 역할 관련 필드                         |
+| V22     | `V22__add_announcements.sql`                     | `announcements` 테이블                                    |
+| V23     | `V23__add_pocket_id_to_budgets.sql`              | `monthly_budgets.pocket_id`                               |
+| V24     | `V24__budget_flexible_period.sql`                | `period_type`/`start_date`/`end_date` + CHECK             |
+| V25     | `V25__add_group_id_to_budgets.sql`               | 그룹 단위 예산                                            |
+| V26     | `V26__add_visibility_support.sql`                | 공유/개인(visibility·owner_id) 전면 도입                   |
+| V27     | `V27__fix_unique_constraints_for_visibility.sql` | visibility 반영 UNIQUE 재정의                             |
+| V28     | `V28__fix_weekly_budget_amounts.sql`             | 주간 예산 금액 보정                                        |
+| V29     | `V29__fix_transaction_visibility_from_category.sql` | 카테고리 기준 거래 visibility 백필                      |
+| V30     | `V30__add_bank_to_payment_method_type.sql`       | 결제수단 타입에 `BANK` 추가                                |
+| V31     | `V31__fix_fk_and_constraints.sql`                | FK/제약 정합성 수정                                        |
+| V32     | `V32__performance_and_cleanup.sql`               | 인덱스 정리 + 미사용 오브젝트 제거                          |
+| V33     | `V33__create_transfers_table.sql`                | **`transfers`** (자산 간 이체)                            |
+| V34     | `V34__add_linked_bank_id.sql`                    | `payment_methods.linked_bank_id` (카드 결제 은행)          |
+| V35     | `V35__add_system_account_and_auto_settlement.sql`| SYSTEM provider + `transfers.auto_settlement_key`         |
+| V36     | `V36__fix_category_unique_with_group.sql`        | 그룹 포함 카테고리 UNIQUE                                  |
+| V37     | `V37__create_insurances_table.sql`               | `insurances`                                              |
+| V38     | `V38__create_couple_preferences.sql`             | `couple_preferences` (즐겨찾기)                            |
+| V39     | `V39__create_spending_plans_table.sql`           | `spending_plans`                                          |
+| V40     | `V40__spending_plan_wishlist_enhancement.sql`    | 위시리스트 확장(우선순위·예상금액·주차)                     |
+| V41     | `V41__create_spending_plan_status_history.sql`   | `spending_plan_status_history`                            |
+| V42     | `V42__create_feedback_posts.sql`                 | `feedback_posts`                                          |
+| V43     | `V43__create_feedback_comments.sql`              | `feedback_comments`                                       |
+| V44     | `V44__create_release_notes.sql`                  | `release_notes` (version UNIQUE)                          |
+| V45     | `V45__create_release_note_feedbacks.sql`         | 릴리스노트 ↔ 피드백 조인 테이블                            |
+| V46     | `V46__allow_zero_amount_transactions.sql`        | 거래 금액 0 허용                                          |
+| V47     | `V47__create_weekly_budget_settlements.sql`      | `weekly_budget_settlements` (주간 예산 정산)               |
+| V48     | `V48__self_couple_backfill.sql`                  | 1인 커플 백필                                             |
+| V49     | `V49__create_feedback_votes.sql`                 | `feedback_votes` + `vote_count` 캐시                       |
+| V50     | `V50__create_category_patterns.sql`              | `category_patterns` (자동 분류 학습)                       |
+| V51     | `V51__add_paid_at_to_transactions.sql`           | `transactions.paid_at` (카드 결제 완료)                    |
+| V52     | `V52__add_is_card_settlement_to_transfers.sql`   | `transfers.is_card_settlement` (이후 `kind` 로 대체)       |
+| V53     | `V53__backfill_card_settlement_data.sql`         | 카드 결제 데이터 백필                                      |
+| V54     | `V54__add_transfer_kind_and_adjustment.sql`      | `transfers.kind` + `ADJUSTMENT` 거래 타입 + 금액 CHECK     |
+| V56     | `V56__add_transfer_kind_index.sql`               | `(couple_id, transfer_date, kind)` 인덱스                  |
+| V57     | `V57__budget_template_override.sql`              | 예산 TEMPLATE/OVERRIDE 구분 (`row_kind`, `end_year_month`) |
+| V58     | `V58__add_category_type_to_groups.sql`           | `category_groups.category_type`                           |
+| V59     | `V59__seed_default_income_group.sql`             | 기본 수입 그룹 시드                                        |
+| V60     | `V60__drop_template_unique_for_multi_segment.sql`| 다구간 TEMPLATE 허용을 위한 UNIQUE 완화                    |
+| V61     | `V61__add_transaction_needs_review.sql`          | `transactions.needs_review`                               |
+| V62     | `V62__backfill_placeholder_emails.sql`           | 이메일 미동의 카카오 계정 placeholder 백필                  |
+| V63     | `V63__add_settlement_transfer_id_to_transactions.sql` | `transactions.settlement_transfer_id`               |
+| V64     | `V64__unify_weekly_budget_conversion.sql`        | 주간 예산 환산 단일화 (`weekly_amount` = source of truth)  |
+
+> V55 는 결번(스킵)이다 — 실제 적용 이력에도 존재하지 않는다.
+> 라이브 적용 상태 확인: `select version, success from flyway_schema_history order by installed_rank desc`.

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -5,16 +5,21 @@
 
 ---
 
-## 🔴 KI-007: 카카오 OAuth 빈 email → 가입 실패 + 식별 불가 (2026-06-04)
-- **발견**: 카카오는 이메일이 선택 동의 → 미동의 시 `CustomOAuth2UserService.kt:64` `?: ""` 로 빈 문자열 저장 (예: 곽소영 `8358d6c8-...`, KAKAO, email='')
-- **버그**: `email`은 `NOT NULL UNIQUE`라 빈 문자열도 1명만 가능. 게다가 중복가입 체크 `findByEmail("")`(`:80`)가 기존 빈-email 유저를 반환 → **2번째 email-미동의 카카오 가입이 "이미 등록된 이메일"로 차단됨**
-- **사실 정정**: 파트너 연결은 email이 아니라 8자리 초대코드 방식(`CoupleService`). email 용도는 ① cross-provider 중복가입 방지 ② 어드민 식별뿐
-- **카카오 제약**: email 필수 동의는 비즈니스 앱 전환 + 검수 필요(즉시 불가). 통과해도 기존 가입자 소급 안 됨 + email 없는 카카오 계정은 여전히 불가
-- **조치 (결정 2026-06-04)**:
-  - Phase 1 (BE, 우선): email 없으면 `{provider}_{providerId}@no-email.local` placeholder 생성 + 중복체크 가드(placeholder skip) + V62 백필(곽소영 등 기존 '' row)
-  - Phase 3 (FE): placeholder/빈 email 유저에게 이메일 등록 유도 + BE email 업데이트 API
-  - Phase 2 (추후): 카카오 비즈니스 앱 전환 → 이메일 필수 동의 검수 신청 (안전 강화, placeholder가 본질 해결)
-- **상태**: Phase 1 착수 예정 (삭제 API 통합테스트 완료 직후, gradle 충돌 방지 순차)
+## 🟢 KI-007: 카카오 OAuth 빈 email → 가입 실패 + 식별 불가 (2026-06-04 발견 / 2026-07-27 코드 확인)
+- **발견**: 카카오는 이메일이 선택 동의 → 미동의 시 `CustomOAuth2UserService` 가 `?: ""` 로 빈 문자열 저장
+- **버그**: `email` 이 `NOT NULL UNIQUE` 라 빈 문자열도 1명만 가능 + 중복가입 체크 `findByEmail("")` 가 기존
+  빈-email 유저를 반환 → **2번째 email-미동의 카카오 가입이 "이미 등록된 이메일"로 차단**
+- **사실 정정**: 파트너 연결은 email 이 아니라 8자리 초대코드(`CoupleService`). email 용도는
+  ① cross-provider 중복가입 방지 ② 어드민 식별뿐
+- **조치 결과 (2026-07-27 코드 확인)**
+  - Phase 1 **완료** — `auth/domain/EmailPolicy.kt` 가 `{provider}_{providerId}@no-email.local`
+    placeholder 를 생성하고 중복체크에서 placeholder 를 skip. `V62__backfill_placeholder_emails.sql`
+    로 기존 빈-email row 백필 (라이브 적용 완료)
+  - Phase 3 **완료** — `settings/.../profile_edit_page.dart` 가 `hasRegisteredEmail` 기준으로
+    이메일 등록을 유도하고 `UpdateProfile(email:)` 로 저장
+  - Phase 2 **미착수(선택)** — 카카오 비즈니스 앱 전환 + 이메일 필수 동의 검수. placeholder 가
+    본질 문제를 해결했으므로 필수 아님
+- **남은 확인**: 이메일 미동의 카카오 계정 2개 동시 가입 라이브 재현 (사용자 검증 미수행)
 
 ## 🟡 KI-006: 완료 처리 시 거래 자동 등록 + 상태 변경
 - **요청**: 지출 계획 완료 처리 시 거래 자동 등록 + COMPLETED 상태 전환

--- a/docs/project-audit.md
+++ b/docs/project-audit.md
@@ -1,7 +1,7 @@
 # Budget Book - Project Audit Report
 
 > 작성일: 2026-03-12
-> 최종 검증일: 2026-04-01
+> 최종 검증일: 2026-07-27 (라이브 health/마이그레이션/CI 재측정)
 > 목적: 프로젝트 전후 비교 분석 → 개선/추가/리팩토링 필요사항 정리
 > 활용: 추후 개발 요청 시 참고 문서
 
@@ -55,7 +55,7 @@
 | Redis | NAS Redis 7 (redis_bb) | 내부 6380 | Live |
 | CI/CD | GitHub Actions (deploy-nas.yml) | SSH + tar/docker | 동작 중 |
 
-- Flyway 마이그레이션: V1~V41 전체 적용 완료
+- Flyway 마이그레이션: V1~V64 전체 적용 완료 (2026-07-27 라이브 `flyway_schema_history` 확인, V55 결번)
 - 자동 배포: `main` 머지 시 SSH → NAS docker build + run (BE) / SCP 전송 (FE)
 - 배포 URL: https://aiva-bb.duckdns.org
 

--- a/docs/sessions/2026-07-27_1_plan.md
+++ b/docs/sessions/2026-07-27_1_plan.md
@@ -1,0 +1,532 @@
+# 정산(스냅샷) 기능 도입 + 전체 상태 점검
+> 날짜: 2026-07-27 | 회차: 1 | 상태: 승인 → 진행 중 (PR 1 구현 완료, PR 2·3 대기)
+
+## 확정된 설계 결정 (2026-07-27 사용자 선택)
+
+1. **화면**: 거래 목록의 3번째 뷰 모드 "정산" (`리스트 | 달력 | 정산`) — §2.5 권장안.
+   기존 리스트/달력의 러닝 밸런스·월 합계 로직 무변경, 배지만 추가.
+2. **선행 PR 1 함께 진행** — D1 필터 드롭 fix + 구조적 수정 + 문서 정정(D2~D4) +
+   Docker 소켓 폴백(D6) + 페이지 크기 정렬(D5).
+3. **추가 범위 포함**: P1(정산 후 변경 감지 ⚠), P2(원본 삭제 표시),
+   P3(미기록 0건 "정산 완료" 배지), P5(needs_review 포함 경고).
+   **제외(별도 회차)**: P4(월말 인앱 알림), P6(홈 대시보드 위젯).
+
+## 요청 내용
+
+(사용자 원문)
+
+> 전체적으로 기획과 다르거나 누락된 부분, 장애 있는지 체크
+>
+> 고도화 기능으로 정산 기능을 도입하려고 한다.
+>
+> 정산 기능 : 스냅샷 개념으로 정산한 시점에 등록한 거래들 체크 => 완료하면 정산 완료 이모티콘이나 아이콘 표시
+> 추후 월말에 누락된 항목 선택 시 어떤 항목들이 정산에 빠졌는지 체크할 수 있음
+> 여러 번 할 수 있고, 스냅샷 별로 기록되면 가장 좋음
+> 스냅샷이 존재하면 하단에 스냅샷에 기록된 거래들이 나오고 상단에는 미 기록 항목들만 표시 (상단/하단에 미기록, 언제 스냅샷 별 기록으로 분리)
+
+---
+
+# PART 1 — 전체 상태 점검 (측정 결과)
+
+## 1.1 정상 확인 (hard evidence)
+
+| 항목 | 측정 | 결과 |
+|:---|:---|:---|
+| 라이브 서비스 | `curl https://aiva-bb.duckdns.org/actuator/health` | 200 |
+| 웹 번들 캐시 헤더 | `curl -sI /main.dart.js` | `cache-control: no-cache, must-revalidate` (모바일 stale 캐시 방지 유지) |
+| 실 DB 마이그레이션 | `flyway_schema_history` 최신 5건 | V60~V64 전부 `success=t` (코드 최신 V64 = 라이브 V64) |
+| BE 테스트 | `DOCKER_HOST=…colima… ./gradlew test` | BUILD SUCCESSFUL (45s) |
+| FE 정적 분석 | `flutter analyze --no-fatal-infos --no-congratulate` | 3 info (테스트 파일 `prefer_const` 만) → CI 통과 기준 |
+| FE 테스트 | `flutter test` | 755 passed, 0 failed |
+| CI/CD | `gh run list` 최근 8건 | 전부 success. paths-filter 로 BE/FE 독립 검증 구조 정상 |
+| git 상태 | `git status --short` | clean |
+
+## 1.2 발견된 결함 · 기획 드리프트
+
+### D1. 필터 전파 누락 3곳 — `needsReviewOnly` 드롭 (P1, 사용자 체감 버그)
+
+2026-04-15 인시던트("월 이동 후 필터 drop")의 구조적 수정으로 `LoadTransactions.fromFilter`
+팩토리가 도입되었으나 **실제 사용처는 `month_sync_handler.dart` 단 1곳**이고, 나머지 경로는
+여전히 필드를 수동 나열하며 `needsReviewOnly` 를 빠뜨린다.
+
+- `frontend/lib/core/websocket/sync_event_handler.dart:101` — 파트너가 거래를 추가/수정하면
+  내 화면의 "확인/입력 필요만 보기" 필터가 해제된다.
+- `frontend/lib/core/widgets/main_shell_page.dart:152` — 다른 탭 갔다 거래 탭으로 복귀 시 동일.
+- `frontend/lib/core/router/app_router.dart:378` — URL 진입(홈/예산에서 거래로 이동) 시 동일.
+
+대조: `transaction_bloc.dart:360,428` 과 `transaction_list_page.dart:220,658` 은 `needsReviewOnly`
+포함 → 같은 필터가 경로에 따라 살아있거나 죽는 비결정적 동작.
+
+근본 원인은 `LoadTransactions` 의 **공개 기본 생성자가 필드 수동 나열을 허용**하는 것.
+→ PART 3 §3.1 구조적 수정 대상.
+
+### D2. `/transactions/settlement` 응답 계약 문서 오류 (P2)
+
+- `docs/api-spec.md:1270` — `ApiResponse<List<SettlementTransactionResponse>>` (배열, TransactionResponse 전체 형태)
+- 실제 코드 — `ApiResponse<SettlementTransactionsResponse>` = `{ totalAmount, transactionCount, transactions: [...] }`
+  (`TransactionDtos.kt:153`), 항목 필드도 축약형(`id/transactionDate/settlementDate/description/amount/categoryName/categoryIcon/type/settlementTransferId`)
+- FE 는 코드 쪽을 따름 (`card_settlement_remote_datasource.dart:41` — `response.data['data'] as Map`)
+
+→ 프로젝트 규칙 "api-spec.md = 단일 진실 소스"가 깨진 상태. 스펙을 코드에 맞춰 정정 필요.
+
+### D3. `docs/erd.md` V12 에서 정지 — 신규 정산 테이블 설계의 기반 문서가 부재 (P1, 이번 작업 직접 영향)
+
+문서화된 테이블: users, refresh_tokens, couples, couple_invitations, categories, transactions,
+category_groups, payment_methods, weekly_budget_snapshots, recurring_transactions, monthly_budgets,
+money_pockets, pocket_transfers (V12 까지).
+
+**누락**: `transfers`, `weekly_budget_settlements`, `spending_plans`, `insurances`, `feedback_*`,
+`announcements`, `category_patterns`, `couple_preferences`, `release_notes` + V49~V64 로 추가된
+컬럼 전부(`paid_at`, `settlement_transfer_id`, `needs_review`, `kind`, `visibility`, `owner_id` …).
+헤더의 "hosted on Supabase" 도 NAS 이전 후 미갱신.
+
+### D4. 문서 상태값 드리프트 (P3)
+
+- `docs/known-issues.md` KI-007 = 🔴 "Phase 1 착수 예정" → 실제로는 Phase 1(EmailPolicy
+  `no-email.local` placeholder + V62 백필) **및** Phase 3(FE `profile_edit_page` 이메일 등록 유도 +
+  `hasRegisteredEmail`) 모두 구현 완료. 남은 것은 Phase 2(카카오 비즈앱 전환)뿐.
+- `docs/project-audit.md` = "Flyway V1~V41 적용 완료" → 실제 V64.
+- `docs/current-tasks.md` = Active Sprint 가 Phase 2b (BE-P2-4/5 TODO) → 실제 Phase 13 까지 완료.
+
+### D8. `/statistics/summary` 가 `needsReviewOnly` 를 무시 (P1, 구현 중 발견)
+
+`StatisticsController.getMonthlySummary` 는 `CommonFilterParams` 를 받으면서 `needsReviewOnly` 만
+서비스로 넘기지 않고, `StatisticsService.getMonthlySummary` 에는 그 파라미터가 아예 없었다.
+FE 도 `getSummary` 호출 시 이 필드를 빼고 있었다.
+
+결과: "확인/입력 필요만 보기" 필터가 켜지면 **목록 행은 필터링되는데 월 합계 바는 전체 금액**을
+표시 → `amount_calculation` 인시던트 계열("합계 ≠ 보이는 행")의 새 사례.
+
+조치(PR 1 포함): BE 파라미터 추가 + `hasContentFilters` 에 포함해 Specification 경로로 유도,
+FE 는 목록과 **같은 필터 VO** 를 summary 에도 전달. 컨트롤러/서비스 양쪽에 회귀 테스트 추가.
+
+### D5. FE 요청 페이지 크기 200 vs BE clamp 100 (P2, 성능/정합성)
+
+- FE `transaction_bloc.dart:93` — `_pageSize = 200`
+- BE `TransactionService.kt:143` — `size.coerceIn(1, 100)`
+
+→ 항상 100건씩 내려온다. 무한스크롤/자동 LoadMore 가 보완하므로 표시는 정상이나,
+왕복이 2배이고 "월 200건/페이지" 라는 설계 기록·mock 기대값과 불일치. 정산 뷰도 같은 목록을
+쓰므로 이번에 정렬(BE clamp 200 상향 또는 FE 100)해야 한다.
+
+### D6. 로컬 BE 테스트 게이트가 이 머신에서 실행 불가 (P2, 개발 환경)
+
+`cd backend && ./gradlew test` → `Kotest > initializationError FAILED` /
+`Could not find a valid Docker environment` (`DockerClientProviderStrategy.java:277`).
+
+원인: `HighApiVersionDockerStrategy.kt:28` 이 소켓 경로를 `/var/run/docker.sock`(Docker Desktop)
+로 하드코딩. 이 머신의 활성 런타임은 colima(`unix:///Users/kdh/.colima/default/docker.sock`)이고
+`/Users/kdh/.docker/run/docker.sock`(Desktop) 심볼릭 링크 대상은 부재.
+
+검증: `DOCKER_HOST=unix:///Users/kdh/.colima/default/docker.sock
+TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock ./gradlew test` → **BUILD SUCCESSFUL**.
+즉 코드 결함이 아니라 소켓 탐색 전략 문제. 이번 작업은 Testcontainers 통합테스트를 추가하므로
+**선결 과제**. 조치: 전략에 소켓 후보 폴백(`DOCKER_HOST` → colima → Desktop) 추가 +
+`.claude/domains/commands.md` 에 환경변수 표기.
+
+### D7. 하네스 재발 방지책 미구현 (P3)
+
+2026-04-15 navigation_state 인시던트의 방지책으로 기록된 `navigation_helpers.dart`
+(year/month required 파라미터 중앙 헬퍼)가 **저장소에 존재하지 않음**(`find frontend/lib -name "*navigation*"`
+→ web_navigation_stub/web 만). 실제로는 `card_settlement_route.dart` 형태의 feature-local
+route 헬퍼가 그 역할을 부분 대체 중 → 이번 정산 뷰도 그 패턴을 따르고, 하네스 방지책 문구를
+실제 구현 형태로 갱신한다.
+
+## 1.3 점검 결론
+
+- **장애(서비스 중단·데이터 손상)는 없음.** 라이브 200, 마이그레이션 V64 전부 success, CI 전건 green,
+  BE 전체 테스트 통과, FE 755 테스트 통과.
+- 실사용자 체감 버그는 **D1(필터 드롭) 1건**.
+- 나머지는 문서-코드 드리프트(D2/D3/D4)와 설계 불일치(D5), 개발환경(D6), 하네스 기록(D7).
+- D1·D3·D6 은 이번 정산 기능과 직접 얽히므로 **선행 PR 로 처리**(PART 4 §4.1).
+
+---
+
+# PART 2 — 정산(스냅샷) 기능 기획
+
+## 2.1 요구사항 해석
+
+| # | 요구 | 해석 |
+|:--|:---|:---|
+| R1 | 정산 시점에 등록된 거래들을 체크 | 장부 항목(거래+이체)을 다중 선택 → "정산 완료" → 그 순간의 **스냅샷** 1건 생성 |
+| R2 | 완료하면 정산 완료 아이콘 표시 | 목록/달력/상세 전 노출 지점에 배지 |
+| R3 | 월말에 누락된 항목 확인 | 어떤 스냅샷에도 안 들어간 항목 = **미기록**. 미기록 목록·건수 조회 |
+| R4 | 여러 번 가능 + 스냅샷별 기록 | 한 달에 N개 스냅샷(회차). 각 스냅샷은 시각·정산자·항목·소계 보존 |
+| R5 | 상단 미기록 / 하단 스냅샷별 기록 | 정산 화면을 2 섹션으로 분리 |
+
+**불변식**: 한 항목은 최대 1개 스냅샷에만 소속 → 미기록/기록이 상호배타 + 전체 포괄(MECE).
+스냅샷 삭제 시 그 항목들은 미기록으로 복귀.
+
+## 2.2 용어 충돌 정리 (선결)
+
+"정산"이 코드/UI 에 이미 두 가지 의미로 존재한다.
+
+- `Transfer(kind=CARD_SETTLEMENT)` = 카드 대금 결제. UI 라벨은 대부분 "카드 결제"인데
+  `card_settlement_page.dart:174,282` 만 "카드 정산 수정" → **"카드 결제 수정"으로 통일**.
+- `WeeklyBudgetSettlement` = 주간 예산 마감. 내부 도메인만 사용(UI 노출 문자열 없음) → 유지.
+
+신규 기능은 코드 네임 `reconciliation`(테이블 `reconciliations` / `reconciliation_items`),
+UI 라벨 "정산"으로 확정. 기존 두 개와 테이블·엔티티·엔드포인트가 겹치지 않는다.
+
+## 2.3 데이터 모델 (V65)
+
+```sql
+-- reconciliations: 스냅샷 헤더
+id              UUID PK
+couple_id       UUID NOT NULL REFERENCES couples(id) ON DELETE CASCADE
+year_month      VARCHAR(7)  NOT NULL          -- 정산 대상 월 'YYYY-MM'
+seq             INT         NOT NULL          -- 월 내 회차 (1,2,3…)
+label           VARCHAR(100)                  -- 사용자 메모 (예: '7월 1차')
+item_count      INT    NOT NULL DEFAULT 0
+total_income    BIGINT NOT NULL DEFAULT 0
+total_expense   BIGINT NOT NULL DEFAULT 0
+total_transfer  BIGINT NOT NULL DEFAULT 0
+reconciled_at   TIMESTAMPTZ NOT NULL
+reconciled_by   UUID NOT NULL REFERENCES users(id)
+created_at/updated_at                          -- BaseTimeEntity
+CONSTRAINT uk_reconciliations_couple_ym_seq UNIQUE (couple_id, year_month, seq)
+INDEX idx_reconciliations_couple_ym (couple_id, year_month)
+
+-- reconciliation_items: 스냅샷에 담긴 항목 + 당시 값
+id                   UUID PK
+reconciliation_id    UUID NOT NULL REFERENCES reconciliations(id) ON DELETE CASCADE
+item_kind            VARCHAR(20) NOT NULL      -- TRANSACTION | TRANSFER
+transaction_id       UUID REFERENCES transactions(id) ON DELETE SET NULL
+transfer_id          UUID REFERENCES transfers(id)    ON DELETE SET NULL
+snapshot_amount      BIGINT NOT NULL           -- 정산 시점 금액
+snapshot_date        DATE   NOT NULL           -- 정산 시점 거래일
+snapshot_description VARCHAR(255)
+snapshot_kind        VARCHAR(20) NOT NULL      -- INCOME/EXPENSE/ADJUSTMENT/GENERIC/EXPENSE_TRANSFER/…
+snapshot_visibility  VARCHAR(10) NOT NULL DEFAULT 'SHARED'
+snapshot_owner_id    UUID                      -- 원본 삭제 후 게이팅 폴백용
+CONSTRAINT ck_recon_items_kind CHECK (item_kind IN ('TRANSACTION','TRANSFER'))
+CONSTRAINT ck_recon_items_ref  CHECK (
+  (item_kind='TRANSACTION' AND transfer_id IS NULL) OR
+  (item_kind='TRANSFER'    AND transaction_id IS NULL))
+CREATE UNIQUE INDEX uk_recon_items_transaction ON reconciliation_items(transaction_id)
+  WHERE transaction_id IS NOT NULL;     -- 거래는 최대 1개 스냅샷 (불변식을 DB 레벨 강제)
+CREATE UNIQUE INDEX uk_recon_items_transfer ON reconciliation_items(transfer_id)
+  WHERE transfer_id IS NOT NULL;
+INDEX idx_recon_items_reconciliation (reconciliation_id)
+```
+
+설계 근거 3가지:
+
+1. **`ON DELETE SET NULL` + snapshot_* 컬럼** — "스냅샷" 의미를 지키려면 원본이 지워져도
+   기록은 남아야 한다. CASCADE 면 정산 이력이 조용히 사라진다. 원본 삭제 시 `transaction_id`
+   만 NULL 이 되고 항목은 "원본 삭제됨"으로 표시된다. (그래서 XOR NOT NULL 대신
+   `item_kind` 판별자 + 조건부 CHECK 를 쓴다.)
+2. **partial UNIQUE 로 불변식을 DB 강제** — 서비스 레이어 검증만 두면 동시 요청(부부 동시 정산)에
+   중복 기록이 생겨 상단/하단이 겹친다. `uk_recon_items_transaction` 위반 → 409 로 변환.
+3. **거래+이체 양쪽 지원** — 장부 목록은 거래 스트림 + 이체 스트림 FE 병합이다
+   (`reference_transaction_merged_transfer_stream_drift`). 정산을 거래에만 붙이면 이체가
+   영원히 미기록으로 남는 drift 가 재발한다.
+
+## 2.4 API 계약 (docs/api-spec.md 선수정)
+
+| # | Method / Path | 용도 |
+|:--|:---|:---|
+| 1 | `GET /api/v1/reconciliations?year&month` | 스냅샷 헤더 목록(seq desc) + 소계 + 정산자 |
+| 2 | `GET /api/v1/reconciliations/{id}` | 헤더 + items[] (조회자 게이팅 후 재집계 소계 동봉) |
+| 3 | `POST /api/v1/reconciliations` | `{yearMonth, label?, transactionIds[], transferIds[]}` → 201 |
+| 4 | `PATCH /api/v1/reconciliations/{id}` | `{label?, addTransactionIds[], addTransferIds[], removeItemIds[]}` |
+| 5 | `DELETE /api/v1/reconciliations/{id}` | 204, 항목은 미기록 복귀 |
+| 6 | `GET /api/v1/reconciliations/summary?year&month` | `{snapshotCount, recordedCount, unrecordedCount, unrecordedIncome/Expense/Transfer}` — 월말 배지/알림용 |
+
+에러: 커플 외 항목 → 403 `FORBIDDEN`, 다른 월 항목 혼입 → 400, 이미 기록된 항목 → 409
+`ALREADY_RECONCILED`, 빈 선택 → 400. Rate limit `@RateLimit(maxRequests=30, windowSeconds=60)`
+(기존 mutation 관례와 동일).
+
+**응답 필드 추가 (양쪽 스트림 동시 — 공통 적용 원칙)**
+
+- `TransactionResponse` + `TransferResponse` 에 `reconciliationId: UUID?`,
+  `reconciliationSeq: Int?`, `reconciledAt: Instant?` 추가 → R2 배지의 단일 소스.
+- `CommonFilterParams` 에 `reconciled: Boolean?` 추가 →
+  `GET /transactions?...&reconciled=false`. **이체 목록도 동일 파라미터 지원**
+  (`GET /transfers?year&month&reconciled=false`) — 한쪽만 넣으면 D1 계열 drift 재발.
+
+## 2.5 화면 설계
+
+### 권장안 — 거래 목록의 3번째 뷰 모드 "정산" (`리스트 | 달력 | 정산`)
+
+기존 토글(`_ViewModeToggle`, `transaction_list_page.dart:1387`)에 세그먼트 1개 추가.
+
+```
+┌ 월 네비게이터 / 검색 / 필터바 ───────── [≡][📅][✅] ┐
+│ 미기록  12건   지출 340,000 · 수입 0 · 이체 50,000  │
+│  ☐ 07-26  스타벅스        -5,500                    │
+│  ☐ 07-25  월급           +3,200,000                 │
+│  … (무한스크롤, BE reconciled=false)                │
+│ ─────────────────────────────────────────────────── │
+│ ▼ 2차  07-20 14:03 · 홍길동 · 8건 · 지출 120,000    │
+│      07-19 편의점  -3,200  ✅                        │
+│ ▶ 1차  07-10 09:12 · 김영희 · 15건 · 지출 220,000   │
+└ [전체 선택]            [선택 12건 정산하기] ────────┘
+```
+
+- 상단 = 미기록(체크박스 다중선택), 하단 = 스냅샷별 `ExpansionTile`(최신 회차 먼저, 기본 접힘).
+- "정산하기" → 라벨 입력 다이얼로그 → `POST` → 스낵바 + 두 섹션 즉시 갱신.
+- 스냅샷 헤더에서 [라벨 수정] [정산 취소(삭제)].
+- 리스트/달력 모드는 **구조 변경 없음**, 배지만 추가.
+
+### 왜 기존 리스트를 직접 2분할하지 않는가 (사용자 결정 필요 지점)
+
+요청 문구는 "스냅샷이 존재하면 하단에 …" 로 기본 리스트 분할을 뜻할 수 있다. 그러나 현재
+리스트 모드에는 **날짜 역순 누적에 의존하는 러닝 밸런스**가 있다
+(`transaction_list_page.dart:994-1017`, MODE A 누적 지출 / MODE B 자산 잔액 = 월말 앵커에서
+역방향 누적). 목록을 미기록/기록 섹션으로 재정렬하면 이 누적 순서가 깨져 잔액 숫자가 틀린다
+(= "금액 표시 다중 위치" 인시던트 계열 재발). 또 월 합계 바(`MonthSummaryBar`)는 BE 서버 합계를
+쓰므로 "합계 ≠ 보이는 행" 불일치가 생긴다.
+
+→ 별도 뷰 모드로 두면 R1~R5 를 모두 충족하면서 기존 금액 로직을 건드리지 않는다.
+   배지(R2)는 리스트·달력·상세 전부에 나오므로 "완료 표시" 요구는 그대로 만족.
+   **대안(리스트 직접 분할)을 원하면 정산 분할이 켜진 동안 러닝 밸런스 컬럼을 숨기는 절충이 필요** —
+   승인 단계에서 선택 요청.
+
+### 배지 노출 지점 (전수 — 한 곳만 수정 금지)
+
+1. `transaction_list_tile.dart` (title Row, `needsReview` 뱃지 옆 — 같은 패턴)
+2. `transfer_list_tile.dart`
+3. `transaction_detail_page.dart` (정산 회차/시각/정산자 표시 + 스냅샷 이동)
+4. 이체 상세(`/transfers/:id`)
+5. `transaction_calendar_view.dart` 셀 (작은 ✓ 점 — 3줄 레이아웃 침범 금지, PR #271/#272 교훈)
+
+공통 위젯 `core/widgets/reconciled_badge.dart` 로 단일화 → 아이콘/색/툴팁 1곳 관리.
+
+## 2.6 추가 제안 (요청 범위 확장, 승인 시 포함)
+
+| # | 제안 | 근거 |
+|:--|:---|:---|
+| P1 | **정산 후 변경 감지** — live 값 ≠ snapshot_amount/date 면 ⚠ "정산 후 수정됨" | 스냅샷의 존재 이유. 정산 뒤 금액을 고치면 대조가 무의미해진다 |
+| P2 | **원본 삭제 표시** — `transaction_id IS NULL` 항목을 "삭제된 거래"로 회색 표시 | 감사 추적 |
+| P3 | **미기록 0건 배지** — 그 달 "정산 완료" 표시 | R3 의 긍정 피드백 |
+| P4 | **월말 리마인더** — 말일에 "미기록 N건" 인앱 알림 | 로드맵의 인앱 알림과 연계 |
+| P5 | **`needs_review` 항목 정산 시 경고** — "확인 필요 3건이 포함됩니다" | 기존 플래그 재활용 |
+| P6 | **홈 대시보드 위젯** "미정산 N건" | 홈 위젯 커스터마이징 구조에 추가 |
+
+P1·P2 는 데이터 모델에 이미 반영(추가 비용 없음) → 기본 포함 권장. P4·P6 은 별도 회차 권장.
+
+---
+
+# PART 3 — 하네스 Scope Audit 결과 (Step 1.5, 필수)
+
+- **실행 명령**: `bash ~/.claude/harness/scripts/pre-change-audit.sh . "db_schema,ui_pattern,filter_propagation,amount_calculation,navigation_state"`
+- **판정**: **OVERALL = 🚫 STRUCTURAL_FIX_REQUIRED** — 게이트 LOCKED
+  - `amount_calculation` 🚫 6건 재발
+  - `filter_propagation` 🚫 3건 재발
+  - `navigation_state` 🚫 3건 재발
+  - `db_schema` ⚠️ WARNING 1건
+  - `ui_pattern` ✅ OK
+- **게이트 해제**: 이 기획서 경로로 `acknowledge-gate.sh budget-book docs/sessions/2026-07-27_1_plan.md`
+  실행 완료(문서 작성 목적). **코드 편집은 사용자 승인 후에만 착수.**
+
+## 3.1 구조적 수정 — filter_propagation (🚫)
+
+**문제**: `LoadTransactions` 의 공개 기본 생성자가 필드 수동 나열을 허용 → 필터 추가 시 누락.
+현재 실물 누락 3곳(PART 1 D1). 이번에 `reconciled` 필터를 추가하면 같은 사고가 4번째로 반복된다.
+
+**조치 (컴파일 타임 강제)**
+
+1. `LoadTransactions` 의 기본 생성자를 `LoadTransactions._internal` 로 비공개화.
+2. 공개 진입점 2개만 남긴다.
+   - `LoadTransactions.fromFilter(year, month, TransactionFilter f, {scrollToDate, clearDateRange})`
+   - `LoadTransactions.monthOnly(year, month)` — 의도적으로 필터 없는 초기 로드용
+3. 기존 호출부 전수 전환(13곳: sync_event_handler, main_shell_page, app_router,
+   transaction_list_page ×3, transaction_bloc ×2, card_settlement_page,
+   spending_plan_bloc, budget_transactions_sheet).
+4. 새 필터 `reconciled` 는 `TransactionFilter` VO + `fromFilter` 만 수정 → 전 경로 자동 전파.
+5. 회귀 테스트: "각 공개 진입점이 TransactionFilter 의 모든 필드를 전달한다"는
+   필드 커버리지 테스트(bloc test)를 추가 — 필드 추가 시 실패로 알림.
+
+## 3.2 구조적 수정 — amount_calculation (🚫)
+
+**과거 6건**: 금액 로직을 한 곳만 고쳐 나머지 누락 / 이체 이중 합산 / 카드 요약 이체 미포함 등.
+
+**조치**
+
+1. 스냅샷 소계(`total_income/expense/transfer`)는 **BE 가 단독 계산**하고 FE 는 표시만 한다
+   (FE 재계산 금지 — 이중 합산 사고의 원인).
+2. BE 집계는 `ReconciliationAggregator` 단일 함수만 사용하고,
+   기존 규칙을 그대로 재사용: `ADJUSTMENT` 는 수입/지출 제외, `CARD_SETTLEMENT` 이체는 전 버킷 제외,
+   `EXPENSE_TRANSFER`→지출, `INCOME_TRANSFER`→수입, `GENERIC`→이체.
+   (FE `LedgerSummary.from` 주석에 명시된 규칙과 1:1 대응하도록 테스트로 고정)
+3. 정합성 property 테스트(Kotest): 임의의 항목 집합에 대해
+   **미기록 소계 + Σ스냅샷 소계 = 월 전체 합계**(같은 규칙으로 계산 시).
+4. FE 미기록 섹션 소계는 `LedgerSummary.from` 재사용(신규 합산 코드 작성 금지).
+5. 조회자 게이팅 후에는 **BE 가 소계를 재계산해 응답**한다. 파트너의 PRIVATE 항목을 뺀 목록에
+   전체 기준 소계를 붙이면 "합계 ≠ 행" 불일치가 된다.
+
+## 3.3 구조적 수정 — navigation_state (🚫)
+
+**과거 3건**: 화면 이동 시 보고 있던 월이 목적지에서 리셋 / 페이지별 수동 reload.
+
+**조치**
+
+1. 정산 진입 경로는 `features/reconciliation/presentation/reconciliation_route.dart` 헬퍼만
+   사용(`card_settlement_route.dart` 의 검증된 패턴). `year`/`month` 를 **required** 로 두어
+   컴파일 타임에 누락 차단.
+2. 월 소유권은 `MonthCubit` 단일 소스. 정산 뷰는 `MonthNavigator` 를 그대로 쓰고
+   자체 month 상태를 갖지 않는다(달력뷰 `_focusedDay` drift 교훈, PR #270).
+3. 뷰 모드는 기존 `_saveViewMode`(SharedPreferences) 확장으로 유지 — 새 저장 키 만들지 않음.
+4. 파일에 없는 방지책(`navigation_helpers.dart`, PART 1 D7)은 하네스 기록을
+   "feature-local route 헬퍼 + required year/month" 로 갱신한다.
+
+## 3.4 db_schema (⚠️ WARNING)
+
+1. V65 작성 전 기존 제약 전수 확인: `grep -rn "CHECK\|CONSTRAINT\|UNIQUE" backend/src/main/resources/db/migration`
+   (마이그레이션/제약 사고 방지 규칙).
+2. **Testcontainers 통합테스트 필수** — mock 은 CHECK/FK/partial UNIQUE 를 검증하지 못한다
+   (PR #270 교훈). `CardSettlementIntegrationTest` 패턴 재사용.
+3. 저장 순서: 헤더 `saveAndFlush` → items 저장 (items 가 헤더 PK 를 FK 참조).
+   벌크 UPDATE 를 쓰게 되면 반드시 flush 선행 (`reference_card_settlement_flush_ordering`).
+4. `docs/erd.md` 갱신 — 최소한 신규 2테이블 + V13~V64 누락 테이블/컬럼 목록(PART 1 D3).
+
+## 3.5 ui_pattern (✅ OK)
+
+`ReconciledBadge` 공통 위젯 1개로 5개 노출 지점 통일(§2.5).
+
+---
+
+# PART 4 — 작업 계획
+
+## 4.1 PR 분할
+
+### PR 1 — 선행 정리 (정산 기능과 독립, 게이트 해제 근거)
+
+| # | 작업 | 담당 | 파일 | 난이도 |
+|:--|:---|:---|:---|:---|
+| 1 | `LoadTransactions` 생성자 봉인 + `fromFilter`/`monthOnly` 강제, 호출부 13곳 전환 | FE | transaction_event.dart 외 12 | M |
+| 2 | `needsReviewOnly` 누락 3곳 fix (D1) | FE | sync_event_handler / main_shell_page / app_router | S |
+| 3 | 필드 커버리지 회귀 테스트 | FE | test/…/transaction_event_test.dart | S |
+| 4 | api-spec `/transactions/settlement` 응답 정정 (D2) | Contract | docs/api-spec.md | S |
+| 5 | erd.md V13~V64 갱신 + Supabase→NAS 문구 (D3) | Contract | docs/erd.md | M |
+| 6 | known-issues KI-007 / project-audit / current-tasks 상태 갱신 (D4) | Contract | docs/*.md | S |
+| 7 | Testcontainers Docker 소켓 폴백 (D6) | BE | HighApiVersionDockerStrategy.kt, commands.md | S |
+| 8 | 페이지 크기 정렬 (D5) — BE clamp 200 상향 | BE | TransactionService.kt + mock/테스트 | S |
+
+### PR 2 — 정산 백엔드
+
+| # | 작업 | 담당 | 파일 | 난이도 |
+|:--|:---|:---|:---|:---|
+| 1 | api-spec 에 정산 6엔드포인트 + 응답 필드 선기재 | Contract | docs/api-spec.md | M |
+| 2 | V65 마이그레이션 (2테이블 + CHECK + partial UNIQUE + 인덱스) | BE | V65__create_reconciliations.sql | M |
+| 3 | 엔티티/리포지토리 | BE | reconciliation/domain, repository | M |
+| 4 | `ReconciliationService` + `ReconciliationAggregator` | BE | reconciliation/service | L |
+| 5 | 컨트롤러 + DTO + RateLimit | BE | reconciliation/controller, dto | M |
+| 6 | `reconciled` 필터 (Specification `NOT EXISTS`) — 거래 + 이체 양쪽 | BE | TransactionSpecifications, CommonFilterParams, TransferService | M |
+| 7 | 응답 필드 벌크 주입 (Transaction/Transfer 각 1쿼리, N+1 금지) | BE | TransactionService, TransferService | M |
+| 8 | SyncEvent `RECONCILIATION` 발행 | BE | ReconciliationService | S |
+| 9 | Kotest 유닛 + 정합성 property + Testcontainers 통합 | BE | src/test/…/reconciliation | L |
+
+### PR 3 — 정산 프론트엔드
+
+| # | 작업 | 담당 | 파일 | 난이도 |
+|:--|:---|:---|:---|:---|
+| 1 | feature 스캐폴딩 (datasource/repo/entity/bloc trio) + DI 등록 | FE | features/reconciliation/** , injection.dart | L |
+| 2 | 정산 뷰 (상단 미기록 + 하단 스냅샷별, 다중선택 액션바) | FE | reconciliation_view.dart | L |
+| 3 | 뷰 토글 3번째 세그먼트 + 저장 | FE | transaction_list_page.dart | S |
+| 4 | `ReconciledBadge` + 노출 5곳 | FE | core/widgets + 5 파일 | M |
+| 5 | route 헬퍼 (required year/month) | FE | reconciliation_route.dart | S |
+| 6 | sync 핸들러 `RECONCILIATION` + 본인 변경 로컬 cross-bloc reload | FE | sync_event_handler.dart | S |
+| 7 | bloc/위젯 테스트 | FE | test/features/reconciliation/** | M |
+
+## 4.2 성능 설계
+
+- **데이터 접근**
+  - 미기록 목록: 기존 거래 Specification 에 `NOT EXISTS (SELECT 1 FROM reconciliation_items ri
+    WHERE ri.transaction_id = t.id)` 1개 서브쿼리 추가 → `uk_recon_items_transaction` partial
+    unique 인덱스로 인덱스 스캔. 쿼리 수 증가 0.
+  - 배지 필드: 월 단위로 `reconciliation_items` 를 `IN (:ids)` 로 **1회 벌크 조회** →
+    `Map<UUID, ReconciliationRef>` 주입. 항목당 조회(N+1) 금지.
+  - 스냅샷 목록: 헤더는 `(couple_id, year_month)` 인덱스 1쿼리. 상세는 items 1쿼리
+    (+ 원본 drift 비교용 거래/이체 각 1쿼리, `IN` 벌크).
+  - 집계는 저장된 소계 컬럼 사용 → 조회 시 재집계 없음(게이팅이 필요한 경우만 재계산).
+- **예상 규모**: 부부 1커플 기준 월 항목 50~300건, 월 스냅샷 1~5건 → `reconciliation_items`
+  연 최대 ~4천 행. 소형 테이블이므로 `reference_postgres_autovacuum` 의 임계치 하향 설정
+  (이미 적용됨) 범위 안.
+- **리소스 제약**: 스냅샷 생성 1건당 items N 건 배치 insert (`saveAll`). 선택 항목 상한
+  1,000건으로 요청 검증 → 단일 트랜잭션 시간 제한.
+- **설계 결정**: 소계 **비정규화 저장**(조회 빈도 ≫ 생성 빈도, 스냅샷 = 불변 기록이므로
+  캐시 무효화 문제 없음). 항목 추가/제거 시에만 헤더 소계 재계산.
+
+## 4.3 자동 검증 계획
+
+- [ ] BE 테스트 (`cd backend && ./gradlew test`) — D6 조치 후 Docker 소켓 자동 인식
+- [ ] BE Testcontainers 통합: 스냅샷 생성/삭제, 원본 삭제 시 `SET NULL`, 중복 기록 시
+      partial unique 위반 → 409, CHECK 위반 케이스
+- [ ] 정합성 property: 미기록 소계 + Σ스냅샷 소계 = 월 전체 합계
+- [ ] FE 전체 분석 (`flutter analyze --no-fatal-infos --no-congratulate` — 부분 경로 금지)
+- [ ] FE 테스트 (`flutter test`) + 필드 커버리지 회귀 테스트
+- [ ] FE 빌드 (`flutter build web`)
+- [ ] BE↔FE↔api-spec 3자 일치 (필드명/응답 래핑/에러 코드)
+- [ ] 보안: 커플 스코프 검증, 파트너 PRIVATE 항목 비노출, 게이팅 후 소계 재계산,
+      `@RateLimit` 적용
+- [ ] 하네스 audit PR 전 재실행
+
+## 4.4 배포 절차
+
+| # | 단계 | 주체 | 확인 |
+|:--|:---|:---|:---|
+| 1 | 브랜치 + PR 생성, CI green | AI | `gh pr checks <N>` |
+| 2 | squash merge | AI | `gh pr merge <N> --squash --delete-branch` |
+| 3 | deploy-nas watch | AI | `gh run watch <id>` |
+| 4 | 실 DB 마이그레이션 확인 | AI | `flyway_schema_history` V65 `success=t` |
+| 5 | health | AI | `curl /actuator/health` = 200 |
+| 6 | 캐시 무효화 후 라이브 확인 | 사용자 | 새로고침 → 시나리오 A/B/C |
+
+## 4.5 사용자 검증 시나리오
+
+### A. 기능 (신규)
+
+| # | 경로 | 조작 | 기대 |
+|:--|:---|:---|:---|
+| A1 | 거래 탭 | 뷰 토글 [✅] 선택 | 상단 "미기록 N건", 하단 스냅샷 없음(첫 사용) |
+| A2 | 정산 뷰 | 항목 3개 체크 → [정산하기] → 라벨 "1차" | 스냅샷 생성, 상단에서 3건 사라지고 하단 "1차 · 3건" 등장 |
+| A3 | 리스트/달력 모드 | 정산된 거래 확인 | ✅ 배지 표시 |
+| A4 | 거래 상세 | 정산된 거래 열기 | "1차 정산 · 07-27 14:03 · 본인" 표시 |
+| A5 | 정산 뷰 | [전체 선택] → 정산 | 미기록 0건 + "이 달 정산 완료" 배지 |
+| A6 | 정산 뷰 | 2차 스냅샷 생성 후 하단 확인 | 회차별로 분리 표시(최신 먼저), 각 소계 정확 |
+| A7 | 정산 뷰 | 1차 스냅샷 [정산 취소] | 해당 항목들이 상단 미기록으로 복귀 |
+| A8 | 이체 | 이체를 정산에 포함 | 이체도 배지 + 스냅샷 소계 "이체" 에 반영 |
+| A9 | 정산 후 수정 | 정산된 거래 금액 변경 | ⚠ "정산 후 수정됨" 표시 (제안 P1 포함 시) |
+
+### B. 회귀 없음
+
+| # | 확인 | 기대 |
+|:--|:---|:---|
+| B1 | 리스트 모드 러닝 밸런스 | 기존과 동일한 누적 지출/자산 잔액 |
+| B2 | 월 합계 바 | 수입/지출/이체 숫자 변화 없음 |
+| B3 | 달력 모드 3줄 레이아웃 | 날짜 침범 없음(배지 추가 후에도) |
+| B4 | "확인/입력 필요만 보기" 필터 | 파트너 변경 sync·탭 복귀·URL 진입 후에도 유지 (D1 fix) |
+| B5 | 카드 결제(구 카드 정산) 플로우 | 등록/수정/삭제 + 미결제 금액 재계산 정상 |
+| B6 | 월 이동 | 필터 유지 + 달력/목록 같은 달 |
+| B7 | 무한스크롤/포커싱 | 과거 날짜 등록 후 스크롤 포커싱 정상 |
+
+### C. 데이터 정합성
+
+| # | 상황 | 기대 |
+|:--|:---|:---|
+| C1 | 정산된 거래 삭제 | 스냅샷 항목은 "삭제된 거래"로 남고 건수/소계 이력 보존 |
+| C2 | 부부 동시 정산(같은 항목) | 한쪽 성공, 다른 쪽 409 "이미 정산된 항목" — 중복 기록 없음 |
+| C3 | 파트너 개인(PRIVATE) 거래 | 내 화면 미기록/스냅샷 목록에 미노출, 소계에도 미포함 |
+| C4 | 미기록 + 기록 합 | 월 전체 합계와 일치 |
+| C5 | 200건 초과 월 | 페이지네이션 하에서도 미기록 판정 누락 없음(BE 필터 기준) |
+
+---
+
+## 기획 검증 결과 (총괄 검토)
+
+- 요구 R1~R5 대응 확인: R1→§2.3/§2.4-3, R2→§2.5 배지 5곳, R3→§2.4-6 summary + 상단 섹션,
+  R4→`seq` + 스냅샷별 섹션, R5→§2.5 2섹션. 미대응 없음.
+- 재발 위험 대조: 병합 스트림 drift(거래+이체 양쪽 지원), 필터 drop(§3.1 컴파일 타임 강제),
+  금액 다중 위치(§3.2 BE 단일 집계 + property test), 월 drift(§3.3 MonthCubit 단일 소스),
+  FK/flush(§3.4 saveAndFlush + Testcontainers), mock 미검출(§3.4) — 전부 조치 대응됨.
+- 잔여 결정 없음 — 화면 방식(3번째 뷰 모드), 선행 PR 1 동반, 추가 범위(P1/P2/P3/P5) 모두
+  문서 상단 "확정된 설계 결정"에 반영됨.
+- P5(needs_review 포함 경고) 반영 지점: 정산 확정 다이얼로그. 선택 항목 중
+  `needsReview=true` 건수를 세어 경고 문구 표시(차단은 아님) — FE 전용, BE 변경 불필요.
+- P3(미기록 0건 배지) 반영 지점: `GET /reconciliations/summary` 의 `unrecordedCount==0`
+  → 정산 뷰 상단 + 리스트 모드 월 헤더. 새 API 없이 §2.4-6 재사용.
+
+## 사용자 승인
+- [ ] 승인 / 수정 요청: ___

--- a/frontend/lib/core/router/app_router.dart
+++ b/frontend/lib/core/router/app_router.dart
@@ -375,25 +375,20 @@ GoRouter createAppRouter(AuthBloc authBloc) => GoRouter(
                   final navPocketIds = shouldCarryNavFilter
                       ? f.pocketIds
                       : const <String>{};
-                  bloc.add(LoadTransactions(
-                    year: year,
-                    month: month,
-                    categoryId: navCategoryId,
-                    paymentMethodId: navPaymentMethodId,
-                    categoryGroupIds: navCategoryGroupIds,
-                    categoryIds: navCategoryIds,
-                    paymentMethodIds: navPaymentMethodIds,
-                    pocketIds: navPocketIds,
-                    // Content 필터 — BLoC 보존 (URL 에 안 박힘).
-                    keyword: f.keyword,
-                    pocketId: f.pocketId,
-                    amountMin: f.amountMin,
-                    amountMax: f.amountMax,
-                    dateFrom: f.dateFrom,
-                    dateTo: f.dateTo,
-                    type: f.type,
-                    transactionTypes: f.transactionTypes,
-                    visibility: f.visibility,
+                  // nav 소유 필터만 덮어쓰고 content 필터는 VO 가 그대로 보존한다.
+                  // (2026-07-27 — 필드 수동 나열로 needsReviewOnly 가 URL 진입 시
+                  //  드롭되던 버그 fix. 새 content 필터도 자동 전파.)
+                  bloc.add(LoadTransactions.fromFilter(
+                    year,
+                    month,
+                    f.withNavigationFilters(
+                      categoryId: navCategoryId,
+                      paymentMethodId: navPaymentMethodId,
+                      categoryGroupIds: navCategoryGroupIds,
+                      categoryIds: navCategoryIds,
+                      paymentMethodIds: navPaymentMethodIds,
+                      pocketIds: navPocketIds,
+                    ),
                   ));
                   transferBloc.add(LoadTransfers(year: year, month: month));
                   // 이중 소스 동기화: 목록(TransactionBloc)을 URL year/month 로

--- a/frontend/lib/core/websocket/sync_event_handler.dart
+++ b/frontend/lib/core/websocket/sync_event_handler.dart
@@ -97,24 +97,12 @@ class SyncEventHandler {
       // 회차 9 — WebSocket sync 시 currentFilter 보존. server-side 변경 시
       // list 가 필터 reset 되지 않도록.
       final bloc = _getIt<TransactionBloc>();
-      final f = bloc.currentFilter;
-      bloc.add(LoadTransactions(
-        year: monthState.year, month: monthState.month,
-        keyword: f.keyword,
-        categoryId: f.categoryId,
-        categoryIds: f.categoryIds,
-        categoryGroupIds: f.categoryGroupIds,
-        paymentMethodId: f.paymentMethodId,
-        paymentMethodIds: f.paymentMethodIds,
-        pocketId: f.pocketId,
-        pocketIds: f.pocketIds,
-        amountMin: f.amountMin,
-        amountMax: f.amountMax,
-        dateFrom: f.dateFrom,
-        dateTo: f.dateTo,
-        type: f.type,
-        transactionTypes: f.transactionTypes,
-        visibility: f.visibility,
+      // 2026-07-27 — 필드 수동 나열로 needsReviewOnly 가 빠져 파트너 변경 sync 시
+      // "확인/입력 필요만 보기" 필터가 풀리던 버그 fix. fromFilter 로 VO 전체 전달.
+      bloc.add(LoadTransactions.fromFilter(
+        monthState.year,
+        monthState.month,
+        bloc.currentFilter,
       ));
       _logger.d('Dispatched LoadTransactions refresh');
     } catch (e) {

--- a/frontend/lib/core/widgets/main_shell_page.dart
+++ b/frontend/lib/core/widgets/main_shell_page.dart
@@ -148,25 +148,11 @@ class _MainShellPageState extends State<MainShellPage> {
               (txnState.year != monthState.year ||
                   txnState.month != monthState.month);
           if (blocMonthDiffers) {
-            final f = txnBloc.currentFilter;
-            txnBloc.add(LoadTransactions(
-              year: monthState.year,
-              month: monthState.month,
-              keyword: f.keyword,
-              categoryId: f.categoryId,
-              categoryIds: f.categoryIds,
-              categoryGroupIds: f.categoryGroupIds,
-              paymentMethodId: f.paymentMethodId,
-              paymentMethodIds: f.paymentMethodIds,
-              pocketId: f.pocketId,
-              pocketIds: f.pocketIds,
-              amountMin: f.amountMin,
-              amountMax: f.amountMax,
-              dateFrom: f.dateFrom,
-              dateTo: f.dateTo,
-              type: f.type,
-              transactionTypes: f.transactionTypes,
-              visibility: f.visibility,
+            // 2026-07-27 — 필드 나열 제거(needsReviewOnly 누락 fix). VO 전체 전달.
+            txnBloc.add(LoadTransactions.fromFilter(
+              monthState.year,
+              monthState.month,
+              txnBloc.currentFilter,
             ));
           }
         // Tab 1 (Analysis) — wrapper 가 자체 BudgetBloc/StatisticsBloc 처리

--- a/frontend/lib/features/budget/presentation/widgets/budget_transactions_sheet.dart
+++ b/frontend/lib/features/budget/presentation/widgets/budget_transactions_sheet.dart
@@ -6,6 +6,7 @@ import 'package:budget_book/core/di/injection.dart';
 import 'package:budget_book/core/utils/currency_formatter.dart';
 import 'package:budget_book/features/transaction/domain/repositories/transaction_repository.dart';
 import 'package:budget_book/features/transaction/presentation/bloc/transaction_bloc.dart';
+import 'package:budget_book/features/transaction/domain/entities/transaction_filter.dart';
 import 'package:budget_book/features/transaction/presentation/bloc/transaction_event.dart';
 import 'package:budget_book/features/transaction/presentation/bloc/transaction_state.dart';
 import 'package:budget_book/features/transaction/presentation/widgets/transaction_list_tile.dart';
@@ -42,14 +43,16 @@ void showBudgetTransactionsSheet({
           // Create a separate TransactionBloc instance for this sheet
           final bloc = TransactionBloc(
             transactionRepository: getIt<TransactionRepository>(),
-          )..add(LoadTransactions(
-              year: year,
-              month: month,
-              categoryId: categoryId,
-              categoryGroupIds:
-                  categoryGroupId != null ? {categoryGroupId} : const {},
-              dateFrom: dateFrom,
-              dateTo: dateTo,
+          )..add(LoadTransactions.fromFilter(
+              year,
+              month,
+              TransactionFilter(
+                categoryId: categoryId,
+                categoryGroupIds:
+                    categoryGroupId != null ? {categoryGroupId} : const {},
+                dateFrom: dateFrom,
+                dateTo: dateTo,
+              ),
             ));
 
           return BlocProvider<TransactionBloc>.value(

--- a/frontend/lib/features/card_settlement/presentation/pages/card_settlement_page.dart
+++ b/frontend/lib/features/card_settlement/presentation/pages/card_settlement_page.dart
@@ -246,9 +246,9 @@ class _CardSettlementPageState extends State<CardSettlementPage> {
           // 정산 이체가 사는 결제일의 달로 거래/이체 BLoC 을 함께 로드해 두
           // BLoC 의 월을 일치시킨다 (과거: TransferBloc 미갱신 → 탭 재진입 전까지
           // 정산 이체 미노출).
-          getIt<TransactionBloc>().add(LoadTransactions(
-            year: _selectedDate.year,
-            month: _selectedDate.month,
+          getIt<TransactionBloc>().add(LoadTransactions.monthOnly(
+            _selectedDate.year,
+            _selectedDate.month,
           ));
           getIt<TransferBloc>().add(LoadTransfers(
             year: _selectedDate.year,

--- a/frontend/lib/features/spending_plan/presentation/bloc/spending_plan_bloc.dart
+++ b/frontend/lib/features/spending_plan/presentation/bloc/spending_plan_bloc.dart
@@ -355,10 +355,9 @@ class SpendingPlanBloc extends Bloc<SpendingPlanEvent, SpendingPlanState> {
             final txDate = DateTime.tryParse(event.transactionDate);
             final year = txDate?.year ?? DateTime.now().year;
             final month = txDate?.month ?? DateTime.now().month;
-            getIt<TransactionBloc>().add(LoadTransactions(
-              year: year,
-              month: month,
-            ));
+            getIt<TransactionBloc>().add(
+              LoadTransactions.monthOnly(year, month),
+            );
           } catch (_) {
             // TransactionBloc might not be registered yet
           }

--- a/frontend/lib/features/spending_plan/presentation/widgets/link_transaction_sheet.dart
+++ b/frontend/lib/features/spending_plan/presentation/widgets/link_transaction_sheet.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:budget_book/core/di/injection.dart';
 import 'package:budget_book/core/utils/currency_formatter.dart';
 import 'package:budget_book/features/transaction/domain/entities/transaction.dart';
+import 'package:budget_book/features/transaction/domain/entities/transaction_filter.dart';
 import 'package:budget_book/features/transaction/domain/repositories/transaction_repository.dart';
 import 'package:budget_book/features/spending_plan/domain/entities/spending_plan.dart';
 
@@ -69,9 +70,11 @@ class _LinkTransactionSheetState extends State<_LinkTransactionSheet> {
     final result = await repo.getTransactions(
       year: year,
       month: month,
-      type: 'EXPENSE',
-      categoryId: keyword == null ? widget.plan.categoryId : null,
-      keyword: keyword,
+      filter: TransactionFilter(
+        type: 'EXPENSE',
+        categoryId: keyword == null ? widget.plan.categoryId : null,
+        keyword: keyword,
+      ),
       size: 50,
     );
 

--- a/frontend/lib/features/statistics/data/datasources/statistics_remote_datasource.dart
+++ b/frontend/lib/features/statistics/data/datasources/statistics_remote_datasource.dart
@@ -5,26 +5,17 @@ import 'package:budget_book/features/statistics/data/models/category_statistics_
 import 'package:budget_book/features/statistics/data/models/monthly_trend_model.dart';
 import 'package:budget_book/features/statistics/data/models/payment_method_statistics_model.dart';
 import 'package:budget_book/features/statistics/data/models/period_summary_model.dart';
+import 'package:budget_book/features/transaction/domain/entities/transaction_filter.dart';
 
 abstract class StatisticsRemoteDataSource {
-  /// 회차 8 — 모든 필터 지원 확장
+  /// 회차 8 — 모든 필터 지원 확장.
+  /// 2026-07-27 — 필터를 [TransactionFilter] VO 로 통일. 거래 목록과 **같은 필터**로
+  /// 합계를 계산해야 "합계 ≠ 보이는 행" 불일치가 생기지 않는다
+  /// (needsReviewOnly 가 목록엔 적용되고 summary 엔 누락돼 있던 버그 fix).
   Future<StatisticsSummaryModel> getSummary({
     required int year,
     required int month,
-    String visibility = 'ALL',
-    String? dateFrom,
-    String? dateTo,
-    String? categoryId,
-    String? paymentMethodId,
-    String? pocketId,
-    Set<String> categoryIds = const {},
-    Set<String> categoryGroupIds = const {},
-    Set<String> paymentMethodIds = const {},
-    Set<String> pocketIds = const {},
-    int? amountMin,
-    int? amountMax,
-    String? keyword,
-    Set<String> transactionTypes = const {},
+    TransactionFilter filter = TransactionFilter.empty,
   });
 
   Future<List<CategoryStatisticsModel>> getCategoryBreakdown({
@@ -71,39 +62,14 @@ class StatisticsRemoteDataSourceImpl implements StatisticsRemoteDataSource {
   Future<StatisticsSummaryModel> getSummary({
     required int year,
     required int month,
-    String visibility = 'ALL',
-    String? dateFrom,
-    String? dateTo,
-    String? categoryId,
-    String? paymentMethodId,
-    String? pocketId,
-    Set<String> categoryIds = const {},
-    Set<String> categoryGroupIds = const {},
-    Set<String> paymentMethodIds = const {},
-    Set<String> pocketIds = const {},
-    int? amountMin,
-    int? amountMax,
-    String? keyword,
-    Set<String> transactionTypes = const {},
+    TransactionFilter filter = TransactionFilter.empty,
   }) async {
+    // 필터 직렬화는 TransactionFilter.toQueryParams() 단일 경로.
+    // 'ALL' visibility 는 BE 기본 동작이라 toQueryParams 가 생략한다(동등).
     final params = <String, dynamic>{
       'year': year,
       'month': month,
-      'visibility': visibility,
-      if (dateFrom != null) 'dateFrom': dateFrom,
-      if (dateTo != null) 'dateTo': dateTo,
-      if (categoryId != null) 'categoryId': categoryId,
-      if (paymentMethodId != null) 'paymentMethodId': paymentMethodId,
-      if (pocketId != null) 'pocketId': pocketId,
-      if (categoryIds.isNotEmpty) 'categoryIds': categoryIds.toList(),
-      if (categoryGroupIds.isNotEmpty) 'categoryGroupIds': categoryGroupIds.toList(),
-      if (paymentMethodIds.isNotEmpty) 'paymentMethodIds': paymentMethodIds.toList(),
-      if (pocketIds.isNotEmpty) 'pocketIds': pocketIds.toList(),
-      if (amountMin != null) 'amountMin': amountMin,
-      if (amountMax != null) 'amountMax': amountMax,
-      if (keyword != null && keyword.isNotEmpty) 'keyword': keyword,
-      if (transactionTypes.isNotEmpty)
-        'transactionTypes': transactionTypes.toList(),
+      ...filter.toQueryParams(),
     };
     final response = await apiClient.dio.get(
       ApiEndpoints.statisticsSummary,

--- a/frontend/lib/features/statistics/data/repositories/statistics_repository_impl.dart
+++ b/frontend/lib/features/statistics/data/repositories/statistics_repository_impl.dart
@@ -9,6 +9,7 @@ import 'package:budget_book/features/statistics/domain/entities/monthly_trend.da
 import 'package:budget_book/features/statistics/domain/entities/payment_method_statistics.dart';
 import 'package:budget_book/features/statistics/domain/entities/period_summary.dart';
 import 'package:budget_book/features/statistics/domain/repositories/statistics_repository.dart';
+import 'package:budget_book/features/transaction/domain/entities/transaction_filter.dart';
 
 class StatisticsRepositoryImpl implements StatisticsRepository {
   final StatisticsRemoteDataSource remoteDataSource;
@@ -19,36 +20,13 @@ class StatisticsRepositoryImpl implements StatisticsRepository {
   Future<Either<Failure, StatisticsSummary>> getSummary({
     required int year,
     required int month,
-    String visibility = 'ALL',
-    String? dateFrom,
-    String? dateTo,
-    String? categoryId,
-    String? paymentMethodId,
-    String? pocketId,
-    Set<String> categoryIds = const {},
-    Set<String> categoryGroupIds = const {},
-    Set<String> paymentMethodIds = const {},
-    Set<String> pocketIds = const {},
-    int? amountMin,
-    int? amountMax,
-    String? keyword,
-    Set<String> transactionTypes = const {},
+    TransactionFilter filter = TransactionFilter.empty,
   }) async {
     try {
       final result = await remoteDataSource.getSummary(
-        year: year, month: month, visibility: visibility,
-        dateFrom: dateFrom, dateTo: dateTo,
-        categoryId: categoryId,
-        paymentMethodId: paymentMethodId,
-        pocketId: pocketId,
-        categoryIds: categoryIds,
-        categoryGroupIds: categoryGroupIds,
-        paymentMethodIds: paymentMethodIds,
-        pocketIds: pocketIds,
-        amountMin: amountMin,
-        amountMax: amountMax,
-        keyword: keyword,
-        transactionTypes: transactionTypes,
+        year: year,
+        month: month,
+        filter: filter,
       );
       return Right(result);
     } on DioException catch (e) {

--- a/frontend/lib/features/statistics/domain/repositories/statistics_repository.dart
+++ b/frontend/lib/features/statistics/domain/repositories/statistics_repository.dart
@@ -5,27 +5,17 @@ import 'package:budget_book/features/statistics/domain/entities/category_statist
 import 'package:budget_book/features/statistics/domain/entities/monthly_trend.dart';
 import 'package:budget_book/features/statistics/domain/entities/payment_method_statistics.dart';
 import 'package:budget_book/features/statistics/domain/entities/period_summary.dart';
+import 'package:budget_book/features/transaction/domain/entities/transaction_filter.dart';
 
 abstract class StatisticsRepository {
   /// 회차 8 — 모든 필터 지원으로 확장. BE 가 정확한 (filtered) 월 합계 반환.
   /// FE 는 client-side fold 대신 이 응답 그대로 사용해야 한다.
+  /// 월 합계. 필터는 거래 목록과 **동일한** [TransactionFilter] VO 로 받는다
+  /// (목록과 합계가 서로 다른 필터로 계산되면 "합계 ≠ 행" 불일치가 발생).
   Future<Either<Failure, StatisticsSummary>> getSummary({
     required int year,
     required int month,
-    String visibility = 'ALL',
-    String? dateFrom,
-    String? dateTo,
-    String? categoryId,
-    String? paymentMethodId,
-    String? pocketId,
-    Set<String> categoryIds = const {},
-    Set<String> categoryGroupIds = const {},
-    Set<String> paymentMethodIds = const {},
-    Set<String> pocketIds = const {},
-    int? amountMin,
-    int? amountMax,
-    String? keyword,
-    Set<String> transactionTypes = const {},
+    TransactionFilter filter = TransactionFilter.empty,
   });
 
   Future<Either<Failure, List<CategoryStatistics>>> getCategoryBreakdown({

--- a/frontend/lib/features/statistics/presentation/bloc/statistics_bloc.dart
+++ b/frontend/lib/features/statistics/presentation/bloc/statistics_bloc.dart
@@ -6,6 +6,7 @@ import 'package:budget_book/features/statistics/domain/entities/statistics_filte
 import 'package:budget_book/features/statistics/domain/repositories/statistics_repository.dart';
 import 'statistics_event.dart';
 import 'statistics_state.dart';
+import 'package:budget_book/features/transaction/domain/entities/transaction_filter.dart';
 
 class StatisticsBloc extends Bloc<StatisticsEvent, StatisticsState> {
   final StatisticsRepository statisticsRepository;
@@ -74,9 +75,11 @@ class StatisticsBloc extends Bloc<StatisticsEvent, StatisticsState> {
         statisticsRepository.getSummary(
           year: event.year,
           month: event.month,
-          visibility: vis,
-          dateFrom: df,
-          dateTo: dt,
+          filter: TransactionFilter(
+            visibility: vis,
+            dateFrom: df,
+            dateTo: dt,
+          ),
         ),
         statisticsRepository.getCategoryBreakdown(
           year: event.year,
@@ -151,9 +154,11 @@ class StatisticsBloc extends Bloc<StatisticsEvent, StatisticsState> {
       final result = await statisticsRepository.getSummary(
         year: event.year,
         month: event.month,
-        visibility: state.visibilityFilter,
-        dateFrom: state.dateFrom,
-        dateTo: state.dateTo,
+        filter: TransactionFilter(
+          visibility: state.visibilityFilter,
+          dateFrom: state.dateFrom,
+          dateTo: state.dateTo,
+        ),
       );
       result.fold(
         (failure) => emit(state.copyWith(
@@ -257,9 +262,13 @@ class StatisticsBloc extends Bloc<StatisticsEvent, StatisticsState> {
       final vis = state.visibilityFilter;
       final results = await Future.wait([
         statisticsRepository.getSummary(
-            year: event.year, month: event.month, visibility: vis),
+            year: event.year,
+            month: event.month,
+            filter: TransactionFilter(visibility: vis)),
         statisticsRepository.getSummary(
-            year: event.year - 1, month: event.month, visibility: vis),
+            year: event.year - 1,
+            month: event.month,
+            filter: TransactionFilter(visibility: vis)),
       ]);
 
       StatisticsSummary? currentSummary;

--- a/frontend/lib/features/transaction/data/datasources/transaction_remote_datasource.dart
+++ b/frontend/lib/features/transaction/data/datasources/transaction_remote_datasource.dart
@@ -6,25 +6,11 @@ import 'package:budget_book/features/transaction/domain/entities/transaction_fil
 import 'package:budget_book/features/transaction/domain/repositories/transaction_repository.dart';
 
 abstract class TransactionRemoteDataSource {
+  /// 필터는 [TransactionFilter] VO 로만 받는다 (필드 나열 금지 — 전파 누락 방지).
   Future<PageResponse<TransactionModel>> getTransactions({
     int? year,
     int? month,
-    String? type,
-    Set<String> transactionTypes,
-    String? categoryId,
-    Set<String> categoryIds = const {},
-    Set<String> categoryGroupIds = const {},
-    String? keyword,
-    String? paymentMethodId,
-    Set<String> paymentMethodIds = const {},
-    String? pocketId,
-    Set<String> pocketIds = const {},
-    int? amountMin,
-    int? amountMax,
-    String? dateFrom,
-    String? dateTo,
-    String? visibility,
-    bool? needsReviewOnly,
+    TransactionFilter filter = TransactionFilter.empty,
     int page = 0,
     int size = 20,
   });
@@ -45,46 +31,12 @@ class TransactionRemoteDataSourceImpl implements TransactionRemoteDataSource {
   Future<PageResponse<TransactionModel>> getTransactions({
     int? year,
     int? month,
-    String? type,
-    Set<String> transactionTypes = const {},
-    String? categoryId,
-    Set<String> categoryIds = const {},
-    Set<String> categoryGroupIds = const {},
-    String? keyword,
-    String? paymentMethodId,
-    Set<String> paymentMethodIds = const {},
-    String? pocketId,
-    Set<String> pocketIds = const {},
-    int? amountMin,
-    int? amountMax,
-    String? dateFrom,
-    String? dateTo,
-    String? visibility,
-    bool? needsReviewOnly,
+    TransactionFilter filter = TransactionFilter.empty,
     int page = 0,
     int size = 20,
   }) async {
     // S2 구조적 수정: 개별 필드 인라인 조립 제거, TransactionFilter.toQueryParams() 로 중앙화.
-    // 신규 필터는 TransactionFilter VO + toQueryParams() 한 곳만 수정하면 FE→BE 전달 자동 반영.
-    // PR-C3: 복수 필드(categoryIds 등) 도 여기서 VO 로 묶여 toQueryParams() 로 직렬화됨.
-    final filter = TransactionFilter(
-      keyword: keyword,
-      categoryId: categoryId,
-      categoryIds: categoryIds,
-      categoryGroupIds: categoryGroupIds,
-      paymentMethodId: paymentMethodId,
-      paymentMethodIds: paymentMethodIds,
-      pocketId: pocketId,
-      pocketIds: pocketIds,
-      amountMin: amountMin,
-      amountMax: amountMax,
-      dateFrom: dateFrom,
-      dateTo: dateTo,
-      type: type,
-      transactionTypes: transactionTypes,
-      visibility: visibility,
-      needsReviewOnly: needsReviewOnly,
-    );
+    // 2026-07-27: VO 를 파라미터로 직접 받아 재조립 단계까지 제거 (재조립 = 누락 기회).
     final queryParams = <String, dynamic>{
       'page': page,
       'size': size,

--- a/frontend/lib/features/transaction/data/repositories/transaction_repository_impl.dart
+++ b/frontend/lib/features/transaction/data/repositories/transaction_repository_impl.dart
@@ -5,6 +5,7 @@ import 'package:budget_book/core/error/dio_error_mapper.dart';
 import 'package:budget_book/features/transaction/data/datasources/transaction_remote_datasource.dart';
 import 'package:budget_book/features/transaction/domain/entities/transaction.dart';
 import 'package:budget_book/features/transaction/domain/entities/page_response.dart';
+import 'package:budget_book/features/transaction/domain/entities/transaction_filter.dart';
 import 'package:budget_book/features/transaction/domain/repositories/transaction_repository.dart';
 
 class TransactionRepositoryImpl implements TransactionRepository {
@@ -16,22 +17,7 @@ class TransactionRepositoryImpl implements TransactionRepository {
   Future<Either<Failure, PageResponse<Transaction>>> getTransactions({
     int? year,
     int? month,
-    String? type,
-    Set<String> transactionTypes = const {},
-    String? categoryId,
-    Set<String> categoryIds = const {},
-    Set<String> categoryGroupIds = const {},
-    String? keyword,
-    String? paymentMethodId,
-    Set<String> paymentMethodIds = const {},
-    String? pocketId,
-    Set<String> pocketIds = const {},
-    int? amountMin,
-    int? amountMax,
-    String? dateFrom,
-    String? dateTo,
-    String? visibility,
-    bool? needsReviewOnly,
+    TransactionFilter filter = TransactionFilter.empty,
     int page = 0,
     int size = 20,
   }) async {
@@ -39,22 +25,7 @@ class TransactionRepositoryImpl implements TransactionRepository {
       final result = await remoteDataSource.getTransactions(
         year: year,
         month: month,
-        type: type,
-        transactionTypes: transactionTypes,
-        categoryId: categoryId,
-        categoryIds: categoryIds,
-        categoryGroupIds: categoryGroupIds,
-        keyword: keyword,
-        paymentMethodId: paymentMethodId,
-        paymentMethodIds: paymentMethodIds,
-        pocketId: pocketId,
-        pocketIds: pocketIds,
-        amountMin: amountMin,
-        amountMax: amountMax,
-        dateFrom: dateFrom,
-        dateTo: dateTo,
-        visibility: visibility,
-        needsReviewOnly: needsReviewOnly,
+        filter: filter,
         page: page,
         size: size,
       );

--- a/frontend/lib/features/transaction/domain/entities/transaction_filter.dart
+++ b/frontend/lib/features/transaction/domain/entities/transaction_filter.dart
@@ -1,4 +1,7 @@
 import 'package:equatable/equatable.dart';
+import 'package:intl/intl.dart';
+
+import 'package:budget_book/core/models/unified_filter_state.dart';
 
 /// 거래 목록 필터 상태의 단일 값 객체 (value object).
 ///
@@ -97,7 +100,30 @@ class TransactionFilter extends Equatable {
     Set<String>? transactionTypes,
     String? visibility,
     bool? needsReviewOnly,
+    /// 명시적 기간 필터 해제용. `??` 기반 copyWith 로는 null 을 넣어 지울 수 없으므로
+    /// UnifiedFilterState.copyWith 와 같은 clear 플래그 관례를 따른다.
+    bool clearDateRange = false,
   }) {
+    if (clearDateRange) {
+      return TransactionFilter(
+        keyword: keyword ?? this.keyword,
+        categoryId: categoryId ?? this.categoryId,
+        categoryIds: categoryIds ?? this.categoryIds,
+        categoryGroupIds: categoryGroupIds ?? this.categoryGroupIds,
+        paymentMethodId: paymentMethodId ?? this.paymentMethodId,
+        paymentMethodIds: paymentMethodIds ?? this.paymentMethodIds,
+        pocketId: pocketId ?? this.pocketId,
+        pocketIds: pocketIds ?? this.pocketIds,
+        amountMin: amountMin ?? this.amountMin,
+        amountMax: amountMax ?? this.amountMax,
+        dateFrom: null,
+        dateTo: null,
+        type: type ?? this.type,
+        transactionTypes: transactionTypes ?? this.transactionTypes,
+        visibility: visibility ?? this.visibility,
+        needsReviewOnly: needsReviewOnly ?? this.needsReviewOnly,
+      );
+    }
     return TransactionFilter(
       keyword: keyword ?? this.keyword,
       categoryId: categoryId ?? this.categoryId,
@@ -115,6 +141,42 @@ class TransactionFilter extends Equatable {
       transactionTypes: transactionTypes ?? this.transactionTypes,
       visibility: visibility ?? this.visibility,
       needsReviewOnly: needsReviewOnly ?? this.needsReviewOnly,
+    );
+  }
+
+  /// URL 내비게이션이 **소유하는** 필터(카테고리/그룹/결제수단/포켓 선택)만 통째로
+  /// 덮어쓴다. 인자를 생략하면 해제(wipe) — `copyWith` 의 `??` carry 와 의미가 다르다.
+  ///
+  /// content 필터(keyword·금액·기간·type·visibility·needsReviewOnly)는 항상 보존되므로,
+  /// 새 content 필터를 추가해도 라우터는 수정할 필요가 없다
+  /// (라우터가 필드를 나열하다 needsReviewOnly 를 빠뜨렸던 사고 재발 방지).
+  TransactionFilter withNavigationFilters({
+    String? categoryId,
+    String? paymentMethodId,
+    Set<String> categoryIds = const {},
+    Set<String> categoryGroupIds = const {},
+    Set<String> paymentMethodIds = const {},
+    Set<String> pocketIds = const {},
+  }) {
+    return TransactionFilter(
+      // nav 소유 필드 — 인자 그대로 (null/빈 값 = 해제)
+      categoryId: categoryId,
+      paymentMethodId: paymentMethodId,
+      categoryIds: categoryIds,
+      categoryGroupIds: categoryGroupIds,
+      paymentMethodIds: paymentMethodIds,
+      pocketIds: pocketIds,
+      // content 필드 — 보존
+      keyword: keyword,
+      pocketId: pocketId,
+      amountMin: amountMin,
+      amountMax: amountMax,
+      dateFrom: dateFrom,
+      dateTo: dateTo,
+      type: type,
+      transactionTypes: transactionTypes,
+      visibility: visibility,
+      needsReviewOnly: needsReviewOnly,
     );
   }
 
@@ -137,6 +199,33 @@ class TransactionFilter extends Equatable {
         visibility,
         needsReviewOnly,
       ];
+}
+
+/// UI 필터 상태(UnifiedFilterState) → 도메인 필터 VO 변환의 **단일** 접근점.
+///
+/// 거래 목록 페이지가 `_filterState` 의 필드를 직접 나열해 LoadTransactions 를 만들면
+/// 새 필터가 추가될 때 화면마다 누락이 생긴다(2026-04-15 인시던트 계열).
+/// 페이지는 이 변환기만 호출하고, 새 필터는 여기 한 곳에 매핑을 추가한다.
+extension UnifiedFilterStateToTransactionFilter on UnifiedFilterState {
+  /// [keywordOverride] — 검색창 텍스트처럼 UI 상태 밖에 있는 키워드를 주입할 때 사용.
+  TransactionFilter toTransactionFilter({String? keywordOverride}) {
+    final fmt = DateFormat('yyyy-MM-dd');
+    return TransactionFilter(
+      keyword: keywordOverride ?? keyword,
+      categoryIds: categoryIds,
+      categoryGroupIds: categoryGroupIds,
+      paymentMethodIds: paymentMethodIds,
+      pocketIds: pocketIds,
+      amountMin: amountMin,
+      amountMax: amountMax,
+      dateFrom: dateFrom != null ? fmt.format(dateFrom!) : null,
+      dateTo: dateTo != null ? fmt.format(dateTo!) : null,
+      transactionTypes: transactionTypes,
+      visibility: visibility,
+      // BE 는 true 일 때만 의미가 있다 (false/null 모두 미적용).
+      needsReviewOnly: needsReviewOnly ? true : null,
+    );
+  }
 }
 
 /// 필터 VO → 네트워크 queryParams 변환의 단일 접근점.

--- a/frontend/lib/features/transaction/domain/repositories/transaction_repository.dart
+++ b/frontend/lib/features/transaction/domain/repositories/transaction_repository.dart
@@ -2,27 +2,19 @@ import 'package:dartz/dartz.dart';
 import 'package:budget_book/core/error/failure.dart';
 import 'package:budget_book/features/transaction/domain/entities/transaction.dart';
 import 'package:budget_book/features/transaction/domain/entities/page_response.dart';
+import 'package:budget_book/features/transaction/domain/entities/transaction_filter.dart';
 
 abstract class TransactionRepository {
+  /// 거래 목록 조회.
+  ///
+  /// 필터는 개별 파라미터가 아니라 [TransactionFilter] VO 하나로 받는다.
+  /// bloc → repository → datasource 3-hop 마다 필드를 나열하면 hop 당 누락 기회가
+  /// 생기고, 실제로 "필터 drop" 인시던트가 4회 재발했다. 새 필터 추가 시
+  /// [TransactionFilter] 와 `toQueryParams()` 두 곳만 고치면 전 구간에 반영된다.
   Future<Either<Failure, PageResponse<Transaction>>> getTransactions({
     int? year,
     int? month,
-    String? type,
-    Set<String> transactionTypes,
-    String? categoryId,
-    Set<String> categoryIds = const {},
-    Set<String> categoryGroupIds = const {},
-    String? keyword,
-    String? paymentMethodId,
-    Set<String> paymentMethodIds = const {},
-    String? pocketId,
-    Set<String> pocketIds = const {},
-    int? amountMin,
-    int? amountMax,
-    String? dateFrom,
-    String? dateTo,
-    String? visibility,
-    bool? needsReviewOnly,
+    TransactionFilter filter = TransactionFilter.empty,
     int page = 0,
     int size = 20,
   });

--- a/frontend/lib/features/transaction/presentation/bloc/transaction_bloc.dart
+++ b/frontend/lib/features/transaction/presentation/bloc/transaction_bloc.dart
@@ -12,51 +12,25 @@ class TransactionBloc extends Bloc<TransactionEvent, TransactionState> {
 
   int _currentYear = DateTime.now().year;
   int _currentMonth = DateTime.now().month;
-  String? _currentKeyword;
-  String? _currentCategoryId;
-  String? get currentCategoryId => _currentCategoryId;
-  Set<String> _currentCategoryIds = const {};
-  Set<String> get currentCategoryIds => _currentCategoryIds;
-  Set<String> _currentCategoryGroupIds = const {};
-  Set<String> get currentCategoryGroupIds => _currentCategoryGroupIds;
-  String? _currentPaymentMethodId;
-  String? get currentPaymentMethodId => _currentPaymentMethodId;
-  Set<String> _currentPaymentMethodIds = const {};
-  Set<String> get currentPaymentMethodIds => _currentPaymentMethodIds;
-  String? _currentPocketId;
-  Set<String> _currentPocketIds = const {};
-  Set<String> get currentPocketIds => _currentPocketIds;
-  int? _currentAmountMin;
-  int? _currentAmountMax;
-  String? _currentDateFrom;
-  String? _currentDateTo;
-  String? _currentType;
-  Set<String> _currentTransactionTypes = const {};
-  String? _currentVisibility;
-  bool? _currentNeedsReviewOnly;
 
-  /// 전체 필터 상태의 단일 스냅샷.
-  /// MonthSyncHandler 등 외부 consumer 가 필드 drop 없이 전체 필터를 전파하도록
-  /// 반드시 이 getter 를 사용한다. 새 필터 추가 시 TransactionFilter 와
-  /// LoadTransactions 시그니처, 이 getter 세 군데를 함께 수정해야 컴파일 통과.
-  TransactionFilter get currentFilter => TransactionFilter(
-        keyword: _currentKeyword,
-        categoryId: _currentCategoryId,
-        categoryIds: _currentCategoryIds,
-        categoryGroupIds: _currentCategoryGroupIds,
-        paymentMethodId: _currentPaymentMethodId,
-        paymentMethodIds: _currentPaymentMethodIds,
-        pocketId: _currentPocketId,
-        pocketIds: _currentPocketIds,
-        amountMin: _currentAmountMin,
-        amountMax: _currentAmountMax,
-        dateFrom: _currentDateFrom,
-        dateTo: _currentDateTo,
-        type: _currentType,
-        transactionTypes: _currentTransactionTypes,
-        visibility: _currentVisibility,
-        needsReviewOnly: _currentNeedsReviewOnly,
-      );
+  /// 전체 필터 상태의 단일 스냅샷 — **필터는 이 VO 하나로만 보관한다.**
+  ///
+  /// 이전에는 `_currentKeyword` … `_currentNeedsReviewOnly` 16개 스칼라를 두고
+  /// getter 에서 VO 를 재조립했다. 그 구조는 (a) LoadTransactions 수신 시 16줄 대입,
+  /// (b) getter 조립, (c) reload 시 16줄 나열 — 총 3곳에서 필드를 손으로 나열해야 해서
+  /// 필터가 추가될 때마다 어딘가 빠졌다(2026-04-15 인시던트 3회 재발).
+  /// VO 하나만 들고 있으면 필드 나열 자체가 불가능하다.
+  TransactionFilter _currentFilter = TransactionFilter.empty;
+
+  TransactionFilter get currentFilter => _currentFilter;
+
+  // 기존 소비자용 편의 getter (VO 위임).
+  String? get currentCategoryId => _currentFilter.categoryId;
+  Set<String> get currentCategoryIds => _currentFilter.categoryIds;
+  Set<String> get currentCategoryGroupIds => _currentFilter.categoryGroupIds;
+  String? get currentPaymentMethodId => _currentFilter.paymentMethodId;
+  Set<String> get currentPaymentMethodIds => _currentFilter.paymentMethodIds;
+  Set<String> get currentPocketIds => _currentFilter.pocketIds;
 
   int get currentYear => _currentYear;
   int get currentMonth => _currentMonth;
@@ -100,22 +74,8 @@ class TransactionBloc extends Bloc<TransactionEvent, TransactionState> {
       final previousState = state;
       _currentYear = event.year;
       _currentMonth = event.month;
-      _currentKeyword = event.keyword;
-      _currentCategoryId = event.categoryId;
-      _currentCategoryIds = event.categoryIds;
-      _currentCategoryGroupIds = event.categoryGroupIds;
-      _currentPaymentMethodId = event.paymentMethodId;
-      _currentPaymentMethodIds = event.paymentMethodIds;
-      _currentPocketId = event.pocketId;
-      _currentPocketIds = event.pocketIds;
-      _currentAmountMin = event.amountMin;
-      _currentAmountMax = event.amountMax;
-      _currentDateFrom = event.dateFrom;
-      _currentDateTo = event.dateTo;
-      _currentType = event.type;
-      _currentTransactionTypes = event.transactionTypes;
-      _currentVisibility = event.visibility;
-      _currentNeedsReviewOnly = event.needsReviewOnly;
+      // 필터 VO 통째로 보관 — 필드 대입 없음(누락 불가).
+      _currentFilter = event.filter;
       // Only show full loading skeleton on initial load, not during search/filter
       if (previousState is! TransactionLoaded) {
         emit(const TransactionLoading());
@@ -128,22 +88,7 @@ class TransactionBloc extends Bloc<TransactionEvent, TransactionState> {
       final txnFuture = transactionRepository.getTransactions(
         year: event.year,
         month: event.month,
-        keyword: event.keyword,
-        categoryId: event.categoryId,
-        categoryIds: event.categoryIds,
-        categoryGroupIds: event.categoryGroupIds,
-        paymentMethodId: event.paymentMethodId,
-        paymentMethodIds: event.paymentMethodIds,
-        pocketId: event.pocketId,
-        pocketIds: event.pocketIds,
-        amountMin: event.amountMin,
-        amountMax: event.amountMax,
-        dateFrom: event.dateFrom,
-        dateTo: event.dateTo,
-        type: event.type,
-        transactionTypes: event.transactionTypes,
-        visibility: event.visibility,
-        needsReviewOnly: event.needsReviewOnly,
+        filter: event.filter,
         page: 0,
         size: _pageSize,
       );
@@ -154,23 +99,12 @@ class TransactionBloc extends Bloc<TransactionEvent, TransactionState> {
       if (statisticsRepository != null) {
         final results = await Future.wait([
           txnFuture,
+          // 목록과 **동일한 필터 VO** 로 합계를 요청 → "합계 ≠ 행" 불일치 차단.
+          // (이전: 필드 수동 나열로 needsReviewOnly 가 summary 에만 빠져 있었다.)
           statisticsRepository!.getSummary(
             year: event.year,
             month: event.month,
-            visibility: event.visibility ?? 'ALL',
-            dateFrom: event.dateFrom,
-            dateTo: event.dateTo,
-            categoryId: event.categoryId,
-            paymentMethodId: event.paymentMethodId,
-            pocketId: event.pocketId,
-            categoryIds: event.categoryIds,
-            categoryGroupIds: event.categoryGroupIds,
-            paymentMethodIds: event.paymentMethodIds,
-            pocketIds: event.pocketIds,
-            amountMin: event.amountMin,
-            amountMax: event.amountMax,
-            keyword: event.keyword,
-            transactionTypes: event.transactionTypes,
+            filter: event.filter,
           ),
         ]);
         final txnResult = results[0] as Either;
@@ -254,22 +188,7 @@ class TransactionBloc extends Bloc<TransactionEvent, TransactionState> {
       final result = await transactionRepository.getTransactions(
         year: _currentYear,
         month: _currentMonth,
-        keyword: _currentKeyword,
-        categoryId: _currentCategoryId,
-        categoryIds: _currentCategoryIds,
-        categoryGroupIds: _currentCategoryGroupIds,
-        paymentMethodId: _currentPaymentMethodId,
-        paymentMethodIds: _currentPaymentMethodIds,
-        pocketId: _currentPocketId,
-        pocketIds: _currentPocketIds,
-        amountMin: _currentAmountMin,
-        amountMax: _currentAmountMax,
-        dateFrom: _currentDateFrom,
-        dateTo: _currentDateTo,
-        type: _currentType,
-        transactionTypes: _currentTransactionTypes,
-        visibility: _currentVisibility,
-        needsReviewOnly: _currentNeedsReviewOnly,
+        filter: _currentFilter,
         page: nextPage,
         size: _pageSize,
       );
@@ -357,26 +276,11 @@ class TransactionBloc extends Bloc<TransactionEvent, TransactionState> {
       final focus = _focusMonthFor(event.transactionDate);
       result.fold(
         (failure) => emit(TransactionError(failure.message)),
-        (_) => add(LoadTransactions(
-              year: focus.year,
-              month: focus.month,
-              keyword: _currentKeyword,
-              categoryId: _currentCategoryId,
-              categoryIds: _currentCategoryIds,
-              categoryGroupIds: _currentCategoryGroupIds,
-              paymentMethodId: _currentPaymentMethodId,
-              paymentMethodIds: _currentPaymentMethodIds,
-              pocketId: _currentPocketId,
-              pocketIds: _currentPocketIds,
-              amountMin: _currentAmountMin,
-              amountMax: _currentAmountMax,
+        (_) => add(LoadTransactions.fromFilter(
+              focus.year,
+              focus.month,
+              _currentFilter,
               scrollToDate: event.transactionDate,
-              dateFrom: _currentDateFrom,
-              dateTo: _currentDateTo,
-              type: _currentType,
-              transactionTypes: _currentTransactionTypes,
-              visibility: _currentVisibility,
-              needsReviewOnly: _currentNeedsReviewOnly,
             )),
       );
     } catch (e) {
@@ -425,26 +329,11 @@ class TransactionBloc extends Bloc<TransactionEvent, TransactionState> {
       final focus = _focusMonthFor(event.transactionDate);
       result.fold(
         (failure) => emit(TransactionError(failure.message)),
-        (_) => add(LoadTransactions(
-              year: focus.year,
-              month: focus.month,
-              keyword: _currentKeyword,
-              categoryId: _currentCategoryId,
-              categoryIds: _currentCategoryIds,
-              categoryGroupIds: _currentCategoryGroupIds,
-              paymentMethodId: _currentPaymentMethodId,
-              paymentMethodIds: _currentPaymentMethodIds,
-              pocketId: _currentPocketId,
-              pocketIds: _currentPocketIds,
-              amountMin: _currentAmountMin,
-              amountMax: _currentAmountMax,
+        (_) => add(LoadTransactions.fromFilter(
+              focus.year,
+              focus.month,
+              _currentFilter,
               scrollToDate: event.transactionDate,
-              dateFrom: _currentDateFrom,
-              dateTo: _currentDateTo,
-              type: _currentType,
-              transactionTypes: _currentTransactionTypes,
-              visibility: _currentVisibility,
-              needsReviewOnly: _currentNeedsReviewOnly,
             )),
       );
     } catch (e) {

--- a/frontend/lib/features/transaction/presentation/bloc/transaction_event.dart
+++ b/frontend/lib/features/transaction/presentation/bloc/transaction_event.dart
@@ -8,55 +8,42 @@ sealed class TransactionEvent extends Equatable {
   List<Object?> get props => [];
 }
 
+/// 거래 목록 로드 이벤트.
+///
+/// **필터는 개별 필드가 아니라 [TransactionFilter] VO 하나로만 전달된다.**
+///
+/// 2026-04-15 "월 이동 후 필터 drop" 인시던트는 소비자들이 필터 필드를 손으로
+/// 나열하다 한 개(`transactionTypes` → 이후 `needsReviewOnly`)를 빠뜨려 3회 재발했다.
+/// `fromFilter` 팩토리만 추가했던 1차 대응은 **기본 생성자가 살아 있어서** 실효가 없었고
+/// (2026-07-27 감사에서 sync_event_handler / main_shell_page / app_router 3곳이
+/// `needsReviewOnly` 를 여전히 누락), 그래서 이번에는 생성자 자체를 봉인한다.
+///
+/// 공개 진입점은 2개뿐이다.
+/// - [LoadTransactions.fromFilter] — 필터가 있는 모든 경로 (기본)
+/// - [LoadTransactions.monthOnly] — 필터 없는 초기/리셋 로드임을 명시할 때만
+///
+/// 새 필터 추가 시 [TransactionFilter] 한 곳만 고치면 모든 경로가 자동 전파된다.
+/// 개별 필드 getter 는 하위 호환용 위임이며, 새 코드는 `event.filter` 를 직접 쓴다.
 class LoadTransactions extends TransactionEvent {
   final int year;
   final int month;
-  final String? keyword;
-  final String? categoryId;
-  final Set<String> categoryIds;
-  final Set<String> categoryGroupIds;
-  final String? paymentMethodId;
-  final Set<String> paymentMethodIds;
-  final String? pocketId;
-  final Set<String> pocketIds;
-  final int? amountMin;
-  final int? amountMax;
-  final String? scrollToDate;
-  final String? dateFrom;
-  final String? dateTo;
-  final String? type;
-  final Set<String> transactionTypes;
-  final String? visibility;
-  /// V61 (2026-05-06) — true 면 needs_review=true 거래만 (확인/입력 필요만 보기).
-  final bool? needsReviewOnly;
 
-  const LoadTransactions({
+  /// 필터 전체 스냅샷. 절대 필드 단위로 분해해 재조립하지 않는다.
+  final TransactionFilter filter;
+
+  final String? scrollToDate;
+
+  const LoadTransactions._({
     required this.year,
     required this.month,
-    this.keyword,
-    this.categoryId,
-    this.categoryIds = const {},
-    this.categoryGroupIds = const {},
-    this.paymentMethodId,
-    this.paymentMethodIds = const {},
-    this.pocketId,
-    this.pocketIds = const {},
-    this.amountMin,
-    this.amountMax,
+    required this.filter,
     this.scrollToDate,
-    this.dateFrom,
-    this.dateTo,
-    this.type,
-    this.transactionTypes = const {},
-    this.visibility,
-    this.needsReviewOnly,
   });
 
   /// 필터 VO 전체를 드롭 없이 전파하는 단일 진입점.
-  /// MonthSyncHandler 등 외부 consumer 가 개별 필드를 수동 나열하다 한 필드를
-  /// 빠뜨리는 사고(2026-04-15 "월 이동 후 필터 drop" 인시던트, transactionTypes·
-  /// needsReviewOnly 누락으로 재발)를 원천 차단한다. 새 필터 추가 시 TransactionFilter
-  /// 와 LoadTransactions 생성자만 고치면 이 팩토리는 자동으로 전체를 전달한다.
+  ///
+  /// [clearDateRange] 는 월 이동 시 특정 월에 종속된 명시적 기간 필터를 해제한다
+  /// (페이지 내비게이터와 동일 규칙).
   factory LoadTransactions.fromFilter(
     int year,
     int month,
@@ -64,52 +51,51 @@ class LoadTransactions extends TransactionEvent {
     String? scrollToDate,
     bool clearDateRange = false,
   }) {
-    return LoadTransactions(
+    return LoadTransactions._(
       year: year,
       month: month,
-      keyword: f.keyword,
-      categoryId: f.categoryId,
-      categoryIds: f.categoryIds,
-      categoryGroupIds: f.categoryGroupIds,
-      paymentMethodId: f.paymentMethodId,
-      paymentMethodIds: f.paymentMethodIds,
-      pocketId: f.pocketId,
-      pocketIds: f.pocketIds,
-      amountMin: f.amountMin,
-      amountMax: f.amountMax,
-      // 월 이동 시 특정 월에 종속된 명시적 기간 필터는 해제(페이지 내비게이터와 동일 규칙).
-      dateFrom: clearDateRange ? null : f.dateFrom,
-      dateTo: clearDateRange ? null : f.dateTo,
-      type: f.type,
-      transactionTypes: f.transactionTypes,
-      visibility: f.visibility,
-      needsReviewOnly: f.needsReviewOnly,
+      filter: clearDateRange ? f.copyWith(clearDateRange: true) : f,
       scrollToDate: scrollToDate,
     );
   }
 
+  /// 필터 없이 해당 월만 로드. "필터를 잃어버린 것"과 "의도적으로 필터가 없는 것"을
+  /// 호출부에서 구분해 읽을 수 있도록 별도 팩토리로 둔다.
+  factory LoadTransactions.monthOnly(
+    int year,
+    int month, {
+    String? scrollToDate,
+  }) {
+    return LoadTransactions._(
+      year: year,
+      month: month,
+      filter: TransactionFilter.empty,
+      scrollToDate: scrollToDate,
+    );
+  }
+
+  // ── 하위 호환 위임 getter (신규 코드는 `filter` 사용) ──
+  String? get keyword => filter.keyword;
+  String? get categoryId => filter.categoryId;
+  Set<String> get categoryIds => filter.categoryIds;
+  Set<String> get categoryGroupIds => filter.categoryGroupIds;
+  String? get paymentMethodId => filter.paymentMethodId;
+  Set<String> get paymentMethodIds => filter.paymentMethodIds;
+  String? get pocketId => filter.pocketId;
+  Set<String> get pocketIds => filter.pocketIds;
+  int? get amountMin => filter.amountMin;
+  int? get amountMax => filter.amountMax;
+  String? get dateFrom => filter.dateFrom;
+  String? get dateTo => filter.dateTo;
+  String? get type => filter.type;
+  Set<String> get transactionTypes => filter.transactionTypes;
+  String? get visibility => filter.visibility;
+
+  /// V61 (2026-05-06) — true 면 needs_review=true 거래만 (확인/입력 필요만 보기).
+  bool? get needsReviewOnly => filter.needsReviewOnly;
+
   @override
-  List<Object?> get props => [
-        year,
-        month,
-        keyword,
-        categoryId,
-        categoryIds,
-        categoryGroupIds,
-        paymentMethodId,
-        paymentMethodIds,
-        pocketId,
-        pocketIds,
-        amountMin,
-        amountMax,
-        scrollToDate,
-        dateFrom,
-        dateTo,
-        type,
-        transactionTypes,
-        visibility,
-        needsReviewOnly,
-      ];
+  List<Object?> get props => [year, month, filter, scrollToDate];
 }
 
 class CreateTransaction extends TransactionEvent {

--- a/frontend/lib/features/transaction/presentation/pages/transaction_list_page.dart
+++ b/frontend/lib/features/transaction/presentation/pages/transaction_list_page.dart
@@ -34,6 +34,7 @@ import 'package:budget_book/core/widgets/error_widget.dart';
 import 'package:budget_book/core/widgets/empty_state_widget.dart';
 import 'package:budget_book/core/widgets/skeleton_loader.dart';
 import 'package:budget_book/core/models/unified_filter_state.dart';
+import 'package:budget_book/features/transaction/domain/entities/transaction_filter.dart';
 import 'package:budget_book/core/widgets/filters/unified_filter_bar.dart';
 import 'package:budget_book/core/widgets/filters/payment_method_filter.dart';
 import 'package:budget_book/features/transaction/presentation/widgets/transaction_calendar_view.dart';
@@ -216,23 +217,11 @@ class _TransactionListPageState extends State<TransactionListPage> {
     final keyword =
         _searchController.text.trim().isEmpty ? null : _searchController.text.trim();
 
-    final fmt = DateFormat('yyyy-MM-dd');
-    context.read<TransactionBloc>().add(LoadTransactions(
-          year: year,
-          month: month,
-          keyword: keyword,
-          categoryIds: _filterState.categoryIds,
-          categoryGroupIds: _filterState.categoryGroupIds,
-          paymentMethodIds: _filterState.paymentMethodIds,
-          pocketIds: _filterState.pocketIds,
-          amountMin: _filterState.amountMin,
-          amountMax: _filterState.amountMax,
-          dateFrom: _filterState.dateFrom != null ? fmt.format(_filterState.dateFrom!) : null,
-          dateTo: _filterState.dateTo != null ? fmt.format(_filterState.dateTo!) : null,
-          transactionTypes: _filterState.transactionTypes,
-          visibility: _filterState.visibility,
-          needsReviewOnly:
-              _filterState.needsReviewOnly ? true : null,
+    // UI 필터 → 도메인 VO 변환은 toTransactionFilter 단일 경로 (필드 나열 금지).
+    context.read<TransactionBloc>().add(LoadTransactions.fromFilter(
+          year,
+          month,
+          _filterState.toTransactionFilter(keywordOverride: keyword),
         ));
     context.read<TransferBloc>().add(LoadTransfers(year: year, month: month));
   }
@@ -653,25 +642,12 @@ class _TransactionListPageState extends State<TransactionListPage> {
             final kw = _searchController.text.trim().isEmpty
                 ? null
                 : _searchController.text.trim();
-            final fmt = DateFormat('yyyy-MM-dd');
             context.read<TransactionBloc>().add(
-                  LoadTransactions(
-                    year: m.year,
-                    month: m.month,
-                    keyword: kw,
-                    categoryIds: _filterState.categoryIds,
-                    categoryGroupIds: _filterState.categoryGroupIds,
-                    paymentMethodIds: _filterState.paymentMethodIds,
-                    pocketIds: _filterState.pocketIds,
-                    amountMin: _filterState.amountMin,
-                    amountMax: _filterState.amountMax,
-                    dateFrom: _filterState.dateFrom != null ? fmt.format(_filterState.dateFrom!) : null,
-                    dateTo: _filterState.dateTo != null ? fmt.format(_filterState.dateTo!) : null,
+                  LoadTransactions.fromFilter(
+                    m.year,
+                    m.month,
+                    _filterState.toTransactionFilter(keywordOverride: kw),
                     scrollToDate: _pendingScrollToDate,
-                    transactionTypes: _filterState.transactionTypes,
-                    visibility: _filterState.visibility,
-                    needsReviewOnly:
-                        _filterState.needsReviewOnly ? true : null,
                   ),
                 );
           },
@@ -1285,7 +1261,7 @@ class _TransactionListPageState extends State<TransactionListPage> {
       message: '거래를 불러오지 못했습니다',
       onRetry: () {
         context.read<TransactionBloc>().add(
-              LoadTransactions(year: now.year, month: now.month),
+              LoadTransactions.monthOnly(now.year, now.month),
             );
       },
       showHomeButton: true,

--- a/frontend/test/core/websocket/sync_event_handler_test.dart
+++ b/frontend/test/core/websocket/sync_event_handler_test.dart
@@ -25,6 +25,7 @@ import 'package:budget_book/features/transaction/domain/entities/transaction.dar
     as tx;
 import 'package:budget_book/features/transaction/domain/entities/page_response.dart';
 import 'package:budget_book/features/budget/domain/entities/budget.dart';
+import 'package:budget_book/features/transaction/domain/entities/transaction_filter.dart';
 
 class MockTransactionRepository extends Mock
     implements TransactionRepository {}
@@ -40,6 +41,11 @@ class MockCategoryGroupRepository extends Mock
     implements CategoryGroupRepository {}
 
 void main() {
+  // mocktail: any(named: 'filter') 사용을 위한 fallback 등록.
+  setUpAll(() {
+    registerFallbackValue(TransactionFilter.empty);
+  });
+
   late GetIt testGetIt;
   late SyncEventHandler handler;
   late MockTransactionRepository mockTransactionRepo;
@@ -66,9 +72,7 @@ void main() {
     when(() => mockTransactionRepo.getTransactions(
           year: any(named: 'year'),
           month: any(named: 'month'),
-          type: any(named: 'type'),
-          transactionTypes: any(named: 'transactionTypes'),
-          categoryId: any(named: 'categoryId'),
+          filter: any(named: 'filter'),
           page: any(named: 'page'),
           size: any(named: 'size'),
         )).thenAnswer((_) async => const Right(
@@ -177,9 +181,7 @@ void main() {
       verify(() => mockTransactionRepo.getTransactions(
             year: any(named: 'year'),
             month: any(named: 'month'),
-            type: any(named: 'type'),
-            transactionTypes: any(named: 'transactionTypes'),
-            categoryId: any(named: 'categoryId'),
+            filter: any(named: 'filter'),
             page: any(named: 'page'),
             size: any(named: 'size'),
           )).called(1);

--- a/frontend/test/features/statistics/statistics_bloc_test.dart
+++ b/frontend/test/features/statistics/statistics_bloc_test.dart
@@ -12,6 +12,7 @@ import 'package:budget_book/features/statistics/presentation/bloc/statistics_blo
 import 'package:budget_book/features/statistics/presentation/bloc/statistics_event.dart';
 import 'package:budget_book/features/statistics/presentation/bloc/statistics_state.dart';
 import 'package:budget_book/features/transaction/domain/entities/transaction_category.dart';
+import 'package:budget_book/features/transaction/domain/entities/transaction_filter.dart';
 
 class MockStatisticsRepository extends Mock implements StatisticsRepository {}
 
@@ -90,7 +91,10 @@ void main() {
     blocTest<StatisticsBloc, StatisticsState>(
       'emits loading then loaded states when LoadAllStatistics succeeds',
       build: () {
-        when(() => mockRepository.getSummary(year: 2026, month: 3))
+        when(() => mockRepository.getSummary(
+              year: 2026,
+              month: 3,
+              filter: const TransactionFilter(visibility: 'ALL')))
             .thenAnswer((_) async => const Right(testSummary));
         when(() => mockRepository.getCategoryBreakdown(
               year: 2026,
@@ -116,7 +120,10 @@ void main() {
     blocTest<StatisticsBloc, StatisticsState>(
       'emits error state when LoadSummary fails',
       build: () {
-        when(() => mockRepository.getSummary(year: 2026, month: 3))
+        when(() => mockRepository.getSummary(
+              year: 2026,
+              month: 3,
+              filter: const TransactionFilter(visibility: 'ALL')))
             .thenAnswer((_) async =>
                 const Left(ServerFailure('통계 요약을 불러오지 못했습니다')));
         return StatisticsBloc(statisticsRepository: mockRepository);
@@ -200,9 +207,15 @@ void main() {
       blocTest<StatisticsBloc, StatisticsState>(
         'emits comparison data when both years succeed',
         build: () {
-          when(() => mockRepository.getSummary(year: 2026, month: 3))
+          when(() => mockRepository.getSummary(
+              year: 2026,
+              month: 3,
+              filter: const TransactionFilter(visibility: 'ALL')))
               .thenAnswer((_) async => const Right(testSummary));
-          when(() => mockRepository.getSummary(year: 2025, month: 3))
+          when(() => mockRepository.getSummary(
+              year: 2025,
+              month: 3,
+              filter: const TransactionFilter(visibility: 'ALL')))
               .thenAnswer((_) async => const Right(testPrevYearSummary));
           return StatisticsBloc(statisticsRepository: mockRepository);
         },
@@ -219,9 +232,15 @@ void main() {
       blocTest<StatisticsBloc, StatisticsState>(
         'handles previous year failure gracefully',
         build: () {
-          when(() => mockRepository.getSummary(year: 2026, month: 3))
+          when(() => mockRepository.getSummary(
+              year: 2026,
+              month: 3,
+              filter: const TransactionFilter(visibility: 'ALL')))
               .thenAnswer((_) async => const Right(testSummary));
-          when(() => mockRepository.getSummary(year: 2025, month: 3))
+          when(() => mockRepository.getSummary(
+              year: 2025,
+              month: 3,
+              filter: const TransactionFilter(visibility: 'ALL')))
               .thenAnswer((_) async =>
                   const Left(ServerFailure('No data')));
           return StatisticsBloc(statisticsRepository: mockRepository);
@@ -239,10 +258,16 @@ void main() {
       blocTest<StatisticsBloc, StatisticsState>(
         'emits error when current year fails',
         build: () {
-          when(() => mockRepository.getSummary(year: 2026, month: 3))
+          when(() => mockRepository.getSummary(
+              year: 2026,
+              month: 3,
+              filter: const TransactionFilter(visibility: 'ALL')))
               .thenAnswer((_) async =>
                   const Left(ServerFailure('통계 요약을 불러오지 못했습니다')));
-          when(() => mockRepository.getSummary(year: 2025, month: 3))
+          when(() => mockRepository.getSummary(
+              year: 2025,
+              month: 3,
+              filter: const TransactionFilter(visibility: 'ALL')))
               .thenAnswer((_) async => const Right(testPrevYearSummary));
           return StatisticsBloc(statisticsRepository: mockRepository);
         },

--- a/frontend/test/features/transaction/data/repositories/transaction_repository_impl_test.dart
+++ b/frontend/test/features/transaction/data/repositories/transaction_repository_impl_test.dart
@@ -9,6 +9,7 @@ import 'package:budget_book/features/transaction/data/models/transaction_author_
 import 'package:budget_book/features/transaction/data/models/transaction_category_model.dart';
 import 'package:budget_book/features/transaction/domain/entities/transaction.dart';
 import 'package:budget_book/features/transaction/domain/entities/page_response.dart';
+import 'package:budget_book/features/transaction/domain/entities/transaction_filter.dart';
 import 'package:budget_book/core/error/failure.dart';
 import 'package:budget_book/features/transaction/domain/repositories/transaction_repository.dart';
 
@@ -18,22 +19,7 @@ class MockTransactionRemoteDataSource extends Mock
   Future<PageResponse<TransactionModel>> getTransactions({
     int? year,
     int? month,
-    String? type,
-    Set<String> transactionTypes = const {},
-    String? categoryId,
-    Set<String> categoryIds = const {},
-    Set<String> categoryGroupIds = const {},
-    String? keyword,
-    String? paymentMethodId,
-    Set<String> paymentMethodIds = const {},
-    String? pocketId,
-    Set<String> pocketIds = const {},
-    int? amountMin,
-    int? amountMax,
-    String? dateFrom,
-    String? dateTo,
-    String? visibility,
-    bool? needsReviewOnly,
+    TransactionFilter filter = TransactionFilter.empty,
     int page = 0,
     int size = 20,
   }) =>
@@ -41,22 +27,7 @@ class MockTransactionRemoteDataSource extends Mock
         Invocation.method(#getTransactions, [], {
           #year: year,
           #month: month,
-          #type: type,
-          #transactionTypes: transactionTypes,
-          #categoryId: categoryId,
-          #categoryIds: categoryIds,
-          #categoryGroupIds: categoryGroupIds,
-          #keyword: keyword,
-          #paymentMethodId: paymentMethodId,
-          #paymentMethodIds: paymentMethodIds,
-          #pocketId: pocketId,
-          #pocketIds: pocketIds,
-          #amountMin: amountMin,
-          #amountMax: amountMax,
-          #dateFrom: dateFrom,
-          #dateTo: dateTo,
-          #visibility: visibility,
-          #needsReviewOnly: needsReviewOnly,
+          #filter: filter,
           #page: page,
           #size: size,
         }),

--- a/frontend/test/features/transaction/presentation/bloc/load_transactions_filter_coverage_test.dart
+++ b/frontend/test/features/transaction/presentation/bloc/load_transactions_filter_coverage_test.dart
@@ -1,0 +1,204 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:budget_book/core/models/unified_filter_state.dart';
+import 'package:budget_book/features/transaction/domain/entities/transaction_filter.dart';
+import 'package:budget_book/features/transaction/presentation/bloc/transaction_event.dart';
+
+/// 필터 전파 회귀 가드 (2026-07-27).
+///
+/// 배경: "월 이동/탭 복귀/파트너 sync 후 필터가 풀린다" 인시던트가 3회 재발했다.
+/// 원인은 매번 동일 — 필터 필드를 손으로 나열하는 지점이 여러 곳 있어서 새 필터
+/// (transactionTypes → needsReviewOnly) 를 한 곳에서 빠뜨렸다.
+///
+/// 구조적 수정: LoadTransactions 는 TransactionFilter VO 만 받고(생성자 봉인),
+/// UI 상태 → VO 변환은 toTransactionFilter 한 곳, 라우터의 nav 필터 덮어쓰기는
+/// withNavigationFilters 한 곳으로 고정했다.
+///
+/// 이 테스트는 그 세 관문이 **모든 필터 필드**를 실어 나르는지 검사한다.
+/// 새 필터를 추가하면 `props` 개수 가드가 먼저 실패하므로, 매핑 추가를 강제한다.
+void main() {
+  // 모든 필드가 기본값과 다른 필터 (드롭 여부를 값 비교로 확인 가능).
+  const fullFilter = TransactionFilter(
+    keyword: '점심',
+    categoryId: 'cat-1',
+    categoryIds: {'cat-2', 'cat-3'},
+    categoryGroupIds: {'grp-1'},
+    paymentMethodId: 'pm-1',
+    paymentMethodIds: {'pm-2'},
+    pocketId: 'pk-1',
+    pocketIds: {'pk-2'},
+    amountMin: 1000,
+    amountMax: 90000,
+    dateFrom: '2026-07-01',
+    dateTo: '2026-07-31',
+    type: 'EXPENSE',
+    transactionTypes: {'EXPENSE', 'TRANSFER'},
+    visibility: 'SHARED',
+    needsReviewOnly: true,
+  );
+
+  group('필터 필드 개수 가드', () {
+    test('TransactionFilter 에 필드가 추가되면 이 테스트를 갱신해야 한다', () {
+      // 새 필터를 추가했다면:
+      //   1) 이 숫자를 갱신
+      //   2) fullFilter 에 값 추가
+      //   3) toQueryParams / toTransactionFilter / withNavigationFilters 매핑 확인
+      expect(fullFilter.props.length, 16,
+          reason: '필터 필드 수 변경 감지 — 전파 경로 3곳의 매핑을 함께 갱신하세요');
+    });
+
+    test('fullFilter 는 모든 필드가 non-null/non-empty 여야 의미가 있다', () {
+      expect(fullFilter.props.any((p) => p == null), isFalse);
+      expect(
+        fullFilter.props.whereType<Set<String>>().any((s) => s.isEmpty),
+        isFalse,
+      );
+    });
+  });
+
+  group('LoadTransactions.fromFilter', () {
+    test('필터 VO 를 한 필드도 잃지 않고 전달한다', () {
+      final event = LoadTransactions.fromFilter(2026, 7, fullFilter);
+
+      expect(event.year, 2026);
+      expect(event.month, 7);
+      expect(event.filter, fullFilter);
+      // 위임 getter 도 동일 값 (기존 소비자 호환).
+      expect(event.keyword, '점심');
+      expect(event.transactionTypes, {'EXPENSE', 'TRANSFER'});
+      expect(event.visibility, 'SHARED');
+      expect(event.needsReviewOnly, isTrue);
+    });
+
+    test('clearDateRange 는 기간만 해제하고 나머지는 보존한다', () {
+      final event =
+          LoadTransactions.fromFilter(2026, 8, fullFilter, clearDateRange: true);
+
+      expect(event.dateFrom, isNull);
+      expect(event.dateTo, isNull);
+      // 나머지 필드는 그대로 (특히 과거에 드롭됐던 두 필드).
+      expect(event.transactionTypes, {'EXPENSE', 'TRANSFER'});
+      expect(event.needsReviewOnly, isTrue);
+      expect(event.filter, fullFilter.copyWith(clearDateRange: true));
+    });
+
+    test('scrollToDate 는 필터와 독립적으로 전달된다', () {
+      final event = LoadTransactions.fromFilter(2026, 7, fullFilter,
+          scrollToDate: '2026-07-15');
+      expect(event.scrollToDate, '2026-07-15');
+      expect(event.filter, fullFilter);
+    });
+
+    test('monthOnly 는 빈 필터임을 명시한다', () {
+      final event = LoadTransactions.monthOnly(2026, 7);
+      expect(event.filter, TransactionFilter.empty);
+      expect(event.filter.hasAny, isFalse);
+    });
+  });
+
+  group('UnifiedFilterState.toTransactionFilter', () {
+    final uiState = UnifiedFilterState(
+      dateFrom: DateTime(2026, 7, 1),
+      dateTo: DateTime(2026, 7, 31),
+      categoryIds: const {'cat-2'},
+      categoryGroupIds: const {'grp-1'},
+      paymentMethodIds: const {'pm-2'},
+      pocketIds: const {'pk-2'},
+      amountMin: 1000,
+      amountMax: 90000,
+      keyword: '커피',
+      transactionTypes: const {'EXPENSE'},
+      visibility: 'SHARED',
+      needsReviewOnly: true,
+    );
+
+    test('UI 필터 상태의 모든 항목이 도메인 VO 로 옮겨진다', () {
+      final f = uiState.toTransactionFilter();
+
+      expect(f.keyword, '커피');
+      expect(f.categoryIds, {'cat-2'});
+      expect(f.categoryGroupIds, {'grp-1'});
+      expect(f.paymentMethodIds, {'pm-2'});
+      expect(f.pocketIds, {'pk-2'});
+      expect(f.amountMin, 1000);
+      expect(f.amountMax, 90000);
+      expect(f.dateFrom, '2026-07-01');
+      expect(f.dateTo, '2026-07-31');
+      expect(f.transactionTypes, {'EXPENSE'});
+      expect(f.visibility, 'SHARED');
+      // 3회 재발의 마지막 누락 필드 — 반드시 전달돼야 한다.
+      expect(f.needsReviewOnly, isTrue);
+    });
+
+    test('needsReviewOnly=false 는 미적용(null)으로 보낸다', () {
+      final f = const UnifiedFilterState(needsReviewOnly: false)
+          .toTransactionFilter();
+      expect(f.needsReviewOnly, isNull);
+      expect(f.toQueryParams().containsKey('needsReviewOnly'), isFalse);
+    });
+
+    test('keywordOverride 가 UI 상태의 keyword 를 대체한다', () {
+      final f = uiState.toTransactionFilter(keywordOverride: '점심');
+      expect(f.keyword, '점심');
+    });
+  });
+
+  group('TransactionFilter.withNavigationFilters', () {
+    test('nav 필터만 덮어쓰고 content 필터는 보존한다', () {
+      final f = fullFilter.withNavigationFilters(
+        categoryId: 'nav-cat',
+        paymentMethodId: 'nav-pm',
+        categoryIds: const {'nav-cat-2'},
+        categoryGroupIds: const {'nav-grp'},
+        paymentMethodIds: const {'nav-pm-2'},
+        pocketIds: const {'nav-pk'},
+      );
+
+      // nav 소유 필드 = 인자 값
+      expect(f.categoryId, 'nav-cat');
+      expect(f.paymentMethodId, 'nav-pm');
+      expect(f.categoryIds, {'nav-cat-2'});
+      expect(f.categoryGroupIds, {'nav-grp'});
+      expect(f.paymentMethodIds, {'nav-pm-2'});
+      expect(f.pocketIds, {'nav-pk'});
+
+      // content 필드 = 보존 (URL 진입 시 드롭됐던 needsReviewOnly 포함)
+      expect(f.keyword, '점심');
+      expect(f.amountMin, 1000);
+      expect(f.amountMax, 90000);
+      expect(f.dateFrom, '2026-07-01');
+      expect(f.dateTo, '2026-07-31');
+      expect(f.type, 'EXPENSE');
+      expect(f.transactionTypes, {'EXPENSE', 'TRANSFER'});
+      expect(f.visibility, 'SHARED');
+      expect(f.needsReviewOnly, isTrue);
+      expect(f.pocketId, 'pk-1');
+    });
+
+    test('인자를 생략하면 nav 필터가 해제된다 (carry 아님)', () {
+      final f = fullFilter.withNavigationFilters();
+
+      expect(f.categoryId, isNull);
+      expect(f.paymentMethodId, isNull);
+      expect(f.categoryIds, isEmpty);
+      expect(f.categoryGroupIds, isEmpty);
+      expect(f.paymentMethodIds, isEmpty);
+      expect(f.pocketIds, isEmpty);
+      // content 는 유지
+      expect(f.keyword, '점심');
+      expect(f.needsReviewOnly, isTrue);
+    });
+  });
+
+  group('toQueryParams (FE→BE 전달)', () {
+    test('needsReviewOnly=true 는 BE 로 전달된다', () {
+      expect(fullFilter.toQueryParams()['needsReviewOnly'], isTrue);
+    });
+
+    test('TRANSFER 의사-타입은 BE 로 보내지 않는다', () {
+      final types =
+          fullFilter.toQueryParams()['transactionTypes'] as List<dynamic>;
+      expect(types, contains('EXPENSE'));
+      expect(types, isNot(contains('TRANSFER')));
+    });
+  });
+}

--- a/frontend/test/features/transaction/presentation/bloc/transaction_bloc_filter_persistence_test.dart
+++ b/frontend/test/features/transaction/presentation/bloc/transaction_bloc_filter_persistence_test.dart
@@ -7,6 +7,7 @@ import 'package:budget_book/features/transaction/domain/repositories/transaction
 import 'package:budget_book/features/transaction/domain/entities/transaction.dart';
 import 'package:budget_book/features/transaction/domain/entities/transaction_author.dart';
 import 'package:budget_book/features/transaction/domain/entities/page_response.dart';
+import 'package:budget_book/features/transaction/domain/entities/transaction_filter.dart';
 import 'package:budget_book/core/error/failure.dart';
 
 /// 회차 1 (2026-05-26) — Bug 1 회귀 방지:
@@ -22,22 +23,7 @@ class _MockTransactionRepository extends Mock implements TransactionRepository {
   Future<Either<Failure, PageResponse<Transaction>>> getTransactions({
     int? year,
     int? month,
-    String? type,
-    Set<String> transactionTypes = const {},
-    String? categoryId,
-    Set<String> categoryIds = const {},
-    Set<String> categoryGroupIds = const {},
-    String? keyword,
-    String? paymentMethodId,
-    Set<String> paymentMethodIds = const {},
-    String? pocketId,
-    Set<String> pocketIds = const {},
-    int? amountMin,
-    int? amountMax,
-    String? dateFrom,
-    String? dateTo,
-    String? visibility,
-    bool? needsReviewOnly,
+    TransactionFilter filter = TransactionFilter.empty,
     int page = 0,
     int size = 20,
   }) async =>
@@ -97,10 +83,10 @@ void main() {
   group('UpdateTransaction → nav 필터 보존', () {
     test('paymentMethodIds 단일 필터 적용 후 update → currentPaymentMethodIds 보존',
         () async {
-      bloc.add(const LoadTransactions(
-        year: 2026,
-        month: 5,
-        paymentMethodIds: {'pm-7'},
+      bloc.add(LoadTransactions.fromFilter(
+        2026,
+        5,
+        const TransactionFilter(paymentMethodIds: {'pm-7'}),
       ));
       await Future<void>.delayed(const Duration(milliseconds: 30));
       expect(bloc.currentPaymentMethodIds, equals({'pm-7'}),
@@ -113,10 +99,10 @@ void main() {
     });
 
     test('categoryId 필터 적용 후 update → currentCategoryId 보존', () async {
-      bloc.add(const LoadTransactions(
-        year: 2026,
-        month: 5,
-        categoryId: 'cat-9',
+      bloc.add(LoadTransactions.fromFilter(
+        2026,
+        5,
+        const TransactionFilter(categoryId: 'cat-9'),
       ));
       await Future<void>.delayed(const Duration(milliseconds: 30));
       expect(bloc.currentCategoryId, equals('cat-9'));
@@ -128,10 +114,10 @@ void main() {
     });
 
     test('categoryGroupIds 적용 후 update → currentCategoryGroupIds 보존', () async {
-      bloc.add(const LoadTransactions(
-        year: 2026,
-        month: 5,
-        categoryGroupIds: {'grp-2', 'grp-3'},
+      bloc.add(LoadTransactions.fromFilter(
+        2026,
+        5,
+        const TransactionFilter(categoryGroupIds: {'grp-2', 'grp-3'}),
       ));
       await Future<void>.delayed(const Duration(milliseconds: 30));
       expect(bloc.currentCategoryGroupIds, equals({'grp-2', 'grp-3'}));
@@ -143,12 +129,14 @@ void main() {
     });
 
     test('keyword + visibility (content 필터) 동시 보존', () async {
-      bloc.add(const LoadTransactions(
-        year: 2026,
-        month: 5,
-        paymentMethodIds: {'pm-1'},
-        keyword: '점심',
-        visibility: 'INCLUDE_ONLY',
+      bloc.add(LoadTransactions.fromFilter(
+        2026,
+        5,
+        const TransactionFilter(
+          paymentMethodIds: {'pm-1'},
+          keyword: '점심',
+          visibility: 'INCLUDE_ONLY',
+        ),
       ));
       await Future<void>.delayed(const Duration(milliseconds: 30));
 

--- a/frontend/test/features/transaction/presentation/bloc/transaction_bloc_test.dart
+++ b/frontend/test/features/transaction/presentation/bloc/transaction_bloc_test.dart
@@ -10,6 +10,7 @@ import 'package:budget_book/features/transaction/domain/entities/transaction.dar
 import 'package:budget_book/features/transaction/domain/entities/transaction_author.dart';
 import 'package:budget_book/features/transaction/domain/entities/transaction_category.dart';
 import 'package:budget_book/features/transaction/domain/entities/page_response.dart';
+import 'package:budget_book/features/transaction/domain/entities/transaction_filter.dart';
 import 'package:budget_book/core/error/failure.dart';
 
 class MockTransactionRepository extends Mock
@@ -18,22 +19,7 @@ class MockTransactionRepository extends Mock
   Future<Either<Failure, PageResponse<Transaction>>> getTransactions({
     int? year,
     int? month,
-    String? type,
-    Set<String> transactionTypes = const {},
-    String? categoryId,
-    Set<String> categoryIds = const {},
-    Set<String> categoryGroupIds = const {},
-    String? keyword,
-    String? paymentMethodId,
-    Set<String> paymentMethodIds = const {},
-    String? pocketId,
-    Set<String> pocketIds = const {},
-    int? amountMin,
-    int? amountMax,
-    String? dateFrom,
-    String? dateTo,
-    String? visibility,
-    bool? needsReviewOnly,
+    TransactionFilter filter = TransactionFilter.empty,
     int page = 0,
     int size = 20,
   }) =>
@@ -41,22 +27,7 @@ class MockTransactionRepository extends Mock
         Invocation.method(#getTransactions, [], {
           #year: year,
           #month: month,
-          #type: type,
-          #transactionTypes: transactionTypes,
-          #categoryId: categoryId,
-          #categoryIds: categoryIds,
-          #categoryGroupIds: categoryGroupIds,
-          #keyword: keyword,
-          #paymentMethodId: paymentMethodId,
-          #paymentMethodIds: paymentMethodIds,
-          #pocketId: pocketId,
-          #pocketIds: pocketIds,
-          #amountMin: amountMin,
-          #amountMax: amountMax,
-          #dateFrom: dateFrom,
-          #dateTo: dateTo,
-          #visibility: visibility,
-          #needsReviewOnly: needsReviewOnly,
+          #filter: filter,
           #page: page,
           #size: size,
         }),
@@ -247,7 +218,7 @@ void main() {
           return transactionBloc;
         },
         act: (bloc) =>
-            bloc.add(const LoadTransactions(year: 2024, month: 1)),
+            bloc.add(LoadTransactions.monthOnly(2024, 1)),
         expect: () => [
           const TransactionLoading(),
           TransactionLoaded(
@@ -266,19 +237,23 @@ void main() {
           when(mockRepository.getTransactions(
             year: 2024,
             month: 1,
-            keyword: 'lunch',
-            amountMin: 5000,
-            amountMax: 20000,
+            filter: const TransactionFilter(
+              keyword: 'lunch',
+              amountMin: 5000,
+              amountMax: 20000,
+            ),
             size: 200,
           )).thenAnswer((_) async => Right(tPageResponse));
           return transactionBloc;
         },
-        act: (bloc) => bloc.add(const LoadTransactions(
-          year: 2024,
-          month: 1,
-          keyword: 'lunch',
-          amountMin: 5000,
-          amountMax: 20000,
+        act: (bloc) => bloc.add(LoadTransactions.fromFilter(
+          2024,
+          1,
+          const TransactionFilter(
+            keyword: 'lunch',
+            amountMin: 5000,
+            amountMax: 20000,
+          ),
         )),
         expect: () => [
           const TransactionLoading(),
@@ -304,7 +279,7 @@ void main() {
           return transactionBloc;
         },
         act: (bloc) =>
-            bloc.add(const LoadTransactions(year: 2024, month: 1)),
+            bloc.add(LoadTransactions.monthOnly(2024, 1)),
         expect: () => [
           const TransactionLoading(),
           const TransactionError('Failed to load transactions'),
@@ -366,7 +341,7 @@ void main() {
         ),
         act: (bloc) {
           // First load to set currentYear/currentMonth
-          bloc.add(const LoadTransactions(year: 2024, month: 1));
+          bloc.add(LoadTransactions.monthOnly(2024, 1));
         },
         skip: 2, // skip Loading and Loaded from LoadTransactions
         verify: (_) {
@@ -402,7 +377,7 @@ void main() {
         },
         act: (bloc) {
           // 5월을 보던 중 (currentYear/Month = 2024/5)
-          bloc.add(const LoadTransactions(year: 2024, month: 5));
+          bloc.add(LoadTransactions.monthOnly(2024, 5));
           // 6월 거래 등록
           bloc.add(const CreateTransaction(
             type: 'EXPENSE',
@@ -566,7 +541,7 @@ void main() {
           return transactionBloc;
         },
         act: (bloc) async {
-          bloc.add(const LoadTransactions(year: 2024, month: 1));
+          bloc.add(LoadTransactions.monthOnly(2024, 1));
           await Future.delayed(const Duration(milliseconds: 100));
           bloc.add(const LoadMoreTransactions());
         },


### PR DESCRIPTION
정산(스냅샷) 기능 기획 중 수행한 전수 점검에서 나온 드리프트를 선행 정리합니다.
기획서: `docs/sessions/2026-07-27_1_plan.md`

## 1. 필터 전파 구조적 수정 — 인시던트 4회 재발 차단

`LoadTransactions.fromFilter`(2026-04-15 인시던트 대책)는 **`month_sync_handler` 1곳에서만** 쓰였고
기본 생성자가 살아 있어 나머지 경로는 여전히 필드를 손으로 나열했습니다. 그 결과 `needsReviewOnly`
가 3곳에서 드롭돼 "확인/입력 필요만 보기" 필터가 경로에 따라 풀렸습니다.

- `sync_event_handler.dart` — 파트너가 거래를 추가/수정하면 내 필터가 해제
- `main_shell_page.dart` — 다른 탭 → 거래 탭 복귀 시 해제
- `app_router.dart` — URL 진입(홈/예산 → 거래) 시 해제

**필드 나열 자체를 불가능하게** 만들었습니다.

- `LoadTransactions` 기본 생성자 봉인 → 공개 진입점은 `fromFilter` / `monthOnly` 2개
- `TransactionRepository` · `RemoteDataSource` · `StatisticsRepository` 가 `TransactionFilter` VO 를
  직접 수신 (bloc→repo→datasource 3-hop 재조립 제거)
- `TransactionBloc` 이 스칼라 16개 대신 VO 1개만 보관
- `UnifiedFilterState.toTransactionFilter` / `TransactionFilter.withNavigationFilters` 로
  UI→도메인 변환, nav 필터 덮어쓰기를 각각 단일 경로화
- 회귀 가드 13건 추가 — **필터 필드 개수 가드**를 포함해 새 필터 추가 시 테스트가 먼저 실패

## 2. "합계 ≠ 보이는 행" fix

`/statistics/summary` 가 `needsReviewOnly` 를 아예 지원하지 않아, 목록은 필터링되는데 월 합계 바는
전체 금액을 표시했습니다. 컨트롤러·서비스에 필터를 전달하고 `hasContentFilters` 에 포함해
Specification 경로를 타게 했으며, FE 는 목록과 **같은 필터 VO** 를 summary 에도 넘깁니다.
컨트롤러/서비스 회귀 테스트 추가.

## 3. 로컬 테스트 게이트 복구

`HighApiVersionDockerStrategy` 와 `build.gradle.kts` 가 소켓을 `/var/run/docker.sock` 로 하드코딩해,
활성 런타임이 colima 인 머신에서는 끊긴 심볼릭 링크를 잡아 `./gradlew test` 가 Kotest
initializationError 로 **전건 실패**했습니다(= 문서상 로컬 CI 게이트를 통과할 수 없는 상태).
존재하는 소켓을 후보 목록(`DOCKER_HOST` → `/var/run` → colima → Desktop → Rancher)에서 골라 주입합니다.

## 4. 기타 정합성

- 거래 목록 페이지 상한 100 → 200 (FE `_pageSize` 와 일치, 왕복 절반)
- `api-spec.md`: `/transactions/settlement` 응답을 실제 구조로 정정 — 배열이 아니라 `totalAmount`
  포함 객체, 항목은 축약 projection, `year`/`month` 필수 파라미터 누락 보완
- `erd.md`: V12 에서 멈춰 있던 문서에 **V13~V64 스키마 증분** 절 추가(누락 테이블 12개 + 변경 컬럼),
  마이그레이션 이력 V14~V64 채움, Supabase→NAS 갱신. 라이브 DB `information_schema` 기준 검증
- `known-issues.md` KI-007 상태 정정(Phase 1·3 이미 완료), `project-audit.md` V64,
  `current-tasks.md` 실제 진행 상황으로 갱신

## 검증

- BE `./gradlew build` — SUCCESS (Docker env 변수 없이 Testcontainers 포함 통과)
- FE `flutter analyze --no-fatal-infos --no-congratulate` — 3 info (기존 테스트 파일 `prefer_const`)
- FE `flutter test` — 768 passed (기존 755 + 신규 13)
- FE `flutter build web` — SUCCESS

라이브 검증 항목(머지 후): 확인/입력 필요만 보기 필터가 ① 파트너 변경 sync ② 탭 복귀
③ URL 진입 후에도 유지되고, 그 상태에서 월 합계 바 숫자가 보이는 행과 일치하는지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)