### PR TITLE
feat(transaction): 거래 수정에서 유형 변경 — 수입↔지출 + 이체로 변환

### DIFF
--- a/backend/src/main/kotlin/com/budgetbook/spendingplan/repository/SpendingPlanRepository.kt
+++ b/backend/src/main/kotlin/com/budgetbook/spendingplan/repository/SpendingPlanRepository.kt
@@ -10,6 +10,12 @@ import java.util.UUID
 
 interface SpendingPlanRepository : JpaRepository<SpendingPlan, UUID> {
 
+    /**
+     * 이 거래에 연결된 계획이 있는지. 거래→이체 변환 가드용
+     * (`linked_transaction_id` FK 에 ON DELETE 가 없어 그냥 지우면 무결성 오류).
+     */
+    fun existsByLinkedTransactionId(transactionId: UUID): Boolean
+
     @Query("""
         SELECT sp FROM SpendingPlan sp
         LEFT JOIN FETCH sp.category c

--- a/backend/src/main/kotlin/com/budgetbook/transaction/controller/TransactionController.kt
+++ b/backend/src/main/kotlin/com/budgetbook/transaction/controller/TransactionController.kt
@@ -19,6 +19,8 @@ import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
+import com.budgetbook.transaction.dto.ConvertToTransferRequest
+import com.budgetbook.transfer.dto.TransferResponse
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.ModelAttribute
@@ -103,6 +105,20 @@ class TransactionController(
         @Valid @RequestBody request: UpdateTransactionRequest
     ): ApiResponse<TransactionResponse> {
         return ApiResponse.ok(transactionService.updateTransaction(userId, id, request))
+    }
+
+    /**
+     * 거래 → 이체 변환. 거래와 이체는 테이블이 달라 `PUT /{id}` 로는 바꿀 수 없다.
+     * 원본 거래 삭제 + 이체 생성이 한 트랜잭션에서 일어나고, 응답은 **생성된 이체**다.
+     */
+    @RateLimit(maxRequests = 30, windowSeconds = 60)
+    @PostMapping("/{id}/convert-to-transfer")
+    fun convertToTransfer(
+        @AuthUser userId: UUID,
+        @PathVariable id: UUID,
+        @Valid @RequestBody request: ConvertToTransferRequest
+    ): ApiResponse<TransferResponse> {
+        return ApiResponse.ok(transactionService.convertToTransfer(userId, id, request))
     }
 
     @RateLimit(maxRequests = 30, windowSeconds = 60)

--- a/backend/src/main/kotlin/com/budgetbook/transaction/domain/Transaction.kt
+++ b/backend/src/main/kotlin/com/budgetbook/transaction/domain/Transaction.kt
@@ -37,9 +37,13 @@ class Transaction(
     @JoinColumn(name = "category_id")
     var category: Category? = null,
 
+    /**
+     * 2026-07-27 — `val` → `var`. 수정 화면에서 수입↔지출 전환을 지원한다
+     * (`ADJUSTMENT` 와의 상호 전환과 정산 기록된 거래는 서비스에서 막는다).
+     */
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)
-    val type: TransactionType,
+    var type: TransactionType,
 
     @Column(nullable = false)
     var amount: Long,

--- a/backend/src/main/kotlin/com/budgetbook/transaction/dto/TransactionDtos.kt
+++ b/backend/src/main/kotlin/com/budgetbook/transaction/dto/TransactionDtos.kt
@@ -88,6 +88,15 @@ data class CreateTransactionRequest(
 )
 
 data class UpdateTransactionRequest(
+    /**
+     * 거래 유형 변경 (2026-07-27). null = 미변경.
+     *
+     * `EXPENSE` ↔ `INCOME` 만 가능하다. `ADJUSTMENT` 는 잔액 보정 전용이라 일반 거래와
+     * 상호 전환하지 않고, **이체로의 변경은 테이블이 달라** 별도 엔드포인트를 쓴다
+     * (`POST /transactions/{id}/convert-to-transfer`).
+     */
+    val type: String? = null,
+
     // Phase 22 T11: @Min(0) 제거. ADJUSTMENT 는 잔액 하향 조정 시 음수 필요.
     // 부호 검증은 TransactionService 에서 type 별로 수행한다.
     @field:Min(-999_999_999)
@@ -177,4 +186,34 @@ data class SettlementTransactionItem(
      * to the settlement being edited.
      */
     val settlementTransferId: UUID? = null
+)
+
+/**
+ * 거래 → 이체 변환 요청 (2026-07-27).
+ *
+ * 거래와 이체는 테이블이 달라 `PATCH /transactions/{id}` 로는 유형을 바꿀 수 없다.
+ * 이 요청은 **원본 거래를 지우고 같은 내용의 이체를 만드는** 한 번의 원자적 작업이다.
+ * 금액·날짜·설명·메모를 생략하면 원본 값을 승계한다.
+ */
+data class ConvertToTransferRequest(
+    @field:NotNull
+    val sourcePaymentMethodId: UUID,
+
+    @field:NotNull
+    val destinationPaymentMethodId: UUID,
+
+    /** 생략 시 결제수단 조합으로 자동 판정 (TransferKindResolver). */
+    val kind: String? = null,
+
+    @field:Min(1)
+    @field:Max(999_999_999)
+    val amount: Long? = null,
+
+    val transferDate: LocalDate? = null,
+
+    @field:Size(max = 255)
+    val description: String? = null,
+
+    @field:Size(max = 1000)
+    val memo: String? = null
 )

--- a/backend/src/main/kotlin/com/budgetbook/transaction/service/TransactionService.kt
+++ b/backend/src/main/kotlin/com/budgetbook/transaction/service/TransactionService.kt
@@ -17,7 +17,10 @@ import com.budgetbook.pocket.repository.MoneyPocketRepository
 import com.budgetbook.smart.service.PatternLearningService
 import com.budgetbook.transaction.domain.Transaction
 import com.budgetbook.transaction.domain.TransactionType
+import com.budgetbook.category.domain.CategoryType
+import com.budgetbook.spendingplan.repository.SpendingPlanRepository
 import com.budgetbook.transaction.dto.CategorySummary
+import com.budgetbook.transaction.dto.ConvertToTransferRequest
 import com.budgetbook.transaction.dto.CreateTransactionRequest
 import com.budgetbook.transaction.dto.PageResponse
 import com.budgetbook.transaction.dto.TransactionResponse
@@ -27,7 +30,11 @@ import com.budgetbook.sync.SyncEventPublisher
 import com.budgetbook.transaction.repository.TransactionRepository
 import com.budgetbook.transaction.repository.TransactionSpecifications
 import com.budgetbook.reconciliation.service.ReconciliationLookup
+import com.budgetbook.transfer.domain.TransferKind
+import com.budgetbook.transfer.dto.CreateTransferRequest
+import com.budgetbook.transfer.dto.TransferResponse
 import com.budgetbook.transfer.repository.TransferRepository
+import com.budgetbook.transfer.service.TransferService
 import org.slf4j.LoggerFactory
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Sort
@@ -49,7 +56,13 @@ class TransactionService(
     private val patternLearningService: PatternLearningService,
     private val transferRepository: TransferRepository,
     // V65 — 목록 응답의 정산 배지용 벌크 조회 (조회 전용 좁은 컴포넌트).
-    private val reconciliationLookup: ReconciliationLookup
+    private val reconciliationLookup: ReconciliationLookup,
+    // 2026-07-27 거래→이체 변환 — 이체 생성 규칙을 재사용한다 (TransferService 는
+    // TransactionService 를 참조하지 않으므로 순환 의존이 아니다).
+    private val transferService: TransferService,
+    // 변환 가드용 — spending_plans.linked_transaction_id 는 ON DELETE 가 없어
+    // 연결된 거래를 지우면 FK 위반으로 터진다.
+    private val spendingPlanRepository: SpendingPlanRepository
 ) : CoupleAwareService {
 
     private val log = LoggerFactory.getLogger(javaClass)
@@ -319,6 +332,10 @@ class TransactionService(
         OwnershipValidator.validateOwnership(transaction.couple.id, couple, "Transaction")
         validatePrivateOwner(transaction.visibility, transaction.owner?.id, userId)
 
+        // 유형 변경 (2026-07-27) — 카테고리/금액 검증보다 **먼저** 반영해야 그 뒤 검증이
+        // 새 유형 기준으로 돌아간다.
+        request.type?.let { applyTypeChange(transaction, it) }
+
         request.amount?.let {
             validateAmountForType(transaction.type, it)
             transaction.amount = it
@@ -405,6 +422,13 @@ class TransactionService(
             }
         }
 
+        // 유형이 바뀌었으면 카테고리·금액 부호가 새 유형과 맞는지 마지막에 확인한다.
+        // (카테고리 patch 가 이 아래에서 적용되므로 여기서 봐야 최종 상태를 본다.)
+        if (request.type != null) {
+            validateCategoryMatchesType(transaction)
+            validateAmountForType(transaction.type, transaction.amount)
+        }
+
         val saved = transactionRepository.save(transaction)
         syncEventPublisher.publish(SyncEvent(
             type = "TRANSACTION_UPDATED",
@@ -415,6 +439,133 @@ class TransactionService(
         ))
         learnPattern(couple.id, saved.description, saved.category?.id)
         return saved.toResponse()
+    }
+
+    /**
+     * 거래 → 이체 변환 (2026-07-27).
+     *
+     * 거래와 이체는 **테이블이 다르다.** 그래서 "유형을 이체로 바꾼다" 는 실제로는
+     * 원본 거래 삭제 + 이체 생성이고, 한 트랜잭션 안에서 처리해 중간 상태(거래도 이체도
+     * 없거나 둘 다 있는)를 남기지 않는다.
+     *
+     * 되돌릴 수 없는 이동이므로 **다른 기능이 이 거래를 붙잡고 있으면 막는다** —
+     * 정산 스냅샷 / 카드 결제 링크 / 지출 계획 연결. 특히 지출 계획은 FK 에 ON DELETE 가
+     * 없어(`spending_plans.linked_transaction_id`) 그냥 지우면 무결성 오류로 터진다.
+     */
+    @Transactional
+    fun convertToTransfer(
+        userId: UUID,
+        transactionId: UUID,
+        request: ConvertToTransferRequest
+    ): TransferResponse {
+        val couple = getActiveCouple(userId)
+        val transaction = transactionRepository.findById(transactionId)
+            .orElseThrow { NotFoundException("TRANSACTION_NOT_FOUND", "Transaction does not exist.") }
+
+        OwnershipValidator.validateOwnership(transaction.couple.id, couple, "Transaction")
+        validatePrivateOwner(transaction.visibility, transaction.owner?.id, userId)
+
+        if (transaction.type == TransactionType.ADJUSTMENT) {
+            throw BusinessException(
+                "VALIDATION_ERROR",
+                "잔액 수정은 이체로 변경할 수 없습니다. 삭제 후 이체로 등록하세요."
+            )
+        }
+        if (reconciliationLookup.refsForTransactions(listOf(transactionId)).isNotEmpty()) {
+            throw BusinessException(
+                "VALIDATION_ERROR",
+                "정산에 기록된 거래는 유형을 변경할 수 없습니다. 정산에서 제외한 뒤 다시 시도하세요."
+            )
+        }
+        if (transaction.settlementTransferId != null) {
+            throw BusinessException(
+                "VALIDATION_ERROR",
+                "카드 결제에 연결된 거래는 이체로 변경할 수 없습니다. 카드 결제에서 제외한 뒤 다시 시도하세요."
+            )
+        }
+        if (spendingPlanRepository.existsByLinkedTransactionId(transactionId)) {
+            throw BusinessException(
+                "VALIDATION_ERROR",
+                "지출 계획에 연결된 거래는 이체로 변경할 수 없습니다. 계획 연결을 먼저 해제하세요."
+            )
+        }
+
+        // 결제수단 검증·종류 판정·이체 저장·TRANSFER_CREATED 발행은 **이체 등록 경로를 그대로
+        // 재사용**한다 (같은 트랜잭션 안에서 호출). 여기서 Transfer 를 직접 만들면 카드 결제
+        // 판정·카드간 이체 금지 같은 규칙이 두 벌이 된다.
+        val created = transferService.createTransfer(
+            userId,
+            CreateTransferRequest(
+                sourcePaymentMethodId = request.sourcePaymentMethodId,
+                destinationPaymentMethodId = request.destinationPaymentMethodId,
+                // 생략된 값은 원본 거래를 승계한다 (사용자가 다시 입력하지 않게).
+                amount = request.amount ?: transaction.amount,
+                description = request.description ?: transaction.description,
+                transferDate = request.transferDate ?: transaction.transactionDate,
+                memo = request.memo ?: transaction.memo,
+                kind = request.kind?.let { raw ->
+                    runCatching { TransferKind.valueOf(raw.uppercase()) }.getOrElse {
+                        throw BusinessException("VALIDATION_ERROR", "지원하지 않는 이체 종류입니다: $raw")
+                    }
+                }
+            )
+        )
+
+        transactionRepository.delete(transaction)
+        // 거래 스트림도 갱신해야 목록이 정합해진다 — 이체 이벤트만 쏘면 파트너 화면에
+        // 원본 거래가 그대로 남는다 (장부 목록은 두 스트림 병합).
+        syncEventPublisher.publish(SyncEvent(
+            type = "TRANSACTION_DELETED",
+            entityType = "TRANSACTION",
+            entityId = transactionId,
+            coupleId = couple.id,
+            authorId = userId
+        ))
+        return created
+    }
+
+    /**
+     * 유형 변경 규칙. `EXPENSE ↔ INCOME` 만 허용한다.
+     *
+     * - `ADJUSTMENT` 는 잔액 보정 전용(부호 있는 증감값)이라 일반 거래와 의미가 달라 전환 금지.
+     * - 정산에 기록된 거래는 금지 — 스냅샷의 `snapshot_kind` 가 정산 당시 분류라, 원본 유형이
+     *   바뀌면 그 달 소계 이력이 흔들린다.
+     */
+    private fun applyTypeChange(transaction: Transaction, rawType: String) {
+        val newType = runCatching { TransactionType.valueOf(rawType.uppercase()) }
+            .getOrElse { throw BusinessException("VALIDATION_ERROR", "지원하지 않는 거래 유형입니다: $rawType") }
+        if (newType == transaction.type) return
+
+        if (newType == TransactionType.ADJUSTMENT || transaction.type == TransactionType.ADJUSTMENT) {
+            throw BusinessException(
+                "VALIDATION_ERROR",
+                "잔액 수정은 수입/지출로 변경할 수 없습니다. 삭제 후 다시 등록하세요."
+            )
+        }
+        if (reconciliationLookup.refsForTransactions(listOf(transaction.id)).isNotEmpty()) {
+            throw BusinessException(
+                "VALIDATION_ERROR",
+                "정산에 기록된 거래는 유형을 변경할 수 없습니다. 정산에서 제외한 뒤 다시 시도하세요."
+            )
+        }
+        transaction.type = newType
+    }
+
+    /** 카테고리는 유형별로 갈린다 (CategoryType). 유형만 바꾸고 카테고리를 두면 분류가 어긋난다. */
+    private fun validateCategoryMatchesType(transaction: Transaction) {
+        val category = transaction.category ?: return
+        val matches = when (transaction.type) {
+            TransactionType.INCOME -> category.type == CategoryType.INCOME
+            TransactionType.EXPENSE -> category.type == CategoryType.EXPENSE
+            TransactionType.ADJUSTMENT -> true
+        }
+        if (!matches) {
+            throw BusinessException(
+                "VALIDATION_ERROR",
+                "선택한 카테고리(${category.name})는 ${transaction.type.name} 거래에 쓸 수 없습니다. " +
+                    "카테고리를 함께 변경하세요."
+            )
+        }
     }
 
     @Transactional

--- a/backend/src/main/kotlin/com/budgetbook/transfer/service/TransferKindResolver.kt
+++ b/backend/src/main/kotlin/com/budgetbook/transfer/service/TransferKindResolver.kt
@@ -1,0 +1,36 @@
+package com.budgetbook.transfer.service
+
+import com.budgetbook.common.exception.BusinessException
+import com.budgetbook.paymentmethod.domain.PaymentMethodType
+import com.budgetbook.transfer.domain.TransferKind
+import org.springframework.stereotype.Component
+
+/**
+ * 이체 종류 자동 판정 + 결제수단 조합 검증 — **이체를 만드는 모든 경로의 단일 소스**.
+ *
+ * 이체 생성 경로가 둘로 늘었다 (사용자 등록 `TransferService.createTransfer`,
+ * 거래→이체 변환 `TransactionService.convertToTransfer`). 각자 판정 로직을 들고 있으면
+ * "등록한 이체는 카드 결제인데 변환한 이체는 일반 이체" 같은 어긋남이 생긴다.
+ *
+ * 규칙 (Phase 22 §2.1)
+ * - `BANK → CREDIT`: 카드 대금 결제 → `CARD_SETTLEMENT`
+ * - `CREDIT → CREDIT`: 금지
+ * - 그 외: `GENERIC`
+ * - `EXPENSE_TRANSFER` / `INCOME_TRANSFER` 는 의미상 자동 판정이 불가능해 사용자가 명시해야 한다
+ *   (이 클래스는 그 둘을 리턴하지 않는다).
+ */
+@Component
+class TransferKindResolver {
+
+    fun validateCombination(sourceType: PaymentMethodType, destType: PaymentMethodType) {
+        if (sourceType == PaymentMethodType.CREDIT && destType == PaymentMethodType.CREDIT) {
+            throw BusinessException("TRANSFER_CREDIT_TO_CREDIT_NOT_ALLOWED", "카드 간 이체는 불가합니다")
+        }
+    }
+
+    fun resolveDefaultKind(sourceType: PaymentMethodType, destType: PaymentMethodType): TransferKind = when {
+        sourceType == PaymentMethodType.BANK && destType == PaymentMethodType.CREDIT ->
+            TransferKind.CARD_SETTLEMENT
+        else -> TransferKind.GENERIC
+    }
+}

--- a/backend/src/main/kotlin/com/budgetbook/transfer/service/TransferService.kt
+++ b/backend/src/main/kotlin/com/budgetbook/transfer/service/TransferService.kt
@@ -35,7 +35,9 @@ class TransferService(
     private val syncEventPublisher: SyncEventPublisher,
     private val transactionRepository: TransactionRepository,
     // V65 — 목록 응답의 정산 배지/필터용 벌크 조회.
-    private val reconciliationLookup: com.budgetbook.reconciliation.service.ReconciliationLookup
+    private val reconciliationLookup: com.budgetbook.reconciliation.service.ReconciliationLookup,
+    // 이체 종류 판정·조합 검증의 단일 소스 (거래→이체 변환 경로와 공유).
+    private val kindResolver: TransferKindResolver
 ) : CoupleAwareService {
 
     @Transactional
@@ -408,11 +410,8 @@ class TransferService(
         return saved.toResponse()
     }
 
-    private fun validateNotCreditToCredit(sourceType: PaymentMethodType, destType: PaymentMethodType) {
-        if (sourceType == PaymentMethodType.CREDIT && destType == PaymentMethodType.CREDIT) {
-            throw BusinessException("TRANSFER_CREDIT_TO_CREDIT_NOT_ALLOWED", "카드 간 이체는 불가합니다")
-        }
-    }
+    private fun validateNotCreditToCredit(sourceType: PaymentMethodType, destType: PaymentMethodType) =
+        kindResolver.validateCombination(sourceType, destType)
 
     /**
      * Phase 22 §2.1 — TransferKind 자동 판정.
@@ -425,10 +424,8 @@ class TransferService(
      * EXPENSE_TRANSFER / INCOME_TRANSFER 는 의미상 자동 판정 불가능 — 사용자가 명시적으로
      * 지정해야 함(요청 본문의 `kind` 필드). 즉 이 함수는 EXPENSE/INCOME_TRANSFER 를 리턴하지 않는다.
      */
-    internal fun resolveDefaultKind(sourceType: PaymentMethodType, destType: PaymentMethodType): TransferKind = when {
-        sourceType == PaymentMethodType.BANK && destType == PaymentMethodType.CREDIT -> TransferKind.CARD_SETTLEMENT
-        else -> TransferKind.GENERIC
-    }
+    internal fun resolveDefaultKind(sourceType: PaymentMethodType, destType: PaymentMethodType): TransferKind =
+        kindResolver.resolveDefaultKind(sourceType, destType)
 
     private fun Transfer.toResponse(
         reconciliationRef: com.budgetbook.reconciliation.dto.ReconciliationRef? = null

--- a/backend/src/test/kotlin/com/budgetbook/transaction/service/TransactionServiceTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/transaction/service/TransactionServiceTest.kt
@@ -19,6 +19,7 @@ import com.budgetbook.paymentmethod.repository.PaymentMethodRepository
 import com.budgetbook.pocket.repository.MoneyPocketRepository
 import com.budgetbook.smart.service.PatternLearningService
 import com.budgetbook.transaction.domain.Transaction
+import com.budgetbook.sync.SyncEvent
 import com.budgetbook.sync.SyncEventPublisher
 import com.budgetbook.transaction.domain.TransactionType
 import com.budgetbook.transaction.dto.CreateTransactionRequest
@@ -55,7 +56,10 @@ class TransactionServiceTest : BehaviorSpec({
     // V65 — 목록 응답의 정산 배지 벌크 조회. 기본은 "정산 기록 없음".
     val reconciliationLookup =
         mockk<com.budgetbook.reconciliation.service.ReconciliationLookup>(relaxed = true)
-    val service = TransactionService(transactionRepository, coupleResolver, userRepository, categoryRepository, paymentMethodRepository, moneyPocketRepository, syncEventPublisher, patternLearningService, transferRepository, reconciliationLookup)
+    val transferService = mockk<com.budgetbook.transfer.service.TransferService>()
+    val spendingPlanRepository =
+        mockk<com.budgetbook.spendingplan.repository.SpendingPlanRepository>(relaxed = true)
+    val service = TransactionService(transactionRepository, coupleResolver, userRepository, categoryRepository, paymentMethodRepository, moneyPocketRepository, syncEventPublisher, patternLearningService, transferRepository, reconciliationLookup, transferService, spendingPlanRepository)
 
     val user1 = User(email = "u1@test.com", nickname = "U1", provider = AuthProvider.GOOGLE, providerId = "g1")
     val user2 = User(email = "u2@test.com", nickname = "U2", provider = AuthProvider.KAKAO, providerId = "k2")
@@ -1166,6 +1170,196 @@ class TransactionServiceTest : BehaviorSpec({
                 }
                 ex.code shouldBe "VALIDATION_ERROR"
                 verify(exactly = 0) { transactionRepository.save(any()) }
+            }
+        }
+    }
+
+    // --- 유형 변경 / 이체 변환 (2026-07-27) ---
+
+    Given("수입↔지출 유형 변경") {
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
+        every { reconciliationLookup.refsForTransactions(any()) } returns emptyMap()
+
+        When("지출 거래를 수입으로 바꾸면 (카테고리 없음)") {
+            val tx = Transaction(
+                couple = couple, author = user1, type = TransactionType.EXPENSE,
+                amount = 15000, description = "환불", transactionDate = LocalDate.of(2026, 7, 15)
+            )
+            every { transactionRepository.findById(tx.id) } returns Optional.of(tx)
+            every { transactionRepository.save(tx) } returns tx
+
+            val result = service.updateTransaction(
+                user1.id, tx.id, UpdateTransactionRequest(type = "INCOME")
+            )
+
+            Then("유형이 바뀐다") {
+                result.type shouldBe "INCOME"
+            }
+        }
+
+        When("지출 카테고리를 그대로 두고 수입으로 바꾸면") {
+            val tx = Transaction(
+                couple = couple, author = user1, type = TransactionType.EXPENSE,
+                amount = 15000, description = "점심", category = category,
+                transactionDate = LocalDate.of(2026, 7, 15)
+            )
+            every { transactionRepository.findById(tx.id) } returns Optional.of(tx)
+            every { transactionRepository.save(tx) } returns tx
+
+            Then("VALIDATION_ERROR — 카테고리를 함께 바꿔야 한다") {
+                // 유형만 바꾸고 지출 카테고리를 남기면 분류가 어긋난 채 저장된다.
+                val ex = shouldThrow<com.budgetbook.common.exception.BusinessException> {
+                    service.updateTransaction(user1.id, tx.id, UpdateTransactionRequest(type = "INCOME"))
+                }
+                ex.code shouldBe "VALIDATION_ERROR"
+                verify(exactly = 0) { transactionRepository.save(any()) }
+            }
+        }
+
+        When("잔액 수정(ADJUSTMENT) 을 지출로 바꾸려 하면") {
+            val tx = Transaction(
+                couple = couple, author = user1, type = TransactionType.ADJUSTMENT,
+                amount = -3000, description = "잔액 조정", transactionDate = LocalDate.of(2026, 7, 15)
+            )
+            every { transactionRepository.findById(tx.id) } returns Optional.of(tx)
+
+            Then("VALIDATION_ERROR") {
+                shouldThrow<com.budgetbook.common.exception.BusinessException> {
+                    service.updateTransaction(user1.id, tx.id, UpdateTransactionRequest(type = "EXPENSE"))
+                }.code shouldBe "VALIDATION_ERROR"
+            }
+        }
+
+        When("정산에 기록된 거래의 유형을 바꾸려 하면") {
+            val tx = Transaction(
+                couple = couple, author = user1, type = TransactionType.EXPENSE,
+                amount = 15000, description = "점심", transactionDate = LocalDate.of(2026, 7, 15)
+            )
+            every { transactionRepository.findById(tx.id) } returns Optional.of(tx)
+            every { reconciliationLookup.refsForTransactions(listOf(tx.id)) } returns mapOf(
+                tx.id to com.budgetbook.reconciliation.dto.ReconciliationRef(
+                    reconciliationId = UUID.randomUUID(),
+                    reconciliationSeq = 1,
+                    reconciledAt = java.time.Instant.now()
+                )
+            )
+
+            Then("VALIDATION_ERROR — 스냅샷 분류 이력이 흔들린다") {
+                shouldThrow<com.budgetbook.common.exception.BusinessException> {
+                    service.updateTransaction(user1.id, tx.id, UpdateTransactionRequest(type = "INCOME"))
+                }.code shouldBe "VALIDATION_ERROR"
+                verify(exactly = 0) { transactionRepository.save(any()) }
+            }
+        }
+    }
+
+    Given("거래 → 이체 변환") {
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
+        every { reconciliationLookup.refsForTransactions(any()) } returns emptyMap()
+        every { spendingPlanRepository.existsByLinkedTransactionId(any()) } returns false
+
+        val srcId = UUID.randomUUID()
+        val dstId = UUID.randomUUID()
+
+        fun convertRequest() = com.budgetbook.transaction.dto.ConvertToTransferRequest(
+            sourcePaymentMethodId = srcId,
+            destinationPaymentMethodId = dstId
+        )
+
+        When("일반 지출 거래를 이체로 바꾸면") {
+            val tx = Transaction(
+                couple = couple, author = user1, type = TransactionType.EXPENSE,
+                amount = 50000, description = "계좌 이동", memo = "메모",
+                transactionDate = LocalDate.of(2026, 7, 15)
+            )
+            every { transactionRepository.findById(tx.id) } returns Optional.of(tx)
+            every { transactionRepository.delete(tx) } returns Unit
+            val created = slot<com.budgetbook.transfer.dto.CreateTransferRequest>()
+            every { transferService.createTransfer(user1.id, capture(created)) } returns
+                mockk(relaxed = true)
+
+            service.convertToTransfer(user1.id, tx.id, convertRequest())
+
+            Then("원본 값을 승계한 이체가 만들어지고 거래는 삭제된다") {
+                created.captured.amount shouldBe 50000
+                created.captured.description shouldBe "계좌 이동"
+                created.captured.memo shouldBe "메모"
+                created.captured.transferDate shouldBe LocalDate.of(2026, 7, 15)
+                verify { transactionRepository.delete(tx) }
+            }
+
+            Then("거래 삭제 이벤트도 발행된다 (장부는 두 스트림 병합)") {
+                val events = mutableListOf<SyncEvent>()
+                verify { syncEventPublisher.publish(capture(events)) }
+                events.any { it.type == "TRANSACTION_DELETED" } shouldBe true
+            }
+        }
+
+        When("잔액 수정을 이체로 바꾸려 하면") {
+            val tx = Transaction(
+                couple = couple, author = user1, type = TransactionType.ADJUSTMENT,
+                amount = -3000, description = "잔액 조정", transactionDate = LocalDate.of(2026, 7, 15)
+            )
+            every { transactionRepository.findById(tx.id) } returns Optional.of(tx)
+
+            Then("VALIDATION_ERROR") {
+                shouldThrow<com.budgetbook.common.exception.BusinessException> {
+                    service.convertToTransfer(user1.id, tx.id, convertRequest())
+                }.code shouldBe "VALIDATION_ERROR"
+                verify(exactly = 0) { transactionRepository.delete(any<Transaction>()) }
+            }
+        }
+
+        When("카드 결제에 연결된 거래를 이체로 바꾸려 하면") {
+            val tx = Transaction(
+                couple = couple, author = user1, type = TransactionType.EXPENSE,
+                amount = 50000, description = "카드 지출", transactionDate = LocalDate.of(2026, 7, 15),
+                settlementTransferId = UUID.randomUUID()
+            )
+            every { transactionRepository.findById(tx.id) } returns Optional.of(tx)
+
+            Then("VALIDATION_ERROR") {
+                shouldThrow<com.budgetbook.common.exception.BusinessException> {
+                    service.convertToTransfer(user1.id, tx.id, convertRequest())
+                }.code shouldBe "VALIDATION_ERROR"
+            }
+        }
+
+        When("지출 계획에 연결된 거래를 이체로 바꾸려 하면") {
+            val tx = Transaction(
+                couple = couple, author = user1, type = TransactionType.EXPENSE,
+                amount = 50000, description = "계획 지출", transactionDate = LocalDate.of(2026, 7, 15)
+            )
+            every { transactionRepository.findById(tx.id) } returns Optional.of(tx)
+            every { spendingPlanRepository.existsByLinkedTransactionId(tx.id) } returns true
+
+            Then("VALIDATION_ERROR — FK 위반으로 터지기 전에 막는다") {
+                // spending_plans.linked_transaction_id 에 ON DELETE 가 없어서
+                // 가드가 없으면 500(무결성 오류)이 난다.
+                shouldThrow<com.budgetbook.common.exception.BusinessException> {
+                    service.convertToTransfer(user1.id, tx.id, convertRequest())
+                }.code shouldBe "VALIDATION_ERROR"
+                verify(exactly = 0) { transactionRepository.delete(any<Transaction>()) }
+            }
+        }
+
+        When("이체 생성이 실패하면 (예: 카드 간 이체, 같은 결제수단)") {
+            val tx = Transaction(
+                couple = couple, author = user1, type = TransactionType.EXPENSE,
+                amount = 50000, description = "지출", transactionDate = LocalDate.of(2026, 7, 15)
+            )
+            every { transactionRepository.findById(tx.id) } returns Optional.of(tx)
+            // 결제수단 조합 검증은 이체 생성 경로가 단일 소스다 (여기서 또 검사하지 않는다).
+            every { transferService.createTransfer(user1.id, any()) } throws
+                com.budgetbook.common.exception.BusinessException(
+                    "VALIDATION_ERROR", "Source and destination payment methods must be different."
+                )
+
+            Then("원본 거래는 지워지지 않는다 (원자성)") {
+                shouldThrow<com.budgetbook.common.exception.BusinessException> {
+                    service.convertToTransfer(user1.id, tx.id, convertRequest())
+                }.code shouldBe "VALIDATION_ERROR"
+                verify(exactly = 0) { transactionRepository.delete(any<Transaction>()) }
             }
         }
     }

--- a/backend/src/test/kotlin/com/budgetbook/transfer/service/TransferServiceTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/transfer/service/TransferServiceTest.kt
@@ -41,7 +41,7 @@ class TransferServiceTest : BehaviorSpec({
     // V65 — 정산 배지/필터용 벌크 조회. 기본은 "정산 기록 없음".
     val reconciliationLookup =
         mockk<com.budgetbook.reconciliation.service.ReconciliationLookup>(relaxed = true)
-    val service = TransferService(transferRepository, coupleResolver, userRepository, paymentMethodRepository, syncEventPublisher, transactionRepository, reconciliationLookup)
+    val service = TransferService(transferRepository, coupleResolver, userRepository, paymentMethodRepository, syncEventPublisher, transactionRepository, reconciliationLookup, TransferKindResolver())
 
     val user1 = User(email = "u1@test.com", nickname = "U1", provider = AuthProvider.GOOGLE, providerId = "g1")
     val user2 = User(email = "u2@test.com", nickname = "U2", provider = AuthProvider.KAKAO, providerId = "k2")

--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -84,6 +84,7 @@ The current backend accepts only the singular `type` query parameter (see §Tran
   - [Create Transaction](#2-create-transaction)
   - [Get Transaction](#3-get-transaction)
   - [Update Transaction](#4-update-transaction)
+  - [Convert Transaction to Transfer](#4-1-convert-transaction-to-transfer)
   - [Delete Transaction](#5-delete-transaction)
   - [Export CSV](#6-export-csv)
   - [List Settlement Candidates](#7-list-settlement-candidates)
@@ -1210,6 +1211,7 @@ Updates an existing transaction. Only the author or the partner can update it.
 
 | Field             | Type     | Required | Description                                                    |
 |:------------------|:---------|:--------:|:---------------------------------------------------------------|
+| `type`            | `string` | No       | 유형 변경. `EXPENSE` ↔ `INCOME` 만 가능 (2026-07-27)             |
 | `amount`          | `long`   | No       | Updated amount (must be > 0)                                   |
 | `description`     | `string` | No       | Updated description (max 255 chars)                            |
 | `categoryId`      | `UUID`   | No       | Updated category (null to unset)                               |
@@ -1224,9 +1226,71 @@ Updates an existing transaction. Only the author or the partner can update it.
 
 | Status | Error Code | Description |
 |:-------|:-----------|:------------|
+| `400`  | `VALIDATION_ERROR` | `type` 변경 시: `ADJUSTMENT` 와의 상호 전환 / 정산에 기록된 거래 / 남아 있는 카테고리가 새 유형과 불일치 |
 | `403`  | `FORBIDDEN` | Transaction belongs to a different couple |
 | `403`  | `PRIVATE_ACCESS_DENIED` | Transaction is PRIVATE and caller is not the owner |
 | `404`  | `TRANSACTION_NOT_FOUND` | Transaction does not exist |
+
+**유형 변경 규칙** (2026-07-27)
+
+- `EXPENSE` ↔ `INCOME` 만 가능하다. 카테고리는 유형별로 갈리므로(`CategoryType`), 기존
+  카테고리가 새 유형과 맞지 않으면 `categoryId` 를 **같은 요청에** 담아야 한다.
+- `ADJUSTMENT`(잔액 수정)는 부호 있는 증감값이라 일반 거래와 상호 전환하지 않는다.
+- 정산 스냅샷에 기록된 거래는 변경 불가 — 스냅샷의 `snapshot_kind` 가 정산 당시 분류라
+  원본 유형이 바뀌면 그 달 소계 이력이 흔들린다. 정산에서 제외한 뒤 시도한다.
+- **이체로의 변경은 이 엔드포인트가 아니다** → `POST /transactions/{id}/convert-to-transfer`.
+
+---
+
+### 4-1. Convert Transaction to Transfer
+
+거래를 이체로 바꾼다. 거래(`transactions`)와 이체(`transfers`)는 테이블이 달라 `PUT` 으로는
+유형을 바꿀 수 없다. 이 엔드포인트는 **원본 거래 삭제 + 이체 생성**을 한 트랜잭션으로 처리하고
+생성된 이체를 돌려준다.
+
+| Item        | Value                                             |
+|:------------|:--------------------------------------------------|
+| **Method**  | `POST`                                            |
+| **Path**    | `/api/v1/transactions/{id}/convert-to-transfer`   |
+| **Auth**    | Required                                          |
+
+**Request Body**
+
+```json
+{
+  "sourcePaymentMethodId": "550e8400-e29b-41d4-a716-446655440031",
+  "destinationPaymentMethodId": "550e8400-e29b-41d4-a716-446655440032",
+  "kind": "GENERIC",
+  "amount": 50000,
+  "transferDate": "2026-07-15",
+  "description": "계좌 이동",
+  "memo": null
+}
+```
+
+| Field                        | Type     | Required | Description                                        |
+|:-----------------------------|:---------|:--------:|:----------------------------------------------------|
+| `sourcePaymentMethodId`      | `UUID`   | Yes      | 출금 결제수단                                        |
+| `destinationPaymentMethodId` | `UUID`   | Yes      | 입금 결제수단 (출금과 달라야 함)                      |
+| `kind`                       | `string` | No       | 생략 시 결제수단 조합으로 자동 판정 (BANK→CREDIT = 카드 결제) |
+| `amount`                     | `long`   | No       | 생략 시 원본 거래 금액 승계                           |
+| `transferDate`               | `string` | No       | 생략 시 원본 거래 날짜 승계                           |
+| `description`                | `string` | No       | 생략 시 원본 설명 승계                                |
+| `memo`                       | `string` | No       | 생략 시 원본 메모 승계                                |
+
+**Response `200 OK`**: `ApiResponse<TransferResponse>` (생성된 이체)
+
+**Error Responses**
+
+| Status | Error Code | Description |
+|:-------|:-----------|:------------|
+| `400`  | `VALIDATION_ERROR` | 잔액 수정(`ADJUSTMENT`) 거래 / 정산에 기록됨 / 카드 결제에 연결됨 / 지출 계획에 연결됨 / 출금·입금 결제수단 동일 |
+| `400`  | `TRANSFER_CREDIT_TO_CREDIT_NOT_ALLOWED` | 카드 → 카드 이체 |
+| `403`  | `FORBIDDEN` | 다른 커플의 거래 |
+| `404`  | `TRANSACTION_NOT_FOUND` / `PAYMENT_METHOD_NOT_FOUND` | 거래 또는 결제수단 없음 |
+
+**동기화**: `TRANSACTION_DELETED` + `TRANSFER_CREATED` **두 이벤트**를 모두 발행한다.
+장부 목록은 거래+이체 병합이라 한쪽만 쏘면 파트너 화면에 원본 거래가 남는다.
 
 ---
 

--- a/docs/sessions/2026-07-27_2_plan.md
+++ b/docs/sessions/2026-07-27_2_plan.md
@@ -199,3 +199,30 @@ BE `UpdateTransactionRequest` 에 `type` 필드가 **없다**(`TransactionDtos.k
 - V5 잔액 수정이 미기록 목록·건수·소계 어디에도 없음. 잔액 수정만 남은 달 → "이 달 정산 완료".
 - V6 달력에서 잔액 수정이 있는 날도 나머지가 정산되면 완료 점 표시.
 - V7 회귀: 리스트 모드 러닝 밸런스·월 합계 바 숫자 불변.
+
+---
+
+## 8. 진행 기록 (구현 중 확정된 것)
+
+### PR #277 (§4.1~4.5) — 머지·배포 완료 (2026-07-27)
+
+- 라이브 헤더로 반증 완료: `/assets/fonts/MaterialIcons-Regular.otf` →
+  `no-cache, must-revalidate`, 새 번들(37,276 B) 서빙.
+  `infra/scripts/verify-cache-headers.sh` 8개 경로 전부 통과, `verify-live` job success.
+- **기획에 없던 발견**: nginx vhost 사본이 두 벌이었다. CI(`sync-nginx`)가 배포하는
+  `ops/nas-nginx/aiva-bb.conf` 에 PR #251 no-cache fix·ACME 챌린지 블록이 빠져 있었고
+  인증서 경로도 달랐다(`AIVABB` vs 실제 `DOaRet`). 다음 nginx 변경 때 조용히 회귀할
+  상태였다 → NAS 실제 파일을 정본으로 채택, `infra/nginx/` 사본 삭제,
+  배포마다 repo↔NAS diff 검사(`verify-live`).
+- 하네스 등록: `ui_pattern`(어포던스 소실) 1건, `static_asset_cache` 2건 →
+  다음 재발 시 STRUCTURAL_FIX_REQUIRED.
+
+### PR #278 (§4.6) — 유형 변경
+
+- 이체 생성은 `TransferService.createTransfer` **재사용**(같은 트랜잭션). 직접 Transfer 를
+  만들면 카드결제 판정·카드간 이체 금지가 두 벌이 되므로 `TransferKindResolver` 로 분리.
+- 기획에 없던 가드 1건 추가: **지출 계획 연결**(`spending_plans.linked_transaction_id` FK 에
+  ON DELETE 없음 → 삭제 시 무결성 오류 500). 변환 전에 400 으로 막는다.
+- `Transaction.type` 을 `val` → `var` 로 (유형 변경 지원). 전환 제약은 서비스가 강제.
+- FE 는 `type` 을 **원래 유형과 다를 때만** 전송 — 로드 실패 상태 저장에서 초기값이 나가
+  수입이 지출로 뒤집히는 경로를 차단.

--- a/frontend/lib/features/transaction/data/datasources/transaction_remote_datasource.dart
+++ b/frontend/lib/features/transaction/data/datasources/transaction_remote_datasource.dart
@@ -4,6 +4,7 @@ import 'package:budget_book/features/transaction/data/models/transaction_model.d
 import 'package:budget_book/features/transaction/domain/entities/page_response.dart';
 import 'package:budget_book/features/transaction/domain/entities/transaction_filter.dart';
 import 'package:budget_book/features/transaction/domain/repositories/transaction_repository.dart';
+import 'package:budget_book/features/transfer/data/models/transfer_model.dart';
 
 abstract class TransactionRemoteDataSource {
   /// 필터는 [TransactionFilter] VO 로만 받는다 (필드 나열 금지 — 전파 누락 방지).
@@ -18,6 +19,9 @@ abstract class TransactionRemoteDataSource {
   Future<TransactionModel> createTransaction(Map<String, dynamic> data);
   Future<TransactionModel> updateTransaction(
       String id, Map<String, dynamic> data);
+
+  /// 거래 → 이체 변환. 응답은 생성된 이체.
+  Future<TransferModel> convertToTransfer(String id, Map<String, dynamic> data);
   Future<void> deleteTransaction(String id);
   Future<List<SuggestionGroup>> getSuggestions(String query, {String? type});
 }
@@ -96,6 +100,18 @@ class TransactionRemoteDataSourceImpl implements TransactionRemoteDataSource {
       data: data,
     );
     return TransactionModel.fromJson(
+      response.data['data'] as Map<String, dynamic>,
+    );
+  }
+
+  @override
+  Future<TransferModel> convertToTransfer(
+      String id, Map<String, dynamic> data) async {
+    final response = await apiClient.dio.post(
+      '${ApiEndpoints.transactions}/$id/convert-to-transfer',
+      data: data,
+    );
+    return TransferModel.fromJson(
       response.data['data'] as Map<String, dynamic>,
     );
   }

--- a/frontend/lib/features/transaction/data/repositories/transaction_repository_impl.dart
+++ b/frontend/lib/features/transaction/data/repositories/transaction_repository_impl.dart
@@ -7,6 +7,7 @@ import 'package:budget_book/features/transaction/domain/entities/transaction.dar
 import 'package:budget_book/features/transaction/domain/entities/page_response.dart';
 import 'package:budget_book/features/transaction/domain/entities/transaction_filter.dart';
 import 'package:budget_book/features/transaction/domain/repositories/transaction_repository.dart';
+import 'package:budget_book/features/transfer/domain/entities/transfer.dart';
 
 class TransactionRepositoryImpl implements TransactionRepository {
   final TransactionRemoteDataSource remoteDataSource;
@@ -86,6 +87,7 @@ class TransactionRepositoryImpl implements TransactionRepository {
   @override
   Future<Either<Failure, Transaction>> updateTransaction({
     required String id,
+    String? type,
     int? amount,
     String? description,
     String? categoryId,
@@ -98,6 +100,8 @@ class TransactionRepositoryImpl implements TransactionRepository {
   }) async {
     try {
       final data = <String, dynamic>{
+        // 유형 변경 (수입↔지출). 서버가 카테고리 정합성·정산 기록 여부를 검증한다.
+        if (type != null) 'type': type,
         if (amount != null) 'amount': amount,
         if (description != null) 'description': description,
         if (categoryId != null) 'categoryId': categoryId,
@@ -114,6 +118,37 @@ class TransactionRepositoryImpl implements TransactionRepository {
       return Left(mapDioError(e, 'Failed to update transaction'));
     } catch (e) {
       return const Left(ServerFailure('Failed to update transaction'));
+    }
+  }
+
+  @override
+  Future<Either<Failure, Transfer>> convertToTransfer({
+    required String id,
+    required String sourcePaymentMethodId,
+    required String destinationPaymentMethodId,
+    String? kind,
+    int? amount,
+    String? transferDate,
+    String? description,
+    String? memo,
+  }) async {
+    try {
+      final data = <String, dynamic>{
+        'sourcePaymentMethodId': sourcePaymentMethodId,
+        'destinationPaymentMethodId': destinationPaymentMethodId,
+        // 생략한 값은 서버가 원본 거래에서 승계한다 — 여기서 채우지 않는다.
+        if (kind != null) 'kind': kind,
+        if (amount != null) 'amount': amount,
+        if (transferDate != null) 'transferDate': transferDate,
+        if (description != null) 'description': description,
+        if (memo != null) 'memo': memo,
+      };
+      final result = await remoteDataSource.convertToTransfer(id, data);
+      return Right(result);
+    } on DioException catch (e) {
+      return Left(mapDioError(e, 'Failed to convert transaction to transfer'));
+    } catch (e) {
+      return const Left(ServerFailure('Failed to convert transaction to transfer'));
     }
   }
 

--- a/frontend/lib/features/transaction/domain/repositories/transaction_repository.dart
+++ b/frontend/lib/features/transaction/domain/repositories/transaction_repository.dart
@@ -3,6 +3,7 @@ import 'package:budget_book/core/error/failure.dart';
 import 'package:budget_book/features/transaction/domain/entities/transaction.dart';
 import 'package:budget_book/features/transaction/domain/entities/page_response.dart';
 import 'package:budget_book/features/transaction/domain/entities/transaction_filter.dart';
+import 'package:budget_book/features/transfer/domain/entities/transfer.dart';
 
 abstract class TransactionRepository {
   /// 거래 목록 조회.
@@ -35,6 +36,9 @@ abstract class TransactionRepository {
 
   Future<Either<Failure, Transaction>> updateTransaction({
     required String id,
+    /// 수입↔지출 유형 변경 (2026-07-27). null = 미변경.
+    /// 이체로의 변경은 테이블이 달라 [convertToTransfer] 를 쓴다.
+    String? type,
     int? amount,
     String? description,
     String? categoryId,
@@ -47,6 +51,19 @@ abstract class TransactionRepository {
   });
 
   Future<Either<Failure, void>> deleteTransaction(String id);
+
+  /// 거래 → 이체 변환. 서버가 원본 거래 삭제 + 이체 생성을 한 트랜잭션으로 처리하고
+  /// **생성된 이체**를 돌려준다. 생략한 값(금액·날짜·설명·메모)은 원본을 승계한다.
+  Future<Either<Failure, Transfer>> convertToTransfer({
+    required String id,
+    required String sourcePaymentMethodId,
+    required String destinationPaymentMethodId,
+    String? kind,
+    int? amount,
+    String? transferDate,
+    String? description,
+    String? memo,
+  });
 
   Future<Either<Failure, List<SuggestionGroup>>> getSuggestions(
     String query, {

--- a/frontend/lib/features/transaction/presentation/bloc/transaction_bloc.dart
+++ b/frontend/lib/features/transaction/presentation/bloc/transaction_bloc.dart
@@ -313,6 +313,7 @@ class TransactionBloc extends Bloc<TransactionEvent, TransactionState> {
     try {
       final result = await transactionRepository.updateTransaction(
         id: event.id,
+        type: event.type,
         amount: event.amount,
         description: event.description,
         categoryId: event.categoryId,

--- a/frontend/lib/features/transaction/presentation/bloc/transaction_event.dart
+++ b/frontend/lib/features/transaction/presentation/bloc/transaction_event.dart
@@ -129,6 +129,9 @@ class CreateTransaction extends TransactionEvent {
 
 class UpdateTransaction extends TransactionEvent {
   final String id;
+  /// 수입↔지출 유형 변경 (2026-07-27). null = 미변경.
+  /// 이체로 바꾸는 건 테이블이 달라 [ConvertTransactionToTransfer] 를 쓴다.
+  final String? type;
   final int? amount;
   final String? description;
   final String? categoryId;
@@ -142,6 +145,7 @@ class UpdateTransaction extends TransactionEvent {
 
   const UpdateTransaction({
     required this.id,
+    this.type,
     this.amount,
     this.description,
     this.categoryId,
@@ -155,7 +159,7 @@ class UpdateTransaction extends TransactionEvent {
 
   @override
   List<Object?> get props =>
-      [id, amount, description, categoryId, transactionDate, memo, clearMemo, paymentMethodId, pocketId, needsReview];
+      [id, type, amount, description, categoryId, transactionDate, memo, clearMemo, paymentMethodId, pocketId, needsReview];
 }
 
 class LoadMoreTransactions extends TransactionEvent {

--- a/frontend/lib/features/transaction/presentation/pages/transaction_form_page.dart
+++ b/frontend/lib/features/transaction/presentation/pages/transaction_form_page.dart
@@ -169,7 +169,22 @@ class _TransactionFormPageState extends State<TransactionFormPage>
   bool _isTransferSubmitting = false;
   int _swapCounter = 0;
 
+  /// 수정 모드에서 고른 유형: `EXPENSE` / `INCOME` / `TRANSFER` (2026-07-27).
+  ///
+  /// 이전에는 "(유형 수정 불가)" 라벨만 있었다. 수입↔지출은 그 자리에서 저장되고,
+  /// `TRANSFER` 를 고르면 이체 폼으로 바뀌며 저장 시 **변환 API**(거래 삭제 + 이체 생성)를 쓴다
+  /// — 거래와 이체는 테이블이 달라 update 로는 바꿀 수 없다.
+  String _editTargetType = 'EXPENSE';
+
+  /// 수정 진입 시점의 원래 유형. 저장할 때 **바뀐 경우에만** `type` 을 보낸다 —
+  /// 거래 로드가 실패한 상태에서 저장하면 초기값(EXPENSE)이 그대로 나가 수입 거래가
+  /// 지출로 뒤집힐 수 있다.
+  String? _originalType;
+
   bool get isEditing => widget.transactionId != null;
+
+  /// 수정 모드에서 이체로 바꾸는 중인가 (본문/저장 경로가 갈린다).
+  bool get _isConvertingToTransfer => isEditing && _editTargetType == 'TRANSFER';
 
   int _resolveInitialTabIndex() {
     // When editing, determine tab from transaction type (no transfer tab for edit)
@@ -236,6 +251,8 @@ class _TransactionFormPageState extends State<TransactionFormPage>
     _descriptionController.text = src.description;
     _memoController.text = src.memo ?? '';
     _selectedType = src.type;
+    _editTargetType = src.type;
+    _originalType = src.type;
     _selectedCategoryId = src.category?.id;
     _selectedCategoryDisplayName = src.category?.displayName;
     _selectedPaymentMethodId = src.paymentMethodId;
@@ -666,35 +683,7 @@ class _TransactionFormPageState extends State<TransactionFormPage>
           bottom: isEditing
               ? PreferredSize(
                   preferredSize: const Size.fromHeight(48),
-                  child: Align(
-                    alignment: Alignment.centerLeft,
-                    child: Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-                      child: Row(
-                        children: [
-                          Icon(
-                            _selectedType == 'INCOME'
-                                ? Icons.arrow_upward
-                                : Icons.arrow_downward,
-                            color: _selectedType == 'INCOME'
-                                ? Colors.green
-                                : Colors.red,
-                            size: 20,
-                          ),
-                          const SizedBox(width: 8),
-                          Text(
-                            '${_selectedType == 'INCOME' ? '수입' : '지출'} (유형 수정 불가)',
-                            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                                  color: Theme.of(context)
-                                      .colorScheme
-                                      .onSurface
-                                      .withValues(alpha: 0.7),
-                                ),
-                          ),
-                        ],
-                      ),
-                    ),
-                  ),
+                  child: _buildEditTypeSelector(context),
                 )
               : TabBar(
                   controller: _tabController,
@@ -706,7 +695,9 @@ class _TransactionFormPageState extends State<TransactionFormPage>
                 ),
         ),
         body: isEditing
-            ? _buildTransactionFormBody(context)
+            ? (_isConvertingToTransfer
+                ? _buildTransferFormContent(context)
+                : _buildTransactionFormBody(context))
             : TabBarView(
                 controller: _tabController,
                 children: [
@@ -726,6 +717,115 @@ class _TransactionFormPageState extends State<TransactionFormPage>
       ),
       ),
     );
+  }
+
+  /// 수정 모드 유형 선택 — 지출 / 수입 / 이체.
+  ///
+  /// 수입↔지출은 카테고리가 유형별로 갈리므로 전환 시 선택을 비운다(서버도 불일치를 400 으로
+  /// 막는다). 이체는 폼 자체가 달라 본문이 이체 폼으로 바뀌고, 저장은 변환 API 를 탄다.
+  Widget _buildEditTypeSelector(BuildContext context) {
+    // 잔액 수정은 잔액 보정 전용(부호 있는 증감값)이라 수입/지출/이체로 바꿀 수 없다
+    // (서버도 400 으로 막는다) → 선택지를 주지 않고 상태만 알린다.
+    if (_selectedType == 'ADJUSTMENT') {
+      return Align(
+        alignment: Alignment.centerLeft,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+          child: Row(
+            children: [
+              Icon(Icons.tune,
+                  size: 16,
+                  color: Theme.of(context).colorScheme.tertiary),
+              const SizedBox(width: 6),
+              Text(
+                '잔액 수정 (유형 변경 불가)',
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                      color: Theme.of(context)
+                          .colorScheme
+                          .onSurface
+                          .withValues(alpha: 0.7),
+                    ),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    return Align(
+      alignment: Alignment.centerLeft,
+      child: SingleChildScrollView(
+        scrollDirection: Axis.horizontal,
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+        child: Row(
+          children: [
+            Text(
+              '유형',
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: Theme.of(context)
+                        .colorScheme
+                        .onSurface
+                        .withValues(alpha: 0.6),
+                  ),
+            ),
+            const SizedBox(width: 8),
+            SegmentedButton<String>(
+              style: const ButtonStyle(
+                visualDensity: VisualDensity.compact,
+                tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+              ),
+              segments: const [
+                ButtonSegment(
+                  value: 'EXPENSE',
+                  icon: Icon(Icons.arrow_downward, size: 14),
+                  label: Text('지출'),
+                ),
+                ButtonSegment(
+                  value: 'INCOME',
+                  icon: Icon(Icons.arrow_upward, size: 14),
+                  label: Text('수입'),
+                ),
+                ButtonSegment(
+                  value: 'TRANSFER',
+                  icon: Icon(Icons.swap_horiz, size: 14),
+                  label: Text('이체'),
+                ),
+              ],
+              selected: {_editTargetType},
+              showSelectedIcon: false,
+              onSelectionChanged: (selection) {
+                if (selection.isEmpty) return;
+                _onEditTypeChanged(selection.first);
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _onEditTypeChanged(String next) {
+    if (next == _editTargetType) return;
+    setState(() {
+      _editTargetType = next;
+      if (next == 'TRANSFER') {
+        // 이체 폼은 금액/설명/메모를 공용 controller 로 쓴다. 날짜만 맞춰 준다.
+        _transferDate = _selectedDate;
+      } else {
+        _selectedType = next;
+        // 카테고리는 유형별로 갈린다 — 남겨두면 서버가 400 으로 막는다.
+        _selectedCategoryId = null;
+        _selectedCategoryDisplayName = null;
+      }
+    });
+    if (next != 'TRANSFER') {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('${next == 'INCOME' ? '수입' : '지출'}으로 변경 — 카테고리를 다시 선택하세요'),
+          duration: const Duration(seconds: 2),
+        ),
+      );
+    }
   }
 
   Widget _buildTransactionFormBody(BuildContext context, {
@@ -1011,6 +1111,19 @@ class _TransactionFormPageState extends State<TransactionFormPage>
 
     setState(() => _isTransferSubmitting = true);
 
+    // 수정 모드에서 유형을 이체로 바꾼 경우 — 새 이체를 만드는 게 아니라 **원본 거래를
+    // 이체로 옮긴다**(서버가 삭제+생성을 한 트랜잭션으로 처리). 여기서 CreateTransfer 를
+    // 쓰면 거래와 이체가 둘 다 남아 금액이 이중 계상된다.
+    if (_isConvertingToTransfer) {
+      _convertToTransfer(
+        amount: amount,
+        description: description,
+        memo: memo,
+        dateStr: dateStr,
+      );
+      return;
+    }
+
     debugPrint('[TransferForm] _submitTransfer: amount=$amount, source=$_transferSourcePaymentMethodId, dest=$_transferDestinationPaymentMethodId, date=$dateStr');
     final bloc = context.read<TransferBloc>();
     bloc.add(CreateTransfer(
@@ -1021,6 +1134,56 @@ class _TransactionFormPageState extends State<TransactionFormPage>
       transferDate: dateStr,
       memo: memo,
     ));
+  }
+
+  /// 거래 → 이체 변환 실행. 성공하면 거래/이체 두 목록을 함께 갱신하고 화면을 닫는다.
+  ///
+  /// BLoC 을 거치지 않고 repository 를 직접 부른다 — 이 작업은 두 스트림(거래 삭제 + 이체
+  /// 생성)에 걸쳐 있어 어느 한쪽 BLoC 의 상태 머신에 얹기가 어색하다. 대신 성공 후 두 BLoC
+  /// 을 모두 재조회해 목록이 갈라지지 않게 한다.
+  Future<void> _convertToTransfer({
+    required int amount,
+    required String? description,
+    required String? memo,
+    required String dateStr,
+  }) async {
+    final txnBloc = context.read<TransactionBloc>();
+    final result = await txnBloc.transactionRepository.convertToTransfer(
+      id: widget.transactionId!,
+      sourcePaymentMethodId: _transferSourcePaymentMethodId!,
+      destinationPaymentMethodId: _transferDestinationPaymentMethodId!,
+      amount: amount,
+      description: description,
+      memo: memo,
+      transferDate: dateStr,
+    );
+    if (!mounted) return;
+    setState(() => _isTransferSubmitting = false);
+
+    result.fold(
+      (failure) => ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(failure.message),
+          backgroundColor: Theme.of(context).colorScheme.error,
+        ),
+      ),
+      (transfer) {
+        final moved = DateTime.parse(transfer.transferDate);
+        // 두 스트림을 함께 갱신 — 하나만 하면 원본 거래가 남아 보이거나 새 이체가 안 보인다.
+        txnBloc.add(LoadTransactions.fromFilter(
+          moved.year,
+          moved.month,
+          txnBloc.currentFilter,
+        ));
+        context
+            .read<TransferBloc>()
+            .add(LoadTransfers(year: moved.year, month: moved.month));
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('이체로 변경되었습니다')),
+        );
+        Navigator.of(context).pop(true);
+      },
+    );
   }
 
   Widget _buildTransferFormBody(BuildContext context) {
@@ -2121,6 +2284,9 @@ class _TransactionFormPageState extends State<TransactionFormPage>
     if (isEditing) {
       bloc.add(UpdateTransaction(
         id: widget.transactionId!,
+        // 유형 변경 (수입↔지출). 바뀐 경우에만 보낸다. 서버가 카테고리 정합성·정산
+        // 기록 여부를 검증한다.
+        type: _editTargetType != _originalType ? _editTargetType : null,
         amount: amount,
         description: description,
         categoryId: resolvedCategoryId,

--- a/frontend/test/features/transaction/presentation/bloc/transaction_bloc_filter_persistence_test.dart
+++ b/frontend/test/features/transaction/presentation/bloc/transaction_bloc_filter_persistence_test.dart
@@ -42,6 +42,7 @@ class _MockTransactionRepository extends Mock implements TransactionRepository {
   @override
   Future<Either<Failure, Transaction>> updateTransaction({
     required String id,
+    String? type,
     int? amount,
     String? description,
     String? categoryId,

--- a/frontend/test/features/transaction/presentation/bloc/transaction_bloc_test.dart
+++ b/frontend/test/features/transaction/presentation/bloc/transaction_bloc_test.dart
@@ -87,6 +87,7 @@ class MockTransactionRepository extends Mock
   @override
   Future<Either<Failure, Transaction>> updateTransaction({
     required String id,
+    String? type,
     int? amount,
     String? description,
     String? categoryId,
@@ -100,6 +101,7 @@ class MockTransactionRepository extends Mock
       super.noSuchMethod(
         Invocation.method(#updateTransaction, [], {
           #id: id,
+          #type: type,
           #amount: amount,
           #description: description,
           #categoryId: categoryId,

--- a/frontend/test/features/transaction/type_change_test.dart
+++ b/frontend/test/features/transaction/type_change_test.dart
@@ -1,0 +1,137 @@
+import 'package:dartz/dartz.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:budget_book/core/error/failure.dart';
+import 'package:budget_book/features/transaction/data/datasources/transaction_remote_datasource.dart';
+import 'package:budget_book/features/transaction/data/models/transaction_model.dart';
+import 'package:budget_book/features/transaction/data/repositories/transaction_repository_impl.dart';
+import 'package:budget_book/features/transfer/data/models/transfer_model.dart';
+
+class _MockDataSource extends Mock implements TransactionRemoteDataSource {}
+
+/// 거래 유형 변경 (2026-07-27) — 전달 체인 고정.
+///
+/// 과거에 필터/파라미터가 repository→datasource hop 에서 조용히 누락된 사고가 3회 있었다
+/// (dateFrom/dateTo, PeriodSummary 필터, LoadCardSettlementSummary year/month).
+/// 여기서는 `type` 과 변환 payload 가 **실제 요청 map 에 들어가는지**를 검증한다.
+void main() {
+  late _MockDataSource ds;
+  late TransactionRepositoryImpl repo;
+
+  final txJson = <String, dynamic>{
+    'id': 't1',
+    'coupleId': 'c1',
+    'author': {'id': 'u1', 'nickname': '홍길동'},
+    'type': 'INCOME',
+    'amount': 15000,
+    'description': '환불',
+    'transactionDate': '2026-07-15',
+    'createdAt': '2026-07-15T10:00:00Z',
+    'updatedAt': '2026-07-15T10:00:00Z',
+  };
+
+  final transferJson = <String, dynamic>{
+    'id': 'tr1',
+    'coupleId': 'c1',
+    'author': {'id': 'u1', 'nickname': '홍길동'},
+    'sourcePaymentMethod': {'id': 'p1', 'name': '은행', 'type': 'BANK'},
+    'destinationPaymentMethod': {'id': 'p2', 'name': '현금', 'type': 'CASH'},
+    'amount': 50000,
+    'transferDate': '2026-07-15',
+    'kind': 'GENERIC',
+    'createdAt': '2026-07-15T10:00:00Z',
+  };
+
+  setUp(() {
+    ds = _MockDataSource();
+    repo = TransactionRepositoryImpl(remoteDataSource: ds);
+  });
+
+  group('updateTransaction type', () {
+    test('type 을 주면 요청 body 에 실린다', () async {
+      when(() => ds.updateTransaction(any(), any()))
+          .thenAnswer((_) async => TransactionModel.fromJson(txJson));
+
+      final result = await repo.updateTransaction(id: 't1', type: 'INCOME');
+
+      expect(result.isRight(), isTrue);
+      final data = verify(() => ds.updateTransaction('t1', captureAny()))
+          .captured
+          .single as Map<String, dynamic>;
+      expect(data['type'], 'INCOME');
+    });
+
+    test('type 을 안 주면 body 에 없다 (미변경)', () async {
+      when(() => ds.updateTransaction(any(), any()))
+          .thenAnswer((_) async => TransactionModel.fromJson(txJson));
+
+      await repo.updateTransaction(id: 't1', amount: 20000);
+
+      final data = verify(() => ds.updateTransaction('t1', captureAny()))
+          .captured
+          .single as Map<String, dynamic>;
+      expect(data.containsKey('type'), isFalse);
+      expect(data['amount'], 20000);
+    });
+  });
+
+  group('convertToTransfer', () {
+    test('결제수단은 필수로, 생략한 값은 body 에서 빠진다 (서버가 원본 승계)', () async {
+      when(() => ds.convertToTransfer(any(), any()))
+          .thenAnswer((_) async => TransferModel.fromJson(transferJson));
+
+      final result = await repo.convertToTransfer(
+        id: 't1',
+        sourcePaymentMethodId: 'p1',
+        destinationPaymentMethodId: 'p2',
+      );
+
+      expect(result.isRight(), isTrue);
+      final data = verify(() => ds.convertToTransfer('t1', captureAny()))
+          .captured
+          .single as Map<String, dynamic>;
+      expect(data['sourcePaymentMethodId'], 'p1');
+      expect(data['destinationPaymentMethodId'], 'p2');
+      expect(data.containsKey('amount'), isFalse);
+      expect(data.containsKey('transferDate'), isFalse);
+    });
+
+    test('금액·날짜·설명·메모를 주면 전부 전달된다', () async {
+      when(() => ds.convertToTransfer(any(), any()))
+          .thenAnswer((_) async => TransferModel.fromJson(transferJson));
+
+      await repo.convertToTransfer(
+        id: 't1',
+        sourcePaymentMethodId: 'p1',
+        destinationPaymentMethodId: 'p2',
+        amount: 50000,
+        transferDate: '2026-07-16',
+        description: '계좌 이동',
+        memo: '메모',
+      );
+
+      final data = verify(() => ds.convertToTransfer('t1', captureAny()))
+          .captured
+          .single as Map<String, dynamic>;
+      expect(data['amount'], 50000);
+      expect(data['transferDate'], '2026-07-16');
+      expect(data['description'], '계좌 이동');
+      expect(data['memo'], '메모');
+    });
+
+    test('실패는 Failure 로 매핑된다', () async {
+      when(() => ds.convertToTransfer(any(), any()))
+          .thenThrow(Exception('boom'));
+
+      final result = await repo.convertToTransfer(
+        id: 't1',
+        sourcePaymentMethodId: 'p1',
+        destinationPaymentMethodId: 'p2',
+      );
+
+      expect(result.isLeft(), isTrue);
+      result.fold((f) => expect(f, isA<ServerFailure>()), (_) => fail('실패해야 한다'));
+    });
+  });
+}

--- a/frontend/test/features/transaction/type_change_test.dart
+++ b/frontend/test/features/transaction/type_change_test.dart
@@ -1,4 +1,3 @@
-import 'package:dartz/dartz.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 


### PR DESCRIPTION
기획: `docs/sessions/2026-07-27_2_plan.md` §4.6 (PR-B)

수정 화면이 `"(유형 수정 불가)"` 라벨로 막고 있었고, BE `UpdateTransactionRequest` 에는 `type` 필드 자체가 없어 **수입↔지출조차** 불가능했다. 이체는 테이블이 달라 update 로는 원천 불가.

## 수입 ↔ 지출

`UpdateTransactionRequest.type` 추가. 가드:
- 카테고리는 유형별로 갈리므로(`CategoryType`) 남은 카테고리가 새 유형과 안 맞으면 **400** → FE 는 전환 시 카테고리를 비우고 재선택을 안내
- 잔액 수정(`ADJUSTMENT`) 과의 상호 전환 금지 (부호 있는 증감값이라 의미가 다름)
- **정산에 기록된 거래 금지** — 스냅샷 `snapshot_kind` 가 정산 당시 분류라 원본 유형이 바뀌면 그 달 소계 이력이 흔들린다

## 이체로 변환 — `POST /transactions/{id}/convert-to-transfer`

원본 거래 삭제 + 이체 생성을 **한 트랜잭션**으로. 금액·날짜·설명·메모 생략 시 원본 승계.

되돌릴 수 없는 이동이라 다른 기능이 붙잡고 있으면 막는다:
- 정산 스냅샷 기록 / 카드 결제 링크(`settlementTransferId`) / 잔액 수정
- **지출 계획 연결** — `spending_plans.linked_transaction_id` FK 에 `ON DELETE` 가 없어 가드 없이 지우면 무결성 오류로 500

이체 생성은 `TransferService.createTransfer` 를 그대로 재사용하고(같은 트랜잭션), 종류 판정·카드간 이체 금지는 `TransferKindResolver` 로 뽑아 **두 경로가 같은 규칙**을 쓴다. 동기화는 `TRANSACTION_DELETED` + `TRANSFER_CREATED` 둘 다 발행 (장부는 두 스트림 병합이라 하나만 쏘면 원본 거래가 남는다).

## FE

- 수정 화면 상단 `유형 [지출|수입|이체]` 세그먼트. 이체 선택 시 본문이 이체 폼으로 바뀌고 저장은 변환 API (CreateTransfer 를 쓰면 거래·이체가 둘 다 남아 이중 계상)
- 잔액 수정 거래는 "잔액 수정 (유형 변경 불가)" 표기
- `type` 은 **원래 유형과 다를 때만** 전송 — 거래 로드 실패 상태의 저장에서 초기값이 나가 수입이 지출로 뒤집히는 것 방지

## 테스트

- BE 9건: 유형 변경(성공 / 카테고리 불일치 400 / ADJUSTMENT 400 / 정산됨 400), 변환(원본 승계·삭제·이벤트, 잔액수정·카드결제·지출계획 가드, 이체 생성 실패 시 원본 보존)
- FE 5건: `type` 유무에 따른 body, 변환 payload 전달, 실패 매핑

로컬 CI: BE `./gradlew test build` SUCCESS / FE analyze 3 info(기존) · test **802 passed** · build web SUCCESS

🤖 Generated with [Claude Code](https://claude.com/claude-code)