### PR TITLE
fix(transaction): 뷰 토글 텍스트 라벨 — 정산 진입점의 아이콘 글리프 의존 제거

### DIFF
--- a/frontend/lib/core/widgets/reconciled_badge.dart
+++ b/frontend/lib/core/widgets/reconciled_badge.dart
@@ -59,18 +59,19 @@ class ReconciledBadge extends StatelessWidget {
               size: 12,
               color: color,
             ),
-            if (seq != null) ...[
-              const SizedBox(width: 2),
-              Text(
-                '$seq차',
-                style: TextStyle(
-                  fontSize: 10,
-                  fontWeight: FontWeight.w600,
-                  color: color,
-                  height: 1.0,
-                ),
+            const SizedBox(width: 2),
+            Text(
+              // 2026-07-28 — 회차가 없어도 **텍스트를 항상 붙인다**.
+              // 아이콘 글리프가 뜨지 않는 기기가 있어(정산 뷰 토글 사례) 아이콘만으로는
+              // 배지 존재 자체가 보이지 않을 수 있다.
+              seq != null ? '$seq차' : '정산',
+              style: TextStyle(
+                fontSize: 10,
+                fontWeight: FontWeight.w600,
+                color: color,
+                height: 1.0,
               ),
-            ],
+            ),
           ],
         ),
       ),

--- a/frontend/lib/features/transaction/presentation/pages/transaction_list_page.dart
+++ b/frontend/lib/features/transaction/presentation/pages/transaction_list_page.dart
@@ -1368,29 +1368,41 @@ class _ViewModeToggle extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // 2026-07-28 — **아이콘 전용 → 텍스트 라벨**.
+    //
+    // 정산 세그먼트(`Icons.fact_check`)만 빈칸으로 보인다는 보고가 캐시 정리 뒤에도 이어졌다.
+    // 서버 쪽은 결백을 확인했다: 라이브 폰트 cmap 에 0xE256 이 있고 글리프에 실제 외곽선이
+    // 있으며(headless Chrome 렌더 확인), 배포된 번들도
+    // `IconData(57942,"MaterialIcons")` 를 요청한다. 즉 남은 변수는 **그 기기의 폰트 상태**뿐인데,
+    // 서버가 되돌릴 수 없는 영역이다.
+    //
+    // 그래서 이 UI 를 아이콘 글리프에 의존하지 않게 만든다. 라벨은 어떤 폰트 상태에서도
+    // 보이고(한글은 NotoSansKR), 아이콘만 보고 뜻을 유추할 필요도 없어진다.
+    // 아이콘+라벨은 좁은 폰에서 폭을 먹으므로 라벨만 둔다.
     return SegmentedButton<_TxViewMode>(
       style: const ButtonStyle(
         visualDensity: VisualDensity.compact,
         tapTargetSize: MaterialTapTargetSize.shrinkWrap,
         padding: WidgetStatePropertyAll(
-          EdgeInsets.symmetric(horizontal: 6, vertical: 0),
+          EdgeInsets.symmetric(horizontal: 8, vertical: 0),
         ),
+        textStyle: WidgetStatePropertyAll(TextStyle(fontSize: 12)),
       ),
       segments: const [
         ButtonSegment(
           value: _TxViewMode.list,
-          icon: Icon(Icons.list, size: 16),
-          tooltip: '리스트',
+          label: Text('목록'),
+          tooltip: '목록 보기',
         ),
         ButtonSegment(
           value: _TxViewMode.calendar,
-          icon: Icon(Icons.calendar_month, size: 16),
-          tooltip: '달력',
+          label: Text('달력'),
+          tooltip: '달력 보기',
         ),
         ButtonSegment(
           value: _TxViewMode.reconciliation,
-          icon: Icon(Icons.fact_check, size: 16),
-          tooltip: '정산',
+          label: Text('정산'),
+          tooltip: '정산 보기 — 미기록 항목 확인/기록',
         ),
       ],
       selected: {mode},

--- a/frontend/test/features/reconciliation/reconciled_badge_test.dart
+++ b/frontend/test/features/reconciliation/reconciled_badge_test.dart
@@ -24,6 +24,14 @@ void main() {
       expect(find.byIcon(Icons.check_circle), findsNothing);
     });
 
