### PR TITLE
fix(transaction): 달력 일자 시트에서 그 날짜로 거래 추가

### DIFF
--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -9,14 +9,16 @@
 ## 1. 현재 상태 (한눈에)
 
 <!-- HNS:STATE -->
-- **단계**: 새 회차 **"이체 → 거래 역변환" 기획 완료 · 사용자 승인 대기**. 코드 변경 0줄
-- **상태**: blocked (승인 대기 — 코드 편집 시작 금지)
-- **정본 문서**: `docs/sessions/2026-07-31_transfer-to-transaction_plan.md` (§0 에 재부팅 후 재개 절차)
-- **repo / 브랜치**: `AIVA-SaaS/budget-book` · 작업 트리 clean, 실행 중 프로세스 없음
-- ⚠ **2026-08-06 이력 재작성됨(회사 이메일 제거) — 전 커밋 SHA 가 바뀌었다.** 로컬은 재작성 완료·**푸시 대기**. 타임라인 참조. 다른 기기의 기존 클론은 pull 이 아니라 **재클론**. 백업 `~/backup/git-email-rewrite-20260806/budget-book.bundle`
-- **CI 3종**: 직전 회차 기준 전부 통과(이번 회차는 아직 코드 없음)
-- **blocker**: 사용자 승인 1건 (승인되면 계획서 §2 부터 추가 승인 없이 자동 진행)
-- **갱신**: 2026-07-31
+- **단계**: **달력 일자 시트 "거래 추가" 진입** 회차 — 구현·로컬 CI 완료, PR 진행 중
+  (`fix/calendar-day-add`). 다음 회차는 **"이체 → 거래 역변환"**(기획 완료·착수 승인 확인 필요)
+- **상태**: in_progress (이 회차) / 다음 회차는 승인 한마디면 즉시 §4 부터 진행
+- **정본 문서**: 다음 회차 = `docs/sessions/2026-07-31_transfer-to-transaction_plan.md` (§0 재개 절차)
+- **repo / 브랜치**: `AIVA-SaaS/budget-book` · 실행 중 프로세스 없음
+- **CI**: 이번 회차 FE 로컬 게이트 전부 통과 — analyze / test 815건 / build web (BE 미변경)
+- **blocker**: 이 회차는 사용자 라이브 검증 1건. 다음 회차는 착수 승인 1건
+- **갱신**: 2026-08-09
+- 이력 재작성(2026-08-06, 회사 이메일 제거)은 **푸시 완료** — 전 커밋 SHA 가 바뀌었으므로 다른 기기의
+  기존 클론은 pull 이 아니라 **재클론**. 백업 `~/backup/git-email-rewrite-20260806/budget-book.bundle`
 <!-- /HNS:STATE -->
 
 ## 2. 타임라인 (append-only)
@@ -123,14 +125,44 @@
     - 교훈: "스캔 결과 0건"은 **스캔 범위가 대상을 덮었을 때만** 근거가 된다. 범위를 먼저 검증할 것.
   - 남은 이력 이슈(별건): `kdh929624@gmail.com` **21건**. 회사 이메일은 아니라 이번 범위 밖 — 정리 여부는 사용자 판단.
 
