### PR TITLE
fix(deploy): 아이콘 폰트 content hash — stale 캐시 원천 차단 + 뷰 토글 라벨 제거

### DIFF
--- a/.github/workflows/deploy-nas.yml
+++ b/.github/workflows/deploy-nas.yml
@@ -37,6 +37,8 @@ jobs:
               - '.github/workflows/deploy-nas.yml'
             frontend:
               - 'frontend/**'
+              # 아이콘 폰트 해시 단계는 FE 산출물을 바꾼다 → 스크립트 변경 시 재빌드/재배포 필요.
+              - 'infra/scripts/hash-icon-font.sh'
               - '.github/workflows/deploy-nas.yml'
             nginx:
               - 'ops/nas-nginx/**'
@@ -209,6 +211,14 @@ jobs:
         # MaterialIcons font 에 codepoint 없어 빈 글리프 표시 회귀 → 영구 fix.
         # Trade-off: offline 미지원. budget-book 는 인증 필요 앱이라 무관.
         run: flutter build web --release --pwa-strategy=none --dart-define=API_BASE_URL=https://aiva-bb.duckdns.org
+
+      # 회차 15 (2026-07-30) — 아이콘 폰트 stale 캐시 영구 fix.
+      # 트리셰이킹 폰트는 내용이 빌드마다 바뀌는데 URL 이 고정이라, 예전에 immutable 로
+      # 캐시한 클라이언트가 구 subset 을 물고 재검증조차 하지 않았다(정산 아이콘만 빈칸).
+      # 파일명에 content hash 를 넣어 URL 신원 = 내용 신원으로 만든다.
+      # 배포 후 verify-live job 의 verify-cache-headers.sh 가 해시 존재를 강제한다.
+      - name: Content-hash icon font (stale cache 차단)
+        run: ../infra/scripts/hash-icon-font.sh build/web
 
       - name: Setup SSH key
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,10 @@
 
 부부 공유 가계부 앱 (수입/지출·예산·통계·실시간 동기화). 한국어 우선, 영어 지원.
 
+> 🗂 **볼트 배선(2026-07-27)**: 이 repo 의 `docs/`(141노트) 는 `~/vaults/projects/aiva-bb` 로 symlink 노출(**열람 전용**).
+> 작업은 반드시 **cwd = 이 repo** 에서 한다 — 이 프로젝트는 `.claude/hooks/pre-edit-guard.sh` **project-local 하드게이트**라 다른 cwd 에서는 강제가 뜨지 않는다(admin `GR1`).
+> 라우팅 등재: `~/vaults/admin/00-registry/projects.md` + `~/vaults/.claude/registry.json`. ⚠ 별칭 "가계부" 는 work-saas 선점 → `aiva-bb`/`budget-book` 으로 부른다.
+
 ## Tech Stack
 - BE: Kotlin + Spring Boot 3.x + Kotest + Gradle (Kotlin DSL)
 - DB: PostgreSQL 16 + Redis 7 (Synology NAS Docker)

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -53,6 +53,12 @@
    - 함께 반영: `CLAUDE.md` 볼트 배선 안내(직전 회차 커밋 누락분)
    - 배포 트리거: `.github/workflows/deploy-nas.yml` 변경 → BE·FE·nginx 3개 job 전부 실행
 
