### PR TITLE
feat(reconciliation): 정산 스냅샷 백엔드 — V65 + 6 엔드포인트 + 미기록 필터

### DIFF
--- a/backend/src/main/kotlin/com/budgetbook/common/dto/CommonFilterParams.kt
+++ b/backend/src/main/kotlin/com/budgetbook/common/dto/CommonFilterParams.kt
@@ -33,7 +33,10 @@ data class CommonFilterParams(
     val transactionTypes: List<String>? = null,
     val status: String? = null,
     // V61 (2026-05-06) — true 면 needs_review=true 거래만 (확인/입력 필요만 보기).
-    val needsReviewOnly: Boolean? = null
+    val needsReviewOnly: Boolean? = null,
+    // V65 (2026-07-27) — 정산 스냅샷 필터. false=미기록만, true=기록된 것만, null=전체.
+    // 거래 목록과 이체 목록 **양쪽** 이 지원한다.
+    val reconciled: Boolean? = null
 ) {
     /**
      * Resolves effective date range from dateFrom/dateTo or year/month.

--- a/backend/src/main/kotlin/com/budgetbook/reconciliation/controller/ReconciliationController.kt
+++ b/backend/src/main/kotlin/com/budgetbook/reconciliation/controller/ReconciliationController.kt
@@ -1,0 +1,97 @@
+package com.budgetbook.reconciliation.controller
+
+import com.budgetbook.common.dto.ApiResponse
+import com.budgetbook.common.ratelimit.RateLimit
+import com.budgetbook.common.security.AuthUser
+import com.budgetbook.reconciliation.dto.CreateReconciliationRequest
+import com.budgetbook.reconciliation.dto.ReconciliationDetailResponse
+import com.budgetbook.reconciliation.dto.ReconciliationResponse
+import com.budgetbook.reconciliation.dto.ReconciliationSummaryResponse
+import com.budgetbook.reconciliation.dto.UpdateReconciliationRequest
+import com.budgetbook.reconciliation.service.ReconciliationService
+import jakarta.validation.Valid
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+/**
+ * 정산 스냅샷 API. 계약: `docs/api-spec.md § Reconciliations (정산 스냅샷)`.
+ */
+@RestController
+@RequestMapping("/api/v1/reconciliations")
+class ReconciliationController(
+    private val reconciliationService: ReconciliationService
+) {
+
+    @GetMapping
+    fun listReconciliations(
+        @AuthUser userId: UUID,
+        @RequestParam @Min(2000) @Max(2100) year: Int,
+        @RequestParam @Min(1) @Max(12) month: Int
+    ): ApiResponse<List<ReconciliationResponse>> {
+        return ApiResponse.ok(reconciliationService.listReconciliations(userId, year, month))
+    }
+
+    /**
+     * 월말 누락 점검 요약. `/{id}` 보다 **먼저** 매핑되어야 한다
+     * (`summary` 가 UUID path variable 로 해석되지 않도록 — Spring 은 더 구체적인 패턴을
+     * 우선하지만 의도를 명시적으로 남긴다).
+     */
+    @GetMapping("/summary")
+    fun getSummary(
+        @AuthUser userId: UUID,
+        @RequestParam @Min(2000) @Max(2100) year: Int,
+        @RequestParam @Min(1) @Max(12) month: Int
+    ): ApiResponse<ReconciliationSummaryResponse> {
+        return ApiResponse.ok(reconciliationService.getSummary(userId, year, month))
+    }
+
+    @GetMapping("/{id}")
+    fun getReconciliation(
+        @AuthUser userId: UUID,
+        @PathVariable id: UUID
+    ): ApiResponse<ReconciliationDetailResponse> {
+        return ApiResponse.ok(reconciliationService.getReconciliation(userId, id))
+    }
+
+    @RateLimit(maxRequests = 30, windowSeconds = 60)
+    @PostMapping
+    fun createReconciliation(
+        @AuthUser userId: UUID,
+        @Valid @RequestBody request: CreateReconciliationRequest
+    ): ResponseEntity<ApiResponse<ReconciliationDetailResponse>> {
+        val result = reconciliationService.createReconciliation(userId, request)
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.ok(result))
+    }
+
+    @RateLimit(maxRequests = 30, windowSeconds = 60)
+    @PatchMapping("/{id}")
+    fun updateReconciliation(
+        @AuthUser userId: UUID,
+        @PathVariable id: UUID,
+        @Valid @RequestBody request: UpdateReconciliationRequest
+    ): ApiResponse<ReconciliationDetailResponse> {
+        return ApiResponse.ok(reconciliationService.updateReconciliation(userId, id, request))
+    }
+
+    @RateLimit(maxRequests = 30, windowSeconds = 60)
+    @DeleteMapping("/{id}")
+    fun deleteReconciliation(
+        @AuthUser userId: UUID,
+        @PathVariable id: UUID
+    ): ResponseEntity<Void> {
+        reconciliationService.deleteReconciliation(userId, id)
+        return ResponseEntity.noContent().build()
+    }
+}

--- a/backend/src/main/kotlin/com/budgetbook/reconciliation/domain/Reconciliation.kt
+++ b/backend/src/main/kotlin/com/budgetbook/reconciliation/domain/Reconciliation.kt
@@ -1,0 +1,84 @@
+package com.budgetbook.reconciliation.domain
+
+import com.budgetbook.auth.domain.User
+import com.budgetbook.common.entity.BaseTimeEntity
+import com.budgetbook.couple.domain.Couple
+import jakarta.persistence.CascadeType
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.OneToMany
+import jakarta.persistence.Table
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * 정산 스냅샷 헤더 (V65).
+ *
+ * 장부(거래 + 이체)를 대조한 시점의 기록. 한 달에 여러 번 만들 수 있고 [seq] 로 회차를 구분한다.
+ * 어떤 스냅샷에도 담기지 않은 항목은 "미기록" 으로 남아 월말 누락 점검에 쓰인다.
+ *
+ * 소계([totalIncome] 등)는 **BE 가 단독 계산해 저장**한다 (조회 빈도 ≫ 생성 빈도, 스냅샷은
+ * 불변 기록이라 캐시 무효화 문제가 없다). FE 는 절대 재계산하지 않는다 — 과거 이중 합산 사고
+ * (2026-04-14 MonthSummaryBar) 의 원인이 FE 재계산이었다.
+ *
+ * 단, 조회자가 볼 수 없는 파트너의 PRIVATE 항목이 섞여 있으면 조회 시점에 게이팅 후
+ * 재계산해서 응답한다 (표시된 행과 합계가 어긋나지 않도록).
+ */
+@Entity
+@Table(name = "reconciliations")
+class Reconciliation(
+    @Id
+    val id: UUID = UUID.randomUUID(),
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "couple_id", nullable = false)
+    val couple: Couple,
+
+    /** 정산 대상 월 `yyyy-MM`. */
+    @Column(name = "year_month", nullable = false, length = 7)
+    val yearMonth: String,
+
+    /** 월 내 회차 (1부터). `(couple_id, year_month, seq)` UNIQUE. */
+    @Column(nullable = false)
+    val seq: Int,
+
+    @Column(length = 100)
+    var label: String? = null,
+
+    @Column(name = "item_count", nullable = false)
+    var itemCount: Int = 0,
+
+    @Column(name = "total_income", nullable = false)
+    var totalIncome: Long = 0,
+
+    @Column(name = "total_expense", nullable = false)
+    var totalExpense: Long = 0,
+
+    @Column(name = "total_transfer", nullable = false)
+    var totalTransfer: Long = 0,
+
+    @Column(name = "reconciled_at", nullable = false)
+    val reconciledAt: Instant = Instant.now(),
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reconciled_by", nullable = false)
+    val reconciledBy: User,
+
+    /**
+     * 항목. 헤더 삭제 시 함께 삭제된다(DB 도 ON DELETE CASCADE).
+     *
+     * 집계에서 lazy proxy 를 신뢰하지 말 것 — 소계 계산은 항목 리스트를 명시적으로
+     * 넘겨받는 [com.budgetbook.reconciliation.service.ReconciliationAggregator] 만 사용한다.
+     */
+    @OneToMany(
+        mappedBy = "reconciliation",
+        cascade = [CascadeType.ALL],
+        orphanRemoval = true,
+        fetch = FetchType.LAZY
+    )
+    val items: MutableList<ReconciliationItem> = mutableListOf()
+) : BaseTimeEntity()

--- a/backend/src/main/kotlin/com/budgetbook/reconciliation/domain/ReconciliationItem.kt
+++ b/backend/src/main/kotlin/com/budgetbook/reconciliation/domain/ReconciliationItem.kt
@@ -1,0 +1,93 @@
+package com.budgetbook.reconciliation.domain
+
+import com.budgetbook.common.entity.BaseTimeEntity
+import com.budgetbook.common.entity.Visibility
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import java.time.LocalDate
+import java.util.UUID
+
+/**
+ * 정산 스냅샷 항목 (V65).
+ *
+ * **원본 참조는 nullable 이다.** 원본 거래/이체가 삭제되면 FK 가 `ON DELETE SET NULL` 로
+ * 끊기고, `snapshot*` 필드가 "정산 당시 이런 항목이 있었다" 는 기록으로 남는다.
+ * (CASCADE 로 지우면 정산 이력이 조용히 사라져 스냅샷의 의미가 무너진다.)
+ *
+ * 그래서 어떤 종류인지는 FK 유무가 아니라 [itemKind] 로 판별한다. DB CHECK 가
+ * `TRANSACTION → transfer_id IS NULL`, `TRANSFER → transaction_id IS NULL` 을 강제한다.
+ *
+ * `transaction_id` / `transfer_id` 에는 각각 partial UNIQUE 인덱스가 있어
+ * **한 항목은 최대 1개 스냅샷에만** 속한다 (부부 동시 정산 시 한쪽은 409 로 실패).
+ */
+@Entity
+@Table(name = "reconciliation_items")
+class ReconciliationItem(
+    @Id
+    val id: UUID = UUID.randomUUID(),
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reconciliation_id", nullable = false)
+    val reconciliation: Reconciliation,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "item_kind", nullable = false, length = 20)
+    val itemKind: ReconciliationItemKind,
+
+    /** 원본 거래 id. [itemKind] 가 TRANSACTION 일 때만 값이 있고, 원본 삭제 시 null 이 된다. */
+    @Column(name = "transaction_id")
+    var transactionId: UUID? = null,
+
+    /** 원본 이체 id. [itemKind] 가 TRANSFER 일 때만 값이 있고, 원본 삭제 시 null 이 된다. */
+    @Column(name = "transfer_id")
+    var transferId: UUID? = null,
+
+    /** 정산 시점 금액. 원본이 나중에 바뀌어도 이 값은 고정. */
+    @Column(name = "snapshot_amount", nullable = false)
+    val snapshotAmount: Long,
+
+    /** 정산 시점 거래일/이체일. */
+    @Column(name = "snapshot_date", nullable = false)
+    val snapshotDate: LocalDate,
+
+    @Column(name = "snapshot_description", length = 255)
+    val snapshotDescription: String? = null,
+
+    /**
+     * 정산 시점 분류. 거래면 `INCOME`/`EXPENSE`/`ADJUSTMENT`,
+     * 이체면 `CARD_SETTLEMENT`/`EXPENSE_TRANSFER`/`INCOME_TRANSFER`/`GENERIC`.
+     * 소계 집계는 이 값으로 한다 (원본 삭제 후에도 집계가 유지되도록).
+     */
+    @Column(name = "snapshot_kind", nullable = false, length = 20)
+    val snapshotKind: String,
+
+    /**
+     * 조회자 게이팅 폴백. 원본이 살아 있으면 **원본의 현재 visibility** 를 쓴다
+     * (원본이 PRIVATE 로 바뀌면 파트너에게 즉시 안 보여야 하므로).
+     * 원본이 삭제된 뒤에는 이 복제값으로 판단한다.
+     */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "snapshot_visibility", nullable = false, length = 10)
+    val snapshotVisibility: Visibility = Visibility.SHARED,
+
+    @Column(name = "snapshot_owner_id")
+    val snapshotOwnerId: UUID? = null
+) : BaseTimeEntity() {
+
+    /** 원본 참조 id (종류 무관). 원본이 삭제되면 null. */
+    val refId: UUID?
+        get() = if (itemKind == ReconciliationItemKind.TRANSACTION) transactionId else transferId
+
+    /** 원본이 삭제되어 참조가 끊긴 항목인지. */
+    val originDeleted: Boolean
+        get() = refId == null
+}
+
+enum class ReconciliationItemKind { TRANSACTION, TRANSFER }

--- a/backend/src/main/kotlin/com/budgetbook/reconciliation/dto/ReconciliationDtos.kt
+++ b/backend/src/main/kotlin/com/budgetbook/reconciliation/dto/ReconciliationDtos.kt
@@ -1,0 +1,105 @@
+package com.budgetbook.reconciliation.dto
+
+import com.budgetbook.couple.dto.UserSummary
+import jakarta.validation.constraints.Pattern
+import jakarta.validation.constraints.Size
+import java.time.Instant
+import java.time.LocalDate
+import java.util.UUID
+
+/** 스냅샷 헤더. 소계는 조회자 게이팅 후 재계산된 값이다 (표시 행과 합계 일치 보장). */
+data class ReconciliationResponse(
+    val id: UUID,
+    val yearMonth: String,
+    val seq: Int,
+    val label: String?,
+    val itemCount: Int,
+    val totalIncome: Long,
+    val totalExpense: Long,
+    val totalTransfer: Long,
+    val reconciledAt: Instant,
+    val reconciledBy: UserSummary,
+    /** 정산 후 원본 금액/날짜가 바뀐 항목이 하나라도 있으면 true (⚠ 표시용). */
+    val hasChangedItems: Boolean = false,
+    /** 원본이 삭제된 항목이 하나라도 있으면 true. */
+    val hasDeletedItems: Boolean = false
+)
+
+data class ReconciliationDetailResponse(
+    val id: UUID,
+    val yearMonth: String,
+    val seq: Int,
+    val label: String?,
+    val itemCount: Int,
+    val totalIncome: Long,
+    val totalExpense: Long,
+    val totalTransfer: Long,
+    val reconciledAt: Instant,
+    val reconciledBy: UserSummary,
+    val hasChangedItems: Boolean,
+    val hasDeletedItems: Boolean,
+    val items: List<ReconciliationItemResponse>
+)
+
+data class ReconciliationItemResponse(
+    /** 스냅샷 항목 id. 제외(remove) 요청에 사용. */
+    val itemId: UUID,
+    val itemKind: String,
+    /** 원본 거래/이체 id. 원본이 삭제되면 null. */
+    val refId: UUID?,
+    val snapshotAmount: Long,
+    val snapshotDate: LocalDate,
+    val snapshotDescription: String?,
+    val snapshotKind: String,
+    /** 현재 원본 금액. 삭제됐으면 null. */
+    val currentAmount: Long?,
+    val currentDate: LocalDate?,
+    /** 금액 또는 날짜가 스냅샷과 다르면 true. */
+    val changedAfterReconcile: Boolean,
+    val originDeleted: Boolean
+)
+
+data class CreateReconciliationRequest(
+    @field:Pattern(regexp = "^\\d{4}-(0[1-9]|1[0-2])$", message = "yearMonth must be in yyyy-MM format")
+    val yearMonth: String,
+
+    @field:Size(max = 100)
+    val label: String? = null,
+
+    val transactionIds: List<UUID> = emptyList(),
+    val transferIds: List<UUID> = emptyList()
+)
+
+data class UpdateReconciliationRequest(
+    @field:Size(max = 100)
+    val label: String? = null,
+    val addTransactionIds: List<UUID> = emptyList(),
+    val addTransferIds: List<UUID> = emptyList(),
+    /** 제외할 **스냅샷 항목 id** (`items[].itemId`). 제외된 항목은 미기록으로 복귀. */
+    val removeItemIds: List<UUID> = emptyList()
+)
+
+/** 월말 누락 점검용 요약. "미기록 N건" 배지가 사용. */
+data class ReconciliationSummaryResponse(
+    val yearMonth: String,
+    val snapshotCount: Int,
+    val recordedCount: Int,
+    val unrecordedCount: Int,
+    val unrecordedIncome: Long,
+    val unrecordedExpense: Long,
+    val unrecordedTransfer: Long,
+    /** 미기록 항목 중 needs_review=true 인 거래 수 (정산 확정 시 경고용). */
+    val needsReviewCount: Int
+)
+
+/**
+ * 거래/이체 응답에 실어 보내는 정산 상태.
+ *
+ * `TransactionResponse` 와 `TransferResponse` **양쪽** 에 같은 필드를 붙인다. 장부 목록은 두
+ * 스트림을 FE 에서 병합하므로 한쪽만 채우면 이체 배지가 영구 미표시되는 drift 가 난다.
+ */
+data class ReconciliationRef(
+    val reconciliationId: UUID,
+    val reconciliationSeq: Int,
+    val reconciledAt: Instant
+)

--- a/backend/src/main/kotlin/com/budgetbook/reconciliation/repository/ReconciliationItemRepository.kt
+++ b/backend/src/main/kotlin/com/budgetbook/reconciliation/repository/ReconciliationItemRepository.kt
@@ -1,0 +1,35 @@
+package com.budgetbook.reconciliation.repository
+
+import com.budgetbook.reconciliation.domain.ReconciliationItem
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import java.util.UUID
+
+interface ReconciliationItemRepository : JpaRepository<ReconciliationItem, UUID> {
+
+    fun findByReconciliationId(reconciliationId: UUID): List<ReconciliationItem>
+
+    fun findByReconciliationIdIn(reconciliationIds: Collection<UUID>): List<ReconciliationItem>
+
+    /**
+     * 주어진 거래 id 중 **이미 어떤 스냅샷에 기록된** 것들.
+     * 생성/추가 시 409 판정과, 목록 응답에 정산 배지를 벌크 주입할 때 쓴다
+     * (항목당 조회 = N+1 금지).
+     */
+    @Query(
+        """
+        SELECT i FROM ReconciliationItem i
+        WHERE i.transactionId IN :transactionIds
+        """
+    )
+    fun findByTransactionIdIn(@Param("transactionIds") transactionIds: Collection<UUID>): List<ReconciliationItem>
+
+    @Query(
+        """
+        SELECT i FROM ReconciliationItem i
+        WHERE i.transferId IN :transferIds
+        """
+    )
+    fun findByTransferIdIn(@Param("transferIds") transferIds: Collection<UUID>): List<ReconciliationItem>
+}

