### PR TITLE
feat(transfer): 이체 → 거래 역변환 (양방향 리로드 공통화 포함)

### DIFF
--- a/backend/src/main/kotlin/com/budgetbook/transaction/dto/TransactionDtos.kt
+++ b/backend/src/main/kotlin/com/budgetbook/transaction/dto/TransactionDtos.kt
@@ -217,3 +217,41 @@ data class ConvertToTransferRequest(
     @field:Size(max = 1000)
     val memo: String? = null
 )
+
+/**
+ * 이체 → 거래 역변환 요청 (2026-08-09).
+ *
+ * `ConvertToTransferRequest` 의 거울상이다. 원본 이체를 지우고 같은 내용의 거래를 만드는
+ * 한 번의 원자적 작업이며, 생략한 값은 원본 이체를 승계한다.
+ *
+ * 승계 규칙 중 결제수단만 유형에 따라 갈린다 — EXPENSE 는 돈이 나간 쪽(출금),
+ * INCOME 은 돈이 들어온 쪽(입금)이 그 거래의 결제수단이다.
+ */
+data class ConvertToTransactionRequest(
+    /** `EXPENSE` | `INCOME`. 이체에는 대응 개념이 없어 사용자가 반드시 지정한다. */
+    @field:NotBlank
+    val type: String,
+
+    /** 생략 시 카테고리 없음. 주면 유형 일치 검증 + visibility 를 이 카테고리에서 파생. */
+    val categoryId: UUID? = null,
+
+    /** 생략 시 EXPENSE → 출금 결제수단 / INCOME → 입금 결제수단 승계. */
+    val paymentMethodId: UUID? = null,
+
+    /** 이체에는 대응 개념이 없어 신규 입력값(승계 없음). */
+    val pocketId: UUID? = null,
+
+    @field:Min(1)
+    @field:Max(999_999_999)
+    val amount: Long? = null,
+
+    val transactionDate: LocalDate? = null,
+
+    @field:Size(max = 255)
+    val description: String? = null,
+
+    @field:Size(max = 1000)
+    val memo: String? = null,
+
+    val needsReview: Boolean = false
+)

--- a/backend/src/main/kotlin/com/budgetbook/transaction/repository/TransactionRepository.kt
+++ b/backend/src/main/kotlin/com/budgetbook/transaction/repository/TransactionRepository.kt
@@ -557,6 +557,15 @@ interface TransactionRepository : JpaRepository<Transaction, UUID>, JpaSpecifica
         @Param("transferId") transferId: UUID
     ): Int
 
