### PR TITLE
fix(transaction): 장부 필터 이체 누출 구조적 수정 + 동적 빈 상태 문구

### DIFF
--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -9,16 +9,17 @@
 ## 1. 현재 상태 (한눈에)
 
 <!-- HNS:STATE -->
-- **단계**: **"이체 → 거래 역변환"** 회차 — 구현 → 로컬 CI → PR #290 머지 → **배포 성공**.
-  서버 측 검증 완료. **남은 것은 사용자 라이브 검증 1건** (이게 통과해야 "완료")
-- **상태**: 사용자 라이브 검증 대기
-- **정본 문서**: `docs/sessions/2026-07-31_transfer-to-transaction_plan.md` (설계 정본, 그대로 구현됨)
-- **repo / 브랜치**: `AIVA-SaaS/budget-book` · `main` = `3215399` · 작업 트리 clean ·
-  실행 중 프로세스 없음
-- **CI / 배포**: 로컬 4종(gradlew test / analyze 전체 / test 820건 / build web) → 원격 CI 2종 →
-  squash 머지 → **deploy-nas run 31298339060 success**(deploy-frontend·deploy-backend·verify-live)
-- **blocker**: 사용자 라이브 검증 1건
-- **갱신**: 2026-08-09
+- **단계**: **"장부 필터 게이팅 단일화 + 동적 빈 상태 문구"** 회차 (Step 1) — 구현 + 로컬 CI 통과.
+  다음은 커밋 → PR → 머지 → 배포 → 사용자 라이브 검증.
+- **직전 회차 종결**: 이체 → 거래 역변환(PR #290) **사용자 라이브 검증 통과 = 완료**(2026-08-10 확인)
+- **상태**: 구현 완료, PR 전
+- **정본 문서**: `docs/sessions/2026-08-10_ledger-filter-gating_plan.md` (§7 에 남은 요구사항 Step 1~7)
+- **repo / 브랜치**: `AIVA-SaaS/budget-book` · `main` = `4845efe` 기준 작업
+- **CI**: 로컬 4종 통과 — analyze(신규 0건) / flutter test **843건** / `./gradlew test` / build web
+- **하네스 게이트**: `filter_propagation` = STRUCTURAL_FIX_REQUIRED → 기획서에 구조적 수정 3종 포함 후
+  `acknowledge-gate.sh` 로 해제
+- **blocker**: 없음
+- **갱신**: 2026-08-10
 - **`/clear` 안전**: 이 상태에서 컨텍스트를 비워도 §3 "다음 액션" 만 보면 이어서 진행 가능
 - 이력 재작성(2026-08-06, 회사 이메일 제거)은 **푸시 완료** — 전 커밋 SHA 가 바뀌었으므로 다른 기기의
   기존 클론은 pull 이 아니라 **재클론**. 백업 `~/backup/git-email-rewrite-20260806/budget-book.bundle`
@@ -202,26 +203,57 @@
      (한글 원문 grep 은 항상 0건 — `reference_live_bundle_string_verification`)
    - **미완**: 사용자 라이브 검증 1건(§3 참조). 이것이 통과할 때까지 이 회차는 "완료" 아님
 
+15. **2026-08-10** — 이체 → 거래 역변환 **사용자 라이브 검증 통과 → 회차 종결(완료)**.
+   - 사용자 확인: 정상 동작. PR #286 기획 → #290 구현 → 배포 → 라이브 검증까지 전 구간 종료
+   - 이 회차의 산출물(양방향 리로드 공통 헬퍼 + 대칭 가드 테스트)은 §4 산출물 지도에 유지
+
+16. **2026-08-10** — 신규 회차 착수: **장부 필터 게이팅 단일화 + 동적 빈 상태 문구** (Step 1).
+   - 사용자 보고: "확인 필요 등 필터 적용 시 이체를 선택 안 했는데도 이체가 보인다" +
+     "결과가 없을 때 선택한 필터에 맞는 동적 문구" + "남은 요구사항 단계 정리"
+   - 진단(hard evidence): `transaction_list_page.dart:727~785` 이체 게이팅이 필터 축을 **수동 나열** →
+     `needsReviewOnly` · 카테고리 · 포켓 · 금액 **4축 누락**, 결제수단은 `paymentMethodIds.first`
+     **1개만** 적용. `Transfer` 엔티티에는 needsReview/category/pocket 필드가 **없어** 해당 축이
+     켜지면 이체는 매칭 불가 = 전량 제외가 정답. 거래·합계는 BE 가 정상 필터
+     (`TransactionSpecifications.kt:100`, `StatisticsService.kt:105`) → "거래는 맞는데 이체만 남는" 비대칭
+   - 하네스 감사: `filter_propagation` **STRUCTURAL_FIX_REQUIRED**(4회째 재발) → 게이트 LOCKED →
+     기획서에 구조적 수정 포함 후 `acknowledge-gate.sh` 로 해제
+   - 결정(사용자 승인): Step 1 범위 = 게이팅 단일화 + 동적 빈 문구 + 결제수단 복수선택 fix 한 PR
+   - 산출물: `ledger_gating.dart`(신설, 이체 게이팅 단일 진입점) /
+     `ledger_empty_message.dart`(신설, 빈 상태 문구 단일 생성기) /
+     `ledger_gating_test.dart` · `ledger_empty_message_test.dart`(신설) /
+     `transaction_list_page.dart`(인라인 게이팅 제거 + 동적 빈 상태 + 필터 초기화 액션) /
+     `unified_filter_state.dart`(`kTransactionTypeLabels` 공용 상수) / `unified_filter_bar.dart`(라벨 참조)
+   - 재발 방지(구조): ① 이체 게이팅 단일 진입점 ② **필드 수 가드** — `UnifiedFilterState` 에 필드가
+     늘면 `kUnifiedFilterAxisCount` 불일치로 테스트 실패 → 이체 판정 갱신 강제
+     ③ 페이지에 인라인 이체 필터링이 재도입되면 소스 검사 테스트가 실패
+   - 게이트: 로컬 CI 4종 통과(analyze 신규 0 / flutter test 843 / gradlew test / build web)
+   - 미해결로 남긴 것: 금액·기간·결제수단 필터만 켠 경우 BE summary 는 이체를 합계에서 빼는데
+     FE 행에는 이체가 남는다(`StatisticsService.kt:147` "필터 활성 시 totalTransfer=0").
+     이번 보고 증상과는 무관한 **기존** 불일치 → 별도 회차 후보로 §3 에 등재
+
 ## 3. 다음 단계
 
 <!-- HNS:NEXT -->
-- **다음 액션 (`/clear` 후 여기서 시작)**: 이체 → 거래 역변환은 **배포까지 끝났다**(타임라인 13·14).
-  남은 것은 **사용자 라이브 검증 1건뿐** — 아래 판정 항목을 사용자에게 확인받는다.
-  검증 통과 보고를 받으면 이 회차를 종결 기록하고, 다음 회차 후보를 제시한다.
-  실패하면 `domains/01-diagnosis.md` 로 들어간다(추측 fix 금지, 증상-역행 grep 먼저).
-- **첫 명령**: 없음(코드 변경 없음). 사용자 확인 대기 상태다.
-- **완료 판정(역변환)**: PR 머지·배포로는 완료가 아니다. **사용자 라이브 검증**까지 —
-  이체 수정 폼에서 지출/수입 선택 → 거래 폼(배너·승계값 확인) → 저장 → 장부 목록에서 이체가 사라지고
-  거래로 표시 + **월 합계·자산 잔액 즉시 갱신**(이 회차에서 같이 고친 부분).
-  함께 볼 것: 정방향(거래 → 이체)도 변환 직후 대시보드·자산이 갱신되는지 — 같은 헬퍼를 쓴다.
+- **다음 액션 (`/clear` 후 여기서 시작)**: Step 1(장부 필터 게이팅) 구현 + 로컬 CI 는 끝났다
+  (타임라인 16). 커밋 → PR → CI → 머지 → 배포 → **사용자 라이브 검증** 순으로 진행한다.
+- **첫 명령**: `git status` 로 변경 확인 → 브랜치 생성 후 커밋(개인 계정이라 머지까지 자동 진행 승인 범위).
+- **완료 판정(Step 1)**: 머지·배포는 완료가 아니다. 거래 탭에서 다음이 전부 확인돼야 한다 —
+  ① 확인/입력 필요만 ON → **이체 0건** + 월합계바 이체 금액 미표시
+  ② 카테고리 / 포켓 필터 → 이체 0건
+  ③ 결제수단 **2개 이상** 선택 → 두 결제수단 이체가 **모두** 표시(예전엔 첫 1개만)
+  ④ 금액범위 → 범위 밖 이체 제외
+  ⑤ 결과 0건일 때 조건에 맞는 문구 + `필터 초기화` 버튼 동작
+  ⑥ 달력뷰에서도 ①~④ 동일(이체 마커가 사라짐)
 - **배포 후 측정 팁**: 한글은 번들에서 `\uXXXX` 이스케이프 → 원문 grep 은 항상 0건.
-  `'거래로 변경'` 은 escaped 형태로 대조하고 `last-modified` + `verify-live` 를 함께 본다
-  (`reference_live_bundle_string_verification`).
-- **그 다음 회차**: 아래 후보 2~5 중 사용자가 지정.
+  `'확인/입력 필요한 거래가 없습니다'` 를 escaped 형태로 대조하고 `last-modified` + `verify-live` 를
+  함께 본다 (`reference_live_bundle_string_verification`).
+- **그 다음 회차**: 아래 Step 2~7 중 사용자가 지정(기획서 §7 과 동일 순서).
 
 ### 다음 회차 후보 — 착수 지점 (이 절만 읽으면 바로 시작 가능)
 
-1. ~~**이체 → 거래 역변환**~~ — ✅ 구현 완료(2026-08-09, 타임라인 13). 라이브 검증만 남음.
+0. ~~**이체 → 거래 역변환**~~ — ✅ **완료**(라이브 검증 통과, 2026-08-10 타임라인 15).
+1. **Step 2 — 남은 라이브 검증 정리**: 정산 스냅샷 A1~A10 / B1~B7 / C1~C5
+   (`docs/sessions/2026-07-27_1_result.md §4.1`), KI-006(지출계획 완료 시 거래 자동 등록).
 2. **P6 홈 대시보드 "미정산 N건" 위젯** (추천 2순위. 기존 API 재사용)
    - 데이터: `GET /reconciliations/summary` (이미 존재, `unrecordedCount`)
    - 위젯 등록: `frontend/lib/features/home/domain/entities/dashboard_widget_config.dart`
@@ -231,14 +263,25 @@
    - 현재는 안내 문구만: `reconciliation_view.dart:191` (+ 배경 주석 `:29`)
    - BLoC: `reconciliation_bloc.dart:24` — 클라 필터링 금지 전제가 주석에 명시돼 있다
    - 거래 목록의 LoadMore 패턴 참조: `reference_transaction_pagination_focus`
-4. **P4 월말 "미기록 N건" 인앱 알림** — 알림 인프라가 없어 선행 작업이 크다(가장 큰 후보)
-5. **Android 배포(Play Store)** — PWA 설치는 이미 가능(`reference_pwa_android_installable`)
+4. **개인 자산(ASSET-PRIVATE)** — PaymentMethod visibility/owner + 이체 visibility 파생.
+   Step 1 이 남긴 임시 전제("이체는 전부 공유 취급")를 정식화하는 회차 —
+   고칠 지점은 `ledger_gating.dart` 의 `_transfersExcludedWholesale` 한 곳으로 좁혀져 있다.
+5. **P4 월말 "미기록 N건" 인앱 알림** — 알림 인프라가 없어 선행 작업이 크다(가장 큰 후보)
+6. **Android 배포(Play Store)** — PWA 설치는 이미 가능(`reference_pwa_android_installable`)
+7. **합계 ≠ 행 잔존 불일치** — 금액/기간/결제수단 필터만 켠 경우 BE summary 는 이체를 빼고
+   (`StatisticsService.kt:147` totalTransfer=0, EXPENSE_TRANSFER 도 미합산) FE 행에는 이체가 남는다.
+   소규모 BE 회차.
 <!-- /HNS:NEXT -->
 
 ## 4. 산출물 지도
 
-- `docs/sessions/2026-07-31_transfer-to-transaction_plan.md` — **현재 회차 설계 정본**(이체→거래 역변환).
-  2026-08-09 그대로 구현 완료 — 설계 변경 없음. 라이브 검증 시 기대 동작의 근거 문서
+- `docs/sessions/2026-08-10_ledger-filter-gating_plan.md` — **현재 회차 설계 정본**(장부 필터 게이팅
+  단일화 + 동적 빈 문구). §7 에 남은 요구사항 Step 1~7 정리
+- `frontend/lib/features/transaction/presentation/utils/ledger_gating.dart` — **이체 게이팅 단일 진입점**.
+  장부에 새 필터 축을 추가할 때 반드시 여기 판정을 먼저 쓴다(필드 수 가드가 강제)
+- `frontend/lib/features/transaction/presentation/utils/ledger_empty_message.dart` — 빈 상태 문구 단일 생성기
+- `docs/sessions/2026-07-31_transfer-to-transaction_plan.md` — 이체→거래 역변환 설계 정본.
+  2026-08-10 라이브 검증 통과로 **종결**. 이력 보존용
 - `frontend/test/features/transfer/convert_wiring_guard_test.dart` — 이체↔거래 변환 **양방향 대칭** 가드
   (네 BLoC 리로드 공통 헬퍼 경유 / 이체 폼은 거래 폼으로 보낸다 / 저장이 변환 API 를 탄다)
 - `backend/src/test/kotlin/com/budgetbook/transfer/integration/TransferToTransactionIntegrationTest.kt`

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -231,6 +231,15 @@
      FE 행에는 이체가 남는다(`StatisticsService.kt:147` "필터 활성 시 totalTransfer=0").
      이번 보고 증상과는 무관한 **기존** 불일치 → 별도 회차 후보로 §3 에 등재
 
+17. **2026-08-10** — PR #292 생성(원격 CI 진행) + 자체 검토에서 잡은 후속 1건 반영.
+   - PR: https://github.com/AIVA-SaaS/budget-book/pull/292 (커밋 `1514728`)
+   - 자체 검토 지적: `toTransactionFilter(keywordOverride:)` 는 override 가 null/빈 문자열이면
+     VO 의 keyword 로 fallback 하는데, FE 게이팅은 빈 검색창(`''`)을 "검색어 없음"으로 처리해
+     **BE 가 좁힌 거래 ↔ FE 가 남긴 이체가 어긋날 수 있었다**(합계 ≠ 행 계열)
+   - 조치: `resolveLedgerKeyword` 로 실효 검색어 규칙을 한 곳에 두고 게이팅·빈 상태 문구가 공유.
+     회귀 테스트 추가(빈 검색창 → VO keyword fallback)
+   - 게이트: 유틸 테스트 31건 통과 / analyze 신규 0건
+
 ## 3. 다음 단계
 
 <!-- HNS:NEXT -->

--- a/docs/sessions/2026-08-10_ledger-filter-gating_plan.md
+++ b/docs/sessions/2026-08-10_ledger-filter-gating_plan.md
@@ -1,0 +1,160 @@
+# 2026-08-10 — 장부 필터 게이팅 단일화 + 동적 빈 상태 문구 (기획)
+
+> 트리거: 사용자 보고 — "확인 필요 등 필터 적용 시 이체를 선택하지 않았는데도 이체가 보인다".
+> 하네스 감사(`filter_propagation`) = **STRUCTURAL_FIX_REQUIRED**(4회째 재발) → 패치 수정 불허.
+> 관련 메모리: `reference_transaction_merged_transfer_stream_drift`, `feedback_filter_vo_single_source`,
+> `reference_month_move_filter_drop`, `feedback_common_scope_audit`.
+
+---
+
+## 1. 증상 → 원인 (hard evidence)
+
+- 증상 관찰 레이어: 거래 탭 목록(그리고 달력·월합계바) 화면.
+- 코드 근거
+  - `frontend/lib/features/transaction/presentation/pages/transaction_list_page.dart:727~785`
+    이체 스트림 게이팅이 필터 필드를 **인라인으로 수동 나열**한다.
+    - 적용됨: `paymentMethodIds.first`(**복수 선택 중 1개만**), `dateFrom/dateTo`, 검색 키워드,
+      `transactionTypes`(TRANSFER 포함 여부), `visibility == 'PRIVATE'`
+    - **누락**: `needsReviewOnly`, `categoryIds` / `categoryGroupIds`, `amountMin/amountMax`, `pocketIds`
+  - `frontend/lib/features/transfer/domain/entities/transfer.dart:49~83`
+    `Transfer` 에는 `needsReview` / category / pocket 필드가 **존재하지 않는다**
+    → 해당 축이 활성이면 이체는 **논리적으로 매칭 불가** = 전량 제외가 정답인데 게이팅이 그 축을 보지 않아 통과된다.
+  - `backend/.../TransactionSpecifications.kt:100`, `StatisticsService.kt:105`
+    거래·합계는 BE 가 `needsReviewOnly` 를 정상 적용 → "거래는 맞는데 이체만 남는" 비대칭이 설명된다.
+- 인과 1문장:
+  **증상 ← 이체 게이팅이 `UnifiedFilterState` 를 수동 나열해 `needsReviewOnly` 축을 보지 않음
+  ← 이체 게이팅이 VO 를 관통하지 않고 페이지 안에 인라인으로 흩어져 있음.**
+
+### 반증 시도 (fix 후에도 증상이 남을 조건)
+
+1. 달력뷰/월합계바가 다른 리스트를 소비한다면 목록만 고쳐도 증상 잔존
+   → 세 소비처가 모두 `visibleTransactions` / `visibleTransfers` 를 쓰는지 확인 완료
+   (`:791` summary, `:854` calendar, `:880`·`:890` list). 게이팅 함수 1개 교체로 3곳 동시 커버.
+2. BE 가 `/transfers` 를 월 단위로만 주고 FE 가 필터를 못 건다면 → 이체 축(기간·금액·결제수단·키워드)은
+   FE 에서 판정 가능함을 엔티티로 확인 완료.
+3. 배포 후 구번들 캐시 → 라이브 검증 시 `last-modified` + escaped 문자열 대조
+   (`reference_live_bundle_string_verification`).
+
+---
+
+## 2. 전수 조사 (공통 적용 범위)
+
+- `UnifiedFilterBar` 사용처는 2곳뿐: `transaction_list_page.dart:698`, `period_summary_page.dart:85`.
+  후자는 `dateRange/category/paymentMethod` 만 활성이고 **이체 병합이 없다** → 이번 누출 범위 밖.
+- 이체 스트림을 거래와 병합하는 화면은 **거래 탭 1곳**(목록·달력·합계바·러닝밸런스).
+- 정산 뷰(`reconciliation_view.dart`)는 서버 필터로 직접 로드 → 범위 밖(자체 빈 문구 보유).
+- ⇒ 게이팅 수정 1곳으로 전수 커버되며, 빈 문구 동적화도 거래 탭 `_buildEmpty`(`:1281`) 1곳.
+
+---
+
+## 3. 구조적 수정 (게이트 해제 요건)
+
+패치가 아니라 **재발을 컴파일/테스트 타임에 막는 장치**를 넣는다.
+
+### S1. 단일 게이팅 진입점 — 순수 함수 모듈
+
+새 파일 `frontend/lib/features/transaction/presentation/utils/ledger_gating.dart`
+(기존 `running_balance.dart` 와 동일한 "순수 함수 + 단위 테스트" 관례를 따른다)
+
+```dart
+class GatedLedger { final List<Transaction> transactions; final List<Transfer> transfers; }
+
+GatedLedger gateLedger({
+  required List<Transaction> transactions,   // BE 가 이미 좁힌 결과
+  required List<Transfer> transfers,         // 월 단위 원본
+  required UnifiedFilterState filter,
+  String? keyword,
+});
+```
+
+- `UnifiedFilterState` 의 **모든 축**에 대해 "이체에 적용 / 이체에 없음→전량 제외 / 무관" 을 **명시적으로** 판정한다.
+  - 이체에 없는 축(`needsReviewOnly`, category, pocket): 활성이면 **이체 0건**
+  - 이체에 있는 축(date, amount, paymentMethodIds **전체 OR 매칭**, keyword, type, visibility): 실제 매칭
+  - `dateRangeLabel` / `categoryName` / `paymentMethodName` / `status`: 표시용·미사용 축으로 명시 분류
+- 페이지는 이 함수의 결과만 소비한다(변수명 `visibleTransactions` / `visibleTransfers` 유지) →
+  목록·달력·합계·러닝밸런스가 **같은 리스트**를 본다.
+
+### S2. 필드 수 가드 테스트 (재발 강제 차단)
+
+`frontend/test/features/transaction/presentation/utils/ledger_gating_test.dart`
+
+- `UnifiedFilterState().props.length` 를 상수와 대조. 불일치 시 실패 메시지:
+  > "UnifiedFilterState 에 필드가 추가/삭제되었다. ledger_gating.dart 의 이체 축 판정에 이 필드를
+  > 명시 처리한 뒤 이 상수를 갱신하라."
+  → **새 필터를 추가하면 이체 게이팅 갱신 없이는 CI 가 빨간불**이 된다(누락의 구조적 봉인).
+- 축별 케이스: needsReview / category / group / pocket → 이체 0건, 금액범위, 결제수단 2개 OR,
+  TRANSFER-only → 거래 0건, PRIVATE → 이체 0건, 무필터 → 전량 통과.
+
+### S3. 인라인 게이팅 재도입 차단
+
+- 같은 테스트 파일에서 `transaction_list_page.dart` 소스를 읽어
+  이체 리스트를 페이지에서 직접 `.where(` 로 거르는 패턴이 없는지 검사(회귀 가드).
+- 페이지에는 "이체 게이팅은 `ledger_gating.dart` 단일 진입점" 주석 앵커를 남긴다.
+
+---
+
+## 4. 동적 빈 상태 문구 (2번째 요구사항)
+
+새 파일 `frontend/lib/features/transaction/presentation/utils/ledger_empty_message.dart` (순수 함수)
+
+```dart
+class LedgerEmptyMessage { final String title; final String? subtitle; final bool hasFilters; }
+LedgerEmptyMessage buildLedgerEmptyMessage(UnifiedFilterState filter, {String? keyword});
+```
+
+- 필터 없음 → `거래 내역이 없습니다` / `이 달에 기록된 거래가 없습니다` (현행 유지)
+- 단일 축 활성 → 그 축 전용 문구
+  - `확인/입력 필요한 거래가 없습니다`
+  - `이체 내역이 없습니다` / `지출 내역이 없습니다` / `수입 내역이 없습니다` (복수 선택 시 `지출/이체 …`)
+  - `개인 거래가 없습니다` / `공유 거래가 없습니다`
+  - `선택한 카테고리의 거래가 없습니다` / `… 결제수단의 …` / `… 포켓의 …`
+  - `해당 금액대의 거래가 없습니다` / `선택한 기간에 거래가 없습니다`
+  - `'{검색어}' 검색 결과가 없습니다`
+- 2축 이상 → title 은 우선순위 최상위 축 문구, subtitle 은 `적용된 필터: 확인 필요 · 지출 · 카테고리`
+- 액션 버튼: 필터가 하나라도 활성이면 **`필터 초기화`**(필터 + 검색어 동시 해제), 아니면 기존 `거래 추가`
+- 값 라벨(카테고리명 등)은 상단 필터 칩이 이미 보여주므로 문구에는 **축 이름만** → getIt 의존 없는 순수 함수 유지
+- 테스트: 축별 문구 + 복합 케이스 + 액션 라벨 분기
+
+---
+
+## 5. 변경 파일 (예상)
+
+- 신규 `frontend/lib/features/transaction/presentation/utils/ledger_gating.dart`
+- 신규 `frontend/lib/features/transaction/presentation/utils/ledger_empty_message.dart`
+- 신규 테스트 2개 (`test/features/transaction/presentation/utils/…`)
+- 수정 `frontend/lib/features/transaction/presentation/pages/transaction_list_page.dart`
+  (인라인 게이팅 → `gateLedger` 호출, `_buildEmpty` → 동적 문구 + 필터 초기화 액션)
+- 수정 `frontend/lib/core/widgets/filters/unified_filter_bar.dart`
+  (`_typeLabels` 를 공용 상수로 승격해 문구 유틸과 공유 — 라벨 이중 정의 방지)
+
+BE 변경 없음(거래·합계는 이미 서버가 정확히 필터).
+
+---
+
+## 6. 검증 계획
+
+- 로컬 CI 4종: `flutter analyze --no-fatal-infos --no-congratulate`(전체 경로) / `flutter test` /
+  `./gradlew test` / `flutter build web`
+- 관찰 레이어 검증(라이브): 거래 탭에서
+  1. 확인/입력 필요만 ON → **이체 0건**, 월합계바 이체 금액 미표시
+  2. 카테고리/포켓 필터 → 이체 0건
+  3. 결제수단 2개 선택 → 두 결제수단 이체 모두 표시(기존엔 1개만)
+  4. 금액범위 → 범위 밖 이체 제외
+  5. 결과 0건일 때 조건에 맞는 문구 + `필터 초기화` 버튼 동작
+  6. 달력뷰에서도 1~4 동일(마커 사라짐)
+
+---
+
+## 7. 남은 요구사항 — 단계 정리 (3번째 요구사항)
+
+| 단계 | 항목 | 근거/문서 | 비고 |
+|---|---|---|---|
+| Step 1 (이번) | 장부 필터 이체 누출 fix + 동적 빈 문구 | 본 기획서 | FE only, PR 1개 |
+| Step 2 | 미종결 라이브 검증 정리 | PROGRESS §3, current-tasks | 역변환(PR #290), RECON-VERIFY A/B/C, KI-006 |
+| Step 3 | RECON-P6 홈 "미정산 N건" 위젯 | current-tasks Backlog | 기존 API 재사용, 소규모 |
+| Step 4 | 미기록 200건 초과 추가 페이지 로드 UI | `reconciliation_view.dart:191` | LoadMore 패턴 재사용 |
+| Step 5 | ASSET-PRIVATE 개인 자산 + 이체 visibility 파생 | 메모리 | 본 fix 의 "이체=SHARED 취급" 임시 전제를 정식화 |
+| Step 6 | RECON-P4 월말 "미기록 N건" 인앱 알림 | current-tasks Backlog | 알림 인프라 선행, 최대 규모 |
+| Step 7 | REL-ANDROID / KI-007-P2 카카오 비즈니스 | current-tasks Backlog | 선택 |
+
+> 표 형식은 기획 문서 내부용. 사용자 보고 시에는 불릿으로 전달(글로벌 §1.9).

--- a/frontend/lib/core/models/unified_filter_state.dart
+++ b/frontend/lib/core/models/unified_filter_state.dart
@@ -13,6 +13,15 @@ enum FilterType {
   needsReview,
 }
 
+/// 거래 유형 표시 라벨의 **단일 정의**.
+/// 'TRANSFER' 는 FE 전용 pseudo-type (BE 는 EXPENSE/INCOME/ADJUSTMENT 만 안다).
+/// 필터 칩·필터 시트·빈 상태 문구가 모두 이 맵을 쓴다(라벨 이중 정의 방지).
+const Map<String, String> kTransactionTypeLabels = {
+  'EXPENSE': '지출',
+  'INCOME': '수입',
+  'TRANSFER': '이체',
+};
+
 class UnifiedFilterState extends Equatable {
   final DateTime? dateFrom;
   final DateTime? dateTo;

--- a/frontend/lib/core/widgets/filters/unified_filter_bar.dart
+++ b/frontend/lib/core/widgets/filters/unified_filter_bar.dart
@@ -57,18 +57,12 @@ class UnifiedFilterBar extends StatelessWidget {
     return count;
   }
 
-  static const Map<String, String> _typeLabels = {
-    'EXPENSE': '지출',
-    'INCOME': '수입',
-    'TRANSFER': '이체',
-  };
-
   List<_ChipData> get _allChips {
     final chips = <_ChipData>[];
     if (enabledFilters.contains(FilterType.transactionType) &&
         state.transactionTypes.isNotEmpty) {
       final labels = state.transactionTypes
-          .map((t) => _typeLabels[t] ?? t)
+          .map((t) => kTransactionTypeLabels[t] ?? t)
           .join('/');
       chips.add(_ChipData(
         label: labels,

--- a/frontend/lib/features/transaction/presentation/pages/transaction_list_page.dart
+++ b/frontend/lib/features/transaction/presentation/pages/transaction_list_page.dart
@@ -42,6 +42,8 @@ import 'package:budget_book/features/transaction/presentation/widgets/transactio
 import 'package:budget_book/features/reconciliation/presentation/bloc/reconciliation_bloc.dart';
 import 'package:budget_book/features/reconciliation/presentation/widgets/reconciliation_view.dart';
 import 'package:budget_book/features/transaction/presentation/utils/running_balance.dart';
+import 'package:budget_book/features/transaction/presentation/utils/ledger_gating.dart';
+import 'package:budget_book/features/transaction/presentation/utils/ledger_empty_message.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:budget_book/features/payment_method/presentation/bloc/payment_method_bloc.dart';
 import 'package:budget_book/features/payment_method/presentation/bloc/payment_method_state.dart';
@@ -724,65 +726,29 @@ class _TransactionListPageState extends State<TransactionListPage> {
                   ? transferState.transfers
                   : <Transfer>[];
 
-              // Filter transfers by payment method if filter is active
-              final filterPmId = _filterState.paymentMethodIds.isNotEmpty
+              // CHANGE 2 / 2026-08-10 구조적 수정 — SINGLE gating step shared by
+              // calendar + list + summary + running-balance so all of them
+              // consume the SAME lists.
+              //
+              // 이체 게이팅을 여기서 인라인으로 나열하지 않는다. 필터 축이 늘 때마다
+              // 이체 스트림에서만 축이 누락되는 사고가 4회 반복됐다(확인 필요/카테고리/
+              // 포켓/금액 누락, 결제수단은 first 1개만 적용). 판정은 전부
+              // `ledger_gating.dart` 의 gateLedger 안에 있고, 필터 VO 에 필드가
+              // 추가되면 필드 수 가드 테스트가 실패해 갱신을 강제한다.
+              final gated = gateLedger(
+                transactions: state.filteredTransactions,
+                transfers: transfers,
+                filter: _filterState,
+                keyword: _searchController.text,
+              );
+              final visibleTransactions = gated.transactions;
+              final visibleTransfers = gated.transfers;
+
+              final types = _filterState.transactionTypes;
+              // 결제수단 1개 필터 시에만 의미가 있는 자산 모드 판정용(MODE B).
+              final filterPmId = _filterState.paymentMethodIds.length == 1
                   ? _filterState.paymentMethodIds.first
                   : null;
-              final filteredTransfers = filterPmId != null
-                  ? transfers.where((t) =>
-                      t.sourcePaymentMethod.id == filterPmId ||
-                      t.destinationPaymentMethod.id == filterPmId).toList()
-                  : transfers;
-
-              // Filter transfers by date if date filter is active
-              final fmt = DateFormat('yyyy-MM-dd');
-              final filterDateFrom = _filterState.dateFrom != null ? fmt.format(_filterState.dateFrom!) : null;
-              final filterDateTo = _filterState.dateTo != null ? fmt.format(_filterState.dateTo!) : null;
-              final dateFilteredTransfers = filterDateFrom != null || filterDateTo != null
-                  ? filteredTransfers.where((t) {
-                      if (filterDateFrom != null && t.transferDate.compareTo(filterDateFrom) < 0) return false;
-                      if (filterDateTo != null && t.transferDate.compareTo(filterDateTo) > 0) return false;
-                      return true;
-                    }).toList()
-                  : filteredTransfers;
-
-              // Filter transfers by keyword if search is active
-              final keyword = _searchController.text.trim().toLowerCase();
-              final searchedTransfers = keyword.isEmpty
-                  ? dateFilteredTransfers
-                  : dateFilteredTransfers.where((t) {
-                      final desc = t.description?.toLowerCase() ?? '';
-                      final src = t.sourcePaymentMethod.name.toLowerCase();
-                      final dst = t.destinationPaymentMethod.name.toLowerCase();
-                      return desc.contains(keyword) ||
-                          src.contains(keyword) ||
-                          dst.contains(keyword);
-                    }).toList();
-
-              // CHANGE 2 — SINGLE gating step shared by calendar + list +
-              // running-balance so all three consume the SAME lists.
-              //
-              // visibleTransactions: client-side type gating. TRANSFER is not a
-              // transaction type, so a TRANSFER-only selection yields zero
-              // transactions (fixes "이체 필터 무효"). Empty set keeps all. BE
-              // already narrows for EXPENSE/INCOME; this is correct + robust.
-              final types = _filterState.transactionTypes;
-              final visibleTransactions = types.isEmpty
-                  ? state.filteredTransactions
-                  : state.filteredTransactions
-                      .where((t) => types.contains(t.type))
-                      .toList();
-
-              // visibleTransfers: hide unless the filter includes transfers
-              // (preserves prior showTransfers), AND hide under the PRIVATE
-              // (개인) visibility filter — transfers are treated as SHARED for
-              // now (all current assets are shared).
-              final includeTransfers =
-                  types.isEmpty || types.contains('TRANSFER');
-              final showTransfers =
-                  includeTransfers && _filterState.visibility != 'PRIVATE';
-              final visibleTransfers =
-                  showTransfers ? searchedTransfers : const <Transfer>[];
 
               // S2: single aggregation entry point via LedgerSummary.from
               // kind/type branching lives inside the factory, including
@@ -1278,15 +1244,33 @@ class _TransactionListPageState extends State<TransactionListPage> {
     }
   }
 
+  /// 빈 상태. 2026-08-10 — 선택한 필터에 맞는 동적 문구.
+  ///
+  /// 문구 생성은 `ledger_empty_message.dart` 순수 함수 한 곳에서 한다(필터 축이
+  /// 늘어날 때 화면마다 문구가 갈라지는 것을 막는다). 필터가 걸려 있으면
+  /// "거래 추가" 보다 "필터 초기화" 가 사용자가 원하는 다음 행동이다.
   Widget _buildEmpty(BuildContext context) {
-    return EmptyStateWidget(
-      icon: Icons.receipt_long,
-      title: '거래 내역이 없습니다',
-      subtitle: '이 달에 기록된 거래가 없습니다',
-      actionLabel: '거래 추가',
-      // 회차 1 (2026-05-26) — 필터된 결제수단 자동 전파를 위해 헬퍼 사용.
-      onAction: () => context.push(_buildCreateTransactionUrl()),
+    final msg = buildLedgerEmptyMessage(
+      _filterState,
+      keyword: _searchController.text,
     );
+    return EmptyStateWidget(
+      icon: msg.hasFilters ? Icons.filter_alt_off : Icons.receipt_long,
+      title: msg.title,
+      subtitle: msg.subtitle,
+      actionLabel: msg.hasFilters ? '필터 초기화' : '거래 추가',
+      // 회차 1 (2026-05-26) — 필터된 결제수단 자동 전파를 위해 헬퍼 사용.
+      onAction: msg.hasFilters
+          ? _clearAllFilters
+          : () => context.push(_buildCreateTransactionUrl()),
+    );
+  }
+
+  /// 필터 + 검색어를 함께 해제하고 재조회한다.
+  /// (검색어는 VO 밖에 있으므로 필터만 비우면 결과가 그대로인 것처럼 보인다)
+  void _clearAllFilters() {
+    _searchController.clear();
+    _onFilterChanged(const UnifiedFilterState());
   }
 
   Widget _buildError(BuildContext context) {

--- a/frontend/lib/features/transaction/presentation/utils/ledger_empty_message.dart
+++ b/frontend/lib/features/transaction/presentation/utils/ledger_empty_message.dart
@@ -8,6 +8,8 @@
 // 순수 함수로 유지한다(getIt/BuildContext 의존 없음) — 카테고리명 같은 **값 라벨**은
 // 상단 필터 칩이 이미 보여주므로 문구에는 축 이름만 쓴다.
 import 'package:budget_book/core/models/unified_filter_state.dart';
+import 'package:budget_book/features/transaction/presentation/utils/ledger_gating.dart'
+    show resolveLedgerKeyword;
 
 class LedgerEmptyMessage {
   final String title;
@@ -44,7 +46,8 @@ LedgerEmptyMessage buildLedgerEmptyMessage(
   UnifiedFilterState filter, {
   String? keyword,
 }) {
-  final kw = (keyword ?? filter.keyword)?.trim() ?? '';
+  // 실효 검색어 규칙은 게이팅과 공유한다(문구가 행/합계와 다른 기준을 쓰지 않도록).
+  final kw = resolveLedgerKeyword(filter, keyword);
   final axes = _activeAxes(filter, kw);
 
   if (axes.isEmpty) {

--- a/frontend/lib/features/transaction/presentation/utils/ledger_empty_message.dart
+++ b/frontend/lib/features/transaction/presentation/utils/ledger_empty_message.dart
@@ -1,0 +1,121 @@
+// 장부(거래 탭) 빈 상태 문구의 **단일 생성기**.
+//
+// 배경 (2026-08-10): 결과가 0건일 때 필터와 무관하게 항상 "거래 내역이 없습니다" 만
+// 떠서, 사용자가 "왜 비었는지"(= 어떤 필터 때문인지) 알 수 없었다.
+// 선택한 조건에 맞는 문구를 돌려주고, 필터가 걸려 있으면 액션 버튼을
+// `거래 추가` 대신 `필터 초기화` 로 바꾼다.
+//
+// 순수 함수로 유지한다(getIt/BuildContext 의존 없음) — 카테고리명 같은 **값 라벨**은
+// 상단 필터 칩이 이미 보여주므로 문구에는 축 이름만 쓴다.
+import 'package:budget_book/core/models/unified_filter_state.dart';
+
+class LedgerEmptyMessage {
+  final String title;
+  final String? subtitle;
+
+  /// 필터/검색어가 하나라도 활성인가. true 면 액션은 `필터 초기화`.
+  final bool hasFilters;
+
+  const LedgerEmptyMessage({
+    required this.title,
+    this.subtitle,
+    required this.hasFilters,
+  });
+}
+
+/// 활성 축 하나를 문구 재료로 표현한 것.
+class _Axis {
+  /// 이 축이 단독일 때(또는 최우선일 때) 쓰는 제목.
+  final String title;
+
+  /// `적용된 필터: …` 요약에 들어가는 짧은 이름.
+  final String chip;
+
+  const _Axis(this.title, this.chip);
+}
+
+/// 필터 상태 → 빈 상태 문구.
+///
+/// [keyword] 는 검색창처럼 VO 밖의 키워드 주입용(`gateLedger` 와 같은 관례).
+///
+/// 제목은 **우선순위 최상위 축 1개**로 정하고, 축이 2개 이상이면 부제에
+/// `적용된 필터: A · B` 를 붙인다.
+LedgerEmptyMessage buildLedgerEmptyMessage(
+  UnifiedFilterState filter, {
+  String? keyword,
+}) {
+  final kw = (keyword ?? filter.keyword)?.trim() ?? '';
+  final axes = _activeAxes(filter, kw);
+
+  if (axes.isEmpty) {
+    return const LedgerEmptyMessage(
+      title: '거래 내역이 없습니다',
+      subtitle: '이 달에 기록된 거래가 없습니다',
+      hasFilters: false,
+    );
+  }
+
+  final subtitle = axes.length == 1
+      ? '필터를 해제하면 이 달의 다른 내역을 볼 수 있습니다'
+      : '적용된 필터: ${axes.map((a) => a.chip).join(' · ')}';
+
+  return LedgerEmptyMessage(
+    title: axes.first.title,
+    subtitle: subtitle,
+    hasFilters: true,
+  );
+}
+
+/// 활성 축을 **우선순위 순서**로 수집한다.
+/// 순서 = 제목 선정 순서 = `적용된 필터:` 나열 순서.
+///
+/// 축을 추가할 때는 `UnifiedFilterState` 의 새 필드를 여기에도 반영한다
+/// (`ledger_empty_message_test.dart` 의 필드 수 가드가 이를 강제한다).
+List<_Axis> _activeAxes(UnifiedFilterState f, String keyword) {
+  final axes = <_Axis>[];
+
+  if (f.needsReviewOnly) {
+    axes.add(const _Axis('확인/입력 필요한 거래가 없습니다', '확인 필요'));
+  }
+  if (f.transactionTypes.isNotEmpty) {
+    final label = _typeLabel(f.transactionTypes);
+    axes.add(_Axis('$label 내역이 없습니다', label));
+  }
+  if (f.visibility == 'PRIVATE') {
+    axes.add(const _Axis('개인 거래가 없습니다', '개인'));
+  } else if (f.visibility == 'SHARED') {
+    axes.add(const _Axis('공유 거래가 없습니다', '공유'));
+  }
+  if (keyword.isNotEmpty) {
+    axes.add(_Axis("'$keyword' 검색 결과가 없습니다", "검색어 '$keyword'"));
+  }
+  if (f.categoryIds.isNotEmpty || f.categoryGroupIds.isNotEmpty) {
+    axes.add(const _Axis('선택한 카테고리의 거래가 없습니다', '카테고리'));
+  }
+  if (f.paymentMethodIds.isNotEmpty) {
+    axes.add(const _Axis('선택한 결제수단의 거래가 없습니다', '결제수단'));
+  }
+  if (f.pocketIds.isNotEmpty) {
+    axes.add(const _Axis('선택한 포켓의 거래가 없습니다', '포켓'));
+  }
+  if (f.amountMin != null || f.amountMax != null) {
+    axes.add(const _Axis('해당 금액대의 거래가 없습니다', '금액'));
+  }
+  if (f.hasDateRange) {
+    axes.add(const _Axis('선택한 기간에 거래가 없습니다', '기간'));
+  }
+
+  // 게이팅과 무관한 축(표시 전용): dateRangeLabel / categoryName /
+  // paymentMethodName. 장부 필터바 미노출 축: status.
+  return axes;
+}
+
+/// {EXPENSE, TRANSFER} → '지출/이체'. Set 순서에 의존하지 않도록 고정 순서로 정렬.
+String _typeLabel(Set<String> types) {
+  const order = ['EXPENSE', 'INCOME', 'TRANSFER'];
+  final ordered = [
+    ...order.where(types.contains),
+    ...types.where((t) => !order.contains(t)),
+  ];
+  return ordered.map((t) => kTransactionTypeLabels[t] ?? t).join('/');
+}

--- a/frontend/lib/features/transaction/presentation/utils/ledger_gating.dart
+++ b/frontend/lib/features/transaction/presentation/utils/ledger_gating.dart
@@ -31,6 +31,17 @@ import 'package:budget_book/features/transfer/domain/entities/transfer.dart';
 /// (새 필터가 이체 스트림에서만 조용히 누락되던 사고의 구조적 봉인)
 const int kUnifiedFilterAxisCount = 16;
 
+/// 실효 검색어 결정 규칙 — FE 게이팅과 BE 전송이 **같은 규칙**을 쓰도록 한 곳에 둔다.
+///
+/// `toTransactionFilter(keywordOverride:)` 는 override 가 null 이면 VO 의 keyword 로
+/// 되돌아간다. 화면이 빈 검색창(`''`)을 넘길 때 FE 만 "검색어 없음"으로 판단하면
+/// 서버가 좁힌 거래 목록과 FE 가 남긴 이체가 어긋난다(합계 ≠ 행 계열).
+String resolveLedgerKeyword(UnifiedFilterState filter, String? override) {
+  final o = override?.trim() ?? '';
+  if (o.isNotEmpty) return o;
+  return filter.keyword?.trim() ?? '';
+}
+
 /// 게이팅 결과. 목록/달력/합계/러닝밸런스가 **이 두 리스트만** 소비한다.
 class GatedLedger {
   final List<Transaction> transactions;
@@ -61,8 +72,7 @@ GatedLedger gateLedger({
       : transactions.where((t) => types.contains(t.type)).toList();
 
   // 이체: 축 전수 판정.
-  final effectiveKeyword =
-      (keyword ?? filter.keyword)?.trim().toLowerCase() ?? '';
+  final effectiveKeyword = resolveLedgerKeyword(filter, keyword).toLowerCase();
   final gatedTransfers = _transfersExcludedWholesale(filter)
       ? const <Transfer>[]
       : transfers

--- a/frontend/lib/features/transaction/presentation/utils/ledger_gating.dart
+++ b/frontend/lib/features/transaction/presentation/utils/ledger_gating.dart
@@ -1,0 +1,152 @@
+// 장부(거래 + 이체 병합 뷰)의 **단일 게이팅 진입점**.
+//
+// 배경 (2026-08-10, 4회째 재발):
+//   거래 목록은 `TransactionBloc`(거래) 과 `TransferBloc`(이체) 를 FE 에서 병합한다.
+//   거래 쪽 필터는 `UnifiedFilterState.toTransactionFilter()` 라는 VO 단일 변환기로
+//   BE 까지 관통하지만, **이체 쪽 게이팅은 페이지 안에 인라인으로 필드를 나열**하고
+//   있었다. 그래서 새 필터가 추가될 때마다 이체 스트림에서만 축이 누락됐다:
+//     - `needsReviewOnly`(확인/입력 필요만) 켜도 이체가 그대로 노출
+//     - 카테고리/포켓 필터를 걸어도 이체가 그대로 노출
+//     - 금액범위가 이체에 미적용
+//     - 결제수단은 복수 선택인데 `paymentMethodIds.first` 1개만 적용
+//
+// 구조적 수정:
+//   1) 이 파일이 **유일한** 게이팅 지점이다. 페이지는 `gateLedger()` 결과만 소비하고
+//      (목록/달력/합계바/러닝밸런스가 같은 리스트를 본다) 이체를 직접 거르지 않는다.
+//   2) `UnifiedFilterState` 의 **모든 축**을 아래 `_transferMatches` 에서 명시적으로
+//      분류한다 — "이체에 적용 / 이체에 없는 축이라 전량 제외 / 게이팅과 무관".
+//   3) `kUnifiedFilterAxisCount` 가드: 필터 VO 에 필드가 추가되면 테스트가 실패해
+//      이 파일을 갱신하지 않고는 CI 를 통과할 수 없다.
+//
+// 관련 메모리: reference_transaction_merged_transfer_stream_drift,
+//              feedback_filter_vo_single_source, reference_month_move_filter_drop
+import 'package:budget_book/core/models/unified_filter_state.dart';
+import 'package:budget_book/features/transaction/domain/entities/transaction.dart';
+import 'package:budget_book/features/transfer/domain/entities/transfer.dart';
+
+/// `UnifiedFilterState` 의 축(=필드) 개수.
+///
+/// 필터 VO 에 필드를 추가/삭제하면 `ledger_gating_test.dart` 가 실패한다.
+/// **먼저** 아래 `_transferMatches` 에 그 축의 이체 판정을 명시한 뒤 이 값을 갱신하라.
+/// (새 필터가 이체 스트림에서만 조용히 누락되던 사고의 구조적 봉인)
+const int kUnifiedFilterAxisCount = 16;
+
+/// 게이팅 결과. 목록/달력/합계/러닝밸런스가 **이 두 리스트만** 소비한다.
+class GatedLedger {
+  final List<Transaction> transactions;
+  final List<Transfer> transfers;
+
+  const GatedLedger({required this.transactions, required this.transfers});
+}
+
+/// 필터 상태를 거래·이체 두 스트림에 **동일한 기준**으로 적용한다.
+///
+/// - [transactions] 는 BE 가 이미 좁힌 결과다. 여기서는 BE 가 알지 못하는
+///   FE 전용 pseudo-type(`TRANSFER`) 때문에 타입 게이팅만 추가로 건다.
+/// - [transfers] 는 월 단위 원본이므로 모든 축을 FE 에서 판정한다.
+/// - [keyword] 는 검색창처럼 VO 밖에 있는 키워드 주입용
+///   (`toTransactionFilter(keywordOverride:)` 와 같은 관례).
+GatedLedger gateLedger({
+  required List<Transaction> transactions,
+  required List<Transfer> transfers,
+  required UnifiedFilterState filter,
+  String? keyword,
+}) {
+  final types = filter.transactionTypes;
+
+  // 거래: 클라 타입 게이팅. TRANSFER 는 거래 타입이 아니므로 TRANSFER 단독 선택은
+  // 거래 0건이 된다(BE 에는 TRANSFER 가 전달되지 않아 서버가 좁히지 못한다).
+  final gatedTransactions = types.isEmpty
+      ? transactions
+      : transactions.where((t) => types.contains(t.type)).toList();
+
+  // 이체: 축 전수 판정.
+  final effectiveKeyword =
+      (keyword ?? filter.keyword)?.trim().toLowerCase() ?? '';
+  final gatedTransfers = _transfersExcludedWholesale(filter)
+      ? const <Transfer>[]
+      : transfers
+          .where((t) => _transferMatches(t, filter, effectiveKeyword))
+          .toList();
+
+  return GatedLedger(
+    transactions: gatedTransactions,
+    transfers: gatedTransfers,
+  );
+}
+
+/// 이체 엔티티에 **존재하지 않는 축**이 활성이면 이체는 논리적으로 매칭 불가 →
+/// 전량 제외한다. (필터를 무시하고 노출하던 것이 버그였다)
+///
+/// `Transfer` 에는 `needsReview` / category / pocket 필드가 없다
+/// (`features/transfer/domain/entities/transfer.dart`).
+bool _transfersExcludedWholesale(UnifiedFilterState f) {
+  // 축: needsReviewOnly — 이체엔 "확인/입력 필요" 개념이 없다.
+  if (f.needsReviewOnly) return true;
+  // 축: categoryIds / categoryGroupIds — 이체엔 카테고리가 없다.
+  if (f.categoryIds.isNotEmpty || f.categoryGroupIds.isNotEmpty) return true;
+  // 축: pocketIds — 이체엔 포켓이 없다(포켓 이체는 별도 기능).
+  if (f.pocketIds.isNotEmpty) return true;
+  // 축: visibility — 이체엔 visibility 가 없어 현재 전부 "공유" 취급.
+  //     개인(PRIVATE) 필터에서는 숨긴다. 개인 자산(ASSET-PRIVATE) 도입 시
+  //     source/dest 자산의 visibility 로 파생하도록 여기를 고친다.
+  if (f.visibility == 'PRIVATE') return true;
+  // 축: transactionTypes — TRANSFER 미포함 선택이면 이체 제외(빈 셋 = 전체).
+  if (f.transactionTypes.isNotEmpty &&
+      !f.transactionTypes.contains('TRANSFER')) {
+    return true;
+  }
+  return false;
+}
+
+/// 이체에 **실제로 적용 가능한 축**의 행 단위 판정.
+///
+/// 나머지 축의 처리는 아래 주석이 전부다 — 축을 추가하면 반드시 여기(또는
+/// [_transfersExcludedWholesale])에 분류를 남긴다.
+///   - dateRangeLabel / categoryName / paymentMethodName: 표시 전용 라벨, 게이팅 무관
+///   - status: 장부 필터바에 노출되지 않는 축(지출계획 등 타 화면 전용), 게이팅 무관
+bool _transferMatches(
+  Transfer t,
+  UnifiedFilterState f,
+  String keywordLower,
+) {
+  // 축: dateFrom / dateTo — transferDate 는 'yyyy-MM-dd' 문자열이라 사전식 비교가 안전.
+  if (f.dateFrom != null && t.transferDate.compareTo(_ymd(f.dateFrom!)) < 0) {
+    return false;
+  }
+  if (f.dateTo != null && t.transferDate.compareTo(_ymd(f.dateTo!)) > 0) {
+    return false;
+  }
+
+  // 축: paymentMethodIds — **복수 선택 전체**를 OR 매칭 (출금/입금 어느 쪽이든).
+  //     기존에는 `.first` 만 봐서 2개 이상 선택 시 나머지가 무시됐다.
+  if (f.paymentMethodIds.isNotEmpty) {
+    final hit = f.paymentMethodIds.contains(t.sourcePaymentMethod.id) ||
+        f.paymentMethodIds.contains(t.destinationPaymentMethod.id);
+    if (!hit) return false;
+  }
+
+  // 축: amountMin / amountMax — 이체 금액도 금액범위 필터를 따른다.
+  if (f.amountMin != null && t.amount < f.amountMin!) return false;
+  if (f.amountMax != null && t.amount > f.amountMax!) return false;
+
+  // 축: keyword — 설명 + 출금/입금 결제수단명.
+  if (keywordLower.isNotEmpty) {
+    final desc = t.description?.toLowerCase() ?? '';
+    final src = t.sourcePaymentMethod.name.toLowerCase();
+    final dst = t.destinationPaymentMethod.name.toLowerCase();
+    if (!desc.contains(keywordLower) &&
+        !src.contains(keywordLower) &&
+        !dst.contains(keywordLower)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/// DateTime → 'yyyy-MM-dd' (intl 의존 없이 순수 함수 유지).
+String _ymd(DateTime d) =>
+    '${d.year.toString().padLeft(4, '0')}-'
+    '${d.month.toString().padLeft(2, '0')}-'
+    '${d.day.toString().padLeft(2, '0')}';

--- a/frontend/test/features/transaction/presentation/utils/ledger_empty_message_test.dart
+++ b/frontend/test/features/transaction/presentation/utils/ledger_empty_message_test.dart
@@ -1,0 +1,110 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:budget_book/core/models/unified_filter_state.dart';
+import 'package:budget_book/features/transaction/presentation/utils/ledger_empty_message.dart';
+import 'package:budget_book/features/transaction/presentation/utils/ledger_gating.dart'
+    show kUnifiedFilterAxisCount;
+
+/// 2026-08-10 — 결과 0건일 때 "왜 비었는지" 를 필터 기준으로 알려주는 문구.
+void main() {
+  group('필터 없음', () {
+    test('기본 문구 + 거래 추가 액션', () {
+      final m = buildLedgerEmptyMessage(const UnifiedFilterState());
+      expect(m.title, '거래 내역이 없습니다');
+      expect(m.subtitle, '이 달에 기록된 거래가 없습니다');
+      expect(m.hasFilters, isFalse);
+    });
+  });
+
+  group('단일 축 — 축 전용 문구', () {
+    void expectTitle(UnifiedFilterState f, String title, {String? keyword}) {
+      final m = buildLedgerEmptyMessage(f, keyword: keyword);
+      expect(m.title, title);
+      expect(m.hasFilters, isTrue);
+      expect(m.subtitle, '필터를 해제하면 이 달의 다른 내역을 볼 수 있습니다');
+    }
+
+    test('확인/입력 필요', () {
+      expectTitle(const UnifiedFilterState(needsReviewOnly: true),
+          '확인/입력 필요한 거래가 없습니다');
+    });
+
+    test('거래 유형 단일 / 복수', () {
+      expectTitle(
+          const UnifiedFilterState(transactionTypes: {'TRANSFER'}), '이체 내역이 없습니다');
+      expectTitle(
+          const UnifiedFilterState(transactionTypes: {'EXPENSE'}), '지출 내역이 없습니다');
+      // Set 순서와 무관하게 지출/수입/이체 고정 순서로 라벨링.
+      expectTitle(
+        const UnifiedFilterState(transactionTypes: {'TRANSFER', 'EXPENSE'}),
+        '지출/이체 내역이 없습니다',
+      );
+    });
+
+    test('공개 범위', () {
+      expectTitle(const UnifiedFilterState(visibility: 'PRIVATE'), '개인 거래가 없습니다');
+      expectTitle(const UnifiedFilterState(visibility: 'SHARED'), '공유 거래가 없습니다');
+    });
+
+    test('검색어', () {
+      expectTitle(const UnifiedFilterState(), "'스타벅스' 검색 결과가 없습니다",
+          keyword: '스타벅스');
+    });
+
+    test('카테고리 / 결제수단 / 포켓 / 금액 / 기간', () {
+      expectTitle(const UnifiedFilterState(categoryIds: {'c1'}),
+          '선택한 카테고리의 거래가 없습니다');
+      expectTitle(const UnifiedFilterState(paymentMethodIds: {'p1'}),
+          '선택한 결제수단의 거래가 없습니다');
+      expectTitle(
+          const UnifiedFilterState(pocketIds: {'k1'}), '선택한 포켓의 거래가 없습니다');
+      expectTitle(
+          const UnifiedFilterState(amountMin: 1000), '해당 금액대의 거래가 없습니다');
+      expectTitle(
+        UnifiedFilterState(
+          dateFrom: DateTime(2026, 8, 1),
+          dateTo: DateTime(2026, 8, 31),
+        ),
+        '선택한 기간에 거래가 없습니다',
+      );
+    });
+
+    test("visibility 'ALL' 은 필터로 치지 않는다", () {
+      final m = buildLedgerEmptyMessage(const UnifiedFilterState(visibility: 'ALL'));
+      expect(m.hasFilters, isFalse);
+      expect(m.title, '거래 내역이 없습니다');
+    });
+  });
+
+  group('복수 축', () {
+    test('제목은 최우선 축, 부제는 적용된 필터 나열', () {
+      final m = buildLedgerEmptyMessage(
+        const UnifiedFilterState(
+          needsReviewOnly: true,
+          transactionTypes: {'EXPENSE'},
+          categoryIds: {'c1'},
+        ),
+      );
+      expect(m.title, '확인/입력 필요한 거래가 없습니다');
+      expect(m.subtitle, '적용된 필터: 확인 필요 · 지출 · 카테고리');
+      expect(m.hasFilters, isTrue);
+    });
+
+    test('검색어도 축으로 합산된다', () {
+      final m = buildLedgerEmptyMessage(
+        const UnifiedFilterState(transactionTypes: {'INCOME'}),
+        keyword: '월급',
+      );
+      expect(m.title, '수입 내역이 없습니다');
+      expect(m.subtitle, "적용된 필터: 수입 · 검색어 '월급'");
+    });
+  });
+
+  test('필터 VO 필드 수가 바뀌면 빈 상태 문구 축도 갱신해야 한다', () {
+    expect(
+      const UnifiedFilterState().props.length,
+      kUnifiedFilterAxisCount,
+      reason: 'UnifiedFilterState 에 필드가 추가/삭제되었다. '
+          'ledger_empty_message.dart 의 _activeAxes 에 새 축의 문구를 추가하라.',
+    );
+  });
+}

--- a/frontend/test/features/transaction/presentation/utils/ledger_gating_test.dart
+++ b/frontend/test/features/transaction/presentation/utils/ledger_gating_test.dart
@@ -222,6 +222,24 @@ void main() {
       );
       expect(byPm.transfers, hasLength(1));
     });
+
+    test('빈 검색창은 VO 의 keyword 로 되돌아간다 (BE 전송 규칙과 동일)', () {
+      // toTransactionFilter(keywordOverride: null) 이 filter.keyword 로 fallback 하므로
+      // FE 게이팅도 같은 규칙이어야 행/합계가 어긋나지 않는다.
+      expect(resolveLedgerKeyword(const UnifiedFilterState(keyword: '월세'), ''),
+          '월세');
+      expect(resolveLedgerKeyword(const UnifiedFilterState(keyword: '월세'), '커피'),
+          '커피');
+      expect(resolveLedgerKeyword(const UnifiedFilterState(), '  '), '');
+
+      final g = gateLedger(
+        transactions: const [],
+        transfers: [tf(id: 'hit', description: '월세 이체'), tf(id: 'miss')],
+        filter: const UnifiedFilterState(keyword: '월세'),
+        keyword: '',
+      );
+      expect(g.transfers.map((t) => t.id), ['hit']);
+    });
   });
 
   group('거래 스트림 타입 게이팅', () {

--- a/frontend/test/features/transaction/presentation/utils/ledger_gating_test.dart
+++ b/frontend/test/features/transaction/presentation/utils/ledger_gating_test.dart
@@ -1,0 +1,248 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:budget_book/core/models/unified_filter_state.dart';
+import 'package:budget_book/features/transaction/domain/entities/transaction.dart';
+import 'package:budget_book/features/transaction/domain/entities/transaction_author.dart';
+import 'package:budget_book/features/transfer/domain/entities/transfer.dart';
+import 'package:budget_book/features/transaction/presentation/utils/ledger_gating.dart';
+
+/// 2026-08-10 회귀 테스트 — "확인 필요 필터를 켰는데 이체가 보인다" (4회째 재발).
+///
+/// 이체 스트림 게이팅이 필터 축을 수동 나열하다 축을 빠뜨리던 사고를 구조적으로 막는다.
+void main() {
+  const author = TransactionAuthor(id: 'u1', nickname: '나');
+
+  Transaction tx({
+    String id = 'tx1',
+    String type = 'EXPENSE',
+    int amount = 1000,
+    String date = '2026-08-10',
+  }) =>
+      Transaction(
+        id: id,
+        coupleId: 'c1',
+        author: author,
+        type: type,
+        amount: amount,
+        description: '커피',
+        transactionDate: date,
+        createdAt: DateTime(2026, 8, 10),
+        updatedAt: DateTime(2026, 8, 10),
+      );
+
+  Transfer tf({
+    String id = 'tf1',
+    int amount = 5000,
+    String date = '2026-08-10',
+    String srcId = 'pm-bank',
+    String dstId = 'pm-cash',
+    String? description = '생활비 이체',
+  }) =>
+      Transfer(
+        id: id,
+        coupleId: 'c1',
+        author: author,
+        sourcePaymentMethod:
+            PaymentMethodRef(id: srcId, name: '국민은행', type: 'BANK'),
+        destinationPaymentMethod:
+            PaymentMethodRef(id: dstId, name: '현금', type: 'CASH'),
+        amount: amount,
+        description: description,
+        transferDate: date,
+        createdAt: DateTime(2026, 8, 10),
+      );
+
+  group('필터 VO 축 가드', () {
+    test('UnifiedFilterState 필드 수가 바뀌면 이체 게이팅을 갱신해야 한다', () {
+      expect(
+        const UnifiedFilterState().props.length,
+        kUnifiedFilterAxisCount,
+        reason: 'UnifiedFilterState 에 필드가 추가/삭제되었다. '
+            'ledger_gating.dart 의 _transfersExcludedWholesale / _transferMatches 에 '
+            '그 축의 이체 판정을 명시한 뒤 kUnifiedFilterAxisCount 를 갱신하라. '
+            '(축 누락으로 이체가 필터를 무시하고 노출되던 사고의 재발 방지)',
+      );
+    });
+
+    test('거래 목록 페이지가 이체를 직접 필터링하지 않는다 (인라인 게이팅 재도입 차단)', () {
+      final src = File(
+        'lib/features/transaction/presentation/pages/transaction_list_page.dart',
+      ).readAsStringSync();
+      for (final banned in [
+        'transfers.where(',
+        'filteredTransfers',
+        'searchedTransfers',
+        'dateFilteredTransfers',
+      ]) {
+        expect(
+          src.contains(banned),
+          isFalse,
+          reason: '이체 게이팅은 ledger_gating.dart 의 gateLedger 단일 진입점에서만 한다. '
+              '페이지에 "$banned" 형태의 인라인 필터링이 다시 들어왔다.',
+        );
+      }
+    });
+  });
+
+  group('이체에 없는 축이 켜지면 이체는 전량 제외', () {
+    test('needsReviewOnly — 확인/입력 필요만 보기', () {
+      final g = gateLedger(
+        transactions: [tx()],
+        transfers: [tf()],
+        filter: const UnifiedFilterState(needsReviewOnly: true),
+      );
+      expect(g.transfers, isEmpty);
+      expect(g.transactions, hasLength(1)); // 거래는 BE 가 이미 좁혔다
+    });
+
+    test('카테고리 / 카테고리 그룹', () {
+      expect(
+        gateLedger(
+          transactions: [tx()],
+          transfers: [tf()],
+          filter: const UnifiedFilterState(categoryIds: {'cat1'}),
+        ).transfers,
+        isEmpty,
+      );
+      expect(
+        gateLedger(
+          transactions: [tx()],
+          transfers: [tf()],
+          filter: const UnifiedFilterState(categoryGroupIds: {'g1'}),
+        ).transfers,
+        isEmpty,
+      );
+    });
+
+    test('포켓', () {
+      expect(
+        gateLedger(
+          transactions: [tx()],
+          transfers: [tf()],
+          filter: const UnifiedFilterState(pocketIds: {'p1'}),
+        ).transfers,
+        isEmpty,
+      );
+    });
+
+    test('개인(PRIVATE) 공개범위 — 이체는 현재 전부 공유 취급', () {
+      expect(
+        gateLedger(
+          transactions: [tx()],
+          transfers: [tf()],
+          filter: const UnifiedFilterState(visibility: 'PRIVATE'),
+        ).transfers,
+        isEmpty,
+      );
+      // 공유(SHARED) 는 이체를 숨기지 않는다.
+      expect(
+        gateLedger(
+          transactions: [tx()],
+          transfers: [tf()],
+          filter: const UnifiedFilterState(visibility: 'SHARED'),
+        ).transfers,
+        hasLength(1),
+      );
+    });
+
+    test('거래 유형에서 이체 미선택', () {
+      expect(
+        gateLedger(
+          transactions: [tx()],
+          transfers: [tf()],
+          filter: const UnifiedFilterState(transactionTypes: {'EXPENSE'}),
+        ).transfers,
+        isEmpty,
+      );
+    });
+  });
+
+  group('이체에 적용 가능한 축은 실제로 매칭', () {
+    test('금액 범위', () {
+      const filter = UnifiedFilterState(amountMin: 1000, amountMax: 3000);
+      final g = gateLedger(
+        transactions: const [],
+        transfers: [tf(id: 'in', amount: 2000), tf(id: 'out', amount: 9000)],
+        filter: filter,
+      );
+      expect(g.transfers.map((t) => t.id), ['in']);
+    });
+
+    test('결제수단 복수 선택 — 전부 OR 매칭 (first 1개만 보던 버그)', () {
+      const filter = UnifiedFilterState(paymentMethodIds: {'pm-a', 'pm-b'});
+      final g = gateLedger(
+        transactions: const [],
+        transfers: [
+          tf(id: 'a', srcId: 'pm-a', dstId: 'pm-z'),
+          tf(id: 'b', srcId: 'pm-z', dstId: 'pm-b'),
+          tf(id: 'c', srcId: 'pm-y', dstId: 'pm-z'),
+        ],
+        filter: filter,
+      );
+      expect(g.transfers.map((t) => t.id), ['a', 'b']);
+    });
+
+    test('기간', () {
+      final filter = UnifiedFilterState(
+        dateFrom: DateTime(2026, 8, 5),
+        dateTo: DateTime(2026, 8, 10),
+      );
+      final g = gateLedger(
+        transactions: const [],
+        transfers: [
+          tf(id: 'before', date: '2026-08-04'),
+          tf(id: 'inside', date: '2026-08-07'),
+          tf(id: 'edge', date: '2026-08-10'),
+          tf(id: 'after', date: '2026-08-11'),
+        ],
+        filter: filter,
+      );
+      expect(g.transfers.map((t) => t.id), ['inside', 'edge']);
+    });
+
+    test('검색어 — 설명 / 출금·입금 결제수단명', () {
+      final g = gateLedger(
+        transactions: const [],
+        transfers: [
+          tf(id: 'desc', description: '월세 이체'),
+          tf(id: 'pm', description: null),
+          tf(id: 'none', description: '기타'),
+        ],
+        filter: const UnifiedFilterState(),
+        keyword: '월세',
+      );
+      expect(g.transfers.map((t) => t.id), ['desc']);
+
+      final byPm = gateLedger(
+        transactions: const [],
+        transfers: [tf(id: 'pm')],
+        filter: const UnifiedFilterState(),
+        keyword: '국민',
+      );
+      expect(byPm.transfers, hasLength(1));
+    });
+  });
+
+  group('거래 스트림 타입 게이팅', () {
+    test('이체만 선택하면 거래는 0건', () {
+      final g = gateLedger(
+        transactions: [tx(type: 'EXPENSE'), tx(id: 'tx2', type: 'INCOME')],
+        transfers: [tf()],
+        filter: const UnifiedFilterState(transactionTypes: {'TRANSFER'}),
+      );
+      expect(g.transactions, isEmpty);
+      expect(g.transfers, hasLength(1));
+    });
+
+    test('필터 없음 = 전부 통과', () {
+      final g = gateLedger(
+        transactions: [tx()],
+        transfers: [tf()],
+        filter: const UnifiedFilterState(),
+      );
+      expect(g.transactions, hasLength(1));
+      expect(g.transfers, hasLength(1));
+    });
+  });
+}


### PR DESCRIPTION
## 증상

"확인/입력 필요만" 필터를 켜도 **이체가 그대로 목록에 남는다**. 거래 유형에서 이체를 선택하지 않았는데도 보인다는 사용자 보고.

## 원인 (hard evidence)

`transaction_list_page.dart:727~785` 의 이체 게이팅이 `UnifiedFilterState` 필드를 **인라인으로 수동 나열**하고 있었다. 거래 쪽은 `toTransactionFilter()` VO 단일 변환기로 BE 까지 관통하는데 **이체 쪽만 페이지 안에 흩어져** 있어, 필터 축이 늘 때마다 이체 스트림에서만 축이 빠졌다.

- 누락 축: `needsReviewOnly` / 카테고리 / 카테고리그룹 / 포켓 / 금액범위
- 결제수단은 `paymentMethodIds.first` **1개만** 적용 (복수 선택 무시)

`Transfer` 엔티티에는 `needsReview`·category·pocket 필드가 **없으므로**(`transfer.dart:49~83`) 그 축이 켜지면 이체는 매칭 불가 = 전량 제외가 정답이다. 거래·합계는 BE 가 정상 필터하고 있어(`TransactionSpecifications.kt:100`, `StatisticsService.kt:105`) "거래는 맞는데 이체만 남는" 비대칭이 나타났다.

하네스 감사 `filter_propagation` = **STRUCTURAL_FIX_REQUIRED**(4회째 재발) → 패치가 아니라 재발을 테스트 타임에 막는 구조로 고쳤다.

## 구조적 수정

- **`ledger_gating.dart` 신설** — 이체 게이팅 단일 진입점. `UnifiedFilterState` 의 모든 축을 "이체에 적용 / 이체에 없어 전량 제외 / 게이팅 무관" 으로 명시 분류. 목록·달력·합계바·러닝밸런스가 같은 리스트를 소비한다.
- **필드 수 가드** — `UnifiedFilterState` 에 필드가 추가/삭제되면 `kUnifiedFilterAxisCount` 불일치로 테스트가 실패한다. 이체 판정을 갱신하지 않으면 CI 를 통과할 수 없다.
- **인라인 재도입 차단** — 페이지에 이체 인라인 필터링이 다시 들어오면 소스 검사 테스트가 실패한다.
- 결제수단 복수 선택을 출금/입금 양쪽에 OR 매칭.

## 동적 빈 상태 문구

- **`ledger_empty_message.dart` 신설** — 선택한 필터에 맞는 문구를 순수 함수로 생성: `확인/입력 필요한 거래가 없습니다`, `이체 내역이 없습니다`, `'키워드' 검색 결과가 없습니다` … 축이 2개 이상이면 부제에 `적용된 필터: A · B`.
- 필터가 걸려 있으면 액션 버튼을 `거래 추가` → **`필터 초기화`**(검색어 포함 해제).
- `kTransactionTypeLabels` 를 공용 상수로 승격해 필터칩과 문구가 라벨을 공유.

## 게이트

- `flutter analyze --no-fatal-infos --no-congratulate` — 신규 0건
- `flutter test` — **843건** 통과 (신규 23건 포함)
- `./gradlew test` — 통과
- `flutter build web --release` — 통과

## 라이브 검증 항목 (머지·배포로는 완료 아님)

1. 확인/입력 필요만 ON → 이체 0건 + 월합계바 이체 금액 미표시
2. 카테고리 / 포켓 필터 → 이체 0건
3. 결제수단 2개 이상 선택 → 두 결제수단 이체가 모두 표시
4. 금액범위 → 범위 밖 이체 제외
5. 결과 0건일 때 조건에 맞는 문구 + `필터 초기화` 동작
6. 달력뷰에서도 1~4 동일 (이체 마커 사라짐)

설계 정본: `docs/sessions/2026-08-10_ledger-filter-gating_plan.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)