--- a/backend/src/main/kotlin/com/budgetbook/reconciliation/repository/ReconciliationRepository.kt
+++ b/backend/src/main/kotlin/com/budgetbook/reconciliation/repository/ReconciliationRepository.kt
@@ -1,0 +1,24 @@
+package com.budgetbook.reconciliation.repository
+
+import com.budgetbook.reconciliation.domain.Reconciliation
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import java.util.UUID
+
+interface ReconciliationRepository : JpaRepository<Reconciliation, UUID> {
+
+    /** 해당 월 스냅샷 헤더 (최신 회차 먼저). `(couple_id, year_month)` 인덱스 사용. */
+    fun findByCoupleIdAndYearMonthOrderBySeqDesc(coupleId: UUID, yearMonth: String): List<Reconciliation>
+
+    fun countByCoupleIdAndYearMonth(coupleId: UUID, yearMonth: String): Int
+
+    /** 다음 회차 번호 계산용. 스냅샷이 없으면 null. */
+    @Query(
+        """
+        SELECT MAX(r.seq) FROM Reconciliation r
+        WHERE r.couple.id = :coupleId AND r.yearMonth = :yearMonth
+        """
+    )
+    fun findMaxSeq(@Param("coupleId") coupleId: UUID, @Param("yearMonth") yearMonth: String): Int?
+}

--- a/backend/src/main/kotlin/com/budgetbook/reconciliation/service/ReconciliationAggregator.kt
+++ b/backend/src/main/kotlin/com/budgetbook/reconciliation/service/ReconciliationAggregator.kt
@@ -1,0 +1,80 @@
+package com.budgetbook.reconciliation.service
+
+import com.budgetbook.reconciliation.domain.ReconciliationItem
+import com.budgetbook.transaction.domain.TransactionType
+import com.budgetbook.transfer.domain.TransferKind
+import org.springframework.stereotype.Component
+
+/**
+ * 정산 스냅샷 소계 집계의 **단일 진입점**.
+ *
+ * 금액 집계 로직이 여러 곳에 흩어져 "한 곳만 고치고 나머지를 빠뜨리는" 사고가 6회 반복됐다
+ * (2026-04-02 19곳 누락, 2026-04-14 이체 이중 합산, 카드 요약 이체 미포함 …).
+ * 그래서 정산 관련 합계는 반드시 이 컴포넌트만 사용한다 — 서비스·컨트롤러에서
+ * `sumOf` 를 직접 쓰지 않는다.
+ *
+ * 규칙은 기존 장부 집계(`ExpenseCalculator`, FE `LedgerSummary.from`) 와 1:1 대응한다.
+ * - Transaction INCOME → 수입 / EXPENSE → 지출 / **ADJUSTMENT → 양쪽 제외**
+ * - Transfer EXPENSE_TRANSFER → 지출 / INCOME_TRANSFER → 수입 / GENERIC → 이체
+ * - Transfer **CARD_SETTLEMENT → 전 버킷 제외** (원본 지출이 이미 집계됨)
+ *
+ * 집계는 항목의 `snapshotKind`/`snapshotAmount` 기준이다. 원본이 삭제된 뒤에도
+ * 스냅샷 소계가 유지되어야 하기 때문이다(= 스냅샷의 존재 이유).
+ */
+@Component
+class ReconciliationAggregator {
+
+    data class Totals(
+        val itemCount: Int,
+        val totalIncome: Long,
+        val totalExpense: Long,
+        val totalTransfer: Long
+    ) {
+        companion object {
+            val ZERO = Totals(0, 0, 0, 0)
+        }
+    }
+
+    /**
+     * 집계 입력의 최소 단위. 스냅샷 항목뿐 아니라 **미기록 항목**(아직 스냅샷이 아닌 거래/이체)도
+     * 같은 규칙으로 집계하기 위한 표현이다 — 규칙이 두 벌로 갈라지면
+     * "미기록 + Σ스냅샷 = 월 전체" 가 깨진다.
+     */
+    data class Entry(val kind: String, val amount: Long)
+
+    fun aggregate(items: Collection<ReconciliationItem>): Totals =
+        aggregateEntries(items.map { Entry(it.snapshotKind, it.snapshotAmount) })
+
+    fun aggregateEntries(entries: Collection<Entry>): Totals {
+        var income = 0L
+        var expense = 0L
+        var transfer = 0L
+
+        for (entry in entries) {
+            when (entry.kind) {
+                TransactionType.INCOME.name -> income += entry.amount
+                TransactionType.EXPENSE.name -> expense += entry.amount
+                // ADJUSTMENT: 실잔액 보정용 — 수입/지출 어디에도 넣지 않는다.
+                TransactionType.ADJUSTMENT.name -> Unit
+                TransferKind.EXPENSE_TRANSFER.name -> expense += entry.amount
+                TransferKind.INCOME_TRANSFER.name -> income += entry.amount
+                TransferKind.GENERIC.name -> transfer += entry.amount
+                // CARD_SETTLEMENT: 원본 EXPENSE 가 이미 집계됨 → 이중 계상 방지로 제외.
+                TransferKind.CARD_SETTLEMENT.name -> Unit
+                else -> Unit
+            }
+        }
+
+        return Totals(
+            itemCount = entries.size,
+            totalIncome = income,
+            totalExpense = expense,
+            totalTransfer = transfer
+        )
+    }
+
+    /** 거래/이체 원본으로부터 스냅샷에 저장할 분류 문자열을 만든다. */
+    fun snapshotKindOf(type: TransactionType): String = type.name
+
+    fun snapshotKindOf(kind: TransferKind): String = kind.name
+}

--- a/backend/src/main/kotlin/com/budgetbook/reconciliation/service/ReconciliationLookup.kt
+++ b/backend/src/main/kotlin/com/budgetbook/reconciliation/service/ReconciliationLookup.kt
@@ -1,0 +1,43 @@
+package com.budgetbook.reconciliation.service
+
+import com.budgetbook.reconciliation.domain.ReconciliationItem
+import com.budgetbook.reconciliation.dto.ReconciliationRef
+import com.budgetbook.reconciliation.repository.ReconciliationItemRepository
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+/**
+ * 거래/이체 목록 응답에 붙일 정산 상태를 **벌크** 로 조회하는 좁은 컴포넌트.
+ *
+ * 목록 서비스(TransactionService·TransferService)가 정산 도메인 전체(ReconciliationService)에
+ * 의존하지 않도록 조회 전용으로 분리했다. 항목당 조회(N+1)를 막는 유일한 진입점이며,
+ * 목록 서비스는 반드시 이 컴포넌트를 통해서만 정산 상태를 읽는다.
+ *
+ * 거래용/이체용 메서드가 **쌍으로** 존재한다는 점이 중요하다 — 장부 목록은 두 스트림 병합이라
+ * 한쪽만 채우면 이체 배지가 영구 미표시되는 drift 가 난다.
+ */
+@Component
+class ReconciliationLookup(
+    private val reconciliationItemRepository: ReconciliationItemRepository
+) {
+
+    fun refsForTransactions(transactionIds: Collection<UUID>): Map<UUID, ReconciliationRef> {
+        if (transactionIds.isEmpty()) return emptyMap()
+        return reconciliationItemRepository.findByTransactionIdIn(transactionIds)
+            .mapNotNull { item -> item.transactionId?.let { it to item.toRef() } }
+            .toMap()
+    }
+
+    fun refsForTransfers(transferIds: Collection<UUID>): Map<UUID, ReconciliationRef> {
+        if (transferIds.isEmpty()) return emptyMap()
+        return reconciliationItemRepository.findByTransferIdIn(transferIds)
+            .mapNotNull { item -> item.transferId?.let { it to item.toRef() } }
+            .toMap()
+    }
+
+    private fun ReconciliationItem.toRef() = ReconciliationRef(
+        reconciliationId = reconciliation.id,
+        reconciliationSeq = reconciliation.seq,
+        reconciledAt = reconciliation.reconciledAt
+    )
+}