+4. **2026-07-30** — PR #281 원격 CI 통과 → 머지·배포.
+   - CI: `backend-ci` pass / `frontend-ci` pass (2m2s)
+   - 머지: squash + branch 삭제 (개인 계정 자동 진행 승인 범위)
+   - 배포 후 자동 검증: `verify-live` job = nginx drift + `verify-cache-headers.sh`
+     (아이콘 폰트 URL 의 content hash 존재 포함)
+
 ## 3. 다음 단계
 
 <!-- HNS:NEXT -->

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -1,0 +1,75 @@
+# Budget Book (aiva-bb) 진행 이력 대장
+
+> **이 파일이 진행 상황의 단일 진입점이다.** `/clear` 후에도 이 파일 하나면 어디까지 왔는지 복원된다.
+> SessionStart 훅 `progress-resume.py` 가 아래 STATE·타임라인 꼬리·NEXT 를 자동 주입한다.
+> 실질 진전(산출물 생성·게이트 통과·결정 확정·실패)마다 §2 타임라인에 append. **무기록 변경 금지**.
+
+---
+
+## 1. 현재 상태 (한눈에)
+
+<!-- HNS:STATE -->
+- **단계**: 아이콘 폰트 stale 캐시 영구 fix + 뷰 토글 라벨 제거 / 라이브 검증 대기
+- **상태**: verifying
+- **정본 문서**: `docs/sessions/2026-07-30_handoff.md` (직전 회차) + 이 대장
+- **repo / 브랜치**: `AIVA-SaaS/budget-book` · `fix/icon-font-content-hash` → main
+- **CI 3종**: `flutter analyze --no-fatal-infos` 통과 / `flutter test` 805건 통과 / `flutter build web --release` 통과 (BE 무변경)
+- **blocker**: 없음
+- **갱신**: 2026-07-30
+<!-- /HNS:STATE -->
+
+## 2. 타임라인 (append-only)
+
+> 형식: `N. **YYYY-MM-DD** — 한 줄 요약.` + 하위 불릿(산출물 / 게이트 결과 / 결정 / 실패·인시던트).
+> 지우지 않는다. 틀린 기록은 지우지 말고 다음 항목에서 정정한다.
+
+1. **2026-07-30** — 대장 신설. 이전 이력은 `docs/sessions/` 회차 문서가 보유(#277~#280 배포 완료,
+   남은 것은 사용자 라이브 검증 5건).
+   - 산출물: 이 파일
+   - 결정: 앞으로 진행 기록은 이 대장이 단일 진입점
+
+2. **2026-07-30** — "정산 아이콘만 안 나온다" 3회차 — 근본 원인 확정 + 구조적 fix.
+   - 측정(hard evidence): 라이브 폰트(37,276B / 293글리프)에 `fact_check 0xE256` **존재**,
+     `list 0xE384`·`calendar_month 0xF06BB` 도 존재. `index.html`·`main.dart.js`·`FontManifest.json`·
+     `.otf` 전부 `no-cache, must-revalidate`. Service Worker 는 이미 비활성(`--pwa-strategy=none`).
+     빌드 산출물 어디에도 폰트 파일명 하드코딩 없음(`FontManifest.json` 참조 2건).
+   - 진단: 캐시 정책이 아니라 **URL 신원 ≠ 내용 신원**. 트리셰이킹 아이콘 폰트는 내용이 빌드마다
+     바뀌는데 URL 이 `assets/fonts/MaterialIcons-Regular.otf` 로 고정 → nginx 가 이 URL 을
+     `immutable` 로 내보내던 시절(2026-07-27 이전)에 캐시한 기기는 **재검증 요청조차 하지 않아**
+     정산 도입 이전 subset 을 계속 사용 → 0xE256 만 빈칸. 헤더 fix(#277)로는 도달 불가.
+   - 결정(사용자 승인): 폰트 파일명 content hash + 뷰 토글 텍스트 라벨 제거를 한 PR 로.
+     라벨 제거는 해시 fix 가 전제 — 순서를 뒤집으면 stale 폰트 기기에서 정산 칸이 완전히 빈칸.
+   - 산출물: `infra/scripts/hash-icon-font.sh`(신설) / `verify-cache-headers.sh` 해시 검증 추가 /
+     `deploy-nas.yml` 배선 + FE 트리거 경로 / `_ViewModeToggle` 아이콘 전용 /
+     `view_mode_toggle_guard_test.dart` 재작성(tooltip + 해시 게이트 배선 고정) /
+     `ops/nas-nginx/aiva-bb.conf` 주석 갱신
+   - 게이트: 합성 픽스처 + **실제 `flutter build web` 산출물**에서 rename·manifest 재작성·재실행
+     안전성 확인 / analyze 통과 / test 805건 통과
+   - 재발 방지: 해시 단계가 빠지면 배포 후 `verify-cache-headers.sh` 가 실패(FontManifest 경로의
+     해시 패턴 검사), 워크플로 배선이 빠지면 `flutter test` 가 실패
+
+## 3. 다음 단계
+
+<!-- HNS:NEXT -->
+- **다음 액션**: 사용자 라이브 검증 — 거래 탭 뷰 토글에서 **정산 아이콘이 보이는지**(글자 없이
+  아이콘 3개), 그리고 `docs/sessions/2026-07-30_handoff.md` §3 의 미확인 5건
+- **선행 조건**: PR 머지 후 deploy-nas 성공 (verify-live 의 캐시/해시 검증 포함)
+- **완료 판정**: 사용자 기기에서 정산 아이콘 노출 확인 = 이 건 종결. 아니면 그 기기에서 다른
+  아이콘도 빈칸인지 함께 확인(기기·브라우저 폰트 문제 분기)
+<!-- /HNS:NEXT -->
+
+## 4. 산출물 지도
+
+- `docs/sessions/2026-07-30_handoff.md` — 직전 회차 인수 문서(배포 현황·라이브 검증 체크리스트). 이력 보존용, 수정 금지
+- `docs/sessions/2026-07-28_icon-missing-handoff.md` — 아이콘 사건 1·2회차 측정 기록. 수정 금지
+- `infra/scripts/hash-icon-font.sh` — 아이콘 폰트 content hash (배포 파이프라인 필수 단계)
+- `infra/scripts/verify-cache-headers.sh` — 배포 후 캐시 정책 + 아이콘 폰트 해시 검증 게이트
+- `frontend/test/features/transaction/view_mode_toggle_guard_test.dart` — 뷰 토글 tooltip + 해시 게이트 배선 가드
+
+## 5. 미해결·리스크
+
+- 사용자 기기의 stale 폰트는 새 URL 로 자동 해소되지만, **폰트 외** 다른 stale 캐시가 남아 있을
+  가능성은 배제하지 못한다. 정산 아이콘이 여전히 빈칸이면 그 기기에서 다른 아이콘의 렌더 여부를
+  먼저 확인해 기기·브라우저 폰트 문제와 분리한다.
+- 프로젝트 폰트(`NotoSansKR-Subset.woff2`)는 여전히 해시 없는 고정 URL(AssetManifest 등재 때문).
+  거의 안 바뀌는 파일이고 `no-cache` 로 서빙되므로 현재는 수용된 리스크.

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -48,6 +48,11 @@
    - 재발 방지: 해시 단계가 빠지면 배포 후 `verify-cache-headers.sh` 가 실패(FontManifest 경로의
      해시 패턴 검사), 워크플로 배선이 빠지면 `flutter test` 가 실패
 
+3. **2026-07-30** — 커밋 → PR 생성 → 머지 → 배포 진입.
+   - 커밋: `fix(deploy): 아이콘 폰트 파일명에 content hash …` (a0de353)
+   - 함께 반영: `CLAUDE.md` 볼트 배선 안내(직전 회차 커밋 누락분)
+   - 배포 트리거: `.github/workflows/deploy-nas.yml` 변경 → BE·FE·nginx 3개 job 전부 실행
+
 ## 3. 다음 단계
 
 <!-- HNS:NEXT -->

--- a/frontend/lib/features/transaction/presentation/pages/transaction_list_page.dart
+++ b/frontend/lib/features/transaction/presentation/pages/transaction_list_page.dart
@@ -1368,43 +1368,44 @@ class _ViewModeToggle extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // 2026-07-28 — **아이콘 전용 → 텍스트 라벨**.
+    // 2026-07-30 — **아이콘 전용** (텍스트 라벨 제거).
     //
-    // 정산 세그먼트(`Icons.fact_check`)만 빈칸으로 보인다는 보고가 캐시 정리 뒤에도 이어졌다.
-    // 서버 쪽은 결백을 확인했다: 라이브 폰트 cmap 에 0xE256 이 있고 글리프에 실제 외곽선이
-    // 있으며(headless Chrome 렌더 확인), 배포된 번들도
-    // `IconData(57942,"MaterialIcons")` 를 요청한다. 즉 남은 변수는 **그 기기의 폰트 상태**뿐인데,
-    // 서버가 되돌릴 수 없는 영역이다.
+    // 라벨은 원래 "글리프가 안 뜨는 기기"용 안전망이었는데(2026-07-28), 그 근본 원인이
+    // 이번에 구조적으로 제거됐다. 원인은 서버 폰트가 아니라 **URL 신원 ≠ 내용 신원**이었다:
+    // 트리셰이킹 아이콘 폰트는 내용이 빌드마다 바뀌는데 URL 이
+    // `assets/fonts/MaterialIcons-Regular.otf` 로 고정이라, nginx 가 그 URL 을 `immutable`
+    // 로 내보내던 시절에 캐시한 기기는 구 subset 을 물고 **재검증 요청조차 하지 않았다**.
+    // 그래서 정산 도입 이전 subset 에 없는 0xE256(fact_check) 만 빈칸이고 목록·달력은
+    // 정상이었다 — 헤더 fix(#277)로는 그 기기에 도달할 수 없었다.
     //
-    // 그래서 **아이콘은 유지하고 텍스트 라벨을 함께 둔다.** 아이콘은 한눈에 구분하는 값을
-    // 주고, 라벨은 글리프가 안 뜨는 기기에서도 기능이 사라지지 않게 하는 안전망이다.
-    // (아이콘 전용은 금지 — `view_mode_toggle_guard_test.dart` 가 고정한다.)
+    // 이제 배포 시 `infra/scripts/hash-icon-font.sh` 가 폰트 파일명에 content hash 를 넣고
+    // FontManifest 를 재작성하므로 stale 캐시가 새 글리프를 가릴 수 없고,
+    // `infra/scripts/verify-cache-headers.sh` 가 배포마다 그 해시를 강제한다.
+    //
+    // 아이콘 전용이므로 각 세그먼트는 tooltip(= 접근성 라벨)을 반드시 갖는다
+    // — `view_mode_toggle_guard_test.dart` 가 고정한다.
     return SegmentedButton<_TxViewMode>(
       style: const ButtonStyle(
         visualDensity: VisualDensity.compact,
         tapTargetSize: MaterialTapTargetSize.shrinkWrap,
         padding: WidgetStatePropertyAll(
-          EdgeInsets.symmetric(horizontal: 6, vertical: 0),
+          EdgeInsets.symmetric(horizontal: 8, vertical: 0),
         ),
-        textStyle: WidgetStatePropertyAll(TextStyle(fontSize: 11)),
       ),
       segments: const [
         ButtonSegment(
           value: _TxViewMode.list,
-          icon: Icon(Icons.list, size: 15),
-          label: Text('목록'),
+          icon: Icon(Icons.list, size: 18),
           tooltip: '목록 보기',
         ),
         ButtonSegment(
           value: _TxViewMode.calendar,
-          icon: Icon(Icons.calendar_month, size: 15),
-          label: Text('달력'),
+          icon: Icon(Icons.calendar_month, size: 18),
           tooltip: '달력 보기',
         ),
         ButtonSegment(
           value: _TxViewMode.reconciliation,
-          icon: Icon(Icons.fact_check, size: 15),
-          label: Text('정산'),
+          icon: Icon(Icons.fact_check, size: 18),
           tooltip: '정산 보기 — 미기록 항목 확인/기록',
         ),
       ],

--- a/frontend/test/features/transaction/view_mode_toggle_guard_test.dart
+++ b/frontend/test/features/transaction/view_mode_toggle_guard_test.dart
@@ -2,17 +2,24 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 
-/// 거래 탭 뷰 토글은 **글리프에 의존하지 않아야 한다** (2026-07-28).
+/// 거래 탭 뷰 토글 가드 (2026-07-30 개정).
 ///
-/// 정산 세그먼트가 아이콘 전용(`Icons.fact_check`)이던 시절, 특정 기기에서 그 글리프만
-/// 렌더되지 않아 3번째 칸이 빈칸으로 보였다. 서버(폰트 cmap·글리프 외곽선·번들 코드포인트)는
-/// 결백했고, 서버가 되돌릴 수 없는 클라이언트 폰트 상태가 원인이었다.
-/// → 진입점 라벨을 텍스트로 두면 어떤 폰트 상태에서도 기능이 보인다.
+/// 경위: 정산 세그먼트(`Icons.fact_check`, 0xE256)만 빈칸으로 보이는 증상이 3회 재발했다.
+/// 서버 폰트는 결백했다(cmap 에 0xE256 존재, 외곽선 존재, headless Chrome 렌더 정상).
+/// 실제 원인은 **URL 신원 ≠ 내용 신원**이었다 — 트리셰이킹 아이콘 폰트는 내용이 빌드마다
+/// 바뀌는데 URL 이 `assets/fonts/MaterialIcons-Regular.otf` 로 고정이라, 그 URL 이
+/// `immutable` 로 나가던 시절에 캐시한 기기는 구 subset 을 물고 재검증조차 하지 않았다.
+///
+/// 그래서 2026-07-28 에는 "아이콘 전용 금지(텍스트 라벨 필수)"로 우회했지만, 근본 원인을
+/// 배포 파이프라인에서 제거한 뒤(폰트 파일명 content hash) 라벨을 걷어냈다.
+/// 이 파일은 그 전제 두 가지를 고정한다:
+///   1. 아이콘 전용이므로 세그먼트마다 tooltip(접근성/식별 수단)이 있다.
+///   2. 폰트 해시 게이트가 배포 파이프라인에 배선돼 있다 — 이게 빠지면 1의 전제가 무너진다.
 ///
 /// 위젯 테스트로 잡으려면 거래 목록 페이지 전체(BLoC 5종 + DI)를 띄워야 해서, 여기서는
 /// 소스 선언 자체를 고정한다 (필터 필드 개수 가드와 같은 방식).
 void main() {
-  test('뷰 토글 3개 세그먼트는 텍스트 라벨을 가진다 (아이콘 전용 금지)', () {
+  test('뷰 토글 3개 세그먼트는 아이콘 + tooltip 을 가진다', () {
     final source = File(
       'lib/features/transaction/presentation/pages/transaction_list_page.dart',
     ).readAsStringSync();
@@ -21,25 +28,51 @@ void main() {
     expect(start, isNonNegative, reason: '_ViewModeToggle 클래스를 찾지 못했다');
     final body = source.substring(start);
 
-    for (final label in ['목록', '달력', '정산']) {
-      expect(
-        body.contains("label: Text('$label')"),
-        isTrue,
-        reason: '$label 세그먼트에 텍스트 라벨이 없다 — 글리프가 안 뜨는 기기에서 빈칸이 된다',
-      );
-    }
-
-    // 아이콘을 다시 넣더라도 라벨과 **함께**여야 한다. 아이콘 전용 세그먼트 금지.
     final segmentsBlock = body.substring(
       body.indexOf('segments:'),
       body.indexOf('selected:'),
     );
+
+    final segmentCount = 'ButtonSegment('.allMatches(segmentsBlock).length;
+    expect(segmentCount, 3, reason: '뷰 토글 세그먼트가 3개(목록/달력/정산)가 아니다');
+
     final iconCount = 'icon: Icon('.allMatches(segmentsBlock).length;
-    final labelCount = 'label: Text('.allMatches(segmentsBlock).length;
+    final tooltipCount = 'tooltip:'.allMatches(segmentsBlock).length;
     expect(
-      labelCount >= iconCount,
+      iconCount,
+      segmentCount,
+      reason: '아이콘 없는 세그먼트가 있다 (icon $iconCount개 / segment $segmentCount개)',
+    );
+    expect(
+      tooltipCount,
+      segmentCount,
+      reason: 'tooltip 없는 세그먼트가 있다 — 아이콘 전용 토글은 이름을 알 방법이 사라진다',
+    );
+  });
+
+  test('아이콘 폰트 content hash 게이트가 배포 파이프라인에 배선돼 있다', () {
+    final script = File('../infra/scripts/hash-icon-font.sh');
+    expect(
+      script.existsSync(),
       isTrue,
-      reason: '아이콘만 있는 세그먼트가 있다 (icon $iconCount개 / label $labelCount개)',
+      reason: 'infra/scripts/hash-icon-font.sh 가 없다 — 아이콘 전용 토글의 전제가 무너진다',
+    );
+
+    final workflow =
+        File('../.github/workflows/deploy-nas.yml').readAsStringSync();
+    expect(
+      workflow.contains('hash-icon-font.sh'),
+      isTrue,
+      reason: 'deploy 워크플로가 hash-icon-font.sh 를 실행하지 않는다 → 폰트 URL 이 고정되고 '
+          '구 subset 을 문 기기에서 새 아이콘이 다시 빈칸이 된다',
+    );
+
+    final verify =
+        File('../infra/scripts/verify-cache-headers.sh').readAsStringSync();
+    expect(
+      verify.contains('FontManifest.json') && verify.contains(r'[0-9a-f]{12}'),
+      isTrue,
+      reason: 'verify-cache-headers.sh 가 아이콘 폰트 URL 의 content hash 를 검증하지 않는다',
     );
   });
 }

--- a/infra/scripts/hash-icon-font.sh
+++ b/infra/scripts/hash-icon-font.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+#
+# 아이콘 폰트 파일명에 content hash 를 넣어 **stale 캐시를 원천 차단**한다.
+#
+# 왜 필요한가 (3회 재발, 매번 "새 아이콘만 빈칸")
+#   Flutter web 은 `--tree-shake-icons`(release 기본값) 로 MaterialIcons 를 그 빌드가
+#   쓰는 코드포인트만 남긴 subset 으로 내보낸다. 즉 **내용은 빌드마다 바뀌는데 URL 은
+#   `assets/fonts/MaterialIcons-Regular.otf` 로 고정**이다.
+#   - 2026-05-04: 옛 Service Worker 캐시의 구 subset → 분석 탭 Icons.insights 빈칸
+#     (→ `--pwa-strategy=none` 로 SW 제거)
+#   - 2026-07-27: nginx 가 이 URL 을 `immutable` 로 내보내던 시절에 캐시한 클라이언트가
+#     구 subset 을 물고 **재검증 요청조차 하지 않음** → 정산 아이콘(0xe256) 만 빈칸.
+#     헤더를 고쳐도(#277) 이미 캐시를 물고 있는 기기에는 도달할 수 없다.
+#   근본 원인은 캐시 정책이 아니라 **URL 신원 ≠ 내용 신원**이다. 파일명에 해시를 넣으면
+#   내용이 바뀌면 URL 도 바뀌므로, 어떤 캐시 상태에서도 구 폰트가 새 글리프를 가릴 수 없다.
+#
+# 무엇을 하는가
+#   build/web/assets/FontManifest.json 의 아이콘 폰트(MaterialIcons*) 를
+#   `MaterialIcons-Regular.<sha256 앞 12자>.otf` 로 rename 하고 manifest 경로를 재작성.
+#   프로젝트 폰트(NotoSansKR 등)는 AssetManifest.bin.json 에도 등재돼 있어 건드리지 않는다.
+#   (재실행 안전 — 이미 해시가 붙어 있으면 건너뛴다.)
+#
+# 사용법:
+#   infra/scripts/hash-icon-font.sh [WEB_DIR]     # WEB_DIR 기본값 frontend/build/web
+#
+# 배선: .github/workflows/deploy-nas.yml (build web 직후, 패키징 직전)
+#       배포 후 검증은 infra/scripts/verify-cache-headers.sh 가 해시 패턴을 강제한다.
+#
+# 종료 코드: 0 = 성공(또는 대상 없음), 1 = manifest 부재/rename 실패
+
+set -euo pipefail
+
+WEB_DIR="${1:-frontend/build/web}"
+MANIFEST="${WEB_DIR}/assets/FontManifest.json"
+
+echo "== Icon font content-hash: ${WEB_DIR}"
+
+if [ ! -f "$MANIFEST" ]; then
+  echo "  FAIL FontManifest.json 없음: $MANIFEST"
+  echo "       (flutter build web 이후에 실행해야 한다. WEB_DIR 인자를 확인하라.)"
+  exit 1
+fi
+
+python3 - "$WEB_DIR" "$MANIFEST" <<'PY'
+import hashlib
+import json
+import os
+import re
+import sys
+
+web_dir, manifest_path = sys.argv[1], sys.argv[2]
+
+with open(manifest_path, encoding="utf-8") as fp:
+    manifest = json.load(fp)
+
+# 이미 해시가 붙은 파일명 (재실행 안전)
+HASHED = re.compile(r"\.[0-9a-f]{12}\.(otf|ttf|woff2?)$")
+# 트리셰이킹 대상 = Flutter 가 심는 아이콘 폰트. 프로젝트 폰트는 제외한다.
+ICON_FONT = re.compile(r"(^|/)MaterialIcons[^/]*\.(otf|ttf|woff2?)$")
+
+renamed = 0
+for family in manifest:
+    for font in family.get("fonts", []):
+        asset = font.get("asset", "")
+        if not ICON_FONT.search(asset):
+            continue
+        if HASHED.search(asset):
+            print(f"  SKIP {asset} — 이미 content hash 있음")
+            renamed += 1
+            continue
+
+        src = os.path.join(web_dir, "assets", asset)
+        if not os.path.isfile(src):
+            print(f"  FAIL manifest 가 가리키는 폰트 파일이 없다: {src}")
+            sys.exit(1)
+
+        with open(src, "rb") as fp:
+            digest = hashlib.sha256(fp.read()).hexdigest()[:12]
+
+        stem, ext = os.path.splitext(asset)
+        new_asset = f"{stem}.{digest}{ext}"
+        os.rename(src, os.path.join(web_dir, "assets", new_asset))
+        font["asset"] = new_asset
+        renamed += 1
+        print(f"  OK   {asset} -> {new_asset} (family={family.get('family')})")
+
+if renamed == 0:
+    # 아이콘 폰트가 아예 없는 빌드(전부 커스텀 아이콘 등)는 정상이다. 다만 조용히 지나가면
+    # "해시 단계가 죽었는데 아무도 모르는" 상태와 구분이 안 되므로 눈에 띄게 남긴다.
+    print("  WARN 아이콘 폰트 항목을 찾지 못했다 — FontManifest 를 확인하라:")
+    print("       " + json.dumps(manifest, ensure_ascii=False))
+    sys.exit(0)
+
+with open(manifest_path, "w", encoding="utf-8") as fp:
+    json.dump(manifest, fp, ensure_ascii=False, separators=(",", ":"))
+
+print(f"== 통과: 아이콘 폰트 {renamed}개 content hash 적용")
+PY

--- a/infra/scripts/verify-cache-headers.sh
+++ b/infra/scripts/verify-cache-headers.sh
@@ -10,6 +10,10 @@
 #   "빌드가 바뀌면 URL 도 바뀐다" 고 가정하고 장기 캐시를 걸었다.
 #   사람이 매번 기억하는 대신 배포 파이프라인이 검사한다.
 #
+#   2026-07-30 보강: 헤더 fix 만으로는 **이미 immutable 로 캐시한 클라이언트**를 구제할 수
+#   없다(재검증 요청 자체를 하지 않는다). 그래서 아이콘 폰트는 파일명에 content hash 를
+#   붙이고(`hash-icon-font.sh`), 이 스크립트가 그 해시의 존재까지 검사한다.
+#
 # 사용법:
 #   infra/scripts/verify-cache-headers.sh [BASE_URL]
 #   BASE_URL 기본값 https://aiva-bb.duckdns.org
@@ -28,7 +32,6 @@ HASHLESS_PATHS=(
   "/flutter_bootstrap.js"
   "/flutter_service_worker.js"
   "/version.json"
-  "/assets/fonts/MaterialIcons-Regular.otf"
   "/assets/AssetManifest.bin.json"
   "/assets/FontManifest.json"
 )
@@ -62,13 +65,49 @@ for path in "${HASHLESS_PATHS[@]}"; do
   fi
 done
 
+# ── 아이콘 폰트: 해시 없는 고정 URL 이면 실패 ──
+#
+# 트리셰이킹 아이콘 폰트는 내용이 빌드마다 바뀐다. 캐시 헤더만으로는 부족했다 —
+# 예전에 `immutable` 로 캐시한 클라이언트는 재검증 요청조차 하지 않아서, 헤더를 고쳐도
+# 구 subset 을 계속 물고 있었다(2026-07-30 "정산 아이콘만 빈칸"의 실제 원인).
+# 그래서 `infra/scripts/hash-icon-font.sh` 가 파일명에 content hash 를 넣는다.
+# 그 단계가 빠지거나 죽으면 증상은 몇 주 뒤 "새 아이콘만 안 보인다"로만 드러나므로,
+# 배포 파이프라인이 매번 검사한다.
+echo "== Icon font URL 검증"
+manifest=$(curl -sS --max-time 20 "${BASE_URL}/assets/FontManifest.json" 2>/dev/null)
+icon_asset=$(printf '%s' "$manifest" |
+  grep -oE '"asset":"[^"]*MaterialIcons[^"]*"' |
+  head -1 | sed 's/.*"asset":"//; s/"$//')
+
+if [ -z "$icon_asset" ]; then
+  echo "  SKIP 아이콘 폰트 항목 없음 (FontManifest: ${manifest:0:200})"
+else
+  icon_url="${BASE_URL}/assets/${icon_asset}"
+  if printf '%s' "$icon_asset" | grep -qE '\.[0-9a-f]{12}\.(otf|ttf|woff2?)$'; then
+    icon_status=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 20 "$icon_url" 2>/dev/null)
+    if [ "$icon_status" = "200" ]; then
+      echo "  OK   /assets/${icon_asset} — content hash 있음"
+    else
+      echo "  FAIL /assets/${icon_asset} — manifest 가 가리키는데 HTTP ${icon_status} (rename 후 배포 누락)"
+      fail=1
+    fi
+  else
+    echo "  FAIL /assets/${icon_asset} — content hash 없는 고정 URL"
+    echo "       hash-icon-font.sh 가 배포 파이프라인에서 실행되지 않았다."
+    fail=1
+  fi
+fi
+
 if [ "$fail" -ne 0 ]; then
   cat <<'EOF'
 
-배포 검증 실패 — 해시 없는 산출물에 장기 캐시가 걸려 있습니다.
+배포 검증 실패 — 캐시로 구버전이 고착될 수 있는 상태입니다.
 증상은 "새 기능/아이콘만 안 보인다" 형태로 나타나며, 사용자는 하드 리프레시 전까지
-계속 구버전을 봅니다. ops/nas-nginx/aiva-bb.conf 의 해당 location 을
-`Cache-Control "no-cache, must-revalidate"` 로 고치고 nginx 를 리로드하세요.
+계속 구버전을 봅니다.
+  - 캐시 헤더 FAIL: ops/nas-nginx/aiva-bb.conf 의 해당 location 을
+    `Cache-Control "no-cache, must-revalidate"` 로 고치고 nginx 를 리로드하세요.
+  - 아이콘 폰트 FAIL: deploy 워크플로에서 infra/scripts/hash-icon-font.sh 가
+    `flutter build web` 직후에 실행되는지 확인하세요.
 EOF
   exit 1
 fi

--- a/ops/nas-nginx/aiva-bb.conf
+++ b/ops/nas-nginx/aiva-bb.conf
@@ -144,7 +144,15 @@ server {
     #   (V65 정산 아이콘 fact_check/check_circle. PR #251 계산기 아이콘과 동일 계열의 2회차).
     #   폰트는 37KB 수준이고 ETag 304 로 재검증되므로 no-cache 비용은 무시할 만하다.
     #
-    # 이 정책은 infra/scripts/verify-cache-headers.sh 가 배포 후 실제 응답 헤더로 검증한다.
+    # 2026-07-30 — 헤더만으로는 부족했다(3회차). **이미 immutable 로 캐시한 클라이언트는
+    #   재검증 요청 자체를 하지 않아** 위 fix 가 도달하지 않는다(정산 아이콘만 빈칸 지속).
+    #   근본 원인은 캐시 정책이 아니라 URL 신원 ≠ 내용 신원이므로, 배포 파이프라인이
+    #   아이콘 폰트 파일명에 content hash 를 넣는다(infra/scripts/hash-icon-font.sh).
+    #   그래도 이 location 은 no-cache 를 유지한다 — 프로젝트 폰트(NotoSansKR-Subset.woff2)는
+    #   여전히 해시 없는 고정 URL 이고, 확장자 정규식은 둘을 구분하지 않는다.
+    #
+    # 이 정책은 infra/scripts/verify-cache-headers.sh 가 배포 후 실제 응답 헤더로 검증한다
+    # (아이콘 폰트는 FontManifest 경로의 content hash 존재까지 함께 검증).
     location ~* \.(ttf|otf|woff|woff2)$ {
         types {
             font/ttf ttf;

--- a/scripts/pre-deploy-check.sh
+++ b/scripts/pre-deploy-check.sh
@@ -20,7 +20,9 @@ echo "✅ Backend tests PASSED"
 echo ""
 echo "[2/4] Running Flutter analyze..."
 cd "$ROOT_DIR/frontend"
-flutter analyze
+# CI(ci-frontend.yml)와 동일한 플래그여야 한다 — 여기만 엄격하면 로컬 게이트가
+# 통과 불가능해지고(기존 info 3건), 반대면 CI 에서 처음 터진다. 2026-07-30 정렬.
+flutter analyze --no-fatal-infos --no-congratulate
 echo "✅ Flutter analyze PASSED"
 
 # 3. Frontend tests


### PR DESCRIPTION
## 문제

"정산 아이콘만 빈칸" 3회차. #277(캐시 헤더) → #279(아이콘 제거) → #280(아이콘 복원) 이후에도 증상 유지.

## 측정 (hard evidence)

- 라이브 폰트(37,276B / 293글리프)에 `fact_check 0xE256` **존재**. `list 0xE384`·`calendar_month 0xF06BB` 도 존재.
- `index.html`·`main.dart.js`·`FontManifest.json`·`.otf` 전부 `no-cache, must-revalidate`.
- Service Worker 는 이미 비활성(`--pwa-strategy=none`, 2026-05-04) → 남은 캐시 경로는 브라우저 HTTP 캐시뿐.
- 빌드 산출물에 폰트 파일명 하드코딩 0건 (`FontManifest.json` 참조만 2건) → 폰트 경로는 manifest 가 유일한 소스.

## 진단

근본 원인은 캐시 정책이 아니라 **URL 신원 ≠ 내용 신원**이다. 트리셰이킹 아이콘 폰트는 내용이 빌드마다 바뀌는데 URL 은 `assets/fonts/MaterialIcons-Regular.otf` 로 고정이다. 그 URL 이 `immutable` 로 나가던 시절(#277 이전)에 캐시한 기기는 **재검증 요청 자체를 하지 않으므로** 정산 도입 이전 subset 을 계속 쓴다 → `0xE256` 만 빈칸이고 목록·달력은 정상. 헤더 fix 로는 그 기기에 도달할 수 없다.

## 수정

1. `infra/scripts/hash-icon-font.sh` 신설 — `FontManifest.json` 의 MaterialIcons 를 `MaterialIcons-Regular.<sha256 12>.otf` 로 rename + manifest 재작성. 재실행 안전, 프로젝트 폰트(NotoSansKR, AssetManifest 등재)는 미변경.
2. `deploy-nas.yml` — `flutter build web` 직후 실행 + FE 트리거 경로에 스크립트 추가.
3. `verify-cache-headers.sh` — FontManifest 경로의 content hash 존재를 배포마다 검증(없으면 배포 실패).
4. `_ViewModeToggle` — 텍스트 라벨 제거(요청) → 아이콘 전용 + tooltip 유지. 라벨은 글리프 미노출 안전망이었고 그 원인이 1~3 으로 제거됐다.
5. `view_mode_toggle_guard_test` — "아이콘 전용 금지" → "tooltip 필수 + 해시 게이트 배선" 으로 재작성.
6. `pre-deploy-check.sh` — `flutter analyze` 플래그를 CI 와 정렬(로컬 게이트가 통과 불가능했다).
7. `docs/PROGRESS.md` 신설 — 진행 대장 단일 진입점.

## 게이트

- 합성 픽스처 + **실제 `flutter build web` 산출물**로 rename·manifest 재작성·재실행 안전성·실패 경로 확인
- `flutter analyze --no-fatal-infos --no-congratulate` 통과
- `flutter test` 805건 통과 (재작성한 가드 테스트 2건 포함)
- `./gradlew build` 통과 (BE 무변경, 대부분 Gradle 캐시)

## 기대 효과

배포 후 폰트 URL 이 바뀌므로 stale 캐시를 문 기기도 **하드 리프레시 없이** 새 폰트를 받는다. 이후 새 아이콘을 추가해도 같은 증상이 재발할 수 없다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)