+10. **2026-08-09** — **달력 일자 시트에 "거래 추가" 진입 신설**(별건 소규모 회차. 역변환 회차와 파일 무겹침).
+   - 사용자 지적: "거래 > 달력에서 거래 클릭해서 별도 노출될 때 거래를 추가할 수 없다"
+   - 측정(hard evidence): `TransactionCalendarView` 가 받는 콜백은 `onTransactionTap`/`onTransferTap`
+     **둘뿐**이었고 일자 시트(`_showDayBottomSheet`) 안에 추가 어포던스가 **전무**(빈 날은 `'거래 없음'`
+     텍스트만). 시트가 모달이라 페이지 FAB 을 배리어로 덮어 그 상태에서 추가 불가, 시트를 닫고 FAB 을
+     눌러도 `_buildCreateTransactionUrl(tab:)` 만 호출돼 **선택 일자가 승계되지 않았다**.
+     목록 모드에는 `_DateHeader.onAddTap` → `_buildCreateTransactionUrl(date:)` 로 이미 있던 진입 —
+     **달력에만 빠진 대칭 결함**(`feedback_common_scope_audit` 유형)
+   - 공통 범위 전수: `TableCalendar` 사용처 **1곳**(이 위젯뿐) · `LedgerDateHeader` 소비처 2곳 중
+     목록 페이지는 이미 보유, 정산 뷰는 그룹 체크박스 선택용이라 추가 진입 대상 아님 → **수정 2파일 확정**
+   - 산출물: `transaction_calendar_view.dart`(`onAddTap` 파라미터 + 시트 헤더 `+` 버튼 + 빈 날
+     [이 날짜에 거래 추가] 버튼 + `_addForDay` = pop 후 콜백) /
+     `transaction_list_page.dart`(호출부에서 `_buildCreateTransactionUrl(date:)` 주입) /
+     `test/features/transaction/calendar_day_sheet_add_test.dart`(신설, 4건)
+   - 설계 결정: URL 조립은 **상위 페이지의 `_buildCreateTransactionUrl` 단일 소스**만 한다. 위젯이 직접
+     push 하면 필터된 결제수단 전파가 끊긴다 → 가드 테스트가 위젯 내 `'/transactions/create'` 문자열
+     **부재**까지 고정
+   - 게이트: `pre-change-audit.sh . "navigation_state ui_pattern"` → OK / gate OPEN ·
+     `flutter analyze` 통과(잔여 info 3건은 기존 테스트 파일, 이번 변경과 무관) ·
+     `flutter test` **815건 통과** · `flutter build web --release` 성공
+   - 아이콘 위험군 아님: 새 코드포인트 없음(`Icons.add` 는 기존 FAB 에서 이미 사용) → 폰트 subset 불변
+   - 정정(§2-16 기록): 이력 재작성 **푸시는 완료**됐다. 측정 — `main` == `origin/main` (`49ef7ed`),
+     원격 실재 52개 브랜치·태그 33/33 전부 동기. 잔여 diff 는 stale `worktree-agent-*` 로컬 브랜치
+     7개뿐(원격과 무관한 폐기 대상)
+
 ## 3. 다음 단계
 
 <!-- HNS:NEXT -->
-- **다음 액션**: 사용자가 기획을 **승인**하면 `docs/sessions/2026-07-31_transfer-to-transaction_plan.md`
-  §4(백엔드) → §5(프론트) → §6(테스트) → §7(로컬 CI) 순서로 구현한다. 승인 전에는 코드 편집 금지.
-- **재부팅 후 첫 명령**: 계획서 §0 (cwd = 이 repo, `git switch main && git pull`, 이 STATE 확인)
-- **선행 조건**: 승인 1건. 유실 위험 없음(로컬 실행 프로세스 없음, 작업 트리 clean)
-- **완료 판정**: BE 4파일 + FE 5파일 + 문서 2 + 테스트 4 반영 → 로컬 CI 3종 통과 → PR 머지 →
+- **다음 액션 (`/clear` 후 여기서 시작)**: 후보 1 **"이체 → 거래 역변환"** 착수.
+  사용자 착수 승인(한마디)을 확인한 뒤 `docs/sessions/2026-07-31_transfer-to-transaction_plan.md`
+  §4(백엔드) → §5(프론트) → §6(테스트) → §7(로컬 CI) 순서로 구현한다. 승인 확인 전 코드 편집 금지(§2 게이트).
+  - 승인 이력: 기획은 2026-07-31 상신, **착수 지정은 아직 명시적으로 받지 않았다**(2026-08-09 회차는
+    사용자가 별건으로 지시한 달력 추가 결함이었다). 계획서 내용 자체는 재검토 불필요.
+- **첫 명령**: 계획서 §0 (cwd = 이 repo, `git switch main && git pull`, 이 STATE 확인)
+- **이번 회차(달력 추가)의 남은 것**: 사용자 라이브 검증 1건 — 거래 탭 → 달력 뷰 → 아무 날짜 탭 →
+  시트에서 `+`(항목 있는 날) 또는 [이 날짜에 거래 추가](빈 날) → **거래 폼의 날짜가 그 날짜로 들어오는지**.
+  결제수단 필터가 걸린 상태에서도 그 결제수단이 함께 승계되는지 같이 본다.
+- **완료 판정(역변환)**: BE 4파일 + FE 5파일 + 문서 2 + 테스트 4 반영 → 로컬 CI 3종 통과 → PR 머지 →
   **사용자 라이브 검증**(이체 폼에서 지출/수입 선택 → 거래로 변환 → 장부 목록에서 이체 사라지고
   거래로 표시 + 월 합계·자산 잔액 즉시 갱신)
 - **다른 후보로 바꾸려면**: 아래 후보 2~5 중 지정. 기획서는 남겨두면 그대로 재사용 가능.
@@ -172,6 +204,8 @@
 - `infra/scripts/hash-icon-font.sh` — 아이콘 폰트 content hash (배포 파이프라인 필수 단계)
 - `infra/scripts/verify-cache-headers.sh` — 배포 후 캐시 정책 + 아이콘 폰트 해시 검증 게이트
 - `frontend/test/features/transaction/view_mode_toggle_guard_test.dart` — 뷰 토글 tooltip + 해시 게이트 배선 가드