--- a/backend/src/main/kotlin/com/budgetbook/reconciliation/service/ReconciliationService.kt
+++ b/backend/src/main/kotlin/com/budgetbook/reconciliation/service/ReconciliationService.kt
@@ -1,0 +1,528 @@
+package com.budgetbook.reconciliation.service
+
+import com.budgetbook.auth.repository.UserRepository
+import com.budgetbook.common.entity.Visibility
+import com.budgetbook.common.exception.BusinessException
+import com.budgetbook.common.exception.ConflictException
+import com.budgetbook.common.exception.ForbiddenException
+import com.budgetbook.common.exception.NotFoundException
+import com.budgetbook.couple.domain.Couple
+import com.budgetbook.couple.dto.UserSummary
+import com.budgetbook.couple.service.CoupleResolver
+import com.budgetbook.reconciliation.domain.Reconciliation
+import com.budgetbook.reconciliation.domain.ReconciliationItem
+import com.budgetbook.reconciliation.domain.ReconciliationItemKind
+import com.budgetbook.reconciliation.dto.CreateReconciliationRequest
+import com.budgetbook.reconciliation.dto.ReconciliationDetailResponse
+import com.budgetbook.reconciliation.dto.ReconciliationItemResponse
+import com.budgetbook.reconciliation.dto.ReconciliationResponse
+import com.budgetbook.reconciliation.dto.ReconciliationSummaryResponse
+import com.budgetbook.reconciliation.dto.UpdateReconciliationRequest
+import com.budgetbook.reconciliation.repository.ReconciliationItemRepository
+import com.budgetbook.reconciliation.repository.ReconciliationRepository
+import com.budgetbook.sync.SyncEvent
+import com.budgetbook.sync.SyncEventPublisher
+import com.budgetbook.transaction.domain.Transaction
+import com.budgetbook.transaction.repository.TransactionRepository
+import com.budgetbook.transaction.repository.TransactionSpecifications
+import com.budgetbook.transfer.domain.Transfer
+import com.budgetbook.transfer.repository.TransferRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+import java.time.YearMonth
+import java.util.UUID
+
+/**
+ * 정산 스냅샷 서비스.
+ *
+ * 핵심 규칙 4가지
+ *  1) **한 항목은 최대 1개 스냅샷** — DB partial unique 로도 강제되지만, 사용자에게 의미 있는
+ *     409 를 주기 위해 서비스에서도 선검사한다. 동시 요청 경합은 DB 제약이 최종 방어선.
+ *  2) **조회자 게이팅 후 재집계** — 파트너의 PRIVATE 항목은 목록에서 빼고 소계도 다시 계산한다.
+ *     전체 기준 소계를 그대로 주면 "합계 ≠ 보이는 행" 불일치가 된다.
+ *  3) **소계 계산은 [ReconciliationAggregator] 단독** — 서비스에서 sumOf 를 직접 쓰지 않는다.
+ *  4) **저장 순서 saveAndFlush(헤더) → items** — items 가 헤더 PK 를 FK 참조하므로,
+ *     flush 없이 진행하면 FK 위반이 날 수 있다 (2026-07-22 카드 정산 FK 사고와 같은 부류).
+ */
+@Service
+class ReconciliationService(
+    private val reconciliationRepository: ReconciliationRepository,
+    private val reconciliationItemRepository: ReconciliationItemRepository,
+    private val transactionRepository: TransactionRepository,
+    private val transferRepository: TransferRepository,
+    private val userRepository: UserRepository,
+    private val coupleResolver: CoupleResolver,
+    private val aggregator: ReconciliationAggregator,
+    private val syncEventPublisher: SyncEventPublisher
+) {
+
+    companion object {
+        /** 한 번에 정산할 수 있는 항목 수 상한 (단일 트랜잭션 시간 보호). */
+        const val MAX_ITEMS_PER_REQUEST = 1000
+    }
+
+    // ── 조회 ──────────────────────────────────────────────────────────────────
+
+    @Transactional(readOnly = true)
+    fun listReconciliations(userId: UUID, year: Int, month: Int): List<ReconciliationResponse> {
+        val couple = coupleResolver.getActiveCouple(userId)
+        val yearMonth = formatYearMonth(year, month)
+
+        val headers = reconciliationRepository
+            .findByCoupleIdAndYearMonthOrderBySeqDesc(couple.id, yearMonth)
+        if (headers.isEmpty()) return emptyList()
+
+        // 항목을 한 번에 벌크 조회 (헤더당 조회 = N+1 금지).
+        val itemsByHeader = reconciliationItemRepository
+            .findByReconciliationIdIn(headers.map { it.id })
+            .groupBy { it.reconciliation.id }
+
+        val origins = loadOrigins(itemsByHeader.values.flatten())
+
+        return headers.map { header ->
+            val visible = itemsByHeader[header.id].orEmpty().filter { visibleTo(it, origins, userId) }
+            val totals = aggregator.aggregate(visible)
+            ReconciliationResponse(
+                id = header.id,
+                yearMonth = header.yearMonth,
+                seq = header.seq,
+                label = header.label,
+                itemCount = totals.itemCount,
+                totalIncome = totals.totalIncome,
+                totalExpense = totals.totalExpense,
+                totalTransfer = totals.totalTransfer,
+                reconciledAt = header.reconciledAt,
+                reconciledBy = header.reconciledBy.toSummary(),
+                hasChangedItems = visible.any { changedAfterReconcile(it, origins) },
+                hasDeletedItems = visible.any { it.originDeleted }
+            )
+        }
+    }
+
+    @Transactional(readOnly = true)
+    fun getReconciliation(userId: UUID, id: UUID): ReconciliationDetailResponse {
+        val couple = coupleResolver.getActiveCouple(userId)
+        val header = findOwnedHeader(id, couple)
+        val items = reconciliationItemRepository.findByReconciliationId(header.id)
+        return toDetail(header, items, userId)
+    }
+
+    /**
+     * 월말 누락 점검 요약.
+     *
+     * 미기록 = 해당 월 항목 중 어떤 스냅샷에도 없는 것. 거래는 조회자 게이팅된 Specification
+     * 으로, 이체는 월 전체를 가져와 계산한다 (이체는 현재 전부 SHARED).
+     */
+    @Transactional(readOnly = true)
+    fun getSummary(userId: UUID, year: Int, month: Int): ReconciliationSummaryResponse {
+        val couple = coupleResolver.getActiveCouple(userId)
+        val yearMonth = formatYearMonth(year, month)
+        val ym = YearMonth.of(year, month)
+
+        val transactions = transactionRepository.findAll(
+            TransactionSpecifications.withFilters(
+                coupleId = couple.id,
+                startDate = ym.atDay(1),
+                endDate = ym.atEndOfMonth(),
+                type = null, categoryId = null, keyword = null,
+                paymentMethodId = null, pocketId = null,
+                amountMin = null, amountMax = null,
+                userId = userId
+            )
+        )
+        val transfers = transferRepository
+            .findByCoupleIdAndTransferDateBetweenOrderByTransferDateDesc(
+                couple.id, ym.atDay(1), ym.atEndOfMonth()
+            )
+
+        val reconciledTxIds = transactions.takeIf { it.isNotEmpty() }
+            ?.let { txs -> reconciliationItemRepository.findByTransactionIdIn(txs.map { it.id }) }
+            ?.mapNotNull { it.transactionId }?.toSet() ?: emptySet()
+        val reconciledTfIds = transfers.takeIf { it.isNotEmpty() }
+            ?.let { tfs -> reconciliationItemRepository.findByTransferIdIn(tfs.map { it.id }) }
+            ?.mapNotNull { it.transferId }?.toSet() ?: emptySet()
+
+        val unrecordedTx = transactions.filter { it.id !in reconciledTxIds }
+        val unrecordedTf = transfers.filter { it.id !in reconciledTfIds }
+
+        // 미기록 소계도 스냅샷과 **같은 집계기** 로 계산한다 (규칙이 두 벌로 갈라지면
+        // "미기록 + Σ스냅샷 = 월 전체" 가 깨진다).
+        val entries =
+            unrecordedTx.map { ReconciliationAggregator.Entry(it.type.name, it.amount) } +
+                unrecordedTf.map { ReconciliationAggregator.Entry(it.kind.name, it.amount) }
+        val totals = aggregator.aggregateEntries(entries)
+
+        return ReconciliationSummaryResponse(
+            yearMonth = yearMonth,
+            snapshotCount = reconciliationRepository.countByCoupleIdAndYearMonth(couple.id, yearMonth),
+            recordedCount = reconciledTxIds.size + reconciledTfIds.size,
+            unrecordedCount = totals.itemCount,
+            unrecordedIncome = totals.totalIncome,
+            unrecordedExpense = totals.totalExpense,
+            unrecordedTransfer = totals.totalTransfer,
+            needsReviewCount = unrecordedTx.count { it.needsReview }
+        )
+    }
+
+    // ── 변경 ──────────────────────────────────────────────────────────────────
+
+    @Transactional
+    fun createReconciliation(userId: UUID, request: CreateReconciliationRequest): ReconciliationDetailResponse {
+        val couple = coupleResolver.getActiveCouple(userId)
+        val user = userRepository.findById(userId)
+            .orElseThrow { NotFoundException("USER_NOT_FOUND", "User not found.") }
+
+        val totalRequested = request.transactionIds.size + request.transferIds.size
+        if (totalRequested == 0) {
+            throw BusinessException("VALIDATION_ERROR", "정산할 항목을 1건 이상 선택하세요.")
+        }
+        if (totalRequested > MAX_ITEMS_PER_REQUEST) {
+            throw BusinessException(
+                "VALIDATION_ERROR",
+                "한 번에 정산할 수 있는 항목은 최대 ${MAX_ITEMS_PER_REQUEST}건입니다."
+            )
+        }
+
+        val nextSeq = (reconciliationRepository.findMaxSeq(couple.id, request.yearMonth) ?: 0) + 1
+        val header = Reconciliation(
+            couple = couple,
+            yearMonth = request.yearMonth,
+            seq = nextSeq,
+            label = request.label?.takeIf { it.isNotBlank() },
+            reconciledBy = user
+        )
+        // items 가 헤더 PK 를 FK 참조 → flush 로 헤더 row 를 먼저 확정한다.
+        val savedHeader = reconciliationRepository.saveAndFlush(header)
+
+        val items = buildItems(
+            couple = couple,
+            userId = userId,
+            header = savedHeader,
+            yearMonth = request.yearMonth,
+            transactionIds = request.transactionIds,
+            transferIds = request.transferIds
+        )
+        reconciliationItemRepository.saveAll(items)
+        applyTotals(savedHeader, items)
+        reconciliationRepository.save(savedHeader)
+
+        publish("RECONCILIATION_CREATED", savedHeader.id, couple.id, userId)
+        return toDetail(savedHeader, items, userId)
+    }
+
+    @Transactional
+    fun updateReconciliation(
+        userId: UUID,
+        id: UUID,
+        request: UpdateReconciliationRequest
+    ): ReconciliationDetailResponse {
+        val couple = coupleResolver.getActiveCouple(userId)
+        val header = findOwnedHeader(id, couple)
+
+        val current = reconciliationItemRepository.findByReconciliationId(header.id).toMutableList()
+
+        // 1) 제외 — 제외된 항목은 미기록으로 복귀한다.
+        if (request.removeItemIds.isNotEmpty()) {
+            val removeIds = request.removeItemIds.toSet()
+            val toRemove = current.filter { it.id in removeIds }
+            val unknown = removeIds - toRemove.map { it.id }.toSet()
+            if (unknown.isNotEmpty()) {
+                throw NotFoundException(
+                    "RECONCILIATION_NOT_FOUND",
+                    "이 정산에 없는 항목이 포함되어 있습니다."
+                )
+            }
+            reconciliationItemRepository.deleteAll(toRemove)
+            current.removeAll(toRemove)
+        }
+
+        // 2) 추가
+        val added = buildItems(
+            couple = couple,
+            userId = userId,
+            header = header,
+            yearMonth = header.yearMonth,
+            transactionIds = request.addTransactionIds,
+            transferIds = request.addTransferIds
+        )
+        if (added.isNotEmpty()) {
+            if (current.size + added.size > MAX_ITEMS_PER_REQUEST) {
+                throw BusinessException(
+                    "VALIDATION_ERROR",
+                    "한 스냅샷의 항목은 최대 ${MAX_ITEMS_PER_REQUEST}건입니다."
+                )
+            }
+            reconciliationItemRepository.saveAll(added)
+            current.addAll(added)
+        }
+
+        request.label?.let { header.label = it.takeIf { l -> l.isNotBlank() } }
+
+        // 3) 항목이 하나도 남지 않으면 빈 스냅샷을 남기지 않고 삭제한다.
+        if (current.isEmpty()) {
+            reconciliationRepository.delete(header)
+            publish("RECONCILIATION_DELETED", header.id, couple.id, userId)
+            return ReconciliationDetailResponse(
+                id = header.id,
+                yearMonth = header.yearMonth,
+                seq = header.seq,
+                label = header.label,
+                itemCount = 0,
+                totalIncome = 0,
+                totalExpense = 0,
+                totalTransfer = 0,
+                reconciledAt = header.reconciledAt,
+                reconciledBy = header.reconciledBy.toSummary(),
+                hasChangedItems = false,
+                hasDeletedItems = false,
+                items = emptyList()
+            )
+        }
+
+        applyTotals(header, current)
+        reconciliationRepository.save(header)
+        publish("RECONCILIATION_UPDATED", header.id, couple.id, userId)
+        return toDetail(header, current, userId)
+    }
+
+    @Transactional
+    fun deleteReconciliation(userId: UUID, id: UUID) {
+        val couple = coupleResolver.getActiveCouple(userId)
+        val header = findOwnedHeader(id, couple)
+        // items 는 FK ON DELETE CASCADE + orphanRemoval 로 함께 삭제되고,
+        // 담겨 있던 거래/이체는 (원본 그대로) 미기록으로 복귀한다.
+        reconciliationRepository.delete(header)
+        publish("RECONCILIATION_DELETED", id, couple.id, userId)
+    }
+
+    // ── 내부 ──────────────────────────────────────────────────────────────────
+
+    /**
+     * 요청 id 들을 검증해 스냅샷 항목으로 만든다.
+     *
+     * 검증: 커플 소속 → 조회자 가시성 → 대상 월 일치 → 이미 정산됨(409).
+     */
+    private fun buildItems(
+        couple: Couple,
+        userId: UUID,
+        header: Reconciliation,
+        yearMonth: String,
+        transactionIds: List<UUID>,
+        transferIds: List<UUID>
+    ): List<ReconciliationItem> {
+        if (transactionIds.isEmpty() && transferIds.isEmpty()) return emptyList()
+
+        val items = mutableListOf<ReconciliationItem>()
+
+        if (transactionIds.isNotEmpty()) {
+            val distinctIds = transactionIds.distinct()
+            val found = transactionRepository.findAllById(distinctIds).associateBy { it.id }
+            val alreadyReconciled = reconciliationItemRepository.findByTransactionIdIn(distinctIds)
+                .mapNotNull { it.transactionId }.toSet()
+
+            for (txId in distinctIds) {
+                val tx = found[txId]
+                    ?: throw NotFoundException("TRANSACTION_NOT_FOUND", "Transaction does not exist.")
+                if (tx.couple.id != couple.id) {
+                    throw ForbiddenException("FORBIDDEN", "Transaction belongs to a different couple.")
+                }
+                if (!canSee(tx.visibility, tx.owner?.id, userId)) {
+                    throw ForbiddenException("FORBIDDEN", "Cannot reconcile a partner's private transaction.")
+                }
+                requireSameMonth(tx.transactionDate, yearMonth)
+                if (txId in alreadyReconciled) {
+                    throw ConflictException(
+                        "ALREADY_RECONCILED",
+                        "이미 정산에 기록된 거래가 포함되어 있습니다."
+                    )
+                }
+                items += ReconciliationItem(
+                    reconciliation = header,
+                    itemKind = ReconciliationItemKind.TRANSACTION,
+                    transactionId = tx.id,
+                    snapshotAmount = tx.amount,
+                    snapshotDate = tx.transactionDate,
+                    snapshotDescription = tx.description,
+                    snapshotKind = aggregator.snapshotKindOf(tx.type),
+                    snapshotVisibility = tx.visibility,
+                    snapshotOwnerId = tx.owner?.id
+                )
+            }
+        }
+
+        if (transferIds.isNotEmpty()) {
+            val distinctIds = transferIds.distinct()
+            val found = transferRepository.findAllById(distinctIds).associateBy { it.id }
+            val alreadyReconciled = reconciliationItemRepository.findByTransferIdIn(distinctIds)
+                .mapNotNull { it.transferId }.toSet()
+
+            for (tfId in distinctIds) {
+                val tf = found[tfId]
+                    ?: throw NotFoundException("TRANSFER_NOT_FOUND", "Transfer does not exist.")
+                if (tf.couple.id != couple.id) {
+                    throw ForbiddenException("FORBIDDEN", "Transfer belongs to a different couple.")
+                }
+                requireSameMonth(tf.transferDate, yearMonth)
+                if (tfId in alreadyReconciled) {
+                    throw ConflictException(
+                        "ALREADY_RECONCILED",
+                        "이미 정산에 기록된 이체가 포함되어 있습니다."
+                    )
+                }
+                items += ReconciliationItem(
+                    reconciliation = header,
+                    itemKind = ReconciliationItemKind.TRANSFER,
+                    transferId = tf.id,
+                    snapshotAmount = tf.amount,
+                    snapshotDate = tf.transferDate,
+                    snapshotDescription = tf.description,
+                    snapshotKind = aggregator.snapshotKindOf(tf.kind),
+                    // 이체는 현재 전부 공유 자산 기준 (개인 자산 도입 시 함께 확장).
+                    snapshotVisibility = Visibility.SHARED,
+                    snapshotOwnerId = null
+                )
+            }
+        }
+
+        return items
+    }
+
+    private fun applyTotals(header: Reconciliation, items: Collection<ReconciliationItem>) {
+        val totals = aggregator.aggregate(items)
+        header.itemCount = totals.itemCount
+        header.totalIncome = totals.totalIncome
+        header.totalExpense = totals.totalExpense
+        header.totalTransfer = totals.totalTransfer
+    }
+
+    private fun findOwnedHeader(id: UUID, couple: Couple): Reconciliation {
+        val header = reconciliationRepository.findById(id).orElseThrow {
+            NotFoundException("RECONCILIATION_NOT_FOUND", "Reconciliation does not exist.")
+        }
+        if (header.couple.id != couple.id) {
+            // 다른 커플의 스냅샷은 존재 자체를 노출하지 않는다.
+            throw NotFoundException("RECONCILIATION_NOT_FOUND", "Reconciliation does not exist.")
+        }
+        return header
+    }
+
+    private fun toDetail(
+        header: Reconciliation,
+        items: Collection<ReconciliationItem>,
+        userId: UUID
+    ): ReconciliationDetailResponse {
+        val origins = loadOrigins(items)
+        val visible = items.filter { visibleTo(it, origins, userId) }
+        val totals = aggregator.aggregate(visible)
+
+        return ReconciliationDetailResponse(
+            id = header.id,
+            yearMonth = header.yearMonth,
+            seq = header.seq,
+            label = header.label,
+            itemCount = totals.itemCount,
+            totalIncome = totals.totalIncome,
+            totalExpense = totals.totalExpense,
+            totalTransfer = totals.totalTransfer,
+            reconciledAt = header.reconciledAt,
+            reconciledBy = header.reconciledBy.toSummary(),
+            hasChangedItems = visible.any { changedAfterReconcile(it, origins) },
+            hasDeletedItems = visible.any { it.originDeleted },
+            items = visible
+                .sortedWith(compareByDescending<ReconciliationItem> { it.snapshotDate }.thenBy { it.id })
+                .map { item ->
+                    val origin = origins.forItem(item)
+                    ReconciliationItemResponse(
+                        itemId = item.id,
+                        itemKind = item.itemKind.name,
+                        refId = item.refId,
+                        snapshotAmount = item.snapshotAmount,
+                        snapshotDate = item.snapshotDate,
+                        snapshotDescription = item.snapshotDescription,
+                        snapshotKind = item.snapshotKind,
+                        currentAmount = origin?.amount,
+                        currentDate = origin?.date,
+                        changedAfterReconcile = changedAfterReconcile(item, origins),
+                        originDeleted = item.originDeleted
+                    )
+                }
+        )
+    }
+
+    /** 항목들의 원본 거래/이체를 벌크 조회 (항목당 조회 금지). */
+    private fun loadOrigins(items: Collection<ReconciliationItem>): Origins {
+        val txIds = items.mapNotNull { it.transactionId }
+        val tfIds = items.mapNotNull { it.transferId }
+        val txs = if (txIds.isEmpty()) emptyMap() else
+            transactionRepository.findAllById(txIds).associateBy { it.id }
+        val tfs = if (tfIds.isEmpty()) emptyMap() else
+            transferRepository.findAllById(tfIds).associateBy { it.id }
+        return Origins(txs, tfs)
+    }
+
+    private data class OriginView(val amount: Long, val date: LocalDate)
+
+    private inner class Origins(
+        val transactions: Map<UUID, Transaction>,
+        val transfers: Map<UUID, Transfer>
+    ) {
+        fun forItem(item: ReconciliationItem): OriginView? = when (item.itemKind) {
+            ReconciliationItemKind.TRANSACTION ->
+                item.transactionId?.let { transactions[it] }?.let { OriginView(it.amount, it.transactionDate) }
+            ReconciliationItemKind.TRANSFER ->
+                item.transferId?.let { transfers[it] }?.let { OriginView(it.amount, it.transferDate) }
+        }
+
+        /** 게이팅 기준 visibility/owner. 원본이 있으면 **원본의 현재 값** 이 우선이다. */
+        fun visibilityOf(item: ReconciliationItem): Pair<Visibility, UUID?> {
+            val tx = item.transactionId?.let { transactions[it] }
+            return if (tx != null) tx.visibility to tx.owner?.id
+            else item.snapshotVisibility to item.snapshotOwnerId
+        }
+    }
+
+    /**
+     * 조회자에게 보이는 항목인지. 원본이 나중에 PRIVATE 로 바뀌면 파트너에게서 즉시 사라진다
+     * (스냅샷 복제값이 아니라 원본 현재 값 기준).
+     */
+    private fun visibleTo(item: ReconciliationItem, origins: Origins, userId: UUID): Boolean {
+        val (visibility, ownerId) = origins.visibilityOf(item)
+        return canSee(visibility, ownerId, userId)
+    }
+
+    private fun canSee(visibility: Visibility, ownerId: UUID?, userId: UUID): Boolean =
+        visibility != Visibility.PRIVATE || ownerId == null || ownerId == userId
+
+    /** 정산 후 원본 금액/날짜가 바뀌었는지. 원본이 삭제된 경우는 [ReconciliationItem.originDeleted] 로 구분. */
+    private fun changedAfterReconcile(item: ReconciliationItem, origins: Origins): Boolean {
+        val origin = origins.forItem(item) ?: return false
+        return origin.amount != item.snapshotAmount || origin.date != item.snapshotDate
+    }
+
+    private fun requireSameMonth(date: LocalDate, yearMonth: String) {
+        if (YearMonth.from(date).toString() != yearMonth) {
+            throw BusinessException(
+                "VALIDATION_ERROR",
+                "정산 대상 월($yearMonth) 이 아닌 항목이 포함되어 있습니다."
+            )
+        }
+    }
+
+    private fun formatYearMonth(year: Int, month: Int): String = YearMonth.of(year, month).toString()
+
+    private fun publish(type: String, entityId: UUID, coupleId: UUID, authorId: UUID) {
+        syncEventPublisher.publish(
+            SyncEvent(
+                type = type,
+                entityType = "RECONCILIATION",
+                entityId = entityId,
+                coupleId = coupleId,
+                authorId = authorId
+            )
+        )
+    }
+
+    private fun com.budgetbook.auth.domain.User.toSummary() =
+        UserSummary(id = id, nickname = nickname, profileImageUrl = profileImageUrl)
+}

--- a/backend/src/main/kotlin/com/budgetbook/transaction/controller/TransactionController.kt
+++ b/backend/src/main/kotlin/com/budgetbook/transaction/controller/TransactionController.kt
@@ -71,7 +71,9 @@ class TransactionController(
             // Phase 22 T10: 다중 타입 필터. `transactionTypes=EXPENSE&transactionTypes=INCOME`.
             transactionTypes = filter.transactionTypes,
             // V61 (2026-05-06) — 확인/입력 필요만 보기.
-            needsReviewOnly = filter.needsReviewOnly
+            needsReviewOnly = filter.needsReviewOnly,
+            // V65 (2026-07-27) — 정산 스냅샷 필터 (미기록만 보기).
+            reconciled = filter.reconciled
         ))
     }
 

--- a/backend/src/main/kotlin/com/budgetbook/transaction/dto/TransactionDtos.kt
+++ b/backend/src/main/kotlin/com/budgetbook/transaction/dto/TransactionDtos.kt
@@ -34,6 +34,12 @@ data class TransactionResponse(
     val ownerId: UUID? = null,
     // V61 (2026-05-06) — 확인/입력 필요 플래그
     val needsReview: Boolean = false,
+    // V65 (2026-07-27) — 정산 스냅샷 소속. 미기록이면 전부 null.
+    // TransferResponse 에도 **같은 3필드**가 있다 (장부 목록이 두 스트림 병합이라 한쪽만
+    // 채우면 이체 배지가 영구 미표시되는 drift 가 난다).
+    val reconciliationId: UUID? = null,
+    val reconciliationSeq: Int? = null,
+    val reconciledAt: Instant? = null,
     val createdAt: Instant,
     val updatedAt: Instant
 )

--- a/backend/src/main/kotlin/com/budgetbook/transaction/repository/TransactionSpecifications.kt
+++ b/backend/src/main/kotlin/com/budgetbook/transaction/repository/TransactionSpecifications.kt
@@ -1,6 +1,7 @@
 package com.budgetbook.transaction.repository
 
 import com.budgetbook.common.entity.Visibility
+import com.budgetbook.reconciliation.domain.ReconciliationItem
 import com.budgetbook.transaction.domain.Transaction
 import com.budgetbook.transaction.domain.TransactionType
 import jakarta.persistence.criteria.CriteriaBuilder