+    testWidgets('회차가 없어도 "정산" 텍스트를 붙인다 (아이콘 글리프 의존 제거)', (tester) async {
+      // 2026-07-28 — 특정 기기에서 아이콘 글리프가 안 뜨는 사례가 있어, 배지는 아이콘만으로
+      // 존재를 알리지 않는다.
+      await tester.pumpWidget(wrap(const ReconciledBadge()));
+
+      expect(find.text('정산'), findsOneWidget);
+    });
+
     testWidgets('compact 모드는 텍스트 없이 점만 (달력 셀 레이아웃 보호)', (tester) async {
       await tester.pumpWidget(wrap(const ReconciledBadge(seq: 3, compact: true)));
 

--- a/frontend/test/features/transaction/view_mode_toggle_guard_test.dart
+++ b/frontend/test/features/transaction/view_mode_toggle_guard_test.dart
@@ -1,0 +1,45 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// 거래 탭 뷰 토글은 **글리프에 의존하지 않아야 한다** (2026-07-28).
+///
+/// 정산 세그먼트가 아이콘 전용(`Icons.fact_check`)이던 시절, 특정 기기에서 그 글리프만
+/// 렌더되지 않아 3번째 칸이 빈칸으로 보였다. 서버(폰트 cmap·글리프 외곽선·번들 코드포인트)는
+/// 결백했고, 서버가 되돌릴 수 없는 클라이언트 폰트 상태가 원인이었다.
+/// → 진입점 라벨을 텍스트로 두면 어떤 폰트 상태에서도 기능이 보인다.
+///
+/// 위젯 테스트로 잡으려면 거래 목록 페이지 전체(BLoC 5종 + DI)를 띄워야 해서, 여기서는
+/// 소스 선언 자체를 고정한다 (필터 필드 개수 가드와 같은 방식).
+void main() {
+  test('뷰 토글 3개 세그먼트는 텍스트 라벨을 가진다 (아이콘 전용 금지)', () {
+    final source = File(
+      'lib/features/transaction/presentation/pages/transaction_list_page.dart',
+    ).readAsStringSync();
+
+    final start = source.indexOf('class _ViewModeToggle');
+    expect(start, isNonNegative, reason: '_ViewModeToggle 클래스를 찾지 못했다');
+    final body = source.substring(start);
+
+    for (final label in ['목록', '달력', '정산']) {
+      expect(
+        body.contains("label: Text('$label')"),
+        isTrue,
+        reason: '$label 세그먼트에 텍스트 라벨이 없다 — 글리프가 안 뜨는 기기에서 빈칸이 된다',
+      );
+    }
+
+    // 아이콘을 다시 넣더라도 라벨과 **함께**여야 한다. 아이콘 전용 세그먼트 금지.
+    final segmentsBlock = body.substring(
+      body.indexOf('segments:'),
+      body.indexOf('selected:'),
+    );
+    final iconCount = 'icon: Icon('.allMatches(segmentsBlock).length;
+    final labelCount = 'label: Text('.allMatches(segmentsBlock).length;
+    expect(
+      labelCount >= iconCount,
+      isTrue,
+      reason: '아이콘만 있는 세그먼트가 있다 (icon $iconCount개 / label $labelCount개)',
+    );
+  });
+}


### PR DESCRIPTION
## 증상

PR #277(폰트 캐시 헤더 fix) 이후에도 **PC 하드 리프레시 + 모바일 사이트 데이터 삭제** 상태에서 거래 탭 뷰 토글의 3번째 칸이 빈칸.

## 측정 — 서버는 결백

- 라이브 폰트 `/assets/fonts/MaterialIcons-Regular.otf`: `no-cache`, cmap 293글리프로 **로컬 빌드 산출물과 완전 동일**(차집합 0)
- `0xE256` → glyph `fact_check_baseline`, 외곽선 `bounds=(43,64,469,448)`. 그 폰트를 headless Chrome 으로 렌더 → **아이콘 정상 표시**
- 배포 번들도 정확히 그 코드포인트를 요청:
  `B.wz=new A.pD(2,"reconciliation")` → `B.a4t=new A.a5(57942,"MaterialIcons",null,!1)`

→ 남은 변수는 **그 기기의 폰트 상태**뿐이고, 서버가 되돌릴 수 있는 영역이 아니다. 원인 추적을 더 하는 대신 **UI 가 글리프에 의존하지 않게** 바꾼다.

## 변경

- 뷰 토글: 아이콘 전용 → `[목록] [달력] [정산]` **텍스트 라벨**. 어떤 폰트 상태에서도 보이고, 아이콘 뜻을 유추할 필요도 없다. (아이콘+라벨은 좁은 폰에서 폭을 먹어 라벨만)
- 정산 배지: 회차가 없을 때도 `정산` 텍스트를 붙여 아이콘만으로 존재를 알리지 않게
- 가드: 세그먼트 라벨 존재 + 아이콘 전용 세그먼트 금지를 소스 수준 테스트로 고정

## 테스트

analyze 3 info(기존) / **804 passed** / build web SUCCESS

🤖 Generated with [Claude Code](https://claude.com/claude-code)