+- `frontend/test/features/transaction/calendar_day_sheet_add_test.dart` — 달력 일자 시트의 거래 추가 진입 +
+  URL 조립 단일 소스(`_buildCreateTransactionUrl` 경유) 가드
 - `frontend/test/core/theme/project_font_pin_guard_test.dart` — 프로젝트 폰트(NotoSansKR) 지문 고정. 교체 시 파일명도 바꾸게 강제
 
 ## 5. 미해결·리스크

--- a/frontend/lib/features/transaction/presentation/pages/transaction_list_page.dart
+++ b/frontend/lib/features/transaction/presentation/pages/transaction_list_page.dart
@@ -857,6 +857,13 @@ class _TransactionListPageState extends State<TransactionListPage> {
                             context.push('/transactions/detail/${tx.id}'),
                         onTransferTap: (tr) =>
                             context.push('/transfers/${tr.id}'),
+                        // 달력 일자 시트의 거래 추가. 목록 모드의 _DateHeader 와 동일하게
+                        // `_buildCreateTransactionUrl` 만 경유한다(필터 결제수단 전파).
+                        onAddTap: (day) => context.push(
+                          _buildCreateTransactionUrl(
+                            date: DateFormat('yyyy-MM-dd').format(day),
+                          ),
+                        ),
                       ),
                     )
                   else if (visibleTransactions.isEmpty &&

--- a/frontend/lib/features/transaction/presentation/widgets/transaction_calendar_view.dart
+++ b/frontend/lib/features/transaction/presentation/widgets/transaction_calendar_view.dart
@@ -22,6 +22,14 @@ class TransactionCalendarView extends StatefulWidget {
   final void Function(Transaction)? onTransactionTap;
   final void Function(Transfer)? onTransferTap;
 
+  /// 일자 시트에서 **그 날짜로 거래 추가** 진입. 인자는 선택된 일자.
+  ///
+  /// URL 조립을 여기서 하지 않는 이유: 거래 추가 URL 은 상위 페이지의
+  /// `_buildCreateTransactionUrl` 단일 소스가 만든다(필터된 결제수단 전파가 그 헬퍼에
+  /// 걸려 있어, 위젯이 직접 push 하면 필터 propagation 이 끊긴다 — 목록 모드의
+  /// `_DateHeader.onAddTap` 과 같은 규약).
+  final void Function(DateTime)? onAddTap;
+
   const TransactionCalendarView({
     super.key,
     required this.year,
@@ -30,6 +38,7 @@ class TransactionCalendarView extends StatefulWidget {
     required this.transfers,
     this.onTransactionTap,
     this.onTransferTap,
+    this.onAddTap,
   });
 
   @override
@@ -306,6 +315,16 @@ class _TransactionCalendarViewState extends State<TransactionCalendarView> {
                             fontWeight: FontWeight.w600,
                           ),
                         ),
+                      if (widget.onAddTap != null) ...[
+                        const SizedBox(width: 4),
+                        IconButton(
+                          onPressed: () => _addForDay(ctx, day),
+                          icon: const Icon(Icons.add),
+                          iconSize: 20,
+                          visualDensity: VisualDensity.compact,
+                          tooltip: '이 날짜에 거래 추가',
+                        ),
+                      ],
                     ],
                   ),
                 ),
@@ -313,12 +332,28 @@ class _TransactionCalendarViewState extends State<TransactionCalendarView> {
                 Expanded(
                   child: !hasItems
                       ? Center(
-                          child: Text(
-                            '거래 없음',
-                            style: TextStyle(
-                              color: theme.colorScheme.onSurface
-                                  .withValues(alpha: 0.5),
-                            ),
+                          child: Column(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              Text(
+                                '거래 없음',
+                                style: TextStyle(
+                                  color: theme.colorScheme.onSurface
+                                      .withValues(alpha: 0.5),
+                                ),
+                              ),
+                              // 빈 날은 헤더의 + 아이콘만으로는 눈에 잘 안 띈다.
+                              // 시트가 FAB 을 가리므로(모달 배리어) 추가 진입이 시트
+                              // 안에 반드시 있어야 한다.
+                              if (widget.onAddTap != null) ...[
+                                const SizedBox(height: 12),
+                                FilledButton.tonalIcon(
+                                  onPressed: () => _addForDay(ctx, day),
+                                  icon: const Icon(Icons.add, size: 18),
+                                  label: const Text('이 날짜에 거래 추가'),
+                                ),
+                              ],
+                            ],
                           ),
                         )
                       : ListView(
@@ -353,6 +388,13 @@ class _TransactionCalendarViewState extends State<TransactionCalendarView> {
         );
       },
     );
+  }
+
+  /// 시트를 먼저 닫고 상위 콜백으로 넘긴다(항목 탭 경로와 동일 규약).
+  /// 닫지 않으면 폼에서 돌아왔을 때 옛 데이터가 담긴 시트가 그대로 남는다.
+  void _addForDay(BuildContext sheetContext, DateTime day) {
+    Navigator.of(sheetContext).pop();
+    widget.onAddTap!(day);
   }
 }
 