+    /**
+     * 이체 → 거래 역변환 가드 (2026-08-09).
+     *
+     * 결제 링크가 남은 이체를 지우면 `transactions.settlement_transfer_id` 가 조용히
+     * NULL 로 끊겨(V63 `ON DELETE SET NULL`) 그 달 미결제 합계가 어긋난다.
+     * `kind == CARD_SETTLEMENT` 검사와 겹치지만, 과거·자동 생성 데이터를 위한 두 번째 방어선.
+     */
+    fun existsBySettlementTransferId(settlementTransferId: UUID): Boolean
+
     @Modifying
     @Query(
         value = """

--- a/backend/src/main/kotlin/com/budgetbook/transaction/service/TransactionService.kt
+++ b/backend/src/main/kotlin/com/budgetbook/transaction/service/TransactionService.kt
@@ -20,6 +20,7 @@ import com.budgetbook.transaction.domain.TransactionType
 import com.budgetbook.category.domain.CategoryType
 import com.budgetbook.spendingplan.repository.SpendingPlanRepository
 import com.budgetbook.transaction.dto.CategorySummary
+import com.budgetbook.transaction.dto.ConvertToTransactionRequest
 import com.budgetbook.transaction.dto.ConvertToTransferRequest
 import com.budgetbook.transaction.dto.CreateTransactionRequest
 import com.budgetbook.transaction.dto.PageResponse
@@ -522,6 +523,146 @@ class TransactionService(
             authorId = userId
         ))
         return created
+    }
+
+    /**
+     * 이체 → 거래 역변환 (2026-08-09). `convertToTransfer` 의 거울상.
+     *
+     * **배치 이유**: 구현이 거래 서비스에 있고 `TransferController` 가 이 서비스를 주입해
+     * 호출한다. 반대로 `TransferService` 에 두면 `TransactionService → TransferService`
+     * 기존 주입(:62)과 맞물려 순환 빈 의존이 된다. 원칙은 "생성 규칙은 항상 **목적지**
+     * 도메인 서비스가 소유한다" — 정방향도 이체 생성을 `TransferService` 에 맡긴다.
+     * (되돌리지 말 것. 컨트롤러 → 다른 서비스 의존은 순환이 아니다.)
+     *
+     * 되돌릴 수 없는 이동이라 다른 기능이 이 이체를 붙잡고 있으면 막는다 —
+     * 정산 스냅샷 / 카드 결제 / 결제 링크 잔존.
+     */
+    @Transactional
+    fun convertFromTransfer(
+        userId: UUID,
+        transferId: UUID,
+        request: ConvertToTransactionRequest
+    ): TransactionResponse {
+        val couple = getActiveCouple(userId)
+        val user = userRepository.findById(userId)
+            .orElseThrow { NotFoundException("USER_NOT_FOUND", "User not found.") }
+        val transfer = transferRepository.findByIdAndCoupleId(transferId, couple.id)
+            ?: throw NotFoundException("TRANSFER_NOT_FOUND", "Transfer does not exist.")
+
+        // 거래는 EXPENSE/INCOME 만 만든다. ADJUSTMENT 는 잔액 보정 전용이라 이체에서 올 수 없다.
+        val transactionType = runCatching { TransactionType.valueOf(request.type.uppercase()) }
+            .getOrElse { throw BusinessException("VALIDATION_ERROR", "지원하지 않는 거래 유형입니다: ${request.type}") }
+        if (transactionType == TransactionType.ADJUSTMENT) {
+            throw BusinessException(
+                "VALIDATION_ERROR",
+                "이체는 잔액 수정으로 변경할 수 없습니다. 지출 또는 수입을 선택하세요."
+            )
+        }
+
+        if (reconciliationLookup.refsForTransfers(listOf(transferId)).isNotEmpty()) {
+            throw BusinessException(
+                "VALIDATION_ERROR",
+                "정산에 기록된 이체는 유형을 변경할 수 없습니다. 정산에서 제외한 뒤 다시 시도하세요."
+            )
+        }
+        if (transfer.kind == TransferKind.CARD_SETTLEMENT) {
+            throw BusinessException(
+                "VALIDATION_ERROR",
+                "카드 결제 이체는 거래로 변경할 수 없습니다. 카드 결제 화면에서 처리하세요."
+            )
+        }
+        if (transactionRepository.existsBySettlementTransferId(transferId)) {
+            throw BusinessException(
+                "VALIDATION_ERROR",
+                "결제에 연결된 거래가 남아 있는 이체는 거래로 변경할 수 없습니다. 연결을 먼저 해제하세요."
+            )
+        }
+
+        // 승계 — 결제수단만 유형에 따라 갈린다 (지출은 돈이 나간 쪽, 수입은 들어온 쪽).
+        val inheritedPaymentMethodId = when (transactionType) {
+            TransactionType.EXPENSE -> transfer.sourcePaymentMethod.id
+            else -> transfer.destinationPaymentMethod.id
+        }
+        // transfers.description 은 nullable 인데 transactions.description 은 NOT NULL 이다.
+        // 여기서 막지 않으면 DB 제약에서 500 이 난다.
+        val description = (request.description ?: transfer.description)?.trim().orEmpty()
+        if (description.isEmpty()) {
+            throw BusinessException("VALIDATION_ERROR", "설명을 입력하세요.")
+        }
+
+        val amount = request.amount ?: transfer.amount
+        validateAmountForType(transactionType, amount)
+
+        val category = request.categoryId?.let { catId ->
+            val cat = categoryRepository.findById(catId)
+                .orElseThrow { NotFoundException("CATEGORY_NOT_FOUND", "Specified category does not exist.") }
+            OwnershipValidator.validateOwnership(cat.couple.id, couple, "Category")
+            cat
+        }
+        // 생성 규칙과 동일 — visibility 는 항상 카테고리에서 파생한다 (요청 값이 아니라).
+        val effectiveVisibility = category?.visibility ?: Visibility.SHARED
+
+        val paymentMethod = (request.paymentMethodId ?: inheritedPaymentMethodId).let { pmId ->
+            val pm = paymentMethodRepository.findById(pmId)
+                .orElseThrow { NotFoundException("PAYMENT_METHOD_NOT_FOUND", "Specified payment method does not exist.") }
+            OwnershipValidator.validateOwnership(pm.couple.id, couple, "Payment method")
+            pm
+        }
+
+        val pocket = request.pocketId?.let { pocketId ->
+            val p = moneyPocketRepository.findById(pocketId)
+                .orElseThrow { NotFoundException("POCKET_NOT_FOUND", "Specified pocket does not exist.") }
+            OwnershipValidator.validateOwnership(p.couple.id, couple, "Pocket")
+            if (!p.isActive) {
+                throw NotFoundException("POCKET_NOT_FOUND", "Specified pocket is not active.")
+            }
+            p
+        }
+
+        val transactionDate = request.transactionDate ?: transfer.transferDate
+        val transaction = Transaction(
+            couple = couple,
+            author = user,
+            category = category,
+            type = transactionType,
+            amount = amount,
+            description = description,
+            memo = request.memo ?: transfer.memo,
+            transactionDate = transactionDate,
+            paymentMethod = paymentMethod,
+            settlementDate = calculateSettlementDate(paymentMethod, transactionDate),
+            pocket = pocket,
+            visibility = effectiveVisibility,
+            owner = if (effectiveVisibility == Visibility.PRIVATE) user else null,
+            needsReview = request.needsReview
+        )
+        // createTransaction 은 카테고리-유형 일치를 검증하지 않는다(update 경로에만 있다).
+        // 변환은 유형을 새로 정하는 경로라 여기서 명시적으로 태운다.
+        validateCategoryMatchesType(transaction)
+
+        // 저장 → flush → 삭제 순서. 같은 트랜잭션에서 이체를 먼저 지우면 삭제 flush 와
+        // 삽입 flush 순서를 JPA 가 보장하지 않는다 (reference_card_settlement_flush_ordering).
+        val saved = transactionRepository.saveAndFlush(transaction)
+        transferRepository.delete(transfer)
+
+        // 이체 스트림도 갱신해야 목록이 정합해진다 — 거래 이벤트만 쏘면 파트너 화면에
+        // 원본 이체가 그대로 남는다 (장부 목록은 두 스트림 병합).
+        syncEventPublisher.publish(SyncEvent(
+            type = "TRANSFER_DELETED",
+            entityType = "TRANSFER",
+            entityId = transferId,
+            coupleId = couple.id,
+            authorId = userId
+        ))
+        syncEventPublisher.publish(SyncEvent(
+            type = "TRANSACTION_CREATED",
+            entityType = "TRANSACTION",
+            entityId = saved.id,
+            coupleId = couple.id,
+            authorId = userId
+        ))
+        learnPattern(couple.id, saved.description, saved.category?.id)
+        return saved.toResponse()
     }
 
     /**

--- a/backend/src/main/kotlin/com/budgetbook/transfer/controller/TransferController.kt
+++ b/backend/src/main/kotlin/com/budgetbook/transfer/controller/TransferController.kt
@@ -3,6 +3,9 @@ package com.budgetbook.transfer.controller
 import com.budgetbook.common.dto.ApiResponse
 import com.budgetbook.common.ratelimit.RateLimit
 import com.budgetbook.common.security.AuthUser
+import com.budgetbook.transaction.dto.ConvertToTransactionRequest
+import com.budgetbook.transaction.dto.TransactionResponse
+import com.budgetbook.transaction.service.TransactionService
 import com.budgetbook.transfer.dto.CreateCardSettlementRequest
 import com.budgetbook.transfer.dto.CreateTransferRequest
 import com.budgetbook.transfer.dto.TransferResponse
@@ -26,7 +29,10 @@ import java.util.UUID
 @RestController
 @RequestMapping("/api/v1/transfers")
 class TransferController(
-    private val transferService: TransferService
+    private val transferService: TransferService,
+    // 이체 → 거래 역변환 (2026-08-09). 구현이 TransactionService 에 있는 이유는
+    // 그 메서드 주석 참고 — 반대로 넣으면 서비스 간 순환 의존이 된다.
+    private val transactionService: TransactionService
 ) {
 
     @RateLimit(maxRequests = 20, windowSeconds = 60)
@@ -114,6 +120,21 @@ class TransferController(
         @Valid @RequestBody request: UpdateTransferRequest
     ): ApiResponse<TransferResponse> {
         return ApiResponse.ok(transferService.updateTransfer(userId, id, request))
+    }
+
+    /**
+     * 이체 → 거래 역변환 (2026-08-09).
+     * 원본 이체 삭제 + 거래 생성이 한 트랜잭션으로 처리된다.
+     * 거래 → 이체(`POST /transactions/{id}/convert-to-transfer`) 의 거울상.
+     */
+    @RateLimit(maxRequests = 30, windowSeconds = 60)
+    @PostMapping("/{id}/convert-to-transaction")
+    fun convertToTransaction(
+        @AuthUser userId: UUID,
+        @PathVariable id: UUID,
+        @Valid @RequestBody request: ConvertToTransactionRequest
+    ): ApiResponse<TransactionResponse> {
+        return ApiResponse.ok(transactionService.convertFromTransfer(userId, id, request))
     }
 
     @RateLimit(maxRequests = 20, windowSeconds = 60)

--- a/backend/src/test/kotlin/com/budgetbook/transaction/service/TransactionServiceTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/transaction/service/TransactionServiceTest.kt
@@ -1363,4 +1363,199 @@ class TransactionServiceTest : BehaviorSpec({
             }
         }
     }
+
+    // --- 이체 → 거래 역변환 (2026-08-09). 위 블록의 거울상. ---
+
+    Given("이체 → 거래 역변환") {
+        every { coupleResolver.getActiveCouple(user1.id) } returns couple
+        every { userRepository.findById(user1.id) } returns Optional.of(user1)
+        every { reconciliationLookup.refsForTransfers(any()) } returns emptyMap()
+        every { transactionRepository.existsBySettlementTransferId(any()) } returns false
+
+        val bank = PaymentMethod(couple = couple, name = "국민은행", type = PaymentMethodType.BANK)
+        val cash = PaymentMethod(couple = couple, name = "현금", type = PaymentMethodType.CASH)
+        every { paymentMethodRepository.findById(bank.id) } returns Optional.of(bank)
+        every { paymentMethodRepository.findById(cash.id) } returns Optional.of(cash)
+
+        fun transfer(
+            description: String? = "계좌 이동",
+            kind: com.budgetbook.transfer.domain.TransferKind =
+                com.budgetbook.transfer.domain.TransferKind.GENERIC
+        ) = com.budgetbook.transfer.domain.Transfer(
+            couple = couple, author = user1,
+            sourcePaymentMethod = bank, destinationPaymentMethod = cash,
+            amount = 50000, description = description, memo = "메모",
+            transferDate = LocalDate.of(2026, 7, 15), kind = kind
+        )
+
+        When("일반 이체를 지출로 바꾸면") {
+            val tr = transfer()
+            every { transferRepository.findByIdAndCoupleId(tr.id, couple.id) } returns tr
+            every { transferRepository.delete(tr) } returns Unit
+            val txSlot = slot<Transaction>()
+            every { transactionRepository.saveAndFlush(capture(txSlot)) } answers { txSlot.captured }
+
+            service.convertFromTransfer(
+                user1.id, tr.id,
+                com.budgetbook.transaction.dto.ConvertToTransactionRequest(type = "EXPENSE")
+            )
+
+            Then("원본 값을 승계한 거래가 만들어지고 이체는 삭제된다") {
+                txSlot.captured.type shouldBe TransactionType.EXPENSE
+                txSlot.captured.amount shouldBe 50000
+                txSlot.captured.description shouldBe "계좌 이동"
+                txSlot.captured.memo shouldBe "메모"
+                txSlot.captured.transactionDate shouldBe LocalDate.of(2026, 7, 15)
+                verify { transferRepository.delete(tr) }
+            }
+
+            Then("지출은 돈이 나간 쪽(출금) 결제수단을 승계한다") {
+                txSlot.captured.paymentMethod?.id shouldBe bank.id
+            }
+
+            Then("이체 삭제 + 거래 생성 이벤트가 모두 발행된다 (장부는 두 스트림 병합)") {
+                val events = mutableListOf<SyncEvent>()
+                verify { syncEventPublisher.publish(capture(events)) }
+                events.any { it.type == "TRANSFER_DELETED" } shouldBe true
+                events.any { it.type == "TRANSACTION_CREATED" } shouldBe true
+            }
+        }
+
+        When("일반 이체를 수입으로 바꾸면") {
+            val tr = transfer()
+            every { transferRepository.findByIdAndCoupleId(tr.id, couple.id) } returns tr
+            every { transferRepository.delete(tr) } returns Unit
+            val txSlot = slot<Transaction>()
+            every { transactionRepository.saveAndFlush(capture(txSlot)) } answers { txSlot.captured }
+
+            service.convertFromTransfer(
+                user1.id, tr.id,
+                com.budgetbook.transaction.dto.ConvertToTransactionRequest(type = "INCOME")
+            )
+
+            Then("수입은 돈이 들어온 쪽(입금) 결제수단을 승계한다") {
+                txSlot.captured.type shouldBe TransactionType.INCOME
+                txSlot.captured.paymentMethod?.id shouldBe cash.id
+            }
+        }
+
+        When("정산에 기록된 이체를 거래로 바꾸려 하면") {
+            val tr = transfer()
+            every { transferRepository.findByIdAndCoupleId(tr.id, couple.id) } returns tr
+            every { reconciliationLookup.refsForTransfers(listOf(tr.id)) } returns mapOf(
+                tr.id to com.budgetbook.reconciliation.dto.ReconciliationRef(
+                    reconciliationId = UUID.randomUUID(),
+                    reconciliationSeq = 1,
+                    reconciledAt = java.time.Instant.now()
+                )
+            )
+
+            Then("VALIDATION_ERROR — 이체는 지워지지 않는다") {
+                shouldThrow<com.budgetbook.common.exception.BusinessException> {
+                    service.convertFromTransfer(
+                        user1.id, tr.id,
+                        com.budgetbook.transaction.dto.ConvertToTransactionRequest(type = "EXPENSE")
+                    )
+                }.code shouldBe "VALIDATION_ERROR"
+                verify(exactly = 0) { transferRepository.delete(any<com.budgetbook.transfer.domain.Transfer>()) }
+            }
+        }
+
+        When("카드 결제 이체를 거래로 바꾸려 하면") {
+            val tr = transfer(kind = com.budgetbook.transfer.domain.TransferKind.CARD_SETTLEMENT)
+            every { transferRepository.findByIdAndCoupleId(tr.id, couple.id) } returns tr
+
+            Then("VALIDATION_ERROR — 전용 화면에서만 처리한다") {
+                shouldThrow<com.budgetbook.common.exception.BusinessException> {
+                    service.convertFromTransfer(
+                        user1.id, tr.id,
+                        com.budgetbook.transaction.dto.ConvertToTransactionRequest(type = "EXPENSE")
+                    )
+                }.code shouldBe "VALIDATION_ERROR"
+                verify(exactly = 0) { transferRepository.delete(any<com.budgetbook.transfer.domain.Transfer>()) }
+            }
+        }
+
+        When("결제 링크가 남은 이체를 거래로 바꾸려 하면") {
+            val tr = transfer()
+            every { transferRepository.findByIdAndCoupleId(tr.id, couple.id) } returns tr
+            every { transactionRepository.existsBySettlementTransferId(tr.id) } returns true
+
+            Then("VALIDATION_ERROR — 링크가 조용히 끊기기 전에 막는다") {
+                // transactions.settlement_transfer_id 는 ON DELETE SET NULL 이라
+                // 가드가 없으면 미결제 합계가 조용히 어긋난다.
+                shouldThrow<com.budgetbook.common.exception.BusinessException> {
+                    service.convertFromTransfer(
+                        user1.id, tr.id,
+                        com.budgetbook.transaction.dto.ConvertToTransactionRequest(type = "EXPENSE")
+                    )
+                }.code shouldBe "VALIDATION_ERROR"
+                verify(exactly = 0) { transferRepository.delete(any<com.budgetbook.transfer.domain.Transfer>()) }
+            }
+        }
+
+        When("설명이 없는 이체를 거래로 바꾸려 하면") {
+            val tr = transfer(description = null)
+            every { transferRepository.findByIdAndCoupleId(tr.id, couple.id) } returns tr
+
+            Then("VALIDATION_ERROR — DB NOT NULL 제약(500) 전에 막는다") {
+                // transfers.description 은 nullable, transactions.description 은 NOT NULL.
+                shouldThrow<com.budgetbook.common.exception.BusinessException> {
+                    service.convertFromTransfer(
+                        user1.id, tr.id,
+                        com.budgetbook.transaction.dto.ConvertToTransactionRequest(type = "EXPENSE")
+                    )
+                }.code shouldBe "VALIDATION_ERROR"
+                verify(exactly = 0) { transactionRepository.saveAndFlush(any<Transaction>()) }
+            }
+        }
+
+        When("유형과 맞지 않는 카테고리를 지정하면") {
+            val tr = transfer()
+            every { transferRepository.findByIdAndCoupleId(tr.id, couple.id) } returns tr
+            // category 는 EXPENSE 형인데 INCOME 거래로 만들려는 경우.
+            every { categoryRepository.findById(category.id) } returns Optional.of(category)
+
+            Then("VALIDATION_ERROR — 저장 전에 막는다") {
+                shouldThrow<com.budgetbook.common.exception.BusinessException> {
+                    service.convertFromTransfer(
+                        user1.id, tr.id,
+                        com.budgetbook.transaction.dto.ConvertToTransactionRequest(
+                            type = "INCOME", categoryId = category.id
+                        )
+                    )
+                }.code shouldBe "VALIDATION_ERROR"
+                verify(exactly = 0) { transactionRepository.saveAndFlush(any<Transaction>()) }
+            }
+        }
+
+        When("잔액 수정으로 바꾸려 하면") {
+            val tr = transfer()
+            every { transferRepository.findByIdAndCoupleId(tr.id, couple.id) } returns tr
+
+            Then("VALIDATION_ERROR — ADJUSTMENT 는 잔액 보정 전용이다") {
+                shouldThrow<com.budgetbook.common.exception.BusinessException> {
+                    service.convertFromTransfer(
+                        user1.id, tr.id,
+                        com.budgetbook.transaction.dto.ConvertToTransactionRequest(type = "ADJUSTMENT")
+                    )
+                }.code shouldBe "VALIDATION_ERROR"
+            }
+        }
+
+        When("다른 커플의 이체를 거래로 바꾸려 하면") {
+            val otherTransferId = UUID.randomUUID()
+            // findByIdAndCoupleId 가 couple 범위로 조회하므로 남의 이체는 애초에 안 잡힌다.
+            every { transferRepository.findByIdAndCoupleId(otherTransferId, couple.id) } returns null
+
+            Then("TRANSFER_NOT_FOUND") {
+                shouldThrow<NotFoundException> {
+                    service.convertFromTransfer(
+                        user1.id, otherTransferId,
+                        com.budgetbook.transaction.dto.ConvertToTransactionRequest(type = "EXPENSE")
+                    )
+                }.code shouldBe "TRANSFER_NOT_FOUND"
+            }
+        }
+    }
 })

--- a/backend/src/test/kotlin/com/budgetbook/transfer/controller/TransferControllerTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/transfer/controller/TransferControllerTest.kt
@@ -20,7 +20,9 @@ import java.util.UUID
 class TransferControllerTest : FunSpec({
 
     val transferService = mockk<TransferService>()
-    val controller = TransferController(transferService)
+    // 이체 → 거래 역변환 위임 대상 (구현은 TransactionService 소유 — 순환 의존 회피).
+    val transactionService = mockk<com.budgetbook.transaction.service.TransactionService>()
+    val controller = TransferController(transferService, transactionService)
     val testUserId = UUID.randomUUID()
 
     fun sampleTransferResponse() = TransferResponse(
@@ -91,5 +93,19 @@ class TransferControllerTest : FunSpec({
 
         result.statusCode shouldBe HttpStatus.NO_CONTENT
         verify { transferService.deleteTransfer(testUserId, transferId) }
+    }
+
+    test("convertToTransaction delegates to TransactionService") {
+        val transferId = UUID.randomUUID()
+        val request = com.budgetbook.transaction.dto.ConvertToTransactionRequest(type = "EXPENSE")
+        every {
+            transactionService.convertFromTransfer(testUserId, transferId, request)
+        } returns mockk(relaxed = true)
+
+        val result = controller.convertToTransaction(testUserId, transferId, request)
+
+        result.success shouldBe true
+        // 이체 서비스가 아니라 거래 서비스가 소유한다 (순환 의존 회피 — 되돌리지 말 것).
+        verify { transactionService.convertFromTransfer(testUserId, transferId, request) }
     }
 })

--- a/backend/src/test/kotlin/com/budgetbook/transfer/integration/TransferToTransactionIntegrationTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/transfer/integration/TransferToTransactionIntegrationTest.kt
@@ -1,0 +1,248 @@
+package com.budgetbook.transfer.integration
+
+import com.budgetbook.admin.integration.HighApiVersionDockerStrategy
+import com.budgetbook.common.exception.BusinessException
+import com.budgetbook.transaction.dto.ConvertToTransactionRequest
+import com.budgetbook.transaction.service.TransactionService
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.extensions.spring.SpringExtension
+import io.kotest.matchers.shouldBe
+import jakarta.persistence.EntityManager
+import jakarta.persistence.PersistenceContext
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.ApplicationContextInitializer
+import org.springframework.context.ConfigurableApplicationContext
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.support.TestPropertySourceUtils
+import org.springframework.transaction.PlatformTransactionManager
+import org.springframework.transaction.support.TransactionTemplate
+import org.testcontainers.containers.PostgreSQLContainer
+import java.time.LocalDate
+import java.util.UUID
+
+/**
+ * Integration test for [TransactionService.convertFromTransfer] (이체 → 거래 역변환)
+ * against a real PostgreSQL container with Flyway migrations applied.
+ *
+ * Why a real DB is required here (mocks cannot catch any of this):
+ * 1. The conversion deletes a `transfers` row and inserts a `transactions` row in ONE transaction.
+ *    Ordering matters — the same class of FK/flush timing bug that hit card settlement in prod
+ *    (see [CardSettlementIntegrationTest]) applies. Mocks never exercise the real constraint.
+ * 2. `transactions.description` is NOT NULL while `transfers.description` is nullable. Without the
+ *    service-side guard this surfaces only as a DB constraint violation (500), never in mock tests.
+ * 3. `transactions.settlement_transfer_id` is `ON DELETE SET NULL` — deleting a transfer that still
+ *    has payment links would silently unlink them rather than fail, so the guard has to be proven
+ *    against real rows.
+ */
+@SpringBootTest
+@ActiveProfiles("integration-test")
+@ContextConfiguration(initializers = [TransferToTransactionIntegrationTest.DataSourceInitializer::class])
+class TransferToTransactionIntegrationTest(
+    private val transactionService: TransactionService,
+    @PersistenceContext private val em: EntityManager,
+    private val txManager: PlatformTransactionManager,
+) : FunSpec() {
+
+    override fun extensions() = listOf(SpringExtension)
+
+    companion object {
+        val postgres: PostgreSQLContainer<*> = PostgreSQLContainer("postgres:16-alpine")
+            .withDatabaseName("budgetbook_test")
+            .withUsername("test")
+            .withPassword("test")
+
+        init {
+            System.setProperty(
+                "testcontainers.docker.client.strategy",
+                HighApiVersionDockerStrategy::class.java.name
+            )
+            postgres.start()
+        }
+    }
+
+    class DataSourceInitializer : ApplicationContextInitializer<ConfigurableApplicationContext> {
+        override fun initialize(ctx: ConfigurableApplicationContext) {
+            TestPropertySourceUtils.addInlinedPropertiesToEnvironment(
+                ctx,
+                "spring.datasource.url=${postgres.jdbcUrl}",
+                "spring.datasource.username=${postgres.username}",
+                "spring.datasource.password=${postgres.password}",
+                "spring.datasource.driver-class-name=org.postgresql.Driver",
+                "spring.jpa.hibernate.ddl-auto=validate",
+                "spring.flyway.enabled=true",
+                "spring.flyway.baseline-on-migrate=true"
+            )
+        }
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────────────
+
+    private fun <T> inTx(action: () -> T): T =
+        TransactionTemplate(txManager).execute { action() }!!
+
+    private fun insertUser(email: String): UUID {
+        val id = UUID.randomUUID()
+        em.createNativeQuery(
+            """INSERT INTO users (id, email, nickname, provider, provider_id, role, is_active, created_at, updated_at)
+               VALUES (:id, :email, 'Converter', 'GOOGLE', :pid, 'USER', true, now(), now())"""
+        ).setParameter("id", id).setParameter("email", email)
+            .setParameter("pid", UUID.randomUUID().toString()).executeUpdate()
+        return id
+    }
+
+    private fun insertSelfCouple(userId: UUID): UUID {
+        val id = UUID.randomUUID()
+        em.createNativeQuery(
+            """INSERT INTO couples (id, user1_id, user2_id, status, is_self, created_at, updated_at)
+               VALUES (:id, :userId, null, 'ACTIVE', true, now(), now())"""
+        ).setParameter("id", id).setParameter("userId", userId).executeUpdate()
+        return id
+    }
+
+    private fun insertCategory(coupleId: UUID): UUID {
+        val id = UUID.randomUUID()
+        em.createNativeQuery(
+            """INSERT INTO categories (id, couple_id, name, type, is_default, display_order, created_at, updated_at)
+               VALUES (:id, :coupleId, '식비', 'EXPENSE', false, 0, now(), now())"""
+        ).setParameter("id", id).setParameter("coupleId", coupleId).executeUpdate()
+        return id
+    }
+
+    private fun insertPaymentMethod(coupleId: UUID, name: String, type: String): UUID {
+        val id = UUID.randomUUID()
+        em.createNativeQuery(
+            """INSERT INTO payment_methods (id, couple_id, name, type, is_active, is_default, display_order, created_at, updated_at)
+               VALUES (:id, :coupleId, :name, :type, true, false, 0, now(), now())"""
+        ).setParameter("id", id).setParameter("coupleId", coupleId)
+            .setParameter("name", name).setParameter("type", type).executeUpdate()
+        return id
+    }
+
+    private fun insertTransfer(
+        coupleId: UUID,
+        authorId: UUID,
+        sourceId: UUID,
+        destinationId: UUID,
+        description: String?,
+        kind: String = "GENERIC",
+    ): UUID {
+        val id = UUID.randomUUID()
+        em.createNativeQuery(
+            """INSERT INTO transfers
+               (id, couple_id, author_id, source_payment_method_id, destination_payment_method_id,
+                amount, description, memo, transfer_date, kind, is_card_settlement, created_at, updated_at)
+               VALUES (:id, :coupleId, :authorId, :src, :dst, 50000, :description, '메모',
+                       :transferDate, :kind, false, now(), now())"""
+        ).setParameter("id", id).setParameter("coupleId", coupleId).setParameter("authorId", authorId)
+            .setParameter("src", sourceId).setParameter("dst", destinationId)
+            .setParameter("description", description)
+            .setParameter("transferDate", LocalDate.of(2026, 7, 15))
+            .setParameter("kind", kind).executeUpdate()
+        return id
+    }
+
+    private fun countTransfers(id: UUID): Long =
+        (em.createNativeQuery("SELECT count(*) FROM transfers WHERE id = :id")
+            .setParameter("id", id).singleResult as Number).toLong()
+
+    // ── Tests ─────────────────────────────────────────────────────────────────
+
+    init {
+        test("convertFromTransfer deletes the transfer and inserts the transaction in one transaction") {
+            lateinit var userId: UUID
+            lateinit var transferId: UUID
+            lateinit var bankId: UUID
+            lateinit var cashId: UUID
+            lateinit var categoryId: UUID
+            inTx {
+                userId = insertUser("convert-${UUID.randomUUID()}@test.com")
+                val coupleId = insertSelfCouple(userId)
+                categoryId = insertCategory(coupleId)
+                bankId = insertPaymentMethod(coupleId, "국민은행", "BANK")
+                cashId = insertPaymentMethod(coupleId, "현금", "CASH")
+                transferId = insertTransfer(coupleId, userId, bankId, cashId, "계좌 이동")
+            }
+
+            val result = transactionService.convertFromTransfer(
+                userId, transferId, ConvertToTransactionRequest(type = "EXPENSE", categoryId = categoryId)
+            )
+
+            result.type shouldBe "EXPENSE"
+            result.amount shouldBe 50000
+            result.description shouldBe "계좌 이동"
+            result.transactionDate shouldBe LocalDate.of(2026, 7, 15)
+            // EXPENSE 는 돈이 나간 쪽(출금) 결제수단을 승계한다.
+            result.paymentMethodId shouldBe bankId
+
+            inTx { countTransfers(transferId) shouldBe 0L }
+        }
+
+        test("INCOME conversion inherits the destination payment method") {
+            lateinit var userId: UUID
+            lateinit var transferId: UUID
+            lateinit var cashId: UUID
+            inTx {
+                userId = insertUser("convert-in-${UUID.randomUUID()}@test.com")
+                val coupleId = insertSelfCouple(userId)
+                val bankId = insertPaymentMethod(coupleId, "국민은행", "BANK")
+                cashId = insertPaymentMethod(coupleId, "현금", "CASH")
+                transferId = insertTransfer(coupleId, userId, bankId, cashId, "현금 입금")
+            }
+
+            val result = transactionService.convertFromTransfer(
+                userId, transferId, ConvertToTransactionRequest(type = "INCOME")
+            )
+
+            result.type shouldBe "INCOME"
+            result.paymentMethodId shouldBe cashId
+            inTx { countTransfers(transferId) shouldBe 0L }
+        }
+
+        test("a transfer without a description is rejected before the NOT NULL constraint fires") {
+            lateinit var userId: UUID
+            lateinit var transferId: UUID
+            inTx {
+                userId = insertUser("convert-nodesc-${UUID.randomUUID()}@test.com")
+                val coupleId = insertSelfCouple(userId)
+                val bankId = insertPaymentMethod(coupleId, "국민은행", "BANK")
+                val cashId = insertPaymentMethod(coupleId, "현금", "CASH")
+                transferId = insertTransfer(coupleId, userId, bankId, cashId, null)
+            }
+
+            // transfers.description 은 nullable, transactions.description 은 NOT NULL.
+            // 가드가 없으면 여기서 DataIntegrityViolationException(500) 이 난다.
+            shouldThrow<BusinessException> {
+                transactionService.convertFromTransfer(
+                    userId, transferId, ConvertToTransactionRequest(type = "EXPENSE")
+                )
+            }.code shouldBe "VALIDATION_ERROR"
+
+            // 원본 이체는 그대로 남아 있어야 한다 (원자성).
+            inTx { countTransfers(transferId) shouldBe 1L }
+        }
+
+        test("a card settlement transfer is rejected and left intact") {
+            lateinit var userId: UUID
+            lateinit var transferId: UUID
+            inTx {
+                userId = insertUser("convert-card-${UUID.randomUUID()}@test.com")
+                val coupleId = insertSelfCouple(userId)
+                val bankId = insertPaymentMethod(coupleId, "국민은행", "BANK")
+                val cardId = insertPaymentMethod(coupleId, "현대카드", "CREDIT")
+                transferId = insertTransfer(
+                    coupleId, userId, bankId, cardId, "현대카드 결제", kind = "CARD_SETTLEMENT"
+                )
+            }
+
+            shouldThrow<BusinessException> {
+                transactionService.convertFromTransfer(
+                    userId, transferId, ConvertToTransactionRequest(type = "EXPENSE")
+                )
+            }.code shouldBe "VALIDATION_ERROR"
+
+            inTx { countTransfers(transferId) shouldBe 1L }
+        }
+    }
+}

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -9,14 +9,15 @@
 ## 1. 현재 상태 (한눈에)
 
 <!-- HNS:STATE -->
-- **단계**: 달력 일자 시트 "거래 추가" 회차 **완료**(PR #287·#288, 라이브 검증 통과 2026-08-09).
-  **열린 작업 없음.** 다음 회차는 **"이체 → 거래 역변환"**(기획 완료, 착수 승인 대기)
-- **상태**: idle — 착수 승인 한마디면 계획서 §4 부터 추가 승인 없이 진행
-- **정본 문서**: 다음 회차 = `docs/sessions/2026-07-31_transfer-to-transaction_plan.md` (§0 재개 절차)
-- **repo / 브랜치**: `AIVA-SaaS/budget-book` · 작업 트리 clean · 실행 중 프로세스 없음
-- **CI / 배포**: 직전 회차 전부 통과(로컬 analyze·test 815건·build web → 원격 CI 2종 →
-  deploy-nas run 31293344811 success, verify-live 포함)
-- **blocker**: 다음 회차 착수 승인 1건
+- **단계**: **"이체 → 거래 역변환"** 회차 — 착수 승인 받음(2026-08-09) → 구현 완료 →
+  **로컬 CI 4종 전부 통과**. 다음은 커밋 → PR → 머지 → 배포 → **사용자 라이브 검증**
+- **상태**: 구현 완료 · PR 진입 대기(추가 승인 불필요 — §2 게이트상 기획 승인 이후는 자동 진행)
+- **정본 문서**: `docs/sessions/2026-07-31_transfer-to-transaction_plan.md` (설계 정본, 그대로 구현됨)
+- **repo / 브랜치**: `AIVA-SaaS/budget-book` · 작업 브랜치 `feat/transfer-to-transaction` ·
+  실행 중 프로세스 없음
+- **CI / 배포**: 로컬 4종 통과 — `./gradlew test` / `flutter analyze`(전체 경로, 신규 지적 0) /
+  `flutter test` **820건** / `flutter build web --release`. 원격 CI·배포는 아직
+- **blocker**: 없음 (라이브 검증은 배포 후)
 - **갱신**: 2026-08-09
 - **`/clear` 안전**: 이 상태에서 컨텍스트를 비워도 §3 "다음 액션" 만 보면 이어서 진행 가능
 - 이력 재작성(2026-08-06, 회사 이메일 제거)은 **푸시 완료** — 전 커밋 SHA 가 바뀌었으므로 다른 기기의
@@ -167,35 +168,49 @@
      시트를 pop 한 뒤 네비게이션하는 `_addForDay`/탭 콜백 규약이 스택을 오염시키지 않았다)
    - 이로써 PR #287·#288 회차 완료. 다음은 §3 "다음 액션"(이체 → 거래 역변환, 착수 승인 대기)
 
+13. **2026-08-09** — **이체 → 거래 역변환: 착수 승인("다음 작업 진행해줘") → 구현 완료 → 로컬 CI 4종 통과.**
+   - 승인: 사용자 착수 지정. 기획 정본(`2026-07-31_transfer-to-transaction_plan.md`)을 그대로 구현,
+     설계 변경 없음
+   - BE 산출물: `ConvertToTransactionRequest`(DTO) / `TransactionService.convertFromTransfer` /
+     `TransactionRepository.existsBySettlementTransferId` /
+     `TransferController POST /{id}/convert-to-transaction`(RateLimit 30/60s)
+   - 배치 결정 유지: 구현은 **거래 서비스**, 호출은 이체 컨트롤러 — 반대로 넣으면
+     `TransactionService → TransferService` 기존 주입과 순환 빈 의존. 근거를 코드 주석에 남김
+   - 차단 3종 + 설명 공백 가드 + 카테고리-유형 일치 검증(`createTransaction` 에는 없어 변환 경로에서
+     명시적으로 태움) / `saveAndFlush` 후 이체 삭제 / `TRANSFER_DELETED` + `TRANSACTION_CREATED` 2건 발행
+   - FE 산출물: `TransferRepository.convertToTransaction`(datasource·impl 포함) /
+     거래 폼 `convertFromTransferId` 모드(이체 fetch → prefill, 이체 탭 숨김, 변경 배너, 저장 시 변환 API) /
+     이체 폼 수정 모드 유형 선택기(지출·수입 선택 → 거래 폼으로 push) / 라우터 query param 배선
+   - **기존 결함 동시 수정**: 정방향 `_convertToTransfer` 가 Dashboard·PaymentMethod 를 리로드하지
+     않던 문제 → **네 BLoC 리로드를 양방향 공통 헬퍼 `_reloadAfterConversion` 로** 묶음
+     (`feedback_common_scope_audit` — 한 곳만 수정 금지)
+   - 테스트: BE 서비스 8케이스(승계·결제수단 방향·차단 4종·이벤트 2건·404) + 컨트롤러 위임 1건 +
+     **Testcontainers 통합 4건**(실제 PG: 이체 삭제+거래 삽입 원자성, INCOME 입금 승계,
+     설명 NULL 400 가드, 카드결제 차단) / FE repository 3건 + 배선 가드 5건(양방향 대칭 고정)
+   - 게이트: `./gradlew test` 통과 · `flutter analyze` 신규 지적 0 · `flutter test` 820건 통과 ·
+     `flutter build web --release` 성공. 아이콘 신규 코드포인트 없음(폰트 subset 불변)
+   - 문서: `docs/api-spec.md` Transfers §4-1 신설 + 양방향 상호 참조 2곳
+   - **미완**: 커밋·PR·머지·배포·사용자 라이브 검증
+
 ## 3. 다음 단계
 
 <!-- HNS:NEXT -->
-- **다음 액션 (`/clear` 후 여기서 시작)**: 후보 1 **"이체 → 거래 역변환"** 착수.
-  사용자 착수 승인(한마디)을 확인한 뒤 `docs/sessions/2026-07-31_transfer-to-transaction_plan.md`
-  §4(백엔드) → §5(프론트) → §6(테스트) → §7(로컬 CI) 순서로 구현한다. 승인 확인 전 코드 편집 금지(§2 게이트).
-  - 승인 이력: 기획은 2026-07-31 상신, **착수 지정은 아직 명시적으로 받지 않았다**(2026-08-09 회차는
-    사용자가 별건으로 지시한 달력 추가 결함이었다). 계획서 내용 자체는 재검토 불필요.
-- **첫 명령**: 계획서 §0 (cwd = 이 repo, `git switch main && git pull`, 이 STATE 확인)
-- **직전 회차(달력 추가)**: 라이브 검증 통과로 **종결**(타임라인 12). 남은 것 없음.
-- **완료 판정(역변환)**: BE 4파일 + FE 5파일 + 문서 2 + 테스트 4 반영 → 로컬 CI 3종 통과 → PR 머지 →
-  **사용자 라이브 검증**(이체 폼에서 지출/수입 선택 → 거래로 변환 → 장부 목록에서 이체 사라지고
-  거래로 표시 + 월 합계·자산 잔액 즉시 갱신)
-- **다른 후보로 바꾸려면**: 아래 후보 2~5 중 지정. 기획서는 남겨두면 그대로 재사용 가능.
+- **다음 액션 (`/clear` 후 여기서 시작)**: 이체 → 거래 역변환 **구현은 끝났다**(타임라인 13).
+  남은 절차는 커밋 → PR 생성 → 원격 CI 2종 → squash 머지 → deploy-nas → **사용자 라이브 검증**.
+  개인 계정(AIVA-SaaS)이라 머지까지 자동 진행 범위다(`feedback_personal_account_auto_merge`).
+- **첫 명령**: `git switch feat/transfer-to-transaction && git status` (작업 트리 확인)
+- **완료 판정(역변환)**: PR 머지·배포로는 완료가 아니다. **사용자 라이브 검증**까지 —
+  이체 수정 폼에서 지출/수입 선택 → 거래 폼(배너·승계값 확인) → 저장 → 장부 목록에서 이체가 사라지고
+  거래로 표시 + **월 합계·자산 잔액 즉시 갱신**(이 회차에서 같이 고친 부분).
+  함께 볼 것: 정방향(거래 → 이체)도 변환 직후 대시보드·자산이 갱신되는지 — 같은 헬퍼를 쓴다.
+- **배포 후 측정 팁**: 한글은 번들에서 `\uXXXX` 이스케이프 → 원문 grep 은 항상 0건.
+  `'거래로 변경'` 은 escaped 형태로 대조하고 `last-modified` + `verify-live` 를 함께 본다
+  (`reference_live_bundle_string_verification`).
+- **그 다음 회차**: 아래 후보 2~5 중 사용자가 지정.
 
 ### 다음 회차 후보 — 착수 지점 (이 절만 읽으면 바로 시작 가능)
 
-1. **이체 → 거래 역변환** — ⏳ **기획 완료(2026-07-31) · 승인 대기.**
-   상세 설계는 `docs/sessions/2026-07-31_transfer-to-transaction_plan.md` 가 정본이다(이 요약보다 우선).
-   - 계약: `POST /api/v1/transfers/{id}/convert-to-transaction` → `ApiResponse<TransactionResponse>`
-   - 구현 위치: `TransactionService.convertFromTransfer` + `TransferController` 에서 호출
-     (반대로 넣으면 `TransactionService → TransferService` 기존 주입과 **순환 의존**)
-   - 차단 3종: 정산 기록됨 / `kind == CARD_SETTLEMENT` / 결제 링크 잔존
-   - 함정 선반영: `transfers.description` 은 nullable, `transactions.description` 은 NOT NULL →
-     승계 결과가 비면 400 으로 먼저 막는다(안 하면 DB 제약 500)
-   - FE: 이체 폼 유형 선택기 → 거래 폼(`convertFromTransferId`)으로 push. 거래 폼이 이미 양쪽 폼을
-     다 갖고 있어 피커 복제를 피한다
-   - 같이 고칠 기존 결함: 정방향 `_convertToTransfer` 가 Dashboard·PaymentMethod BLoC 을 리로드하지
-     않는다 → 네 BLoC 리로드를 양방향 공통 헬퍼로 (`feedback_common_scope_audit`)
+1. ~~**이체 → 거래 역변환**~~ — ✅ 구현 완료(2026-08-09, 타임라인 13). 라이브 검증만 남음.
 2. **P6 홈 대시보드 "미정산 N건" 위젯** (추천 2순위. 기존 API 재사용)
    - 데이터: `GET /reconciliations/summary` (이미 존재, `unrecordedCount`)
    - 위젯 등록: `frontend/lib/features/home/domain/entities/dashboard_widget_config.dart`
@@ -212,7 +227,11 @@
 ## 4. 산출물 지도
 
 - `docs/sessions/2026-07-31_transfer-to-transaction_plan.md` — **현재 회차 설계 정본**(이체→거래 역변환).
-  재부팅/`/clear` 후 이 대장 다음으로 읽을 문서. 승인 시 이 문서 순서대로 구현한다
+  2026-08-09 그대로 구현 완료 — 설계 변경 없음. 라이브 검증 시 기대 동작의 근거 문서
+- `frontend/test/features/transfer/convert_wiring_guard_test.dart` — 이체↔거래 변환 **양방향 대칭** 가드
+  (네 BLoC 리로드 공통 헬퍼 경유 / 이체 폼은 거래 폼으로 보낸다 / 저장이 변환 API 를 탄다)
+- `backend/src/test/kotlin/com/budgetbook/transfer/integration/TransferToTransactionIntegrationTest.kt`
+  — 실제 PG 로 원자성·NOT NULL·FK 가드 검증(mock 으로는 안 잡히는 층)
 - `docs/incidents/2026-07-30_icon-font-stale-cache.md` — **아이콘 캐시 사건 정본**(5회 발생 분석·방어선·진단 순서). 비슷한 증상이면 코드보다 이 문서를 먼저 본다
 - `docs/sessions/2026-07-30_handoff.md` — 직전 회차 인수 문서(배포 현황·라이브 검증 체크리스트). 이력 보존용, 수정 금지
 - `docs/sessions/2026-07-28_icon-missing-handoff.md` — 아이콘 사건 1·2회차 측정 기록. 수정 금지

--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -1292,6 +1292,9 @@ Updates an existing transaction. Only the author or the partner can update it.
 **동기화**: `TRANSACTION_DELETED` + `TRANSFER_CREATED` **두 이벤트**를 모두 발행한다.
 장부 목록은 거래+이체 병합이라 한쪽만 쏘면 파트너 화면에 원본 거래가 남는다.
 
+**역방향**: 이체를 거래로 되돌리려면 `POST /api/v1/transfers/{id}/convert-to-transaction`
+(Transfers §4-1). 두 방향의 차단 규칙·이벤트 규약은 대칭이다.
+
 ---
 
 ### 5. Delete Transaction
@@ -3493,6 +3496,70 @@ All fields are optional (partial update). Omitted fields retain their current va
 | `404`  | `TRANSFER_NOT_FOUND`       | Transfer does not exist or belongs to another couple     |
 | `404`  | `PAYMENT_METHOD_NOT_FOUND` | Specified payment method does not exist                  |
 | `403`  | `FORBIDDEN`                | Payment method belongs to another couple                 |
+
+> **거래로의 변경은 이 엔드포인트가 아니다.** 이체를 지출/수입으로 바꾸려면
+> `POST /api/v1/transfers/{id}/convert-to-transaction` (§4-1) 을 쓴다 — 테이블이 다르므로
+> 필드 수정이 아니라 삭제+생성이다.
+
+---
+
+### 4-1. Convert Transfer to Transaction
+
+이체를 거래(지출/수입)로 바꾼다. `### 4-1. Convert Transaction to Transfer` (거래 → 이체) 의
+거울상이며, 마찬가지로 **원본 이체 삭제 + 거래 생성**을 한 트랜잭션으로 처리하고 생성된 거래를
+돌려준다.
+
+| Item        | Value                                             |
+|:------------|:--------------------------------------------------|
+| **Method**  | `POST`                                            |
+| **Path**    | `/api/v1/transfers/{id}/convert-to-transaction`   |
+| **Auth**    | Required                                          |
+| **RateLimit** | 30 req / 60s                                    |
+
+**Request Body**
+
+```json
+{
+  "type": "EXPENSE",
+  "categoryId": "550e8400-e29b-41d4-a716-446655440021",
+  "paymentMethodId": null,
+  "pocketId": null,
+  "amount": 50000,
+  "transactionDate": "2026-07-15",
+  "description": "계좌 이동",
+  "memo": null,
+  "needsReview": false
+}
+```
+
+| Field             | Type      | Required | Description                                                     |
+|:------------------|:----------|:--------:|:-----------------------------------------------------------------|
+| `type`            | `string`  | Yes      | `EXPENSE` \| `INCOME`. 그 외(`ADJUSTMENT` 포함) 는 `400`          |
+| `categoryId`      | `UUID`    | No       | 주면 유형 일치 검증. visibility 는 이 카테고리에서 파생            |
+| `paymentMethodId` | `UUID`    | No       | 생략 시 `EXPENSE` → 출금 결제수단 / `INCOME` → 입금 결제수단 승계 |
+| `pocketId`        | `UUID`    | No       | 이체에 대응 개념이 없어 신규 입력값 (승계 없음)                   |
+| `amount`          | `long`    | No       | 생략 시 원본 이체 금액 승계                                        |
+| `transactionDate` | `string`  | No       | 생략 시 원본 `transferDate` 승계                                  |
+| `description`     | `string`  | No       | 생략 시 원본 설명 승계. **승계 결과가 비면 `400`**                 |
+| `memo`            | `string`  | No       | 생략 시 원본 메모 승계                                             |
+| `needsReview`     | `boolean` | No       | 기본 `false`                                                      |
+
+**Response `200 OK`**: `ApiResponse<TransactionResponse>` (생성된 거래)
+
+**Error Responses**
+
+| Status | Error Code | Description |
+|:-------|:-----------|:------------|
+| `400`  | `VALIDATION_ERROR` | 지원하지 않는 `type` / 정산에 기록됨 / 카드 결제(`CARD_SETTLEMENT`) 이체 / 결제 링크가 남은 이체 / 카테고리가 유형과 불일치 / 설명이 비어 있음 |
+| `403`  | `FORBIDDEN` | 다른 커플의 카테고리·결제수단·포켓 |
+| `404`  | `TRANSFER_NOT_FOUND` / `CATEGORY_NOT_FOUND` / `PAYMENT_METHOD_NOT_FOUND` / `POCKET_NOT_FOUND` | 대상 없음 (다른 커플의 이체도 `TRANSFER_NOT_FOUND`) |
+
+**설명 nullable 비대칭 주의**: `transfers.description` 은 nullable 인데
+`transactions.description` 은 NOT NULL 이다. 승계 결과가 비면 DB 제약(500) 전에 서버가
+`400 VALIDATION_ERROR("설명을 입력하세요.")` 로 먼저 막는다 — FE 는 이 경우 설명을 필수 입력으로 표시한다.
+
+**동기화**: `TRANSFER_DELETED` + `TRANSACTION_CREATED` **두 이벤트**를 모두 발행한다.
+장부 목록은 거래+이체 병합이라 한쪽만 쏘면 파트너 화면에 원본 이체가 남는다.
 
 ---
 

--- a/frontend/lib/core/router/app_router.dart
+++ b/frontend/lib/core/router/app_router.dart
@@ -432,6 +432,10 @@ GoRouter createAppRouter(AuthBloc authBloc) => GoRouter(
                     // 배치 4 D-4 (2026-04-26): state.extra 는 새로고침 유실 → copyFromId query param 권장
                     final copyFrom = state.extra as Transaction?;
                     final copyFromId = state.uri.queryParameters['copyFromId'];
+                    // 이체 → 거래 역변환 (2026-08-09). copyFromId 와 같은 이유로 query
+                    // param 이다 — 새로고침해도 변환 대상이 유지된다.
+                    final convertFromTransferId =
+                        state.uri.queryParameters['convertFromTransferId'];
                     final dateStr = state.uri.queryParameters['date'];
                     final initialPaymentMethodId = state.uri.queryParameters['paymentMethodId'];
                     DateTime? initialDate;
@@ -464,6 +468,7 @@ GoRouter createAppRouter(AuthBloc authBloc) => GoRouter(
                         initialTab: tab,
                         copyFrom: copyFrom,
                         copyFromId: copyFromId,
+                        convertFromTransferId: convertFromTransferId,
                         initialDate: initialDate,
                         initialPaymentMethodId: initialPaymentMethodId,
                       ),

--- a/frontend/lib/features/transaction/presentation/pages/transaction_form_page.dart
+++ b/frontend/lib/features/transaction/presentation/pages/transaction_form_page.dart
@@ -44,6 +44,7 @@ import 'package:budget_book/features/ai/domain/entities/ai_classify_result.dart'
 import 'package:budget_book/features/transaction/presentation/bloc/transaction_bloc.dart';
 import 'package:budget_book/features/transaction/presentation/bloc/transaction_event.dart';
 import 'package:budget_book/features/transaction/presentation/bloc/transaction_state.dart';
+import 'package:budget_book/features/transfer/domain/entities/transfer.dart';
 import 'package:budget_book/features/transfer/presentation/bloc/transfer_bloc.dart';
 import 'package:budget_book/features/transfer/presentation/bloc/transfer_event.dart';
 import 'package:budget_book/features/transfer/presentation/bloc/transfer_state.dart';
@@ -67,6 +68,14 @@ class TransactionFormPage extends StatefulWidget {
   /// 새로고침 시에도 URL 에서 보존되어 prefill 가능.
   final String? copyFromId;
 
+  /// 이체 → 거래 역변환 대상 이체의 id (2026-08-09, query param).
+  ///
+  /// 지정되면 이 폼은 "새 거래 등록" 이 아니라 **원본 이체를 거래로 옮기는** 모드가 된다:
+  /// 저장 시 변환 API(이체 삭제 + 거래 생성)를 타고, 이체 탭은 숨긴다.
+  /// 변환을 이체 폼이 아니라 이 폼에서 하는 이유는 카테고리·포켓 피커가 여기에만 있어
+  /// 복제를 피하기 위함이다 (거래 → 이체 변환도 이 폼에서 일어난다).
+  final String? convertFromTransferId;
+
   /// Optional initial date for the transaction.
   /// Used when navigating from a date header in the transaction list.
   final DateTime? initialDate;
@@ -85,6 +94,7 @@ class TransactionFormPage extends StatefulWidget {
     this.initialType,
     this.copyFrom,
     this.copyFromId,
+    this.convertFromTransferId,
     this.initialDate,
     this.initialPaymentMethodId,
     this.initialTab,
@@ -186,6 +196,12 @@ class _TransactionFormPageState extends State<TransactionFormPage>
   /// 수정 모드에서 이체로 바꾸는 중인가 (본문/저장 경로가 갈린다).
   bool get _isConvertingToTransfer => isEditing && _editTargetType == 'TRANSFER';
 
+  /// 이체 → 거래 역변환 모드인가 (저장 경로가 갈린다. 정방향의 거울상).
+  bool get _isConvertingFromTransfer => widget.convertFromTransferId != null;
+
+  /// 이체 탭을 숨겨야 하는가 — 수정 모드, 그리고 역변환 모드(목적지가 거래로 고정).
+  bool get _hidesTransferTab => isEditing || _isConvertingFromTransfer;
+
   int _resolveInitialTabIndex() {
     // When editing, determine tab from transaction type (no transfer tab for edit)
     if (isEditing) {
@@ -213,9 +229,10 @@ class _TransactionFormPageState extends State<TransactionFormPage>
     // Initialize tab controller (hide transfer tab when editing)
     final initialIndex = _resolveInitialTabIndex();
     _tabController = TabController(
-      length: isEditing ? 2 : 3,
+      length: _hidesTransferTab ? 2 : 3,
       vsync: this,
-      initialIndex: isEditing ? initialIndex.clamp(0, 1) : initialIndex,
+      initialIndex:
+          _hidesTransferTab ? initialIndex.clamp(0, 1) : initialIndex,
     );
     _tabController.addListener(_onTabChanged);
 
@@ -235,6 +252,11 @@ class _TransactionFormPageState extends State<TransactionFormPage>
     if (isEditing) {
       _isLoadingTransaction = true;
       _loadTransaction();
+    } else if (_isConvertingFromTransfer) {
+      // copyFromId 와 같은 방식 — query param 의 id 로 fetch 후 prefill 하므로
+      // 새로고침해도 변환 대상이 살아남는다.
+      _isLoadingTransaction = true;
+      _loadConvertFromTransfer(widget.convertFromTransferId!);
     } else if (widget.copyFrom != null) {
       _prefillFromTransaction(widget.copyFrom!);
     } else if (widget.copyFromId != null) {
@@ -273,6 +295,58 @@ class _TransactionFormPageState extends State<TransactionFormPage>
       }
     });
   }
+
+  /// 역변환 원본 이체. 결제수단 승계(지출=출금 / 수입=입금)에 계속 필요해서 들고 있는다.
+  Transfer? _sourceTransfer;
+
+  Future<void> _loadConvertFromTransfer(String id) async {
+    try {
+      final repo = context.read<TransferBloc>().transferRepository;
+      final result = await repo.getTransfer(id);
+      if (!mounted) return;
+      result.fold(
+        (failure) {
+          setState(() => _isLoadingTransaction = false);
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text('변환할 이체를 불러올 수 없습니다: ${failure.message}'),
+              backgroundColor: Theme.of(context).colorScheme.error,
+            ),
+          );
+        },
+        (transfer) {
+          setState(() {
+            _isLoadingTransaction = false;
+            _prefillFromTransfer(transfer);
+          });
+        },
+      );
+    } catch (_) {
+      if (mounted) setState(() => _isLoadingTransaction = false);
+    }
+  }
+
+  /// 이체 값을 거래 폼에 승계한다. 서버 승계 규칙(§4)과 **같은 규칙**이어야 한다 —
+  /// 화면에 보이는 값과 저장되는 값이 갈라지면 사용자가 틀린 걸 확인하고 저장하게 된다.
+  void _prefillFromTransfer(Transfer transfer) {
+    _sourceTransfer = transfer;
+    _descriptionController.text = transfer.description ?? '';
+    _memoController.text = transfer.memo ?? '';
+    _selectedPaymentMethodId = _inheritedPaymentMethodId(transfer);
+    final parsed = DateTime.tryParse(transfer.transferDate);
+    if (parsed != null) _selectedDate = parsed;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) {
+        _amountController.text = CurrencyFormatter.format(transfer.amount);
+      }
+    });
+  }
+
+  /// 지출은 돈이 나간 쪽(출금), 수입은 들어온 쪽(입금)이 그 거래의 결제수단이다.
+  String _inheritedPaymentMethodId(Transfer transfer) =>
+      _selectedType == 'INCOME'
+          ? transfer.destinationPaymentMethod.id
+          : transfer.sourcePaymentMethod.id;
 
   Future<void> _loadCopyFromTransaction(String id) async {
     try {
@@ -313,6 +387,12 @@ class _TransactionFormPageState extends State<TransactionFormPage>
           _selectedType = 'INCOME';
           _selectedCategoryId = null;
           _selectedCategoryDisplayName = null;
+        }
+        // 역변환 모드에서 지출↔수입을 바꾸면 승계할 결제수단도 반대쪽이 된다
+        // (지출=출금 / 수입=입금). 안 바꾸면 화면 값과 서버 승계 규칙이 갈라진다.
+        final source = _sourceTransfer;
+        if (source != null && _tabController.index < 2) {
+          _selectedPaymentMethodId = _inheritedPaymentMethodId(source);
         }
         // Tab 2 (transfer) doesn't change _selectedType
       });
@@ -672,7 +752,9 @@ class _TransactionFormPageState extends State<TransactionFormPage>
         },
         child: Scaffold(
           appBar: AppBar(
-            title: Text(isEditing ? '거래 수정' : '거래 추가'),
+            title: Text(isEditing
+                ? '거래 수정'
+                : (_isConvertingFromTransfer ? '거래로 변경' : '거래 추가')),
           actions: [
             if (isEditing)
               IconButton(
@@ -687,10 +769,13 @@ class _TransactionFormPageState extends State<TransactionFormPage>
                 )
               : TabBar(
                   controller: _tabController,
-                  tabs: const [
-                    Tab(icon: Icon(Icons.arrow_downward), text: '지출'),
-                    Tab(icon: Icon(Icons.arrow_upward), text: '수입'),
-                    Tab(icon: Icon(Icons.swap_horiz), text: '이체'),
+                  tabs: [
+                    const Tab(icon: Icon(Icons.arrow_downward), text: '지출'),
+                    const Tab(icon: Icon(Icons.arrow_upward), text: '수입'),
+                    // 역변환 모드에서는 목적지가 거래로 고정이라 이체 탭이 없다
+                    // (TabController.length 와 반드시 같은 조건이어야 한다).
+                    if (!_hidesTransferTab)
+                      const Tab(icon: Icon(Icons.swap_horiz), text: '이체'),
                   ],
                 ),
         ),
@@ -698,23 +783,55 @@ class _TransactionFormPageState extends State<TransactionFormPage>
             ? (_isConvertingToTransfer
                 ? _buildTransferFormContent(context)
                 : _buildTransactionFormBody(context))
-            : TabBarView(
-                controller: _tabController,
+            : Column(
                 children: [
-                  // Tab 0: Expense form
-                  _buildTransactionFormBody(context, formKey: _expenseFormKey),
-                  // Tab 1: Income form
-                  _buildTransactionFormBody(context,
-                    formKey: _incomeFormKey,
-                    categoryFocusNode: _incomeCategoryFocusNode,
-                    pmFocusNode: _incomePmFocusNode,
-                    pocketFocusNode: _incomePocketFocusNode,
+                  if (_isConvertingFromTransfer) _buildConvertBanner(context),
+                  Expanded(
+                    child: TabBarView(
+                      controller: _tabController,
+                      children: [
+                        // Tab 0: Expense form
+                        _buildTransactionFormBody(context,
+                            formKey: _expenseFormKey),
+                        // Tab 1: Income form
+                        _buildTransactionFormBody(context,
+                          formKey: _incomeFormKey,
+                          categoryFocusNode: _incomeCategoryFocusNode,
+                          pmFocusNode: _incomePmFocusNode,
+                          pocketFocusNode: _incomePocketFocusNode,
+                        ),
+                        // Tab 2: Transfer form (embedded)
+                        if (!_hidesTransferTab) _buildTransferFormBody(context),
+                      ],
+                    ),
                   ),
-                  // Tab 2: Transfer form (embedded)
-                  _buildTransferFormBody(context),
                 ],
               ),
       ),
+      ),
+    );
+  }
+
+  /// 역변환 모드 안내 — 저장이 "추가" 가 아니라 "이동" 임을 미리 알린다.
+  Widget _buildConvertBanner(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    return Container(
+      width: double.infinity,
+      color: scheme.tertiaryContainer,
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+      child: Row(
+        children: [
+          Icon(Icons.swap_horiz, size: 18, color: scheme.onTertiaryContainer),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              '이체 → 거래로 변경 — 저장하면 원본 이체가 삭제됩니다',
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: scheme.onTertiaryContainer,
+                  ),
+            ),
+          ),
+        ],
       ),
     );
   }
@@ -1169,21 +1286,78 @@ class _TransactionFormPageState extends State<TransactionFormPage>
       ),
       (transfer) {
         final moved = DateTime.parse(transfer.transferDate);
-        // 두 스트림을 함께 갱신 — 하나만 하면 원본 거래가 남아 보이거나 새 이체가 안 보인다.
-        txnBloc.add(LoadTransactions.fromFilter(
-          moved.year,
-          moved.month,
-          txnBloc.currentFilter,
-        ));
-        context
-            .read<TransferBloc>()
-            .add(LoadTransfers(year: moved.year, month: moved.month));
+        _reloadAfterConversion(moved.year, moved.month);
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(content: Text('이체로 변경되었습니다')),
         );
         Navigator.of(context).pop(true);
       },
     );
+  }
+
+  /// 이체 → 거래 역변환 실행. 정방향 [_convertToTransfer] 의 거울상.
+  ///
+  /// 마찬가지로 BLoC 을 거치지 않고 repository 를 직접 부른다 — 이체 삭제 + 거래 생성이
+  /// 두 스트림에 걸쳐 있어 어느 한쪽 BLoC 의 상태 머신에 얹기가 어색하다.
+  Future<void> _convertToTransaction({
+    required int amount,
+    required String description,
+    required String? memo,
+    required String dateStr,
+    required String? categoryId,
+  }) async {
+    final repo = context.read<TransferBloc>().transferRepository;
+    final result = await repo.convertToTransaction(
+      id: widget.convertFromTransferId!,
+      type: _selectedType,
+      categoryId: categoryId,
+      paymentMethodId: _selectedPaymentMethodId,
+      pocketId: _selectedPocketId,
+      amount: amount,
+      transactionDate: dateStr,
+      description: description,
+      memo: memo,
+      needsReview: _needsReview,
+    );
+    if (!mounted) return;
+    _submitTimeoutTimer?.cancel();
+    setState(() => _isSubmitting = false);
+
+    result.fold(
+      (failure) => ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(failure.message),
+          backgroundColor: Theme.of(context).colorScheme.error,
+        ),
+      ),
+      (transaction) {
+        final moved = DateTime.parse(transaction.transactionDate);
+        _reloadAfterConversion(moved.year, moved.month);
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('거래로 변경되었습니다')),
+        );
+        // 원본 이체는 이제 없다 — 진입 경로(이체 수정 폼)로 pop 하면 사라진 이체의
+        // 폼으로 되돌아간다. 장부 목록으로 보낸다.
+        context.go('/transactions?year=${moved.year}&month=${moved.month}');
+      },
+    );
+  }
+
+  /// 변환 성공 후 재조회 — **양방향 공통**.
+  ///
+  /// 네 BLoC 을 모두 갱신해야 한다: 거래·이체(장부는 두 스트림 병합) + 대시보드(월 합계)
+  /// + 결제수단(자산 잔액). 이전에는 정방향이 앞의 둘만 갱신해 변환 직후 월 합계와 자산
+  /// 잔액이 그대로였다 — 한쪽만 고치면 또 갈라지므로 두 방향이 이 헬퍼를 함께 쓴다.
+  void _reloadAfterConversion(int year, int month) {
+    final txnBloc = context.read<TransactionBloc>();
+    txnBloc.add(LoadTransactions.fromFilter(
+      year,
+      month,
+      txnBloc.currentFilter,
+    ));
+    context.read<TransferBloc>().add(LoadTransfers(year: year, month: month));
+    getIt<DashboardBloc>().add(LoadDashboard(year: year, month: month));
+    getIt<PaymentMethodBloc>().add(const LoadPaymentMethods());
   }
 
   Widget _buildTransferFormBody(BuildContext context) {
@@ -2280,6 +2454,20 @@ class _TransactionFormPageState extends State<TransactionFormPage>
     );
     final amount = submission.amount;
     final resolvedCategoryId = submission.categoryId;
+
+    // 역변환 모드 — 새 거래를 만드는 게 아니라 **원본 이체를 거래로 옮긴다**(서버가
+    // 삭제+생성을 한 트랜잭션으로 처리). 여기서 CreateTransaction 을 쓰면 이체와 거래가
+    // 둘 다 남아 금액이 이중 계상된다 (정방향 _submitTransfer 의 거울상 분기).
+    if (_isConvertingFromTransfer) {
+      _convertToTransaction(
+        amount: amount,
+        description: description,
+        memo: memo,
+        dateStr: dateStr,
+        categoryId: resolvedCategoryId,
+      );
+      return;
+    }
 
     if (isEditing) {
       bloc.add(UpdateTransaction(

--- a/frontend/lib/features/transfer/data/datasources/transfer_remote_datasource.dart
+++ b/frontend/lib/features/transfer/data/datasources/transfer_remote_datasource.dart
@@ -1,5 +1,6 @@
 import 'package:budget_book/core/network/api_client.dart';
 import 'package:budget_book/core/constants/api_endpoints.dart';
+import 'package:budget_book/features/transaction/data/models/transaction_model.dart';
 import 'package:budget_book/features/transfer/data/models/transfer_model.dart';
 
 abstract class TransferRemoteDataSource {
@@ -14,6 +15,12 @@ abstract class TransferRemoteDataSource {
   Future<TransferModel> updateCardSettlement(
       String id, Map<String, dynamic> data);
   Future<TransferModel> updateTransfer(String id, Map<String, dynamic> data);
+
+  /// 이체 → 거래 역변환. 서버가 원본 이체 삭제 + 거래 생성을 한 트랜잭션으로 처리하고
+  /// **거래**를 돌려준다 (거래 → 이체 변환의 거울상).
+  Future<TransactionModel> convertToTransaction(
+      String id, Map<String, dynamic> data);
+
   Future<void> deleteTransfer(String id);
 }
 
@@ -96,6 +103,18 @@ class TransferRemoteDataSourceImpl implements TransferRemoteDataSource {
       data: data,
     );
     return TransferModel.fromJson(
+      response.data['data'] as Map<String, dynamic>,
+    );
+  }
+
+  @override
+  Future<TransactionModel> convertToTransaction(
+      String id, Map<String, dynamic> data) async {
+    final response = await apiClient.dio.post(
+      '${ApiEndpoints.transfers}/$id/convert-to-transaction',
+      data: data,
+    );
+    return TransactionModel.fromJson(
       response.data['data'] as Map<String, dynamic>,
     );
   }

--- a/frontend/lib/features/transfer/data/repositories/transfer_repository_impl.dart
+++ b/frontend/lib/features/transfer/data/repositories/transfer_repository_impl.dart
@@ -2,6 +2,7 @@ import 'package:dartz/dartz.dart';
 import 'package:dio/dio.dart';
 import 'package:budget_book/core/error/failure.dart';
 import 'package:budget_book/core/error/dio_error_mapper.dart';
+import 'package:budget_book/features/transaction/domain/entities/transaction.dart';
 import 'package:budget_book/features/transfer/data/datasources/transfer_remote_datasource.dart';
 import 'package:budget_book/features/transfer/domain/entities/transfer.dart';
 import 'package:budget_book/features/transfer/domain/repositories/transfer_repository.dart';
@@ -165,6 +166,41 @@ class TransferRepositoryImpl implements TransferRepository {
       return Left(mapDioError(e, '이체를 수정하지 못했습니다'));
     } catch (e) {
       return const Left(ServerFailure('이체를 수정하지 못했습니다'));
+    }
+  }
+
+  @override
+  Future<Either<Failure, Transaction>> convertToTransaction({
+    required String id,
+    required String type,
+    String? categoryId,
+    String? paymentMethodId,
+    String? pocketId,
+    int? amount,
+    String? transactionDate,
+    String? description,
+    String? memo,
+    bool? needsReview,
+  }) async {
+    try {
+      final data = <String, dynamic>{
+        'type': type,
+        // 생략한 값은 서버가 원본 이체에서 승계한다 — 여기서 채우지 않는다.
+        if (categoryId != null) 'categoryId': categoryId,
+        if (paymentMethodId != null) 'paymentMethodId': paymentMethodId,
+        if (pocketId != null) 'pocketId': pocketId,
+        if (amount != null) 'amount': amount,
+        if (transactionDate != null) 'transactionDate': transactionDate,
+        if (description != null) 'description': description,
+        if (memo != null) 'memo': memo,
+        if (needsReview != null) 'needsReview': needsReview,
+      };
+      final result = await remoteDataSource.convertToTransaction(id, data);
+      return Right(result);
+    } on DioException catch (e) {
+      return Left(mapDioError(e, '이체를 거래로 변경하지 못했습니다'));
+    } catch (e) {
+      return const Left(ServerFailure('이체를 거래로 변경하지 못했습니다'));
     }
   }
 

--- a/frontend/lib/features/transfer/domain/repositories/transfer_repository.dart
+++ b/frontend/lib/features/transfer/domain/repositories/transfer_repository.dart
@@ -1,5 +1,6 @@
 import 'package:dartz/dartz.dart';
 import 'package:budget_book/core/error/failure.dart';
+import 'package:budget_book/features/transaction/domain/entities/transaction.dart';
 import 'package:budget_book/features/transfer/domain/entities/transfer.dart';
 
 abstract class TransferRepository {
@@ -56,6 +57,26 @@ abstract class TransferRepository {
     String? memo,
     bool clearMemo = false,
     TransferKind? kind,
+  });
+
+  /// 이체 → 거래 역변환 (원본 이체 삭제 + 거래 생성을 서버가 한 트랜잭션으로 처리).
+  ///
+  /// 정방향(`TransactionRepository.convertToTransfer`)이 **source 쪽 repository** 에
+  /// 있으므로 역방향은 여기가 소유한다 — 대칭이 깨지면 다음 사람이 한쪽만 고친다.
+  ///
+  /// 생략한 값은 서버가 원본 이체에서 승계한다. [paymentMethodId] 를 생략하면
+  /// `EXPENSE` → 출금 / `INCOME` → 입금 결제수단이 승계된다.
+  Future<Either<Failure, Transaction>> convertToTransaction({
+    required String id,
+    required String type,
+    String? categoryId,
+    String? paymentMethodId,
+    String? pocketId,
+    int? amount,
+    String? transactionDate,
+    String? description,
+    String? memo,
+    bool? needsReview,
   });
 
   Future<Either<Failure, void>> deleteTransfer(String id);

--- a/frontend/lib/features/transfer/presentation/pages/transfer_form_page.dart
+++ b/frontend/lib/features/transfer/presentation/pages/transfer_form_page.dart
@@ -302,9 +302,93 @@ class _TransferFormPageState extends State<TransferFormPage> {
                 onPressed: _isSubmitting ? null : () => _confirmDelete(context),
               ),
           ],
+          bottom: _showsTypeSelector
+              ? PreferredSize(
+                  preferredSize: const Size.fromHeight(48),
+                  child: _buildTypeSelector(context),
+                )
+              : null,
         ),
         body: _buildForm(context),
       ),
+    );
+  }
+
+  /// 유형 선택기를 보일 조건 (2026-08-09).
+  ///
+  /// 수정 모드에서 원본 이체를 읽어온 뒤에만 보인다 — 종류를 모르면 카드 결제 이체를
+  /// 걸러낼 수 없다. 카드 결제는 전용 플로우(`/card-settlement`)가 있어 애초에 이 폼으로
+  /// 오지 않지만, 서버도 400 으로 막는 규칙이라 UI 에서도 선택지를 주지 않는다.
+  bool get _showsTypeSelector =>
+      isEditing &&
+      _existingTransfer != null &&
+      _existingTransfer!.kind != TransferKind.cardSettlement;
+
+  /// 유형 선택 — 지출 / 수입 / 이체. 거래 폼의 수정 모드 선택기(`_buildEditTypeSelector`)와
+  /// 같은 모양이다.
+  ///
+  /// 지출/수입을 고르면 **거래 폼으로 보낸다**. 이 폼에 카테고리·포켓 피커를 복제하지 않기
+  /// 위해서다 — 변환은 언제나 거래 폼에서 일어난다(거래 → 이체 방향도 마찬가지).
+  Widget _buildTypeSelector(BuildContext context) {
+    return Align(
+      alignment: Alignment.centerLeft,
+      child: SingleChildScrollView(
+        scrollDirection: Axis.horizontal,
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+        child: Row(
+          children: [
+            Text(
+              '유형',
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: Theme.of(context)
+                        .colorScheme
+                        .onSurface
+                        .withValues(alpha: 0.6),
+                  ),
+            ),
+            const SizedBox(width: 8),
+            SegmentedButton<String>(
+              style: const ButtonStyle(
+                visualDensity: VisualDensity.compact,
+                tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+              ),
+              segments: const [
+                ButtonSegment(
+                  value: 'EXPENSE',
+                  icon: Icon(Icons.arrow_downward, size: 14),
+                  label: Text('지출'),
+                ),
+                ButtonSegment(
+                  value: 'INCOME',
+                  icon: Icon(Icons.arrow_upward, size: 14),
+                  label: Text('수입'),
+                ),
+                ButtonSegment(
+                  value: 'TRANSFER',
+                  icon: Icon(Icons.swap_horiz, size: 14),
+                  label: Text('이체'),
+                ),
+              ],
+              selected: const {'TRANSFER'},
+              showSelectedIcon: false,
+              onSelectionChanged: (selection) {
+                if (selection.isEmpty) return;
+                _onTypeSelected(selection.first);
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _onTypeSelected(String next) {
+    if (next == 'TRANSFER') return;
+    // 거래 폼이 원본 이체를 fetch 해 prefill 한다 (query param 이라 새로고침에도 유지).
+    final tab = next == 'INCOME' ? 'income' : 'expense';
+    context.push(
+      '/transactions/create'
+      '?convertFromTransferId=${widget.transferId}&tab=$tab',
     );
   }
 

--- a/frontend/test/features/transfer/convert_to_transaction_test.dart
+++ b/frontend/test/features/transfer/convert_to_transaction_test.dart
@@ -1,0 +1,101 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:budget_book/core/error/failure.dart';
+import 'package:budget_book/features/transaction/data/models/transaction_model.dart';
+import 'package:budget_book/features/transfer/data/datasources/transfer_remote_datasource.dart';
+import 'package:budget_book/features/transfer/data/repositories/transfer_repository_impl.dart';
+
+class _MockDataSource extends Mock implements TransferRemoteDataSource {}
+
+/// 이체 → 거래 역변환 (2026-08-09) — 전달 체인 고정.
+///
+/// `type_change_test.dart` (거래 → 이체) 의 거울상이다. repository→datasource hop 에서
+/// 파라미터가 조용히 누락된 사고가 반복됐던 자리라, **실제 요청 map** 을 검증한다.
+/// 특히 "생략하면 서버가 원본 이체를 승계한다" 는 계약이므로, 생략한 필드가 body 에
+/// null 로라도 실리면 안 된다 (실리면 승계가 아니라 덮어쓰기가 된다).
+void main() {
+  late _MockDataSource ds;
+  late TransferRepositoryImpl repo;
+
+  final txJson = <String, dynamic>{
+    'id': 't1',
+    'coupleId': 'c1',
+    'author': {'id': 'u1', 'nickname': '홍길동'},
+    'type': 'EXPENSE',
+    'amount': 50000,
+    'description': '계좌 이동',
+    'transactionDate': '2026-07-15',
+    'createdAt': '2026-07-15T10:00:00Z',
+    'updatedAt': '2026-07-15T10:00:00Z',
+  };
+
+  setUp(() {
+    ds = _MockDataSource();
+    repo = TransferRepositoryImpl(remoteDataSource: ds);
+  });
+
+  group('convertToTransaction', () {
+    test('type 만 필수로 실리고, 생략한 값은 body 에서 빠진다 (서버가 원본 승계)', () async {
+      when(() => ds.convertToTransaction(any(), any()))
+          .thenAnswer((_) async => TransactionModel.fromJson(txJson));
+
+      final result = await repo.convertToTransaction(id: 'tr1', type: 'EXPENSE');
+
+      expect(result.isRight(), isTrue);
+      final data = verify(() => ds.convertToTransaction('tr1', captureAny()))
+          .captured
+          .single as Map<String, dynamic>;
+      expect(data['type'], 'EXPENSE');
+      expect(data.containsKey('amount'), isFalse);
+      expect(data.containsKey('transactionDate'), isFalse);
+      expect(data.containsKey('description'), isFalse);
+      expect(data.containsKey('paymentMethodId'), isFalse);
+    });
+
+    test('카테고리·결제수단·포켓·금액·날짜·설명·메모·needsReview 를 주면 전부 전달된다',
+        () async {
+      when(() => ds.convertToTransaction(any(), any()))
+          .thenAnswer((_) async => TransactionModel.fromJson(txJson));
+
+      await repo.convertToTransaction(
+        id: 'tr1',
+        type: 'INCOME',
+        categoryId: 'c9',
+        paymentMethodId: 'p2',
+        pocketId: 'pk1',
+        amount: 50000,
+        transactionDate: '2026-07-16',
+        description: '계좌 이동',
+        memo: '메모',
+        needsReview: true,
+      );
+
+      final data = verify(() => ds.convertToTransaction('tr1', captureAny()))
+          .captured
+          .single as Map<String, dynamic>;
+      expect(data['type'], 'INCOME');
+      expect(data['categoryId'], 'c9');
+      expect(data['paymentMethodId'], 'p2');
+      expect(data['pocketId'], 'pk1');
+      expect(data['amount'], 50000);
+      expect(data['transactionDate'], '2026-07-16');
+      expect(data['description'], '계좌 이동');
+      expect(data['memo'], '메모');
+      expect(data['needsReview'], true);
+    });
+
+    test('실패는 Failure 로 매핑된다', () async {
+      when(() => ds.convertToTransaction(any(), any()))
+          .thenThrow(Exception('boom'));
+
+      final result = await repo.convertToTransaction(id: 'tr1', type: 'EXPENSE');
+
+      expect(result.isLeft(), isTrue);
+      result.fold(
+        (f) => expect(f, isA<ServerFailure>()),
+        (_) => fail('실패해야 한다'),
+      );
+    });
+  });
+}

--- a/frontend/test/features/transfer/convert_wiring_guard_test.dart
+++ b/frontend/test/features/transfer/convert_wiring_guard_test.dart
@@ -1,0 +1,86 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// 이체 ↔ 거래 변환 배선 가드 (2026-08-09).
+///
+/// 두 폼 페이지를 실제로 띄우려면 BLoC 6종 + DI + 라우터가 필요해, 선언 자체를 고정한다
+/// (`calendar_day_sheet_add_test.dart` / `view_mode_toggle_guard_test.dart` 와 같은 방식).
+///
+/// 지키려는 것은 **양방향 대칭**이다. 과거 정방향(거래 → 이체)은 거래·이체 BLoC 만 리로드하고
+/// 대시보드·결제수단은 빠뜨려, 변환 직후 월 합계와 자산 잔액이 갱신되지 않았다. 역방향만
+/// 고치면 또 갈라지므로 두 방향이 같은 헬퍼를 쓰도록 강제한다.
+void main() {
+  final transactionForm = File(
+    'lib/features/transaction/presentation/pages/transaction_form_page.dart',
+  ).readAsStringSync();
+  final transferForm = File(
+    'lib/features/transfer/presentation/pages/transfer_form_page.dart',
+  ).readAsStringSync();
+
+  String bodyOf(String source, String signature) {
+    final start = source.indexOf(signature);
+    expect(start, isNonNegative, reason: '$signature 를 찾지 못했다');
+    // 클래스 멤버의 닫는 중괄호(들여쓰기 2칸 + 단독 줄)까지를 본문으로 본다.
+    // `\n  }` 만 찾으면 여러 줄 파라미터 목록의 `  }) async {` 에 먼저 걸린다.
+    final end = source.indexOf('\n  }\n', start + signature.length);
+    return source.substring(start, end == -1 ? source.length : end);
+  }
+
+  group('변환 성공 후 리로드', () {
+    test('양방향 모두 _reloadAfterConversion 을 경유한다', () {
+      expect(bodyOf(transactionForm, 'Future<void> _convertToTransfer(')
+          .contains('_reloadAfterConversion('), isTrue,
+          reason: '정방향이 공통 헬퍼를 안 쓰면 대시보드·결제수단 리로드가 다시 빠진다');
+      expect(bodyOf(transactionForm, 'Future<void> _convertToTransaction(')
+          .contains('_reloadAfterConversion('), isTrue,
+          reason: '역방향이 공통 헬퍼를 안 쓰면 두 방향이 갈라진다');
+    });
+
+    test('헬퍼가 네 BLoC 을 모두 갱신한다', () {
+      final helper = bodyOf(transactionForm, 'void _reloadAfterConversion(');
+      // 거래·이체: 장부는 두 스트림 병합 / 대시보드: 월 합계 / 결제수단: 자산 잔액.
+      expect(helper.contains('LoadTransactions.fromFilter('), isTrue);
+      expect(helper.contains('LoadTransfers('), isTrue);
+      expect(helper.contains('LoadDashboard('), isTrue);
+      expect(helper.contains('LoadPaymentMethods('), isTrue);
+    });
+  });
+
+  group('이체 폼 유형 선택기', () {
+    test('지출/수입 선택은 거래 폼으로 보낸다 (피커 복제 금지)', () {
+      final body = bodyOf(transferForm, 'void _onTypeSelected(');
+      expect(body.contains('/transactions/create'), isTrue,
+          reason: '이체 폼에서 직접 변환하면 카테고리·포켓 피커가 두 벌이 된다');
+      expect(body.contains('convertFromTransferId='), isTrue,
+          reason: 'query param 이 아니면 새로고침 시 변환 대상이 유실된다');
+      expect(body.contains('tab='), isTrue,
+          reason: '탭을 지정하지 않으면 지출/수입 선택이 폼에 반영되지 않는다');
+    });
+
+    test('카드 결제 이체에는 선택기를 노출하지 않는다', () {
+      final body = bodyOf(transferForm, 'bool get _showsTypeSelector =>');
+      expect(body.contains('TransferKind.cardSettlement'), isTrue,
+          reason: '서버가 400 으로 막는 경로를 UI 가 열어두면 안 된다');
+    });
+  });
+
+  group('역변환 모드 폼', () {
+    test('저장은 CreateTransaction 이 아니라 변환 API 를 탄다', () {
+      final body = bodyOf(transactionForm, 'void _onSubmit() {');
+      final convertIdx = body.indexOf('_isConvertingFromTransfer');
+      final createIdx = body.indexOf('CreateTransaction(');
+      expect(convertIdx, isNonNegative,
+          reason: '역변환 분기가 없으면 이체와 거래가 둘 다 남아 이중 계상된다');
+      expect(convertIdx < createIdx, isTrue,
+          reason: '분기가 CreateTransaction 뒤에 있으면 도달하지 않는다');
+    });
+
+    test('역변환 모드에서는 이체 탭을 숨긴다', () {
+      expect(transactionForm.contains(
+          'bool get _hidesTransferTab => isEditing || _isConvertingFromTransfer'),
+          isTrue,
+          reason: 'TabController.length 와 tabs 목록이 같은 조건을 써야 한다');
+    });
+  });
+}


### PR DESCRIPTION
## 요약

이체를 지출/수입 거래로 되돌리는 역변환을 추가한다. 거래 → 이체 변환(2026-07-27)의 거울상으로, **원본 이체 삭제 + 거래 생성을 한 트랜잭션**에서 처리한다.

- 계약: `POST /api/v1/transfers/{id}/convert-to-transaction` → `ApiResponse<TransactionResponse>` (RateLimit 30/60s)
- 설계 정본: `docs/sessions/2026-07-31_transfer-to-transaction_plan.md` (설계 변경 없이 그대로 구현)
- DB 마이그레이션 없음

## 백엔드

- 구현은 `TransactionService.convertFromTransfer` 가 소유하고 `TransferController` 가 호출한다. 반대로 넣으면 기존 `TransactionService → TransferService` 주입과 맞물려 **순환 빈 의존**이 된다 (근거를 코드 주석에 남겼다).
- 차단 3종: 정산 기록됨 / `kind == CARD_SETTLEMENT` / 결제 링크 잔존
- **설명 nullable 비대칭 가드**: `transfers.description` 은 nullable 인데 `transactions.description` 은 NOT NULL → 승계 결과가 비면 400 으로 먼저 막는다 (없으면 DB 제약에서 500).
- `createTransaction` 에 없는 카테고리-유형 일치 검증을 변환 경로에서 명시적으로 태운다.
- `saveAndFlush` 후 이체 삭제. `TRANSFER_DELETED` + `TRANSACTION_CREATED` **2건** 발행 (장부는 두 스트림 병합이라 한쪽만 쏘면 파트너 화면에 원본이 남는다).

## 프론트엔드

- 변환은 언제나 **거래 폼**에서 일어난다. 이체 폼의 유형 선택기는 거래 폼으로 보내는 라우터 역할만 한다 — 이체 폼에 카테고리·포켓 피커를 복제하지 않기 위해서다.
- `convertFromTransferId` 는 query param 이라 새로고침에도 변환 대상이 살아남는다 (`copyFromId` 와 같은 이유).
- 결제수단 승계는 지출=출금 / 수입=입금. 탭을 바꾸면 승계 대상도 함께 바뀐다.

## 함께 고친 기존 결함

정방향 `_convertToTransfer` 가 Dashboard·PaymentMethod 를 리로드하지 않아 **변환 직후 월 합계와 자산 잔액이 갱신되지 않았다.** 역방향만 고치면 또 갈라지므로 네 BLoC 리로드를 양방향 공통 헬퍼 `_reloadAfterConversion` 으로 묶고, 대칭이 깨지지 않게 배선 가드 테스트를 뒀다.

## 테스트

- BE: 서비스 8케이스(승계·결제수단 방향·차단 4종·이벤트 2건·404) + 컨트롤러 위임 1건
- BE **Testcontainers 통합 4건** (실제 PG): 원자성 / INCOME 입금 승계 / 설명 NULL 400 / 카드결제 차단 — mock 은 FK·NOT NULL 을 검증하지 않는다
- FE: repository 전달 체인 3건 + 양방향 배선 가드 5건

로컬 CI 4종 전부 통과: `./gradlew test` · `flutter analyze`(전체 경로, 신규 지적 0) · `flutter test` 820건 · `flutter build web --release`

## 라이브 검증 항목 (머지·배포 후)

1. 이체 수정 폼 → 유형에서 지출/수입 선택 → 거래 폼에 배너와 승계값(금액·날짜·설명·결제수단) 확인
2. 저장 → 장부 목록에서 이체가 사라지고 거래로 표시
3. **월 합계·자산 잔액이 즉시 갱신**되는지 (이번에 같이 고친 부분)
4. 정방향(거래 → 이체)도 3번이 같이 되는지 — 같은 헬퍼를 쓴다

🤖 Generated with [Claude Code](https://claude.com/claude-code)