@@ -37,9 +38,14 @@ object TransactionSpecifications {
         types: Set<TransactionType> = emptySet(),
         // V61 (2026-05-06) — true 면 needs_review=true 거래만 (확인/입력 필요만 보기).
         // null/false 모두 미적용으로 처리 — "false 만 보기" 시나리오는 현재 요구 없음.
-        needsReviewOnly: Boolean? = null
+        needsReviewOnly: Boolean? = null,
+        // V65 (2026-07-27) 정산 스냅샷 필터.
+        //   false = 미기록만 (어떤 스냅샷에도 없는 거래), true = 기록된 것만, null = 전체.
+        // 목록은 페이지네이션되므로 미기록 판정을 클라이언트에서 하면 미로드 페이지 항목이
+        // 누락된다 → 반드시 서버(이 조건)에서 걸러야 한다.
+        reconciled: Boolean? = null
     ): Specification<Transaction> {
-        return Specification { root: Root<Transaction>, _: CriteriaQuery<*>, cb: CriteriaBuilder ->
+        return Specification { root: Root<Transaction>, query: CriteriaQuery<*>, cb: CriteriaBuilder ->
             val predicates = mutableListOf<Predicate>()
 
             predicates.add(cb.equal(root.get<Any>("couple").get<UUID>("id"), coupleId))
@@ -92,6 +98,19 @@ object TransactionSpecifications {
             // V61 — 확인/입력 필요만 보기. true 일 때만 조건 추가.
             if (needsReviewOnly == true) {
                 predicates.add(cb.isTrue(root.get("needsReview")))
+            }
+
+            // V65 — 정산 스냅샷 소속 여부. reconciliation_items 에 이 거래를 참조하는 행이
+            // 있는지로 판정한다. partial unique index `uk_recon_items_transaction` 가
+            // (transaction_id) 를 덮으므로 인덱스 스캔 1회로 끝난다.
+            reconciled?.let { wantReconciled ->
+                val subquery = query.subquery(UUID::class.java)
+                val itemRoot = subquery.from(ReconciliationItem::class.java)
+                subquery.select(itemRoot.get("id"))
+                subquery.where(cb.equal(itemRoot.get<UUID>("transactionId"), root.get<UUID>("id")))
+                predicates.add(
+                    if (wantReconciled) cb.exists(subquery) else cb.not(cb.exists(subquery))
+                )
             }
 
             // Visibility 필터:

--- a/backend/src/main/kotlin/com/budgetbook/transaction/service/TransactionService.kt
+++ b/backend/src/main/kotlin/com/budgetbook/transaction/service/TransactionService.kt
@@ -26,6 +26,7 @@ import com.budgetbook.sync.SyncEvent
 import com.budgetbook.sync.SyncEventPublisher
 import com.budgetbook.transaction.repository.TransactionRepository
 import com.budgetbook.transaction.repository.TransactionSpecifications
+import com.budgetbook.reconciliation.service.ReconciliationLookup
 import com.budgetbook.transfer.repository.TransferRepository
 import org.slf4j.LoggerFactory
 import org.springframework.data.domain.PageRequest
@@ -46,7 +47,9 @@ class TransactionService(
     private val moneyPocketRepository: MoneyPocketRepository,
     private val syncEventPublisher: SyncEventPublisher,
     private val patternLearningService: PatternLearningService,
-    private val transferRepository: TransferRepository
+    private val transferRepository: TransferRepository,
+    // V65 — 목록 응답의 정산 배지용 벌크 조회 (조회 전용 좁은 컴포넌트).
+    private val reconciliationLookup: ReconciliationLookup
 ) : CoupleAwareService {
 
     private val log = LoggerFactory.getLogger(javaClass)
@@ -78,7 +81,11 @@ class TransactionService(
         // 단수 `type` 과 병존 시 `transactionTypes` 우선 (FE toQueryParams 와 일치).
         transactionTypes: List<String>? = null,
         // V61 (2026-05-06) — true 면 needs_review=true 거래만.
-        needsReviewOnly: Boolean? = null
+        needsReviewOnly: Boolean? = null,
+        // V65 (2026-07-27) — 정산 스냅샷 필터. false=미기록만 / true=기록된 것만 / null=전체.
+        // 페이지네이션 하에서 미기록 판정을 FE 가 하면 미로드 페이지 항목이 누락되므로
+        // 반드시 서버에서 건다.
+        reconciled: Boolean? = null
     ): PageResponse<TransactionResponse> {
         val couple = getActiveCouple(userId)
 
@@ -157,7 +164,9 @@ class TransactionService(
         val hasExtendedFilters = keyword != null || paymentMethodId != null ||
             pocketId != null || amountMin != null || amountMax != null ||
             visibilityFilter != null || hasMultiFilters ||
-            needsReviewOnly == true
+            needsReviewOnly == true ||
+            // legacy JPQL 경로는 정산 서브쿼리를 모른다 → Spec 경로로 강제.
+            reconciled != null
 
         val result = if (hasExtendedFilters) {
             // 단수 categoryId 는 Set 에 이미 합쳐졌으므로 Spec 에는 Set 만 전달 (중복 조건 방지).
@@ -184,7 +193,8 @@ class TransactionService(
                 paymentMethodIds = effectivePaymentMethodIds,
                 pocketIds = effectivePocketIds,
                 types = effectiveTransactionTypes,
-                needsReviewOnly = needsReviewOnly
+                needsReviewOnly = needsReviewOnly,
+                reconciled = reconciled
             )
             transactionRepository.findAll(spec, pageable)
         } else {
@@ -199,8 +209,12 @@ class TransactionService(
             )
         }
 
+        // 정산 배지용 ref 를 **한 번의 쿼리로** 벌크 주입 (항목당 조회 = N+1 금지).
+        val reconciliationRefs =
+            reconciliationLookup.refsForTransactions(result.content.map { it.id })
+
         return PageResponse(
-            content = result.content.map { it.toResponse() },
+            content = result.content.map { it.toResponse(reconciliationRefs[it.id]) },
             page = result.number,
             size = result.size,
             totalElements = result.totalElements,
@@ -589,7 +603,9 @@ class TransactionService(
         return LocalDate.of(yearMonth.year, yearMonth.month, day)
     }
 
-    private fun Transaction.toResponse() = TransactionResponse(
+    private fun Transaction.toResponse(
+        reconciliationRef: com.budgetbook.reconciliation.dto.ReconciliationRef? = null
+    ) = TransactionResponse(
         id = id,
         coupleId = couple.id,
         author = UserSummary(
@@ -622,6 +638,9 @@ class TransactionService(
         visibility = visibility.name,
         ownerId = owner?.id,
         needsReview = needsReview,
+        reconciliationId = reconciliationRef?.reconciliationId,
+        reconciliationSeq = reconciliationRef?.reconciliationSeq,
+        reconciledAt = reconciliationRef?.reconciledAt,
         createdAt = createdAt,
         updatedAt = updatedAt
     )

--- a/backend/src/main/kotlin/com/budgetbook/transfer/controller/TransferController.kt
+++ b/backend/src/main/kotlin/com/budgetbook/transfer/controller/TransferController.kt
@@ -91,9 +91,11 @@ class TransferController(
     fun listTransfers(
         @AuthUser userId: UUID,
         @RequestParam year: Int,
-        @RequestParam month: Int
+        @RequestParam month: Int,
+        // V65 — 정산 필터. 거래 목록(`GET /transactions?reconciled=`) 과 동일 의미.
+        @RequestParam(required = false) reconciled: Boolean? = null
     ): ApiResponse<List<TransferResponse>> {
-        return ApiResponse.ok(transferService.listTransfers(userId, year, month))
+        return ApiResponse.ok(transferService.listTransfers(userId, year, month, reconciled))
     }
 
     @GetMapping("/{id}")

--- a/backend/src/main/kotlin/com/budgetbook/transfer/dto/TransferDtos.kt
+++ b/backend/src/main/kotlin/com/budgetbook/transfer/dto/TransferDtos.kt
@@ -159,5 +159,9 @@ data class TransferResponse(
     val memo: String?,
     val transferDate: LocalDate,
     val kind: TransferKind,
+    // V65 (2026-07-27) — 정산 스냅샷 소속. TransactionResponse 와 동일 3필드.
+    val reconciliationId: UUID? = null,
+    val reconciliationSeq: Int? = null,
+    val reconciledAt: Instant? = null,
     val createdAt: Instant
 )

--- a/backend/src/main/kotlin/com/budgetbook/transfer/service/TransferService.kt
+++ b/backend/src/main/kotlin/com/budgetbook/transfer/service/TransferService.kt
@@ -33,7 +33,9 @@ class TransferService(
     private val userRepository: UserRepository,
     private val paymentMethodRepository: PaymentMethodRepository,
     private val syncEventPublisher: SyncEventPublisher,
-    private val transactionRepository: TransactionRepository
+    private val transactionRepository: TransactionRepository,
+    // V65 — 목록 응답의 정산 배지/필터용 벌크 조회.
+    private val reconciliationLookup: com.budgetbook.reconciliation.service.ReconciliationLookup
 ) : CoupleAwareService {
 
     @Transactional
@@ -84,15 +86,35 @@ class TransferService(
     }
 
     @Transactional(readOnly = true)
-    fun listTransfers(userId: UUID, year: Int, month: Int): List<TransferResponse> {
+    /**
+     * 월 이체 목록.
+     *
+     * [reconciled] 는 거래 목록과 **동일한 의미** 의 정산 필터다 (false=미기록만, true=기록만,
+     * null=전체). 장부 목록은 거래+이체 병합이므로 한쪽 스트림만 필터를 지원하면
+     * "이체만 계속 남아 보이는" drift 가 난다 — 두 엔드포인트를 항상 같이 확장할 것.
+     */
+    fun listTransfers(
+        userId: UUID,
+        year: Int,
+        month: Int,
+        reconciled: Boolean? = null
+    ): List<TransferResponse> {
         val couple = getActiveCouple(userId)
         val yearMonth = YearMonth.of(year, month)
         val startDate = yearMonth.atDay(1)
         val endDate = yearMonth.atEndOfMonth()
 
-        return transferRepository.findByCoupleIdAndTransferDateBetweenOrderByTransferDateDesc(
+        val transfers = transferRepository.findByCoupleIdAndTransferDateBetweenOrderByTransferDateDesc(
             couple.id, startDate, endDate
-        ).map { it.toResponse() }
+        )
+        // 정산 ref 를 한 번에 벌크 조회 (항목당 조회 = N+1 금지).
+        val refs = reconciliationLookup.refsForTransfers(transfers.map { it.id })
+        val filtered = when (reconciled) {
+            null -> transfers
+            true -> transfers.filter { refs.containsKey(it.id) }
+            false -> transfers.filter { !refs.containsKey(it.id) }
+        }
+        return filtered.map { it.toResponse(refs[it.id]) }
     }
 
     @Transactional(readOnly = true)
@@ -408,7 +430,9 @@ class TransferService(
         else -> TransferKind.GENERIC
     }
 
-    private fun Transfer.toResponse() = TransferResponse(
+    private fun Transfer.toResponse(
+        reconciliationRef: com.budgetbook.reconciliation.dto.ReconciliationRef? = null
+    ) = TransferResponse(
         id = id,
         coupleId = couple.id,
         author = UserSummary(
@@ -431,6 +455,9 @@ class TransferService(
         memo = memo,
         transferDate = transferDate,
         kind = kind,
+        reconciliationId = reconciliationRef?.reconciliationId,
+        reconciliationSeq = reconciliationRef?.reconciliationSeq,
+        reconciledAt = reconciliationRef?.reconciledAt,
         createdAt = createdAt
     )
 }

--- a/backend/src/main/resources/db/migration/V65__create_reconciliations.sql
+++ b/backend/src/main/resources/db/migration/V65__create_reconciliations.sql
@@ -1,0 +1,75 @@
+-- V65 (2026-07-27) — 정산 스냅샷 (reconciliation)
+--
+-- 장부를 대조한 시점의 스냅샷을 기록한다. 어떤 스냅샷에도 담기지 않은 항목은
+-- "미기록" 으로 남아 월말 누락 점검에 쓰인다.
+--
+-- 이름이 비슷한 기존 개념과 무관한 별도 테이블이다:
+--   - 카드 결제      : transfers.kind = 'CARD_SETTLEMENT'
+--   - 주간 예산 정산 : weekly_budget_settlements
+--
+-- 설계 결정 3가지 (docs/sessions/2026-07-27_1_plan.md §2.3)
+--  1) 원본 삭제 시 FK 는 SET NULL + snapshot_* 컬럼으로 당시 값을 보존한다.
+--     CASCADE 면 정산 이력이 조용히 사라져 "스냅샷" 의 의미가 무너진다.
+--     그래서 XOR NOT NULL 대신 item_kind 판별자 + 조건부 CHECK 를 쓴다.
+--  2) "한 항목은 최대 1개 스냅샷" 불변식을 partial unique index 로 DB 강제한다.
+--     서비스 검증만 두면 부부가 동시에 정산할 때 중복 기록이 생겨 상단(미기록)/
+--     하단(기록) 목록이 겹친다.
+--  3) 거래와 이체 **양쪽** 을 담는다. 장부 목록은 transactions + transfers 병합이므로
+--     거래만 지원하면 이체가 영구 미기록으로 남는다.
+
+CREATE TABLE reconciliations (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    couple_id       UUID        NOT NULL REFERENCES couples(id) ON DELETE CASCADE,
+    year_month      VARCHAR(7)  NOT NULL,
+    seq             INTEGER     NOT NULL,
+    label           VARCHAR(100),
+    item_count      INTEGER     NOT NULL DEFAULT 0,
+    total_income    BIGINT      NOT NULL DEFAULT 0,
+    total_expense   BIGINT      NOT NULL DEFAULT 0,
+    total_transfer  BIGINT      NOT NULL DEFAULT 0,
+    reconciled_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    reconciled_by   UUID        NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    CONSTRAINT uk_reconciliations_couple_ym_seq UNIQUE (couple_id, year_month, seq),
+    CONSTRAINT ck_reconciliations_year_month CHECK (year_month ~ '^[0-9]{4}-(0[1-9]|1[0-2])$'),
+    CONSTRAINT ck_reconciliations_seq CHECK (seq >= 1),
+    CONSTRAINT ck_reconciliations_item_count CHECK (item_count >= 0)
+);
+
+CREATE INDEX idx_reconciliations_couple_ym ON reconciliations (couple_id, year_month);
+
+CREATE TABLE reconciliation_items (
+    id                   UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    reconciliation_id    UUID        NOT NULL REFERENCES reconciliations(id) ON DELETE CASCADE,
+    item_kind            VARCHAR(20) NOT NULL,
+    -- 원본이 삭제되면 NULL 이 되고, 아래 snapshot_* 값으로 "삭제된 거래" 를 표시한다.
+    transaction_id       UUID REFERENCES transactions(id) ON DELETE SET NULL,
+    transfer_id          UUID REFERENCES transfers(id)    ON DELETE SET NULL,
+    snapshot_amount      BIGINT      NOT NULL,
+    snapshot_date        DATE        NOT NULL,
+    snapshot_description VARCHAR(255),
+    snapshot_kind        VARCHAR(20) NOT NULL,
+    -- 원본 삭제 후 조회자 게이팅에 쓰는 폴백 값 (원본이 살아 있으면 원본 값이 우선).
+    snapshot_visibility  VARCHAR(10) NOT NULL DEFAULT 'SHARED',
+    snapshot_owner_id    UUID REFERENCES users(id) ON DELETE SET NULL,
+    created_at           TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at           TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    CONSTRAINT ck_recon_items_kind CHECK (item_kind IN ('TRANSACTION', 'TRANSFER')),
+    CONSTRAINT ck_recon_items_ref CHECK (
+        (item_kind = 'TRANSACTION' AND transfer_id IS NULL) OR
+        (item_kind = 'TRANSFER'    AND transaction_id IS NULL)
+    ),
+    CONSTRAINT ck_recon_items_visibility CHECK (snapshot_visibility IN ('SHARED', 'PRIVATE'))
+);
+
+-- 불변식: 한 거래/이체는 전 기간에 걸쳐 최대 1개 스냅샷에만 속한다.
+-- (PostgreSQL 은 NULL 을 서로 다른 값으로 보므로 partial index 로 NULL 을 제외한다.)
+CREATE UNIQUE INDEX uk_recon_items_transaction
+    ON reconciliation_items (transaction_id) WHERE transaction_id IS NOT NULL;
+CREATE UNIQUE INDEX uk_recon_items_transfer
+    ON reconciliation_items (transfer_id) WHERE transfer_id IS NOT NULL;
+
+CREATE INDEX idx_recon_items_reconciliation ON reconciliation_items (reconciliation_id);

--- a/backend/src/test/kotlin/com/budgetbook/reconciliation/controller/ReconciliationControllerTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/reconciliation/controller/ReconciliationControllerTest.kt
@@ -1,0 +1,118 @@
+package com.budgetbook.reconciliation.controller
+
+import com.budgetbook.couple.dto.UserSummary
+import com.budgetbook.reconciliation.dto.CreateReconciliationRequest
+import com.budgetbook.reconciliation.dto.ReconciliationDetailResponse
+import com.budgetbook.reconciliation.dto.ReconciliationResponse
+import com.budgetbook.reconciliation.dto.ReconciliationSummaryResponse
+import com.budgetbook.reconciliation.dto.UpdateReconciliationRequest
+import com.budgetbook.reconciliation.service.ReconciliationService
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.springframework.http.HttpStatus
+import java.time.Instant
+import java.util.UUID
+
+class ReconciliationControllerTest : FunSpec({
+
+    val service = mockk<ReconciliationService>(relaxed = true)
+    val controller = ReconciliationController(service)
+    val userId = UUID.randomUUID()
+    val reconciliationId = UUID.randomUUID()
+    val author = UserSummary(id = userId, nickname = "홍길동", profileImageUrl = null)
+
+    fun header(seq: Int) = ReconciliationResponse(
+        id = reconciliationId,
+        yearMonth = "2026-07",
+        seq = seq,
+        label = "${seq}차",
+        itemCount = 3,
+        totalIncome = 0,
+        totalExpense = 30000,
+        totalTransfer = 0,
+        reconciledAt = Instant.parse("2026-07-20T14:03:00Z"),
+        reconciledBy = author
+    )
+
+    fun detail() = ReconciliationDetailResponse(
+        id = reconciliationId,
+        yearMonth = "2026-07",
+        seq = 1,
+        label = "1차",
+        itemCount = 3,
+        totalIncome = 0,
+        totalExpense = 30000,
+        totalTransfer = 0,
+        reconciledAt = Instant.parse("2026-07-20T14:03:00Z"),
+        reconciledBy = author,
+        hasChangedItems = false,
+        hasDeletedItems = false,
+        items = emptyList()
+    )
+
+    test("listReconciliations 는 year/month 를 서비스로 전달한다") {
+        every { service.listReconciliations(userId, 2026, 7) } returns listOf(header(2), header(1))
+
+        val result = controller.listReconciliations(userId, 2026, 7)
+
+        result.success shouldBe true
+        result.data!!.size shouldBe 2
+        // 최신 회차 먼저 (서비스 정렬을 그대로 노출).
+        result.data!!.first().seq shouldBe 2
+        verify { service.listReconciliations(userId, 2026, 7) }
+    }
+
+    test("getSummary 는 미기록 집계를 그대로 반환한다") {
+        every { service.getSummary(userId, 2026, 7) } returns ReconciliationSummaryResponse(
+            yearMonth = "2026-07",
+            snapshotCount = 2,
+            recordedCount = 23,
+            unrecordedCount = 12,
+            unrecordedIncome = 0,
+            unrecordedExpense = 340000,
+            unrecordedTransfer = 50000,
+            needsReviewCount = 3
+        )
+
+        val result = controller.getSummary(userId, 2026, 7)
+
+        result.data!!.unrecordedCount shouldBe 12
+        result.data!!.unrecordedExpense shouldBe 340000
+        result.data!!.needsReviewCount shouldBe 3
+    }
+
+    test("createReconciliation 은 201 로 응답한다") {
+        val request = CreateReconciliationRequest(
+            yearMonth = "2026-07",
+            label = "1차",
+            transactionIds = listOf(UUID.randomUUID())
+        )
+        every { service.createReconciliation(userId, request) } returns detail()
+
+        val response = controller.createReconciliation(userId, request)
+
+        response.statusCode shouldBe HttpStatus.CREATED
+        response.body!!.data!!.seq shouldBe 1
+        verify { service.createReconciliation(userId, request) }
+    }
+
+    test("updateReconciliation 은 라벨/항목 변경 요청을 위임한다") {
+        val request = UpdateReconciliationRequest(label = "수정된 라벨")
+        every { service.updateReconciliation(userId, reconciliationId, request) } returns detail()
+
+        val result = controller.updateReconciliation(userId, reconciliationId, request)
+
+        result.success shouldBe true
+        verify { service.updateReconciliation(userId, reconciliationId, request) }
+    }
+
+    test("deleteReconciliation 은 204 를 반환한다") {
+        val response = controller.deleteReconciliation(userId, reconciliationId)
+
+        response.statusCode shouldBe HttpStatus.NO_CONTENT
+        verify { service.deleteReconciliation(userId, reconciliationId) }
+    }
+})

--- a/backend/src/test/kotlin/com/budgetbook/reconciliation/integration/ReconciliationIntegrationTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/reconciliation/integration/ReconciliationIntegrationTest.kt
@@ -1,0 +1,460 @@
+package com.budgetbook.reconciliation.integration
+
+import com.budgetbook.admin.integration.HighApiVersionDockerStrategy
+import com.budgetbook.common.exception.ConflictException
+import com.budgetbook.reconciliation.dto.CreateReconciliationRequest
+import com.budgetbook.reconciliation.dto.UpdateReconciliationRequest
+import com.budgetbook.reconciliation.service.ReconciliationService
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.extensions.spring.SpringExtension
+import io.kotest.matchers.shouldBe
+import jakarta.persistence.EntityManager
+import jakarta.persistence.PersistenceContext
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.ApplicationContextInitializer
+import org.springframework.context.ConfigurableApplicationContext
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.support.TestPropertySourceUtils
+import org.springframework.transaction.PlatformTransactionManager
+import org.springframework.transaction.support.TransactionTemplate
+import org.testcontainers.containers.PostgreSQLContainer
+import java.time.LocalDate
+import java.util.UUID
+
+/**
+ * 정산 스냅샷(V65) 통합테스트 — 실 PostgreSQL + Flyway.
+ *
+ * mock 기반 테스트로는 검증할 수 없는 것만 여기서 확인한다 (2026-07-22 카드 정산 FK 사고 교훈:
+ * mock 은 CHECK/FK/partial UNIQUE 를 절대 잡지 못한다).
+ *
+ * 1. 헤더→항목 저장 순서 (items 가 헤더 PK 를 FK 참조 → saveAndFlush 필요)
+ * 2. `uk_recon_items_transaction` partial UNIQUE — 한 거래는 최대 1개 스냅샷
+ * 3. 원본 거래 삭제 시 `ON DELETE SET NULL` — 스냅샷 기록은 남고 참조만 끊긴다
+ * 4. `ck_recon_items_ref` CHECK — item_kind 와 FK 조합 강제
+ * 5. 스냅샷 삭제 시 항목 CASCADE + 원본 거래는 보존
+ */
+@SpringBootTest
+@ActiveProfiles("integration-test")
+@ContextConfiguration(initializers = [ReconciliationIntegrationTest.DataSourceInitializer::class])
+class ReconciliationIntegrationTest(
+    private val reconciliationService: ReconciliationService,
+    @PersistenceContext private val em: EntityManager,
+    private val txManager: PlatformTransactionManager,
+) : FunSpec() {
+
+    override fun extensions() = listOf(SpringExtension)
+
+    companion object {
+        val postgres: PostgreSQLContainer<*> = PostgreSQLContainer("postgres:16-alpine")
+            .withDatabaseName("budgetbook_test")
+            .withUsername("test")
+            .withPassword("test")
+
+        init {
+            System.setProperty(
+                "testcontainers.docker.client.strategy",
+                HighApiVersionDockerStrategy::class.java.name
+            )
+            postgres.start()
+        }
+    }
+
+    class DataSourceInitializer : ApplicationContextInitializer<ConfigurableApplicationContext> {
+        override fun initialize(ctx: ConfigurableApplicationContext) {
+            TestPropertySourceUtils.addInlinedPropertiesToEnvironment(
+                ctx,
+                "spring.datasource.url=${postgres.jdbcUrl}",
+                "spring.datasource.username=${postgres.username}",
+                "spring.datasource.password=${postgres.password}",
+                "spring.datasource.driver-class-name=org.postgresql.Driver",
+                "spring.jpa.hibernate.ddl-auto=validate",
+                "spring.flyway.enabled=true",
+                "spring.flyway.baseline-on-migrate=true"
+            )
+        }
+    }
+
+    init {
+        test("스냅샷 생성 — 헤더/항목이 실제로 커밋되고 소계가 저장된다") {
+            val f = inTx { fixture("recon-create") }
+
+            val result = inTx {
+                reconciliationService.createReconciliation(
+                    f.userId,
+                    CreateReconciliationRequest(
+                        yearMonth = "2026-06",
+                        label = "1차",
+                        transactionIds = listOf(f.expenseTxnId, f.incomeTxnId),
+                        transferIds = listOf(f.genericTransferId)
+                    )
+                )
+            }
+
+            result.seq shouldBe 1
+            result.label shouldBe "1차"
+            result.itemCount shouldBe 3
+            result.totalExpense shouldBe 10000
+            result.totalIncome shouldBe 30000
+            result.totalTransfer shouldBe 5000
+
+            // 헤더 소계가 DB 에 저장돼 있어야 한다 (조회 때 재집계 없이 사용).
+            inTx {
+                countRows("reconciliations", result.id) shouldBe 1
+                itemCountOf(result.id) shouldBe 3
+                totalExpenseOf(result.id) shouldBe 10000L
+            }
+        }
+
+        test("한 거래는 최대 1개 스냅샷 — 두 번째 정산은 409") {
+            val f = inTx { fixture("recon-dup") }
+
+            inTx {
+                reconciliationService.createReconciliation(
+                    f.userId,
+                    CreateReconciliationRequest("2026-06", "1차", listOf(f.expenseTxnId))
+                )
+            }
+
+            shouldThrow<ConflictException> {
+                inTx {
+                    reconciliationService.createReconciliation(
+                        f.userId,
+                        CreateReconciliationRequest("2026-06", "2차", listOf(f.expenseTxnId))
+                    )
+                }
+            }.code shouldBe "ALREADY_RECONCILED"
+        }
+
+        test("partial UNIQUE 가 DB 레벨에서 중복 기록을 막는다 (동시 요청 최종 방어선)") {
+            val f = inTx { fixture("recon-db-unique") }
+            val created = inTx {
+                reconciliationService.createReconciliation(
+                    f.userId,
+                    CreateReconciliationRequest("2026-06", "1차", listOf(f.expenseTxnId))
+                )
+            }
+
+            // 서비스 선검사를 우회해 같은 transaction_id 를 직접 INSERT → 인덱스 위반이어야 한다.
+            shouldThrow<org.hibernate.exception.ConstraintViolationException> {
+                inTx {
+                    em.createNativeQuery(
+                        """INSERT INTO reconciliation_items
+                           (id, reconciliation_id, item_kind, transaction_id, snapshot_amount,
+                            snapshot_date, snapshot_kind, snapshot_visibility, created_at, updated_at)
+                           VALUES (:id, :rid, 'TRANSACTION', :txId, 10000, :d, 'EXPENSE', 'SHARED', now(), now())"""
+                    ).setParameter("id", UUID.randomUUID())
+                        .setParameter("rid", created.id)
+                        .setParameter("txId", f.expenseTxnId)
+                        .setParameter("d", LocalDate.of(2026, 6, 15))
+                        .executeUpdate()
+                    em.flush()
+                }
+            }
+        }
+
+        test("ck_recon_items_ref — item_kind 와 어긋난 FK 조합은 거부된다") {
+            val f = inTx { fixture("recon-check") }
+            val created = inTx {
+                reconciliationService.createReconciliation(
+                    f.userId,
+                    CreateReconciliationRequest("2026-06", "1차", listOf(f.expenseTxnId))
+                )
+            }
+
+            // item_kind=TRANSACTION 인데 transfer_id 를 채우면 CHECK 위반.
+            shouldThrow<org.hibernate.exception.ConstraintViolationException> {
+                inTx {
+                    em.createNativeQuery(
+                        """INSERT INTO reconciliation_items
+                           (id, reconciliation_id, item_kind, transfer_id, snapshot_amount,
+                            snapshot_date, snapshot_kind, snapshot_visibility, created_at, updated_at)
+                           VALUES (:id, :rid, 'TRANSACTION', :tfId, 5000, :d, 'GENERIC', 'SHARED', now(), now())"""
+                    ).setParameter("id", UUID.randomUUID())
+                        .setParameter("rid", created.id)
+                        .setParameter("tfId", f.genericTransferId)
+                        .setParameter("d", LocalDate.of(2026, 6, 20))
+                        .executeUpdate()
+                    em.flush()
+                }
+            }
+        }
+
+        test("원본 거래 삭제 — 스냅샷 항목은 남고 참조만 끊긴다 (SET NULL)") {
+            val f = inTx { fixture("recon-origin-delete") }
+            val created = inTx {
+                reconciliationService.createReconciliation(
+                    f.userId,
+                    CreateReconciliationRequest("2026-06", "1차", listOf(f.expenseTxnId))
+                )
+            }
+
+            inTx {
+                em.createNativeQuery("DELETE FROM transactions WHERE id = :id")
+                    .setParameter("id", f.expenseTxnId).executeUpdate()
+            }
+
+            // 항목 row 는 그대로, transaction_id 만 NULL.
+            inTx { itemCountOf(created.id) shouldBe 1 }
+            inTx {
+                (
+                    em.createNativeQuery(
+                        "SELECT count(*) FROM reconciliation_items WHERE reconciliation_id = :rid AND transaction_id IS NULL"
+                    ).setParameter("rid", created.id).singleResult as Number
+                    ).toInt() shouldBe 1
+            }
+
+            // 상세 응답은 "원본 삭제됨" 으로 표시하고, 소계는 스냅샷 값을 유지한다.
+            val detail = inTx { reconciliationService.getReconciliation(f.userId, created.id) }
+            detail.items.single().originDeleted shouldBe true
+            detail.items.single().currentAmount shouldBe null
+            detail.totalExpense shouldBe 10000
+        }
+
+        test("정산 후 원본 금액 변경 — changedAfterReconcile 로 표면화") {
+            val f = inTx { fixture("recon-drift") }
+            val created = inTx {
+                reconciliationService.createReconciliation(
+                    f.userId,
+                    CreateReconciliationRequest("2026-06", "1차", listOf(f.expenseTxnId))
+                )
+            }
+
+            inTx {
+                em.createNativeQuery("UPDATE transactions SET amount = 99999 WHERE id = :id")
+                    .setParameter("id", f.expenseTxnId).executeUpdate()
+            }
+
+            val detail = inTx { reconciliationService.getReconciliation(f.userId, created.id) }
+            detail.items.single().changedAfterReconcile shouldBe true
+            detail.items.single().currentAmount shouldBe 99999
+            // 스냅샷 소계는 정산 당시 값 유지 (대조 이력이므로).
+            detail.totalExpense shouldBe 10000
+            detail.hasChangedItems shouldBe true
+        }
+
+        test("스냅샷 삭제 — 항목은 CASCADE, 원본 거래는 보존되어 미기록으로 복귀") {
+            val f = inTx { fixture("recon-delete") }
+            val created = inTx {
+                reconciliationService.createReconciliation(
+                    f.userId,
+                    CreateReconciliationRequest("2026-06", "1차", listOf(f.expenseTxnId))
+                )
+            }
+
+            inTx { reconciliationService.deleteReconciliation(f.userId, created.id) }
+
+            inTx {
+                countRows("reconciliations", created.id) shouldBe 0
+                itemCountOf(created.id) shouldBe 0
+                // 원본 거래는 살아 있다.
+                (
+                    em.createNativeQuery("SELECT count(*) FROM transactions WHERE id = :id")
+                        .setParameter("id", f.expenseTxnId).singleResult as Number
+                    ).toInt() shouldBe 1
+            }
+
+            // 미기록으로 복귀 → summary 가 다시 센다.
+            val summary = inTx { reconciliationService.getSummary(f.userId, 2026, 6) }
+            summary.snapshotCount shouldBe 0
+            summary.recordedCount shouldBe 0
+            summary.unrecordedExpense shouldBe 10000
+        }
+
+        test("항목 제외로 비면 스냅샷 자체가 삭제된다") {
+            val f = inTx { fixture("recon-empty") }
+            val created = inTx {
+                reconciliationService.createReconciliation(
+                    f.userId,
+                    CreateReconciliationRequest("2026-06", "1차", listOf(f.expenseTxnId))
+                )
+            }
+            val itemId = created.items.single().itemId
+
+            val patched = inTx {
+                reconciliationService.updateReconciliation(
+                    f.userId, created.id,
+                    UpdateReconciliationRequest(removeItemIds = listOf(itemId))
+                )
+            }
+
+            patched.itemCount shouldBe 0
+            inTx { countRows("reconciliations", created.id) shouldBe 0 }
+        }
+
+        test("summary — 미기록 + 기록 = 월 전체 (ADJUSTMENT/카드결제 규칙 준수)") {
+            val f = inTx { fixture("recon-summary") }
+
+            val before = inTx { reconciliationService.getSummary(f.userId, 2026, 6) }
+            // 지출 10000 + 수입 30000 + 이체 5000 + ADJUSTMENT(집계 제외) + 카드결제 이체(제외)
+            before.unrecordedCount shouldBe 5
+            before.unrecordedExpense shouldBe 10000
+            before.unrecordedIncome shouldBe 30000
+            before.unrecordedTransfer shouldBe 5000
+
+            inTx {
+                reconciliationService.createReconciliation(
+                    f.userId,
+                    CreateReconciliationRequest("2026-06", "1차", listOf(f.expenseTxnId))
+                )
+            }
+
+            val after = inTx { reconciliationService.getSummary(f.userId, 2026, 6) }
+            after.snapshotCount shouldBe 1
+            after.recordedCount shouldBe 1
+            after.unrecordedCount shouldBe 4
+            // 기록된 지출이 미기록에서 빠진다 → 합은 보존.
+            after.unrecordedExpense shouldBe 0
+            (after.unrecordedExpense + 10000) shouldBe before.unrecordedExpense
+        }
+
+        test("다른 달 항목을 섞으면 400") {
+            val f = inTx { fixture("recon-month") }
+            shouldThrow<com.budgetbook.common.exception.BusinessException> {
+                inTx {
+                    reconciliationService.createReconciliation(
+                        f.userId,
+                        CreateReconciliationRequest("2026-07", "잘못된 달", listOf(f.expenseTxnId))
+                    )
+                }
+            }.code shouldBe "VALIDATION_ERROR"
+        }
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────────────
+
+    private data class Fixture(
+        val userId: UUID,
+        val coupleId: UUID,
+        val expenseTxnId: UUID,
+        val incomeTxnId: UUID,
+        val adjustmentTxnId: UUID,
+        val genericTransferId: UUID,
+        val cardSettlementTransferId: UUID
+    )
+
+    private fun <T> inTx(action: () -> T): T =
+        TransactionTemplate(txManager).execute { action() }!!
+
+    /** 2026-06 에 거래 3건(지출/수입/조정) + 이체 2건(일반/카드결제)을 만든다. */
+    private fun fixture(tag: String): Fixture {
+        val userId = insertUser("$tag@test.com")
+        val coupleId = insertSelfCouple(userId)
+        val categoryId = insertCategory(coupleId)
+        val bankId = insertPaymentMethod(coupleId, "$tag-은행", "BANK")
+        val cashId = insertPaymentMethod(coupleId, "$tag-현금", "CASH")
+        val cardId = insertPaymentMethod(coupleId, "$tag-카드", "CREDIT")
+
+        return Fixture(
+            userId = userId,
+            coupleId = coupleId,
+            expenseTxnId = insertTxn(coupleId, userId, categoryId, "EXPENSE", 10000, LocalDate.of(2026, 6, 15)),
+            incomeTxnId = insertTxn(coupleId, userId, categoryId, "INCOME", 30000, LocalDate.of(2026, 6, 10)),
+            adjustmentTxnId = insertTxn(coupleId, userId, null, "ADJUSTMENT", -2000, LocalDate.of(2026, 6, 18)),
+            genericTransferId = insertTransfer(coupleId, userId, bankId, cashId, 5000, "GENERIC"),
+            cardSettlementTransferId = insertTransfer(coupleId, userId, bankId, cardId, 70000, "CARD_SETTLEMENT")
+        )
+    }
+
+    private fun insertUser(email: String): UUID {
+        val id = UUID.randomUUID()
+        em.createNativeQuery(
+            """INSERT INTO users (id, email, nickname, provider, provider_id, role, is_active, created_at, updated_at)
+               VALUES (:id, :email, 'Reconciler', 'GOOGLE', :pid, 'USER', true, now(), now())"""
+        ).setParameter("id", id).setParameter("email", email)
+            .setParameter("pid", UUID.randomUUID().toString()).executeUpdate()
+        return id
+    }
+
+    private fun insertSelfCouple(userId: UUID): UUID {
+        val id = UUID.randomUUID()
+        em.createNativeQuery(
+            """INSERT INTO couples (id, user1_id, user2_id, status, is_self, created_at, updated_at)
+               VALUES (:id, :userId, null, 'ACTIVE', true, now(), now())"""
+        ).setParameter("id", id).setParameter("userId", userId).executeUpdate()
+        return id
+    }
+
+    private fun insertCategory(coupleId: UUID): UUID {
+        val id = UUID.randomUUID()
+        em.createNativeQuery(
+            """INSERT INTO categories (id, couple_id, name, type, is_default, display_order, created_at, updated_at)
+               VALUES (:id, :coupleId, '식비', 'EXPENSE', false, 0, now(), now())"""
+        ).setParameter("id", id).setParameter("coupleId", coupleId).executeUpdate()
+        return id
+    }
+
+    private fun insertPaymentMethod(coupleId: UUID, name: String, type: String): UUID {
+        val id = UUID.randomUUID()
+        em.createNativeQuery(
+            """INSERT INTO payment_methods (id, couple_id, name, type, is_active, is_default, display_order, created_at, updated_at)
+               VALUES (:id, :coupleId, :name, :type, true, false, 0, now(), now())"""
+        ).setParameter("id", id).setParameter("coupleId", coupleId)
+            .setParameter("name", name).setParameter("type", type).executeUpdate()
+        return id
+    }
+
+    private fun insertTxn(
+        coupleId: UUID,
+        authorId: UUID,
+        categoryId: UUID?,
+        type: String,
+        amount: Long,
+        date: LocalDate
+    ): UUID {
+        val id = UUID.randomUUID()
+        em.createNativeQuery(
+            """INSERT INTO transactions
+               (id, couple_id, author_id, category_id, type, amount, description, transaction_date,
+                visibility, needs_review, created_at, updated_at)
+               VALUES (:id, :coupleId, :authorId, :categoryId, :type, :amount, :desc, :d,
+                       'SHARED', false, now(), now())"""
+        ).setParameter("id", id).setParameter("coupleId", coupleId).setParameter("authorId", authorId)
+            .setParameter("categoryId", categoryId).setParameter("type", type)
+            .setParameter("amount", amount).setParameter("desc", "$type 거래")
+            .setParameter("d", date).executeUpdate()
+        return id
+    }
+
+    private fun insertTransfer(
+        coupleId: UUID,
+        authorId: UUID,
+        sourceId: UUID,
+        destId: UUID,
+        amount: Long,
+        kind: String
+    ): UUID {
+        val id = UUID.randomUUID()
+        em.createNativeQuery(
+            """INSERT INTO transfers
+               (id, couple_id, author_id, source_payment_method_id, destination_payment_method_id,
+                amount, description, transfer_date, is_card_settlement, kind, created_at, updated_at)
+               VALUES (:id, :coupleId, :authorId, :src, :dst, :amount, :desc, :d, :isCard, :kind, now(), now())"""
+        ).setParameter("id", id).setParameter("coupleId", coupleId).setParameter("authorId", authorId)
+            .setParameter("src", sourceId).setParameter("dst", destId)
+            .setParameter("amount", amount).setParameter("desc", "$kind 이체")
+            .setParameter("d", LocalDate.of(2026, 6, 20))
+            .setParameter("isCard", kind == "CARD_SETTLEMENT")
+            .setParameter("kind", kind).executeUpdate()
+        return id
+    }
+
+    private fun countRows(table: String, id: UUID): Int =
+        (
+            em.createNativeQuery("SELECT count(*) FROM $table WHERE id = :id")
+                .setParameter("id", id).singleResult as Number
+            ).toInt()
+
+    private fun itemCountOf(reconciliationId: UUID): Int =
+        (
+            em.createNativeQuery("SELECT count(*) FROM reconciliation_items WHERE reconciliation_id = :rid")
+                .setParameter("rid", reconciliationId).singleResult as Number
+            ).toInt()
+
+    private fun totalExpenseOf(reconciliationId: UUID): Long =
+        (
+            em.createNativeQuery("SELECT total_expense FROM reconciliations WHERE id = :id")
+                .setParameter("id", reconciliationId).singleResult as Number
+            ).toLong()
+}

--- a/backend/src/test/kotlin/com/budgetbook/reconciliation/service/ReconciliationAggregatorTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/reconciliation/service/ReconciliationAggregatorTest.kt
@@ -1,0 +1,122 @@
+package com.budgetbook.reconciliation.service
+
+import com.budgetbook.transaction.domain.TransactionType
+import com.budgetbook.transfer.domain.TransferKind
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.enum
+import io.kotest.property.arbitrary.int
+import io.kotest.property.arbitrary.list
+import io.kotest.property.arbitrary.long
+import io.kotest.property.arbitrary.map
+import io.kotest.property.checkAll
+
+/**
+ * 정산 소계 집계 규칙 고정.
+ *
+ * 금액 로직을 한 곳만 고쳐 나머지를 빠뜨리는 사고가 6회 반복됐다. 이 테스트는 규칙 자체
+ * (어떤 종류가 어느 버킷으로 가는지)와 **분할 정합성**(미기록 + Σ스냅샷 = 전체)을 고정한다.
+ */
+class ReconciliationAggregatorTest : FunSpec({
+
+    val aggregator = ReconciliationAggregator()
+
+    fun entry(kind: String, amount: Long) = ReconciliationAggregator.Entry(kind, amount)
+
+    test("Transaction INCOME/EXPENSE 는 각 버킷으로 간다") {
+        val totals = aggregator.aggregateEntries(
+            listOf(
+                entry(TransactionType.INCOME.name, 30000),
+                entry(TransactionType.EXPENSE.name, 10000)
+            )
+        )
+        totals.totalIncome shouldBe 30000
+        totals.totalExpense shouldBe 10000
+        totals.totalTransfer shouldBe 0
+        totals.itemCount shouldBe 2
+    }
+
+    test("ADJUSTMENT 는 수입/지출 어디에도 들어가지 않는다") {
+        val totals = aggregator.aggregateEntries(
+            listOf(entry(TransactionType.ADJUSTMENT.name, -5000))
+        )
+        totals.totalIncome shouldBe 0
+        totals.totalExpense shouldBe 0
+        totals.totalTransfer shouldBe 0
+        // 항목 수에는 포함된다 (정산 대상 항목이긴 하다).
+        totals.itemCount shouldBe 1
+    }
+
+    test("CARD_SETTLEMENT 이체는 전 버킷에서 제외된다 (원본 지출 이중 계상 방지)") {
+        val totals = aggregator.aggregateEntries(
+            listOf(entry(TransferKind.CARD_SETTLEMENT.name, 500000))
+        )
+        totals.totalIncome shouldBe 0
+        totals.totalExpense shouldBe 0
+        totals.totalTransfer shouldBe 0
+    }
+
+    test("EXPENSE_TRANSFER→지출, INCOME_TRANSFER→수입, GENERIC→이체") {
+        val totals = aggregator.aggregateEntries(
+            listOf(
+                entry(TransferKind.EXPENSE_TRANSFER.name, 7000),
+                entry(TransferKind.INCOME_TRANSFER.name, 8000),
+                entry(TransferKind.GENERIC.name, 9000)
+            )
+        )
+        totals.totalExpense shouldBe 7000
+        totals.totalIncome shouldBe 8000
+        totals.totalTransfer shouldBe 9000
+    }
+
+    test("빈 입력은 0") {
+        aggregator.aggregateEntries(emptyList()) shouldBe ReconciliationAggregator.Totals.ZERO
+    }
+
+    // ── 분할 정합성 (property) ────────────────────────────────────────────────
+    //
+    // "미기록 + Σ스냅샷 = 월 전체" 는 정산 화면의 상단/하단이 MECE 라는 전제 그 자체다.
+    // 임의의 항목 집합을 임의로 쪼개도 합이 보존되는지 확인한다.
+
+    test("항목 집합을 어떻게 쪼개도 소계 합은 전체와 같다") {
+        val kindArb = Arb.enum<SplitKind>().map { it.wire }
+        val entriesArb = Arb.list(
+            Arb.long(0L..1_000_000L).map { amount -> amount },
+            0..40
+        )
+
+        checkAll(entriesArb, Arb.list(kindArb, 0..40), Arb.int(0..40)) { amounts, kinds, splitAt ->
+            val entries = amounts.zip(kinds) { amount, kind -> entry(kind, amount) }
+            val whole = aggregator.aggregateEntries(entries)
+
+            val cut = splitAt.coerceIn(0, entries.size)
+            val left = aggregator.aggregateEntries(entries.take(cut))
+            val right = aggregator.aggregateEntries(entries.drop(cut))
+
+            (left.itemCount + right.itemCount) shouldBe whole.itemCount
+            (left.totalIncome + right.totalIncome) shouldBe whole.totalIncome
+            (left.totalExpense + right.totalExpense) shouldBe whole.totalExpense
+            (left.totalTransfer + right.totalTransfer) shouldBe whole.totalTransfer
+        }
+    }
+
+    test("알 수 없는 종류는 어느 버킷에도 더해지지 않는다 (미래 enum 추가 시 오염 방지)") {
+        val totals = aggregator.aggregateEntries(listOf(entry("SOME_FUTURE_KIND", 12345)))
+        totals.totalIncome shouldBe 0
+        totals.totalExpense shouldBe 0
+        totals.totalTransfer shouldBe 0
+        totals.itemCount shouldBe 1
+    }
+})
+
+/** property 테스트용 종류 목록 (거래 타입 + 이체 kind 전체). */
+private enum class SplitKind(val wire: String) {
+    INCOME("INCOME"),
+    EXPENSE("EXPENSE"),
+    ADJUSTMENT("ADJUSTMENT"),
+    CARD_SETTLEMENT("CARD_SETTLEMENT"),
+    EXPENSE_TRANSFER("EXPENSE_TRANSFER"),
+    INCOME_TRANSFER("INCOME_TRANSFER"),
+    GENERIC("GENERIC")
+}

--- a/backend/src/test/kotlin/com/budgetbook/reconciliation/service/ReconciliationServiceTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/reconciliation/service/ReconciliationServiceTest.kt
@@ -1,0 +1,344 @@
+package com.budgetbook.reconciliation.service
+
+import com.budgetbook.auth.domain.AuthProvider
+import com.budgetbook.auth.domain.User
+import com.budgetbook.auth.repository.UserRepository
+import com.budgetbook.common.entity.Visibility
+import com.budgetbook.common.exception.BusinessException
+import com.budgetbook.common.exception.ConflictException
+import com.budgetbook.common.exception.ForbiddenException
+import com.budgetbook.common.exception.NotFoundException
+import com.budgetbook.couple.domain.Couple
+import com.budgetbook.couple.domain.CoupleStatus
+import com.budgetbook.couple.service.CoupleResolver
+import com.budgetbook.reconciliation.domain.Reconciliation
+import com.budgetbook.reconciliation.domain.ReconciliationItem
+import com.budgetbook.reconciliation.domain.ReconciliationItemKind
+import com.budgetbook.reconciliation.dto.CreateReconciliationRequest
+import com.budgetbook.reconciliation.repository.ReconciliationItemRepository
+import com.budgetbook.reconciliation.repository.ReconciliationRepository
+import com.budgetbook.sync.SyncEvent
+import com.budgetbook.sync.SyncEventPublisher
+import com.budgetbook.transaction.domain.Transaction
+import com.budgetbook.transaction.domain.TransactionType
+import com.budgetbook.transaction.repository.TransactionRepository
+import com.budgetbook.transfer.repository.TransferRepository
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import java.time.LocalDate
+import java.util.Optional
+import java.util.UUID
+
+/**
+ * 정산 서비스 검증 경계 테스트 (mock 기반).
+ *
+ * DB 제약(CHECK/FK/partial UNIQUE)은 mock 으로 검증할 수 없으므로
+ * [com.budgetbook.reconciliation.integration.ReconciliationIntegrationTest] 가 담당한다.
+ * 여기서는 **서비스 레이어 규칙** 만 고정한다: 입력 검증, 커플/가시성 게이팅, 소계 저장,
+ * 조회자 게이팅 후 재집계, sync 이벤트 발행.
+ */
+class ReconciliationServiceTest : BehaviorSpec({
+
+    isolationMode = IsolationMode.InstancePerLeaf
+
+    val reconciliationRepository = mockk<ReconciliationRepository>()
+    val reconciliationItemRepository = mockk<ReconciliationItemRepository>(relaxed = true)
+    val transactionRepository = mockk<TransactionRepository>()
+    val transferRepository = mockk<TransferRepository>()
+    val userRepository = mockk<UserRepository>()
+    val coupleResolver = mockk<CoupleResolver>()
+    val syncEventPublisher = mockk<SyncEventPublisher>(relaxed = true)
+    val service = ReconciliationService(
+        reconciliationRepository,
+        reconciliationItemRepository,
+        transactionRepository,
+        transferRepository,
+        userRepository,
+        coupleResolver,
+        ReconciliationAggregator(),
+        syncEventPublisher
+    )
+
+    val me = User(email = "me@test.com", nickname = "Me", provider = AuthProvider.GOOGLE, providerId = "g1")
+    val partner = User(email = "p@test.com", nickname = "Partner", provider = AuthProvider.KAKAO, providerId = "k1")
+    val couple = Couple(user1 = me, user2 = partner, status = CoupleStatus.ACTIVE)
+    val otherCouple = Couple(user1 = partner, user2 = null, status = CoupleStatus.ACTIVE)
+
+    fun txn(
+        amount: Long = 10000,
+        type: TransactionType = TransactionType.EXPENSE,
+        date: LocalDate = LocalDate.of(2026, 7, 15),
+        owningCouple: Couple = couple,
+        visibility: Visibility = Visibility.SHARED,
+        owner: User? = null
+    ) = Transaction(
+        couple = owningCouple,
+        author = me,
+        type = type,
+        amount = amount,
+        description = "테스트 거래",
+        transactionDate = date,
+        visibility = visibility,
+        owner = owner
+    )
+
+    // 공통 stub. `beforeEach` 를 쓰면 InstancePerLeaf 에서 **컨테이너 본문(When 블록)이 먼저
+    // 실행**되어 stub 이 아직 없거나, 반대로 컨테이너에서 세팅한 구체 stub 을 beforeEach 가
+    // 덮어써 테스트가 조용히 무력화된다. 그래서 각 When 블록이 명시적으로 호출한다.
+    fun defaults() {
+        every { coupleResolver.getActiveCouple(me.id) } returns couple
+        every { userRepository.findById(me.id) } returns Optional.of(me)
+        every { reconciliationRepository.findMaxSeq(couple.id, any()) } returns null
+        every { reconciliationRepository.saveAndFlush(any<Reconciliation>()) } answers { firstArg() }
+        every { reconciliationRepository.save(any<Reconciliation>()) } answers { firstArg() }
+        every { reconciliationItemRepository.findByTransactionIdIn(any()) } returns emptyList()
+        every { reconciliationItemRepository.findByTransferIdIn(any()) } returns emptyList()
+        every { transferRepository.findAllById(any()) } returns emptyList()
+    }
+
+    Given("정산 생성 입력 검증") {
+        When("선택 항목이 하나도 없으면") {
+            defaults()
+            Then("VALIDATION_ERROR") {
+                shouldThrow<BusinessException> {
+                    service.createReconciliation(me.id, CreateReconciliationRequest("2026-07"))
+                }.code shouldBe "VALIDATION_ERROR"
+            }
+        }
+
+        When("항목이 상한(1000건)을 넘으면") {
+            defaults()
+            Then("VALIDATION_ERROR") {
+                val tooMany = (1..1001).map { UUID.randomUUID() }
+                shouldThrow<BusinessException> {
+                    service.createReconciliation(
+                        me.id,
+                        CreateReconciliationRequest("2026-07", transactionIds = tooMany)
+                    )
+                }.code shouldBe "VALIDATION_ERROR"
+            }
+        }
+
+        When("대상 월과 다른 달의 거래가 섞이면") {
+            defaults()
+            val tx = txn(date = LocalDate.of(2026, 8, 3))
+            every { transactionRepository.findAllById(listOf(tx.id)) } returns listOf(tx)
+
+            Then("VALIDATION_ERROR") {
+                shouldThrow<BusinessException> {
+                    service.createReconciliation(
+                        me.id,
+                        CreateReconciliationRequest("2026-07", transactionIds = listOf(tx.id))
+                    )
+                }.code shouldBe "VALIDATION_ERROR"
+            }
+        }
+
+        When("존재하지 않는 거래 id 면") {
+            defaults()
+            val missing = UUID.randomUUID()
+            every { transactionRepository.findAllById(listOf(missing)) } returns emptyList()
+
+            Then("TRANSACTION_NOT_FOUND") {
+                shouldThrow<NotFoundException> {
+                    service.createReconciliation(
+                        me.id,
+                        CreateReconciliationRequest("2026-07", transactionIds = listOf(missing))
+                    )
+                }.code shouldBe "TRANSACTION_NOT_FOUND"
+            }
+        }
+    }
+
+    Given("커플/가시성 게이팅") {
+        When("다른 커플의 거래를 정산하려 하면") {
+            defaults()
+            val tx = txn(owningCouple = otherCouple)
+            every { transactionRepository.findAllById(listOf(tx.id)) } returns listOf(tx)
+
+            Then("FORBIDDEN") {
+                shouldThrow<ForbiddenException> {
+                    service.createReconciliation(
+                        me.id,
+                        CreateReconciliationRequest("2026-07", transactionIds = listOf(tx.id))
+                    )
+                }.code shouldBe "FORBIDDEN"
+            }
+        }
+
+        When("파트너의 개인(PRIVATE) 거래를 정산하려 하면") {
+            defaults()
+            val tx = txn(visibility = Visibility.PRIVATE, owner = partner)
+            every { transactionRepository.findAllById(listOf(tx.id)) } returns listOf(tx)
+
+            Then("FORBIDDEN — 볼 수 없는 항목은 정산도 못 한다") {
+                shouldThrow<ForbiddenException> {
+                    service.createReconciliation(
+                        me.id,
+                        CreateReconciliationRequest("2026-07", transactionIds = listOf(tx.id))
+                    )
+                }.code shouldBe "FORBIDDEN"
+            }
+        }
+
+        When("본인의 개인 거래면") {
+            defaults()
+            val tx = txn(visibility = Visibility.PRIVATE, owner = me)
+            every { transactionRepository.findAllById(listOf(tx.id)) } returns listOf(tx)
+
+            Then("정상 정산된다") {
+                val result = service.createReconciliation(
+                    me.id,
+                    CreateReconciliationRequest("2026-07", transactionIds = listOf(tx.id))
+                )
+                result.itemCount shouldBe 1
+                result.totalExpense shouldBe 10000
+            }
+        }
+    }
+
+    Given("이미 정산된 항목") {
+        val tx = txn()
+        When("다른 스냅샷에 이미 기록돼 있으면") {
+            defaults()
+            every { transactionRepository.findAllById(listOf(tx.id)) } returns listOf(tx)
+            every { reconciliationItemRepository.findByTransactionIdIn(listOf(tx.id)) } returns listOf(
+                ReconciliationItem(
+                    reconciliation = Reconciliation(
+                        couple = couple, yearMonth = "2026-07", seq = 1, reconciledBy = me
+                    ),
+                    itemKind = ReconciliationItemKind.TRANSACTION,
+                    transactionId = tx.id,
+                    snapshotAmount = 10000,
+                    snapshotDate = tx.transactionDate,
+                    snapshotKind = "EXPENSE"
+                )
+            )
+
+            Then("409 ALREADY_RECONCILED") {
+                shouldThrow<ConflictException> {
+                    service.createReconciliation(
+                        me.id,
+                        CreateReconciliationRequest("2026-07", transactionIds = listOf(tx.id))
+                    )
+                }.code shouldBe "ALREADY_RECONCILED"
+            }
+        }
+    }
+
+    Given("정산 생성 성공") {
+        val expense = txn(amount = 10000, type = TransactionType.EXPENSE)
+        val income = txn(amount = 30000, type = TransactionType.INCOME)
+        val adjustment = txn(amount = -2000, type = TransactionType.ADJUSTMENT)
+
+        When("지출/수입/조정 3건을 정산하면") {
+            defaults()
+            every { transactionRepository.findAllById(any()) } returns listOf(expense, income, adjustment)
+
+            val result = service.createReconciliation(
+                me.id,
+                CreateReconciliationRequest(
+                    "2026-07", "1차",
+                    transactionIds = listOf(expense.id, income.id, adjustment.id)
+                )
+            )
+
+            Then("회차는 1, 소계는 집계 규칙대로 (ADJUSTMENT 제외)") {
+                result.seq shouldBe 1
+                result.label shouldBe "1차"
+                result.itemCount shouldBe 3
+                result.totalExpense shouldBe 10000
+                result.totalIncome shouldBe 30000
+                result.totalTransfer shouldBe 0
+                result.items shouldHaveSize 3
+            }
+
+            Then("헤더에 소계가 저장된다 (FE 재계산 금지 전제)") {
+                val saved = slot<Reconciliation>()
+                verify { reconciliationRepository.save(capture(saved)) }
+                saved.captured.itemCount shouldBe 3
+                saved.captured.totalExpense shouldBe 10000
+                saved.captured.totalIncome shouldBe 30000
+            }
+
+            Then("RECONCILIATION 동기화 이벤트가 발행된다") {
+                val event = slot<SyncEvent>()
+                verify { syncEventPublisher.publish(capture(event)) }
+                event.captured.entityType shouldBe "RECONCILIATION"
+                event.captured.type shouldBe "RECONCILIATION_CREATED"
+                event.captured.coupleId shouldBe couple.id
+                event.captured.authorId shouldBe me.id
+            }
+        }
+
+        When("회차가 이미 2까지 있으면") {
+            defaults()
+            every { reconciliationRepository.findMaxSeq(couple.id, "2026-07") } returns 2
+            every { transactionRepository.findAllById(any()) } returns listOf(expense)
+
+            Then("다음 회차는 3") {
+                service.createReconciliation(
+                    me.id,
+                    CreateReconciliationRequest("2026-07", transactionIds = listOf(expense.id))
+                ).seq shouldBe 3
+            }
+        }
+    }
+
+    Given("조회 게이팅") {
+        val header = Reconciliation(couple = couple, yearMonth = "2026-07", seq = 1, reconciledBy = me)
+        val mine = txn(amount = 10000, visibility = Visibility.PRIVATE, owner = me)
+        val partners = txn(amount = 50000, visibility = Visibility.PRIVATE, owner = partner)
+
+        fun itemOf(tx: Transaction) = ReconciliationItem(
+            reconciliation = header,
+            itemKind = ReconciliationItemKind.TRANSACTION,
+            transactionId = tx.id,
+            snapshotAmount = tx.amount,
+            snapshotDate = tx.transactionDate,
+            snapshotKind = tx.type.name,
+            snapshotVisibility = tx.visibility,
+            snapshotOwnerId = tx.owner?.id
+        )
+
+        When("파트너의 개인 항목이 스냅샷에 포함돼 있으면") {
+            defaults()
+            every { reconciliationRepository.findById(header.id) } returns Optional.of(header)
+            every { reconciliationItemRepository.findByReconciliationId(header.id) } returns
+                listOf(itemOf(mine), itemOf(partners))
+            every { transactionRepository.findAllById(any()) } returns listOf(mine, partners)
+
+            val detail = service.getReconciliation(me.id, header.id)
+
+            Then("목록에서 제외되고 소계도 게이팅 후 재계산된다") {
+                detail.items shouldHaveSize 1
+                detail.items.single().refId shouldBe mine.id
+                // 50000(파트너 개인) 이 빠진 금액이어야 한다 — 안 빠지면 "합계 ≠ 행".
+                detail.totalExpense shouldBe 10000
+                detail.itemCount shouldBe 1
+            }
+        }
+    }
+
+    Given("다른 커플의 스냅샷 접근") {
+        val foreign = Reconciliation(couple = otherCouple, yearMonth = "2026-07", seq = 1, reconciledBy = partner)
+
+        When("id 로 직접 조회하면") {
+            defaults()
+            every { reconciliationRepository.findById(foreign.id) } returns Optional.of(foreign)
+
+            Then("존재 자체를 노출하지 않고 404") {
+                shouldThrow<NotFoundException> {
+                    service.getReconciliation(me.id, foreign.id)
+                }.code shouldBe "RECONCILIATION_NOT_FOUND"
+            }
+        }
+    }
+})

--- a/backend/src/test/kotlin/com/budgetbook/transaction/service/TransactionServiceTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/transaction/service/TransactionServiceTest.kt
@@ -52,7 +52,10 @@ class TransactionServiceTest : BehaviorSpec({
     val syncEventPublisher = mockk<SyncEventPublisher>(relaxed = true)
     val patternLearningService = mockk<PatternLearningService>(relaxed = true)
     val transferRepository = mockk<TransferRepository>()
-    val service = TransactionService(transactionRepository, coupleResolver, userRepository, categoryRepository, paymentMethodRepository, moneyPocketRepository, syncEventPublisher, patternLearningService, transferRepository)
+    // V65 — 목록 응답의 정산 배지 벌크 조회. 기본은 "정산 기록 없음".
+    val reconciliationLookup =
+        mockk<com.budgetbook.reconciliation.service.ReconciliationLookup>(relaxed = true)
+    val service = TransactionService(transactionRepository, coupleResolver, userRepository, categoryRepository, paymentMethodRepository, moneyPocketRepository, syncEventPublisher, patternLearningService, transferRepository, reconciliationLookup)
 
     val user1 = User(email = "u1@test.com", nickname = "U1", provider = AuthProvider.GOOGLE, providerId = "g1")
     val user2 = User(email = "u2@test.com", nickname = "U2", provider = AuthProvider.KAKAO, providerId = "k2")

--- a/backend/src/test/kotlin/com/budgetbook/transfer/service/TransferServiceTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/transfer/service/TransferServiceTest.kt
@@ -38,7 +38,10 @@ class TransferServiceTest : BehaviorSpec({
     val paymentMethodRepository = mockk<PaymentMethodRepository>()
     val syncEventPublisher = mockk<SyncEventPublisher>(relaxed = true)
     val transactionRepository = mockk<com.budgetbook.transaction.repository.TransactionRepository>(relaxed = true)
-    val service = TransferService(transferRepository, coupleResolver, userRepository, paymentMethodRepository, syncEventPublisher, transactionRepository)
+    // V65 — 정산 배지/필터용 벌크 조회. 기본은 "정산 기록 없음".
+    val reconciliationLookup =
+        mockk<com.budgetbook.reconciliation.service.ReconciliationLookup>(relaxed = true)
+    val service = TransferService(transferRepository, coupleResolver, userRepository, paymentMethodRepository, syncEventPublisher, transactionRepository, reconciliationLookup)
 
     val user1 = User(email = "u1@test.com", nickname = "U1", provider = AuthProvider.GOOGLE, providerId = "g1")
     val user2 = User(email = "u2@test.com", nickname = "U2", provider = AuthProvider.KAKAO, providerId = "k2")

--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -143,6 +143,13 @@ The current backend accepts only the singular `type` query parameter (see §Tran
   - [Update Transfer](#4-update-transfer)
   - [Delete Transfer](#5-delete-transfer)
   - [Edit Card Settlement Transfer](#6-edit-card-settlement-transfer)
+- [Reconciliations (정산 스냅샷)](#reconciliations-정산-스냅샷)
+  - [List Reconciliations](#1-list-reconciliations)
+  - [Get Reconciliation](#2-get-reconciliation)
+  - [Create Reconciliation](#3-create-reconciliation)
+  - [Update Reconciliation](#4-update-reconciliation)
+  - [Delete Reconciliation](#5-delete-reconciliation)
+  - [Reconciliation Summary](#6-reconciliation-summary)
 - [Insurances](#insurances)
   - [List Insurances](#1-list-insurances)
   - [Create Insurance](#2-create-insurance)
@@ -3547,6 +3554,308 @@ This endpoint is the **only** supported way to modify source, destination, amoun
 
 ---
 
+## Reconciliations (정산 스냅샷)
+
+Base path: `/api/v1/reconciliations`
+
+All endpoints require the `Authorization: Bearer {accessToken}` header.
+
+장부를 대조(정산)한 시점의 **스냅샷**을 기록한다. 사용자가 확인을 마친 장부 항목(거래 + 이체)을
+선택해 "정산 완료" 하면 그 순간의 금액·날짜·설명이 스냅샷 항목으로 보존되고, 어떤 스냅샷에도
+담기지 않은 항목은 **미기록(unrecorded)** 으로 남아 월말에 누락 점검에 쓰인다.
+
+**이름이 비슷한 세 개념 구분**
+
+| 개념 | 저장소 | 의미 |
+|:---|:---|:---|
+| 정산 스냅샷 (이 섹션) | `reconciliations` / `reconciliation_items` | 장부 대조 이력 |
+| 카드 결제 | `transfers.kind = CARD_SETTLEMENT` | 카드 대금 결제 이체 |
+| 주간 예산 정산 | `weekly_budget_settlements` | 주간 예산 마감 |
+
+**불변식**
+
+- 한 장부 항목은 **최대 1개** 스냅샷에만 속한다 (DB partial unique index 로 강제).
+  따라서 `미기록`과 `기록됨`은 상호배타이며 그 합은 해당 월 전체 항목이다.
+- 스냅샷을 삭제하면 그 항목들은 다시 미기록이 된다.
+- 스냅샷은 **불변 기록**이다. 원본 거래/이체가 나중에 수정·삭제돼도 스냅샷의 금액·날짜는
+  그대로 남고, 응답의 `changedAfterReconcile` / `originDeleted` 플래그로 차이를 알린다.
+- 조회자가 볼 수 없는 항목(파트너의 `PRIVATE`)은 목록에서 제외되며, **소계도 게이팅 후 재계산**
+  되어 표시된 행과 합계가 항상 일치한다.
+
+**집계 규칙** (거래 목록/통계와 동일)
+
+- `Transaction(INCOME)` → `totalIncome`, `Transaction(EXPENSE)` → `totalExpense`
+- `Transaction(ADJUSTMENT)` → 수입/지출 모두 제외
+- `Transfer(EXPENSE_TRANSFER)` → `totalExpense`, `Transfer(INCOME_TRANSFER)` → `totalIncome`
+- `Transfer(GENERIC)` → `totalTransfer`
+- `Transfer(CARD_SETTLEMENT)` → 전 버킷 제외 (원본 지출이 이미 집계됨)
+
+---
+
+### 1. List Reconciliations
+
+해당 월의 스냅샷 헤더 목록. 최신 회차(`seq`) 먼저.
+
+| Item        | Value                          |
+|:------------|:-------------------------------|
+| **Method**  | `GET`                          |
+| **Path**    | `/api/v1/reconciliations`      |
+| **Auth**    | Required                       |
+
+**Query Parameters**
+
+| Parameter | Type      | Required | Description               |
+|:----------|:----------|:--------:|:--------------------------|
+| `year`    | `integer` | Yes      | 정산 대상 연도 (2000-2100) |
+| `month`   | `integer` | Yes      | 정산 대상 월 (1-12)        |
+
+**Response `200 OK`**: `ApiResponse<List<ReconciliationResponse>>`
+
+| Field            | Type          | Description                                              |
+|:-----------------|:--------------|:---------------------------------------------------------|
+| `id`             | `UUID`        |                                                          |
+| `yearMonth`      | `string`      | `YYYY-MM`                                                |
+| `seq`            | `integer`     | 월 내 회차 (1부터)                                        |
+| `label`          | `string`/null | 사용자 메모 (예: `"1차"`)                                 |
+| `itemCount`      | `integer`     | 조회자가 볼 수 있는 항목 수                                |
+| `totalIncome`    | `integer`     | 게이팅 후 재계산된 수입 소계                               |
+| `totalExpense`   | `integer`     | 게이팅 후 재계산된 지출 소계                               |
+| `totalTransfer`  | `integer`     | 게이팅 후 재계산된 이체 소계                               |
+| `reconciledAt`   | `datetime`    | 정산 시각                                                 |
+| `reconciledBy`   | `UserSummary` | 정산한 사용자                                             |
+| `hasChangedItems`| `boolean`     | 정산 후 원본이 수정된 항목이 하나라도 있으면 `true`         |
+| `hasDeletedItems`| `boolean`     | 원본이 삭제된 항목이 하나라도 있으면 `true`                |
+
+```json
+{
+  "success": true,
+  "data": [
+    {
+      "id": "550e8400-e29b-41d4-a716-446655440300",
+      "yearMonth": "2026-07",
+      "seq": 2,
+      "label": "2차",
+      "itemCount": 8,
+      "totalIncome": 0,
+      "totalExpense": 120000,
+      "totalTransfer": 0,
+      "reconciledAt": "2026-07-20T14:03:00Z",
+      "reconciledBy": {
+        "id": "550e8400-e29b-41d4-a716-446655440000",
+        "nickname": "홍길동",
+        "profileImageUrl": null
+      },
+      "hasChangedItems": false,
+      "hasDeletedItems": false
+    }
+  ],
+  "timestamp": "2026-07-27T10:00:00Z"
+}
+```
+
+---
+
+### 2. Get Reconciliation
+
+| Item        | Value                            |
+|:------------|:---------------------------------|
+| **Method**  | `GET`                            |
+| **Path**    | `/api/v1/reconciliations/{id}`   |
+| **Auth**    | Required                         |
+
+**Response `200 OK`**: `ApiResponse<ReconciliationDetailResponse>`
+
+헤더 필드(위와 동일) + `items`:
+
+| Field                   | Type            | Description                                                     |
+|:------------------------|:----------------|:----------------------------------------------------------------|
+| `itemId`                | `UUID`          | 스냅샷 항목 id (제외 시 `removeItemIds` 에 사용)                  |
+| `itemKind`              | `enum`          | `TRANSACTION` / `TRANSFER`                                      |
+| `refId`                 | `UUID`/null     | 원본 거래/이체 id. 원본 삭제 시 `null`                            |
+| `snapshotAmount`        | `integer`       | 정산 시점 금액                                                   |
+| `snapshotDate`          | `date`          | 정산 시점 거래일                                                 |
+| `snapshotDescription`   | `string`/null   | 정산 시점 설명                                                   |
+| `snapshotKind`          | `string`        | `INCOME`/`EXPENSE`/`ADJUSTMENT` 또는 `TransferKind`              |
+| `currentAmount`         | `integer`/null  | 현재 원본 금액. 삭제됐으면 `null`                                 |
+| `currentDate`           | `date`/null     | 현재 원본 거래일                                                 |
+| `changedAfterReconcile` | `boolean`       | 금액 또는 날짜가 스냅샷과 다르면 `true`                           |
+| `originDeleted`         | `boolean`       | 원본이 삭제됐으면 `true`                                          |
+
+**Error Responses**
+
+| Status | Error Code                  | Description                                  |
+|:------:|:----------------------------|:---------------------------------------------|
+| `404`  | `RECONCILIATION_NOT_FOUND`  | 존재하지 않거나 다른 커플의 스냅샷            |
+
+---
+
+### 3. Create Reconciliation
+
+선택한 항목들로 새 스냅샷을 만든다. 회차(`seq`)는 서버가 해당 월의 `max(seq) + 1` 로 부여한다.
+
+| Item        | Value                       |
+|:------------|:----------------------------|
+| **Method**  | `POST`                      |
+| **Path**    | `/api/v1/reconciliations`   |
+| **Auth**    | Required                    |
+| **Returns** | `201 Created`               |
+| **Rate**    | 30 requests / 60s           |
+
+**Request Body**
+
+| Field            | Type       | Required | Constraints          | Description                          |
+|:-----------------|:-----------|:--------:|:---------------------|:-------------------------------------|
+| `yearMonth`      | `string`   | Yes      | `YYYY-MM`            | 정산 대상 월                          |
+| `label`          | `string`   | No       | max=100              | 사용자 메모                           |
+| `transactionIds` | `UUID[]`   | No       | —                    | 정산에 담을 거래 id                    |
+| `transferIds`    | `UUID[]`   | No       | —                    | 정산에 담을 이체 id                    |
+
+`transactionIds` 와 `transferIds` 를 합쳐 **1건 이상, 1000건 이하**여야 한다.
+
+**Request Example**
+
+```json
+{
+  "yearMonth": "2026-07",
+  "label": "1차",
+  "transactionIds": [
+    "550e8400-e29b-41d4-a716-446655440030",
+    "550e8400-e29b-41d4-a716-446655440031"
+  ],
+  "transferIds": ["550e8400-e29b-41d4-a716-446655440200"]
+}
+```
+
+**Response `201 Created`**: `ApiResponse<ReconciliationDetailResponse>`
+
+**Error Responses**
+
+| Status | Error Code             | Description                                                     |
+|:------:|:-----------------------|:----------------------------------------------------------------|
+| `400`  | `VALIDATION_ERROR`     | 빈 선택 / 1000건 초과 / `yearMonth` 형식 오류                     |
+| `400`  | `VALIDATION_ERROR`     | 항목의 날짜가 `yearMonth` 와 다른 달                              |
+| `403`  | `FORBIDDEN`            | 다른 커플의 항목, 또는 파트너의 `PRIVATE` 항목                    |
+| `404`  | `TRANSACTION_NOT_FOUND` / `TRANSFER_NOT_FOUND` | 존재하지 않는 항목                |
+| `409`  | `ALREADY_RECONCILED`   | 이미 다른 스냅샷에 기록된 항목이 포함됨 (부부 동시 정산 경합 포함) |
+
+---
+
+### 4. Update Reconciliation
+
+라벨 수정 + 항목 추가/제외.
+
+| Item        | Value                            |
+|:------------|:---------------------------------|
+| **Method**  | `PATCH`                          |
+| **Path**    | `/api/v1/reconciliations/{id}`   |
+| **Auth**    | Required                         |
+| **Rate**    | 30 requests / 60s                |
+
+**Request Body** (모든 필드 선택 — 생략 시 미변경)
+
+| Field               | Type      | Description                                  |
+|:--------------------|:----------|:---------------------------------------------|
+| `label`             | `string`  | 라벨 변경 (`""` 은 빈 라벨)                   |
+| `addTransactionIds` | `UUID[]`  | 추가할 거래 id                                |
+| `addTransferIds`    | `UUID[]`  | 추가할 이체 id                                |
+| `removeItemIds`     | `UUID[]`  | 제외할 **스냅샷 항목 id**(`items[].itemId`)    |
+
+제외된 항목은 미기록으로 복귀한다. 항목 변경 시 헤더 소계(`itemCount`/`total*`)가 재계산된다.
+모든 항목을 제외하면 스냅샷 자체가 삭제된다(빈 스냅샷은 남기지 않는다).
+
+**Response `200 OK`**: `ApiResponse<ReconciliationDetailResponse>`
+
+**Error Responses**: Create 와 동일 + `404 RECONCILIATION_NOT_FOUND`
+
+---
+
+### 5. Delete Reconciliation
+
+| Item        | Value                            |
+|:------------|:---------------------------------|
+| **Method**  | `DELETE`                         |
+| **Path**    | `/api/v1/reconciliations/{id}`   |
+| **Auth**    | Required                         |
+| **Returns** | `204 No Content`                 |
+| **Rate**    | 30 requests / 60s                |
+
+스냅샷과 그 항목이 삭제되고, 담겨 있던 거래/이체는 미기록으로 복귀한다. 원본 거래/이체 자체는
+삭제되지 않는다.
+
+**Error Responses**
+
+| Status | Error Code                  | Description                       |
+|:------:|:----------------------------|:----------------------------------|
+| `404`  | `RECONCILIATION_NOT_FOUND`  | 존재하지 않거나 다른 커플의 스냅샷 |
+
+---
+
+### 6. Reconciliation Summary
+
+월말 누락 점검용 요약. 홈/거래 화면의 "미기록 N건" 배지가 사용한다.
+
+| Item        | Value                                  |
+|:------------|:---------------------------------------|
+| **Method**  | `GET`                                  |
+| **Path**    | `/api/v1/reconciliations/summary`      |
+| **Auth**    | Required                               |
+
+**Query Parameters**: `year` (required), `month` (required)
+
+**Response `200 OK`**: `ApiResponse<ReconciliationSummaryResponse>`
+
+| Field                | Type      | Description                                        |
+|:---------------------|:----------|:---------------------------------------------------|
+| `yearMonth`          | `string`  | `YYYY-MM`                                          |
+| `snapshotCount`      | `integer` | 그 달의 스냅샷 개수                                 |
+| `recordedCount`      | `integer` | 스냅샷에 기록된 항목 수                              |
+| `unrecordedCount`    | `integer` | 미기록 항목 수 (0 이면 그 달 정산 완료)              |
+| `unrecordedIncome`   | `integer` | 미기록 수입 소계                                    |
+| `unrecordedExpense`  | `integer` | 미기록 지출 소계                                    |
+| `unrecordedTransfer` | `integer` | 미기록 이체 소계                                    |
+| `needsReviewCount`   | `integer` | 미기록 항목 중 `needsReview=true` 인 거래 수         |
+
+```json
+{
+  "success": true,
+  "data": {
+    "yearMonth": "2026-07",
+    "snapshotCount": 2,
+    "recordedCount": 23,
+    "unrecordedCount": 12,
+    "unrecordedIncome": 0,
+    "unrecordedExpense": 340000,
+    "unrecordedTransfer": 50000,
+    "needsReviewCount": 3
+  },
+  "timestamp": "2026-07-27T10:00:00Z"
+}
+```
+
+---
+
+### 7. Reconciliation filter on ledger endpoints
+
+정산 상태는 거래/이체 목록에서도 필터·표시할 수 있다. **두 스트림 모두** 동일 파라미터를 지원한다
+(거래 목록은 페이지네이션되므로, 미기록 판정을 클라이언트에서 하면 미로드 페이지의 항목이 누락된다
+→ 반드시 서버 필터를 사용할 것).
+
+**추가 쿼리 파라미터** (`GET /api/v1/transactions`, `GET /api/v1/transfers`)
+
+| Parameter    | Type      | Description                                                     |
+|:-------------|:----------|:----------------------------------------------------------------|
+| `reconciled` | `boolean` | `false` = 미기록만, `true` = 기록된 것만. 생략 = 전체            |
+
+**추가 응답 필드** (`TransactionResponse`, `TransferResponse`)
+
+| Field               | Type          | Description                                        |
+|:--------------------|:--------------|:---------------------------------------------------|
+| `reconciliationId`  | `UUID`/null   | 이 항목이 속한 스냅샷 id. 미기록이면 `null`         |
+| `reconciliationSeq` | `integer`/null| 스냅샷 회차 (배지에 "N차" 표시용)                   |
+| `reconciledAt`      | `datetime`/null | 정산 시각                                         |
+
+---
+
 ## Insurances
 
 Insurance policy management for the couple. Each insurance record tracks a recurring premium payment. The `visibility` field follows the same `SHARED`/`PRIVATE` semantics used across other entities.
@@ -5294,3 +5603,5 @@ Permanently removes a user and all data they own from the database. This operati
 | `EMAIL_REQUIRED_FOR_COUPLE`       | `400`       | Email registration is required before linking a partner              |
 | `EMAIL_ALREADY_IN_USE`            | `400`       | Email is already used by another account                             |
 | `INVALID_EMAIL`                   | `400`       | Invalid email (placeholder domain not allowed)                       |
+| `RECONCILIATION_NOT_FOUND`        | `404`       | Requested reconciliation snapshot does not exist or belongs to another couple |
+| `ALREADY_RECONCILED`              | `409`       | One or more selected ledger items already belong to another reconciliation snapshot |

--- a/docs/erd.md
+++ b/docs/erd.md
@@ -6,8 +6,8 @@
 > Migrations are managed via Flyway with `V{N}__` naming convention.
 >
 > **문서 범위 주의 (2026-07-27 감사)**: 아래 `## Table Details` 의 상세 표는 V12 까지만
-> 작성되어 있었고 V13~V64 에서 추가된 테이블·컬럼이 빠져 있었다. 그 공백은
-> [§ V13~V64 스키마 증분](#v13v64-스키마-증분) 에 정리했다. 신규 마이그레이션을 작성할 때는
+> 작성되어 있었고 V13 이후 추가된 테이블·컬럼이 빠져 있었다. 그 공백은
+> [§ V13~V65 스키마 증분](#v13v65-스키마-증분) 에 정리했다. 신규 마이그레이션을 작성할 때는
 > **반드시 두 절을 함께** 확인할 것 (누락된 CHECK/UNIQUE 제약을 모른 채 작성하면
 > prod 에서 제약 위반이 난다 — 과거 실제 사고).
 >
@@ -608,7 +608,7 @@ Records transfers of funds between pockets. Affects balance calculation for both
 
 ---
 
-## V13~V64 스키마 증분
+## V13~V65 스키마 증분
 
 > 위 `## Table Details` 는 V12 시점 스냅샷이다. 이 절은 그 이후 추가/변경분을 정리한다.
 > 컬럼 목록은 2026-07-27 라이브 DB(`information_schema.columns`) 기준으로 검증했다.
@@ -724,6 +724,47 @@ Records transfers of funds between pockets. Affects balance calculation for both
 - `feedback_comments`: `id`, `post_id`, `author_id`, `content`, `is_admin_reply`, `created_at`
 - `feedback_votes`: `id`, `post_id`, `user_id`, `created_at`
 
+#### `reconciliations` / `reconciliation_items` (V65)
+
+정산 스냅샷. 장부(거래 + 이체)를 대조한 시점의 기록이며, 어떤 스냅샷에도 없는 항목은
+**미기록**으로 남아 월말 누락 점검에 쓰인다.
+
+`reconciliations` (헤더)
+
+| 컬럼 | 타입 | 비고 |
+|:---|:---|:---|
+| `id` | UUID PK | |
+| `couple_id` | UUID NOT NULL | FK `couples` ON DELETE CASCADE |
+| `year_month` | VARCHAR(7) NOT NULL | CHECK `^[0-9]{4}-(0[1-9]\|1[0-2])$` |
+| `seq` | INTEGER NOT NULL | 월 내 회차. CHECK `>= 1`, UNIQUE `(couple_id, year_month, seq)` |
+| `label` | VARCHAR(100) | 사용자 메모 |
+| `item_count` / `total_income` / `total_expense` / `total_transfer` | INTEGER / BIGINT | 비정규화 소계 (조회 시 재집계 없음) |
+| `reconciled_at` | TIMESTAMPTZ NOT NULL | 정산 시각 |
+| `reconciled_by` | UUID NOT NULL | FK `users` ON DELETE RESTRICT |
+
+`reconciliation_items` (항목 — 정산 당시 값 보존)
+
+| 컬럼 | 타입 | 비고 |
+|:---|:---|:---|
+| `id` | UUID PK | |
+| `reconciliation_id` | UUID NOT NULL | FK `reconciliations` ON DELETE CASCADE |
+| `item_kind` | VARCHAR(20) NOT NULL | CHECK `TRANSACTION`/`TRANSFER` — **FK 유무가 아니라 이 값이 판별자** |
+| `transaction_id` | UUID | FK `transactions` **ON DELETE SET NULL** |
+| `transfer_id` | UUID | FK `transfers` **ON DELETE SET NULL** |
+| `snapshot_amount` / `snapshot_date` / `snapshot_description` / `snapshot_kind` | BIGINT / DATE / VARCHAR(255) / VARCHAR(20) | 정산 시점 값. 원본이 바뀌어도 불변 |
+| `snapshot_visibility` / `snapshot_owner_id` | VARCHAR(10) / UUID | 원본 삭제 후 게이팅 폴백 (원본 존재 시 원본 값 우선) |
+
+제약·인덱스
+
+- `ck_recon_items_ref` — `item_kind='TRANSACTION'` 이면 `transfer_id IS NULL`, 그 반대도 동일
+- `uk_recon_items_transaction` / `uk_recon_items_transfer` — **partial UNIQUE**
+  (`WHERE ... IS NOT NULL`). "한 항목은 최대 1개 스냅샷" 불변식을 DB 가 강제 → 부부 동시 정산 시
+  한쪽은 409. 이 인덱스는 `reconciled` 필터의 `EXISTS` 서브쿼리에도 사용된다
+- `idx_reconciliations_couple_ym (couple_id, year_month)`, `idx_recon_items_reconciliation`
+
+설계 의도: `ON DELETE SET NULL` + `snapshot_*` 조합은 **원본이 삭제돼도 정산 이력을 남기기**
+위한 것이다. CASCADE 로 지우면 "언제 무엇을 대조했는가" 가 사라져 스냅샷의 의미가 무너진다.
+
 #### `release_notes` (V44) / `release_note_feedbacks` (V45)
 
 - `release_notes`: `id`, `version`(UNIQUE), `title`, `content`, `is_published`,
@@ -831,6 +872,8 @@ Records transfers of funds between pockets. Affects balance calculation for both
 | V62     | `V62__backfill_placeholder_emails.sql`           | 이메일 미동의 카카오 계정 placeholder 백필                  |
 | V63     | `V63__add_settlement_transfer_id_to_transactions.sql` | `transactions.settlement_transfer_id`               |
 | V64     | `V64__unify_weekly_budget_conversion.sql`        | 주간 예산 환산 단일화 (`weekly_amount` = source of truth)  |
+
+| V65     | `V65__create_reconciliations.sql`                | **`reconciliations` / `reconciliation_items`** (정산 스냅샷)|
 
 > V55 는 결번(스킵)이다 — 실제 적용 이력에도 존재하지 않는다.
 > 라이브 적용 상태 확인: `select version, success from flyway_schema_history order by installed_rank desc`.


### PR DESCRIPTION
정산(스냅샷) 기능의 백엔드입니다. 기획서 `docs/sessions/2026-07-27_1_plan.md` PART 2 / PR 2.
FE(정산 뷰 + 배지)는 다음 PR입니다.

## 데이터 모델 (V65)

`reconciliations`(헤더) + `reconciliation_items`(항목). 설계 결정 3가지:

1. **원본 삭제 시 `ON DELETE SET NULL` + `snapshot_*` 보존** — CASCADE 면 정산 이력이 조용히
   사라져 "스냅샷"의 의미가 무너집니다. 그래서 종류 판별은 FK 유무가 아니라 `item_kind` +
   조건부 CHECK 입니다.
2. **"한 항목은 최대 1개 스냅샷"을 partial UNIQUE 로 DB 강제** — 서비스 검증만 두면 부부가
   동시에 정산할 때 중복 기록이 생겨 미기록/기록 목록이 겹칩니다.
3. **거래 + 이체 양쪽 지원** — 장부 목록이 두 스트림 병합이라 거래만 지원하면 이체가 영구
   미기록으로 남습니다.

## API

`docs/api-spec.md § Reconciliations (정산 스냅샷)` 를 먼저 기재하고 구현했습니다.

- `GET /reconciliations?year&month` — 헤더 목록(최신 회차 먼저)
- `GET /reconciliations/{id}` — 항목 + drift 플래그
- `POST /reconciliations` — 생성(회차 자동 부여, 1~1000건)
- `PATCH /reconciliations/{id}` — 라벨/항목 추가·제외(전부 제외하면 스냅샷 삭제)
- `DELETE /reconciliations/{id}` — 삭제 → 항목은 미기록 복귀
- `GET /reconciliations/summary` — 미기록 건수/소계 + needsReview 건수

**장부 엔드포인트 확장 (거래·이체 동시)**

- `reconciled=false|true` 필터. 목록이 페이지네이션되므로 미기록 판정을 FE 가 하면 미로드
  페이지 항목이 누락됩니다 → 서버에서 `EXISTS` 서브쿼리로 처리(partial unique 인덱스 사용).
- 응답에 `reconciliationId` / `reconciliationSeq` / `reconciledAt` 3필드 추가. `ReconciliationLookup`
  으로 목록당 1쿼리 벌크 주입(N+1 금지).

## 정합성 · 재발 방지

- 소계는 `ReconciliationAggregator` **단독** 계산 — ADJUSTMENT 제외, CARD_SETTLEMENT 제외,
  EXPENSE/INCOME_TRANSFER→지출/수입, GENERIC→이체 (기존 장부 규칙과 1:1). 미기록 소계도 같은
  집계기를 써서 **"미기록 + Σ스냅샷 = 월 전체"** 를 보장합니다.
- **조회자 게이팅 후 소계 재계산** — 파트너 PRIVATE 항목을 뺀 목록에 전체 기준 소계를 붙이면
  "합계 ≠ 보이는 행"이 됩니다.
- 저장 순서 `saveAndFlush(헤더)` → items (items 가 헤더 PK 를 FK 참조).
- 정산 후 원본 변경/삭제는 `changedAfterReconcile` / `originDeleted` 로 표면화.

## 테스트

- **Testcontainers 통합 10건** — CHECK / partial UNIQUE / SET NULL / CASCADE 를 실 PostgreSQL 로
  검증 (mock 은 DB 제약을 절대 잡지 못합니다 — 2026-07-22 카드 정산 FK 사고 교훈)
- **집계 property** — 임의 항목 집합을 임의로 쪼개도 소계 합 보존
- 서비스 유닛 — 입력 검증, 커플/가시성 게이팅, 409, 회차 부여, sync 이벤트
- 컨트롤러 — 위임/상태코드

`./gradlew build` SUCCESS (통합테스트 포함).

## 배포 후 확인 항목

`flyway_schema_history` 에 V65 `success=t` (신규 테이블 2개 + partial unique 2개 생성).
API 는 FE 없이도 확인 가능하지만, 사용자 검증은 PR 3(정산 뷰) 이후에 드립니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)