--- a/frontend/test/features/transaction/calendar_day_sheet_add_test.dart
+++ b/frontend/test/features/transaction/calendar_day_sheet_add_test.dart
@@ -1,0 +1,135 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/date_symbol_data_local.dart';
+
+import 'dart:io';
+
+import 'package:budget_book/features/transaction/domain/entities/transaction.dart';
+import 'package:budget_book/features/transaction/domain/entities/transaction_author.dart';
+import 'package:budget_book/features/transaction/presentation/widgets/transaction_calendar_view.dart';
+
+/// 달력 일자 시트의 "거래 추가" 진입 가드.
+///
+/// 경위: 달력 뷰에서 날짜를 누르면 일자 시트(`_showDayBottomSheet`)가 열리는데 시트 안에
+/// 추가 진입이 전혀 없었다. 시트는 모달이라 페이지 FAB 을 배리어로 덮으므로 그 상태에서는
+/// 거래를 추가할 방법이 없고, 시트를 닫고 FAB 을 눌러도 선택한 날짜가 승계되지 않았다
+/// (목록 모드에는 `_DateHeader.onAddTap` 으로 이미 있던 진입이 달력에만 빠져 있었다).
+void main() {
+  setUpAll(() async {
+    await initializeDateFormatting('ko', null);
+  });
+
+  const author = TransactionAuthor(id: 'u1', nickname: '홍길동');
+
+  Transaction txn(String date) => Transaction(
+        id: 't1',
+        coupleId: 'c1',
+        author: author,
+        type: 'EXPENSE',
+        amount: 10000,
+        description: '점심',
+        transactionDate: date,
+        visibility: 'SHARED',
+        createdAt: DateTime.utc(2026, 8, 1),
+        updatedAt: DateTime.utc(2026, 8, 1),
+      );
+
+  Future<void> pump(
+    WidgetTester tester, {
+    required List<Transaction> transactions,
+    void Function(DateTime)? onAddTap,
+  }) async {
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: TransactionCalendarView(
+          year: 2026,
+          month: 8,
+          transactions: transactions,
+          transfers: const [],
+          onAddTap: onAddTap,
+        ),
+      ),
+    ));
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('거래 없는 날: 시트에 [이 날짜에 거래 추가] 버튼이 있고 그 날짜로 콜백된다',
+      (tester) async {
+    DateTime? added;
+    await pump(tester, transactions: const [], onAddTap: (d) => added = d);
+
+    await tester.tap(find.text('15'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('거래 없음'), findsOneWidget);
+    expect(find.text('이 날짜에 거래 추가'), findsOneWidget);
+
+    await tester.tap(find.text('이 날짜에 거래 추가'));
+    await tester.pumpAndSettle();
+
+    expect(added, isNotNull);
+    expect(added!.year, 2026);
+    expect(added!.month, 8);
+    expect(added!.day, 15);
+    // 시트는 닫힌 뒤 콜백된다 — 남겨두면 폼에서 돌아왔을 때 옛 데이터가 보인다.
+    expect(find.text('거래 없음'), findsNothing);
+  });
+
+  testWidgets('거래 있는 날: 시트 헤더의 + 버튼으로도 같은 날짜로 추가된다', (tester) async {
+    DateTime? added;
+    await pump(
+      tester,
+      transactions: [txn('2026-08-15')],
+      onAddTap: (d) => added = d,
+    );
+
+    await tester.tap(find.text('15'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('점심'), findsOneWidget);
+    final addButton = find.byTooltip('이 날짜에 거래 추가');
+    expect(addButton, findsOneWidget);
+
+    await tester.tap(addButton);
+    await tester.pumpAndSettle();
+
+    expect(added, isNotNull);
+    expect(added!.day, 15);
+  });
+
+  testWidgets('onAddTap 미주입 시 추가 어포던스를 노출하지 않는다', (tester) async {
+    await pump(tester, transactions: [txn('2026-08-15')]);
+
+    await tester.tap(find.text('15'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('점심'), findsOneWidget);
+    expect(find.byTooltip('이 날짜에 거래 추가'), findsNothing);
+    expect(find.text('이 날짜에 거래 추가'), findsNothing);
+  });
+
+  /// 진입 URL 은 `_buildCreateTransactionUrl` 단일 소스만 만든다(필터된 결제수단 전파).
+  /// 위젯이 직접 push 하거나 상위가 URL 을 수동 조립하면 필터 propagation 이 끊긴다.
+  /// 목록 페이지 전체를 띄우려면 BLoC 5종 + DI 가 필요해 선언 자체를 고정한다
+  /// (`view_mode_toggle_guard_test.dart` 와 같은 방식).
+  test('달력 onAddTap 배선은 _buildCreateTransactionUrl 을 경유한다', () {
+    final page = File(
+      'lib/features/transaction/presentation/pages/transaction_list_page.dart',
+    ).readAsStringSync();
+
+    final start = page.indexOf('TransactionCalendarView(');
+    expect(start, isNonNegative, reason: 'TransactionCalendarView 호출부를 찾지 못했다');
+    final callSite = page.substring(start, page.indexOf('),', page.indexOf('onAddTap:', start)));
+
+    expect(callSite.contains('onAddTap:'), isTrue,
+        reason: '달력에 거래 추가 진입이 배선되지 않았다');
+    expect(callSite.contains('_buildCreateTransactionUrl('), isTrue,
+        reason: '헬퍼를 경유하지 않으면 필터된 결제수단이 전파되지 않는다');
+
+    final widget = File(
+      'lib/features/transaction/presentation/widgets/transaction_calendar_view.dart',
+    ).readAsStringSync();
+    expect(widget.contains("'/transactions/create"), isFalse,
+        reason: '달력 위젯이 직접 URL 을 조립하면 헬퍼 단일 소스가 깨진다');
+  });
+}


### PR DESCRIPTION
## 문제

거래 탭 → 달력 뷰에서 날짜를 누르면 일자 시트(`_showDayBottomSheet`)가 열리는데, 시트 안에 거래 추가 진입이 **전혀 없었다**.

- 시트가 모달이라 페이지 FAB 을 배리어로 덮음 → 그 상태에서는 추가 불가
- 시트를 닫고 FAB 을 눌러도 `_buildCreateTransactionUrl(tab:)` 만 호출 → **선택한 날짜가 승계되지 않음**(오늘로 들어감)
- 목록 모드에는 `_DateHeader.onAddTap` → `_buildCreateTransactionUrl(date:)` 로 이미 있던 진입 → **달력에만 빠진 대칭 결함**

## 변경

- `TransactionCalendarView`: `onAddTap` 파라미터 신설 — 시트 헤더 `+` 버튼(항목 있는 날) + `[이 날짜에 거래 추가]` 버튼(빈 날). `_addForDay` 가 시트를 먼저 닫고 콜백(항목 탭 경로와 동일 규약 — 안 닫으면 폼에서 돌아왔을 때 옛 데이터 시트가 남는다)
- `transaction_list_page`: 호출부에서 `_buildCreateTransactionUrl(date:)` 주입. **URL 조립은 이 헬퍼 단일 소스만** 한다 — 위젯이 직접 push 하면 필터된 결제수단 전파가 끊긴다
- `calendar_day_sheet_add_test.dart` 신설(4건)

## 범위 전수 (`feedback_common_scope_audit`)

- `TableCalendar` 사용처 **1곳**(이 위젯뿐)
- `LedgerDateHeader` 소비처 2곳: 목록 페이지는 이미 진입 보유 / 정산 뷰는 그룹 체크박스 선택용으로 대상 아님
- → 수정 2파일 확정

## 게이트

- `pre-change-audit.sh . "navigation_state ui_pattern"` → OK, gate OPEN
- `flutter analyze --no-fatal-infos` 통과 (잔여 info 3건은 기존 테스트 파일, 이번 변경 무관)
- `flutter test` **815건 통과** / `flutter build web --release` 성공
- BE 미변경. 새 아이콘 코드포인트 없음(`Icons.add` 는 기존 FAB 에서 사용) → 폰트 subset 불변 = 아이콘 캐시 위험군 아님

## 라이브 검증 (머지 후)

거래 탭 → 달력 뷰 → 아무 날짜 탭 → 시트에서 `+` 또는 `[이 날짜에 거래 추가]` → 거래 폼 날짜가 **그 날짜**로 들어오는지. 결제수단 필터가 걸린 상태에서도 그 결제수단이 함께 승계되는지 같이 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)