### PR TITLE
fix(transaction): 뷰 토글 아이콘 복원 — 아이콘 + 텍스트 라벨

### DIFF
--- a/frontend/lib/features/transaction/presentation/pages/transaction_list_page.dart
+++ b/frontend/lib/features/transaction/presentation/pages/transaction_list_page.dart
@@ -1376,31 +1376,34 @@ class _ViewModeToggle extends StatelessWidget {
     // `IconData(57942,"MaterialIcons")` 를 요청한다. 즉 남은 변수는 **그 기기의 폰트 상태**뿐인데,
     // 서버가 되돌릴 수 없는 영역이다.
     //
-    // 그래서 이 UI 를 아이콘 글리프에 의존하지 않게 만든다. 라벨은 어떤 폰트 상태에서도
-    // 보이고(한글은 NotoSansKR), 아이콘만 보고 뜻을 유추할 필요도 없어진다.
-    // 아이콘+라벨은 좁은 폰에서 폭을 먹으므로 라벨만 둔다.
+    // 그래서 **아이콘은 유지하고 텍스트 라벨을 함께 둔다.** 아이콘은 한눈에 구분하는 값을
+    // 주고, 라벨은 글리프가 안 뜨는 기기에서도 기능이 사라지지 않게 하는 안전망이다.
+    // (아이콘 전용은 금지 — `view_mode_toggle_guard_test.dart` 가 고정한다.)
     return SegmentedButton<_TxViewMode>(
       style: const ButtonStyle(
         visualDensity: VisualDensity.compact,
         tapTargetSize: MaterialTapTargetSize.shrinkWrap,
         padding: WidgetStatePropertyAll(
-          EdgeInsets.symmetric(horizontal: 8, vertical: 0),
+          EdgeInsets.symmetric(horizontal: 6, vertical: 0),
         ),
-        textStyle: WidgetStatePropertyAll(TextStyle(fontSize: 12)),
+        textStyle: WidgetStatePropertyAll(TextStyle(fontSize: 11)),
       ),
       segments: const [
         ButtonSegment(
           value: _TxViewMode.list,
+          icon: Icon(Icons.list, size: 15),
           label: Text('목록'),
           tooltip: '목록 보기',
         ),
         ButtonSegment(
           value: _TxViewMode.calendar,
+          icon: Icon(Icons.calendar_month, size: 15),
           label: Text('달력'),
           tooltip: '달력 보기',
         ),
         ButtonSegment(
           value: _TxViewMode.reconciliation,
+          icon: Icon(Icons.fact_check, size: 15),
           label: Text('정산'),
           tooltip: '정산 보기 — 미기록 항목 확인/기록',
         ),


### PR DESCRIPTION
PR #279 에서 글리프 의존 제거를 위해 라벨 전용으로 바꿨으나, 아이콘의 식별 가치를 버릴 필요는 없다는 피드백. **아이콘을 되살리고 라벨을 안전망으로 함께** 둔다.

- 평소: 아이콘으로 한눈에 구분
- 글리프가 안 뜨는 기기: 라벨이 있어 기능이 사라지지 않음
- 폭: 세그먼트당 ~10px 증가 (텍스트 11px / 아이콘 15px / 패딩 6px). 필터 칩 영역이 `Expanded`+스크롤이라 토글 폭은 그대로 유지된다.

아이콘 전용 금지 가드(`view_mode_toggle_guard_test.dart`)는 `label >= icon` 을 요구하므로 이 구성에서 통과.

로컬 CI: analyze 3 info(기존) / **804 passed** / build web SUCCESS

🤖 Generated with [Claude Code](https://claude.com/claude-code)