### PR TITLE
feat(month-navigator): 연/월 드릴다운 피커 + "오늘" 버튼

### DIFF
--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -9,17 +9,19 @@
 ## 1. 현재 상태 (한눈에)
 
 <!-- HNS:STATE -->
-- **단계**: **"월말 점검(미기록 N건) 카드"** 회차 — PR #293(홈 전제 오류) → PR #294(분석 탭 이전)
-  → 배포 → **사용자 라이브 검증 통과 = 완료**(2026-08-11, 타임라인 26)
-- **상태**: **열린 작업 없음.** 다음 회차는 아래 §3 에 착수 지점까지 고정돼 있다
-- **회차 경계**: 다음 회차는 **`/clear` 후 새 세션**에서 시작한다
+- **단계**: **"월 네비게이터 개선(연/월 드릴다운 피커 + 오늘 버튼)"** 회차 — 2026-08-11 착수.
+  재측정 → 기획 v2 → 사용자 결정(진입 단계) → 하네스 게이트 해제 완료 → **구현 중**
+- **상태**: 열린 작업 = 이 회차. 직전 회차(월말 점검 카드)는 라이브 검증 통과로 종결(타임라인 26)
+- **회차 경계**: 이 회차 종결 후 다음 회차는 **`/clear` 후 새 세션**에서 시작한다
 - ⚠ **이 앱에 홈 대시보드 화면은 없다** — `/home` → `/transactions` redirect,
   `DashboardPage` 는 미라우팅(죽은 코드), 탭 4개(거래·분석·자산·더보기).
   설정의 "홈 화면 구성" 도 고아 항목이다. **홈 위젯 전제의 계획·후보는 전부 무효**
   (메모리 `reference_dead_home_dashboard`)
-- **정본 문서**: 종결 회차 = `docs/sessions/2026-08-10_2_reconciliation-widget_plan.md` /
-  **다음 회차 = `docs/sessions/2026-08-10_3_month-navigator_plan.md`**
-- **repo / 브랜치**: `AIVA-SaaS/budget-book` · `main` = `49fccfa` 이후 · 작업 트리 clean
+- **정본 문서**: **진행 중 회차 = `docs/sessions/2026-08-10_3_month-navigator_plan.md` (v2)** /
+  직전 종결 회차 = `docs/sessions/2026-08-10_2_reconciliation-widget_plan.md`
+- **하네스 게이트**: `navigation_state` STRUCTURAL_FIX_REQUIRED → 기획 v2 §2(S1~S4) 근거로
+  `acknowledge-gate.sh` 해제 완료(2026-08-11)
+- **repo / 브랜치**: `AIVA-SaaS/budget-book` · `main` = `a70a2ef` 이후
 - **CI 게이트(4종 + 1)**: analyze 신규 0 / flutter test **894** / `./gradlew test` /
   `build web --release` + **배포 전 번들 문자열 확인**(신규 UI 가 트리셰이킹되지 않았는지).
   마지막 항목은 이번 회차에서 추가됐다
@@ -411,36 +413,74 @@
    - **회차 경계**: 여기서 멈춘다. 다음 회차는 `/clear` 후 새 세션에서 시작
      (메모리 `feedback_round_boundary_clear`)
 
+27. **2026-08-11** — 월 네비게이터 회차 **착수**: 재측정으로 기획서 사실 오류 2건 정정(v2) →
+   사용자 결정 → 하네스 게이트 해제. 코드 변경은 아직 0줄.
+   - **하네스**: `pre-change-audit.sh . navigation_state` → 🚫 **STRUCTURAL_FIX_REQUIRED**
+     (인시던트 4건: 2026-04-14 / 04-15 ×2 / **08-10 죽은 화면 배포**). v1 기획의 구조 항목이
+     무효가 된 Step 3(홈 통합)에 의존하고 있어 **그대로는 게이트를 못 넘는 상태**였다
+   - **정정 ①**: "사용처 13개 페이지" → **실제 렌더되는 호스트는 9개**.
+     `statistics_page:68` · `budget_list_page:269/566` 은 `showMonthNavigator: false` 로만
+     쓰이는 죽은 분기(유일 사용처가 `analysis_page:117/135`, `/budgets`·`/statistics` 는 redirect)
+   - **정정 ②**: v1 Step 3(홈 `_MonthHeader` → MonthNavigator 통합) **무효** — 홈은 미라우팅.
+     삭제도 하지 않는다(홈 복원 여부 미결 + `dashboard_widget_registry_guard_test` 연쇄 정리 필요)
+   - **추가 측정**: `showCalendarPickerDialog` 호출부 18곳 중 **17곳이 "날짜 입력"이 본질**
+     → 기존 함수 무변경, 월 피커 신설 / `Icons.today` 기존 사용 중 → **신규 아이콘 코드포인트 없음**
+     (폰트 subset 리스크 해당 없음) / `MonthNavigator` 전용 테스트 **0건**
+   - **구조적 수정 4종**(게이트 해제 근거): S1 자체 월 헤더 금지 스캔 —
+     **`dashboard_page` 는 "미라우팅인 동안만" 예외**라 홈을 되살리면 테스트가 깨져 이행 강제 /
+     S2 월 피커 단일 소스 / S3 **도달성 고정**(9개 호스트 목록 + 라우터 참조 검사 — 08-10 인시던트
+     직결) / S4 MonthNavigator 위젯 테스트 신설
+   - **사용자 결정(진입 단계)**: 거래 탭은 **일 달력 먼저**(기존 유지) + 헤더 탭으로 월→연도
+     드릴업. 나머지 8곳은 월 그리드 진입. 기각안(거래 탭도 월 그리드)은 달 이동 1탭이 되는 대신
+     같은 달 일 스크롤이 2→3탭으로 퇴보 — **퇴보 없는 쪽을 택했다**
+   - 게이트: `acknowledge-gate.sh budget-book <plan>` ✅ 편집 허용
+   - **미완**: 구현 · 로컬 CI 4종+번들 검증 · PR · 배포 · 사용자 라이브 검증
+
+28. **2026-08-11** — 월 네비게이터 구현 완료 · **로컬 게이트 5종 전부 통과**. 커밋/PR 전.
+   - 브랜치 `feat/month-navigator-drilldown-picker`
+   - 산출물(신규): `core/widgets/month_year_picker_dialog.dart` —
+     `MonthPickerResult{year, month, day?}` + 3단(`year ↔ month ↔ day`) 드릴다운.
+     **`day == null` 이 "월까지만 골랐다"** 는 신호라, 1일 선택과 월 선택이 구별된다
+     (`DateTime` 하나로 뭉갰으면 거래 목록이 매번 스크롤했을 것)
+   - 산출물(수정): `core/widgets/month_navigator.dart` —
+     `allowDaySelection: onDatePicked != null` / **`Icons.today` "오늘" 버튼**
+     (이번 달이면 비활성, 툴팁 `이번 달로`) / 좌측 48 스페이서로 대칭 유지 +
+     `Flexible`+ellipsis(좁은 화면·큰 글꼴 배율 overflow 방어)
+   - 산출물(테스트 신규 30건): 가드 `month_navigator_single_source_guard_test.dart`(S1~S3) ·
+     `month_navigator_test.dart`(S4) · `month_year_picker_dialog_test.dart`
+   - **게이트**: analyze 신규 0(기존 info 3건만) / flutter test **924**(894 + 30) /
+     `./gradlew test` BUILD SUCCESSFUL / `build web --release` ✅
+   - **배포 전 번들 검증 ✅**: `이번 달로` 1 · `월 선택으로` 1 · `연도 선택` 2 · `월 선택` 2 ·
+     `날짜 선택` 2 — 신규 UI 가 트리셰이킹되지 않았다
+   - ⚠ **검증 방법 정정**: dart2js 는 한글을 **소문자** hex 로 이스케이프한다(`이`).
+     대문자 `이` 로만 grep 하면 **0건이 나와 오탐**한다. 이번에 실제로 한 번 겪었다
+     → 메모리 `reference_live_bundle_string_verification` 보강 대상
+   - **미완**: PR · 머지 · 배포 · 사용자 라이브 검증
+
 ## 3. 다음 단계
 
 <!-- HNS:NEXT -->
-- **현재 상태**: 월말 점검 카드 회차 **라이브 검증 통과 = 완료**(타임라인 26). **열린 작업 없음.**
+- **현재 상태**: **월 네비게이터 개선 — 구현·로컬 게이트 5종 완료**(타임라인 28).
+  남은 것은 PR → 머지 → 배포 → **사용자 라이브 검증**(기획서 §6 A1~C2).
 - **회차 경계 규칙**: 회차가 끝나면 종결 기록 + 착수 지점 고정까지만 하고 **멈춘다**.
   다음 회차는 **반드시 `/clear` 후 새 세션에서 시작**한다 — 같은 세션에서 이어서 착수 금지
   (메모리 `feedback_round_boundary_clear`)
 
-### 다음 회차 — **월 네비게이터 개선** (기획 완료, 착수 지점 고정)
+### 진행 중 회차 — **월 네비게이터 개선** (기획 v2 확정, 구현 단계)
 
-정본: `docs/sessions/2026-08-10_3_month-navigator_plan.md` (사용자 요청 2026-08-10)
+정본: `docs/sessions/2026-08-10_3_month-navigator_plan.md` **(v2 — 2026-08-11 재측정 반영)**
 
-- **요청**: `< yyyy년 mm월 >` 의 달력 팝업에서 **연도별 보기 → 연도 내 달 선택**이 편하도록 +
-  **팝업 전에 "오늘로 가는 버튼"** 을 적절한 위치에
-- **첫 명령**: `bash ~/.claude/harness/scripts/pre-change-audit.sh . navigation_state`
-  (게이트 확인 — 이번 회차의 `ledgerLocation` 이행 이력을 근거로 처리) →
-  기획서 §2 Step 1(`showMonthYearPickerDialog`)부터 순서대로
-- **핵심 측정(이미 완료, 재조사 불필요)**:
-  - 공용 위젯 `lib/core/widgets/month_navigator.dart` 하나를 **13개 페이지**가 쓴다 →
-    한 곳 수정이 전체 반영
-  - 팝업 `lib/core/widgets/calendar_picker_dialog.dart` 의 `CalendarDatePicker` 는
-    **연도 선택은 이미 되지만 월 그리드가 없다** — 연도를 골라도 원하는 달까지 좌우로
-    넘겨야 한다. 이것이 요청의 정확한 결손 지점
-  - `onDatePicked`(일 선택) 실사용은 **1곳뿐**(`transaction_list_page.dart:679`, 선택 일자로
-    스크롤) → 나머지 12곳은 "월 우선" 전환에 부작용 없음
-  - **"오늘" 버튼은 어디에도 없다**(네비게이터·팝업 모두)
-  - 홈 대시보드 `_MonthHeader` 통합(기획서 Step 3)은 **홈 화면이 죽은 코드이므로 무의미** →
-    착수 시 그 Step 은 제외하고 시작한다(기획서는 이 사실 발견 전에 작성됐다)
-- **주의**: 회귀 범위가 13개 페이지로 넓다. 각 페이지의 기존 위젯 테스트 유무를 먼저 전수 확인하고,
-  없는 페이지는 `MonthNavigator` 자체 위젯 테스트로 대체 커버한다
+- **요청**(사용자 2026-08-10): `< yyyy년 mm월 >` 팝업에서 **연도별 보기 → 연도 내 달 선택** +
+  **"오늘로 가는 버튼"**
+- **남은 작업**: PR 생성 → 원격 CI → 머지 → 배포 → 라이브 번들 확인 → **사용자 라이브 검증**.
+  구현 1~4 단계는 타임라인 28 에서 완료됐다
+- **되풀이 금지 — 이미 측정 끝난 사실**:
+  - 렌더되는 호스트는 **9개**(13 아님). `statistics_page` · `budget_list_page` 의
+    MonthNavigator 3곳은 `showMonthNavigator: false` 로만 쓰이는 죽은 분기
+  - 홈 `_MonthHeader` 는 **손대지 않는다**(미라우팅). S1 가드가 "되살아나면 실패" 로 고정
+  - `MonthNavigator` 전용 테스트 0건 → 9곳을 공용 위젯 테스트로 일괄 커버
+- **배포 전 게이트(5번째)**: 번들에서 `이번 달로` 등 신규 문자열을 **escaped 형태로** 대조
+  (`reference_live_bundle_string_verification`)
 
 ### 그 다음 대기열 (착수 순서 아님)
 

--- a/docs/sessions/2026-08-10_3_month-navigator_plan.md
+++ b/docs/sessions/2026-08-10_3_month-navigator_plan.md
@@ -1,105 +1,243 @@
 # 월 네비게이터 개선 — 연/월 드릴다운 피커 + "오늘" 버튼
 
-- 회차: **다음 회차 후보 1번** (2026-08-10 기획, 착수 전)
-- 상태: **기획 완료 · 착수 승인 대기**. 코드 변경 0줄
+- 회차: **다음 회차 후보 1번** → **2026-08-11 착수 회차**
+- 상태: **기획 v2 (재측정 반영) · 착수 승인 대기**. 코드 변경 0줄
 - 요청(사용자, 2026-08-10): "거래 상단 `< yyyy년 mm월 >` 에서 날짜 선택 시 뜨는 달력 팝업에서
   **연도별 보기 → 연도 내 달 선택**이 편했으면 좋겠다. 또 **팝업 전에 '오늘로 가는 버튼'** 이
   적절한 위치에 있으면 좋겠다."
 
----
-
-## 1. 측정된 현재 상태 (hard evidence)
-
-1. **월 네비게이터는 공용 위젯 하나다** — `lib/core/widgets/month_navigator.dart`.
-   사용처 **13개 페이지**(거래·이체·통계·분석·리포트·예산·주간예산·주간정산·지출계획·
-   결제수단·자산관리·달력뷰). 여기만 고치면 13곳에 한 번에 반영된다.
-2. **예외가 1곳 있다 — 홈 대시보드.** `dashboard_page.dart:235 _MonthHeader` 는 MonthNavigator 를
-   쓰지 않는 **자체 구현**이고, 가운데 날짜가 `Text` 라 **눌러도 팝업이 뜨지 않는다.**
-   즉 이번 요청을 공용 위젯에만 반영하면 홈은 여전히 좌우 화살표밖에 없다
-   (메모리 `feedback_common_scope_audit` — 한 곳만 고치면 안 되는 전형).
-3. **팝업은 `core/widgets/calendar_picker_dialog.dart` 하나**(`showCalendarPickerDialog`).
-   내부는 Material 의 `CalendarDatePicker`.
-   - 연도 선택은 **이미 가능하다** — `CalendarDatePicker` 자체 모드 토글(상단 "2026년 3월 ▾")로
-     연도 목록이 열린다.
-   - 그런데 **월 그리드가 없다.** 연도를 고르면 곧바로 그 연도의 *같은 달* 일 그리드로 돌아오고,
-     원하는 달까지 좌우로 넘겨야 한다. 사용자가 말한 "연도 내 달 선택" 이 정확히 이 빠진 단계다.
-4. **일(day) 선택을 실제로 쓰는 호출부는 1곳뿐** — `transaction_list_page.dart:679 onDatePicked`
-   (선택한 날짜로 목록 스크롤). 나머지 12곳은 연/월만 쓴다.
-   → 피커를 "월 우선" 으로 바꿔도 12곳은 부작용이 없고, 거래 목록만 일 선택을 유지하면 된다.
-5. **"오늘" 버튼은 어디에도 없다** — MonthNavigator · `_MonthHeader` · 팝업 전부.
-   현재 이번 달로 돌아오려면 화살표를 눌러 세거나 팝업을 열어 오늘 날짜를 찾아야 한다.
+> **v1 → v2 변경 이유(2026-08-11 재측정)**: v1 의 사실 2건이 틀렸다.
+> ① "사용처 13개 페이지" → 실제로 **렌더되는 호스트는 9개**. 3개 호출부는 `showMonthNavigator: false`
+> 로만 쓰여 화면에 나오지 않는다. ② v1 Step 3(홈 `_MonthHeader` 통합)은 홈 화면이 미라우팅
+> 죽은 코드라 **무효**. 그런데 v1 의 구조적 수정(Step 4)이 그 Step 3 에 의존하고 있었다 →
+> 구조 항목을 재설계했다.
 
 ---
 
-## 2. 설계
+## 1. 측정된 현재 상태 (hard evidence, 2026-08-11)
 
-### Step 1 — 연/월 드릴다운 피커 (`showMonthYearPickerDialog`)
+### 1.1 월 네비게이터는 공용 위젯 하나다 `[측정]`
 
-`calendar_picker_dialog.dart` 를 확장해 3단 드릴다운으로 만든다.
+`lib/core/widgets/month_navigator.dart` (106줄). `MonthNavigator(` 호출부는 소스상 12곳/11파일.
 
-- **연도 그리드** → 그 연도의 **12개월 그리드** → (필요한 호출부만) **일 그리드**
-- 헤더: `< 2026년 >` 좌우 이동 + 현재 단계 표시. 뒤로 가면 상위 단계로.
-- 기본 진입 단계는 **월 그리드**(대부분의 호출부가 월만 쓰기 때문). 연도 헤더를 누르면 연도 그리드.
-- `MonthNavigator` 에 `bool allowDaySelection` 추가 — `onDatePicked` 가 주어진 호출부(거래 목록)만
-  true 로 켜서 일 그리드까지 내려간다. 나머지는 월 선택에서 바로 닫힌다(탭 수가 줄어든다).
-- 기존 `showCalendarPickerDialog` 는 **남긴다** — 거래 폼의 날짜 입력 등 "일 선택이 본질" 인
-  호출부가 있는지 착수 시 전수 확인하고, 없으면 통합·있으면 두 함수를 명확히 분리한다.
+### 1.2 그중 **실제 화면에 렌더되는 호스트는 9개** `[측정]`
 
-### Step 2 — "오늘" 버튼
+라우팅되어 사용자에게 도달하는 호출부:
 
-- 위치: `MonthNavigator` 행의 `>` **오른쪽**(가운데 텍스트 대칭을 유지).
-- **이번 달을 보고 있으면 비활성**(회색) — 누를 이유가 없는 상태를 시각적으로 구분.
-- 동작: `MonthCubit.changeMonth(today.year, today.month)` — 기존 월 변경 경로와 동일하므로
-  `MonthSyncHandler` 가 관련 BLoC 리로드를 그대로 처리한다(새 동기화 경로를 만들지 않는다).
-- 아이콘: `Icons.today` 사용 여부는 착수 시 기존 사용처를 확인한다. 신규 코드포인트라도
-  파일명 content hash 파이프라인이 처리하지만(`infra/scripts/hash-icon-font.sh`),
-  폰트 subset 변화는 기록에 남긴다.
+1. `transaction/…/transaction_list_page.dart:678` — 거래 탭. **유일하게 `onDatePicked` 사용**
+2. `analysis/…/analysis_page.dart:47` — 분석 탭 (예산/통계 sub-tab 공용)
+3. `transfer/…/transfer_list_page.dart:72` — `/transfers`
+4. `payment_method/…/payment_method_page.dart:134` — `/payment-methods`
+5. `settings/…/asset_management_page.dart:117` — 자산 탭 + `/asset-management`
+6. `weekly_budget/…/weekly_budget_page.dart:60` — `onMonthChanged` 커스텀
+7. `weekly_budget/…/weekly_settlement_page.dart:97` — `onMonthChanged` 커스텀
+8. `report/…/report_page.dart:85` — `onMonthChanged` 커스텀
+9. `spending_plan/…/spending_plan_list_page.dart:118` — `onMonthChanged` 커스텀
 
-### Step 3 — 홈 `_MonthHeader` 통합
+**렌더되지 않는 호출부 3곳** — 이번 변경의 검증 대상이 아니다:
 
-- `dashboard_page.dart` 의 `_MonthHeader` 를 제거하고 `MonthNavigator` 로 교체한다.
-- 홈은 글자가 더 크다(`headlineSmall` vs `titleMedium`) → `MonthNavigator` 에
-  `TextStyle? labelStyle` 또는 `bool prominent` 를 추가해 겉모습을 보존한다.
-- 통합 효과: 홈에서도 날짜를 눌러 피커를 열 수 있고, "오늘" 버튼도 자동으로 생긴다.
+- `statistics_page.dart:68` — `if (showMonthNavigator && !state.hasDateRange)`
+- `budget_list_page.dart:269`, `:566` — `if (widget.showMonthNavigator)`
+- 두 페이지의 유일한 사용처가 `analysis_page.dart:117/135` 의
+  `showMonthNavigator: false` 이고, `/budgets`·`/statistics` 라우트는 분석 탭으로 redirect 다.
+  즉 이 3곳은 **파라미터로 꺼져 있는 죽은 분기**다.
 
-### Step 4 — 재발 방지(구조)
+**추가 예외 1곳** — `home/…/dashboard_page.dart:198 _MonthHeader`. MonthNavigator 를 쓰지 않는
+자체 구현이고 가운데가 `Text` 라 눌러도 팝업이 없다. 그러나 **홈은 미라우팅**
+(`app_router.dart:792` `/home` → `/transactions` redirect)이라 사용자에게 도달하지 않는다.
+→ v1 이 계획한 "홈 통합" 은 **무효**. 삭제도 하지 않는다(홈 탭 복원 여부는 미결 사항).
 
-- 소스 스캔 가드: `lib/features/**/pages/*.dart` 에 `MonthCubit.changeMonth` 를 직접 호출하는
-  **자체 월 헤더**가 새로 생기면 실패시킨다(공용 위젯 우회 금지). 현재 위반 1건(`_MonthHeader`)은
-  Step 3 에서 제거되므로 가드가 성립한다.
-- 이유: 이번 요청이 "공용 위젯에는 있는데 홈에는 없다" 형태로 드러난 문제였다.
-  같은 구멍이 다시 생기지 않게 테스트로 막는다.
+### 1.3 팝업은 `showCalendarPickerDialog` 하나이고, **일 선택이 본질인 호출부가 17곳**이다 `[측정]`
+
+`core/widgets/calendar_picker_dialog.dart` → 내부는 Material `CalendarDatePicker`.
+호출부 18곳 중 **MonthNavigator 는 1곳**이고, 나머지 17곳은 전부 "특정 날짜 입력"이다:
+`period_selector.dart` 5곳(기간 필터 시작/종료), 거래·이체·보험·지출계획·카드정산 폼,
+포켓 시트 2곳, `transaction_list_page.dart:1225`.
+
+→ **결론: 기존 함수는 손대지 않는다.** 월 피커는 별도 함수로 신설한다.
+(v1 은 "통합 여부를 착수 시 확인" 으로 열어뒀는데, 측정 결과 통합은 17곳 회귀 위험만 있다.)
+
+### 1.4 결손 지점 `[측정]`
+
+- `CalendarDatePicker` 는 연도 목록은 열리지만 **월 그리드가 없다.** 연도를 골라도 그 연도의
+  *같은 달* 일 그리드로 돌아오고, 원하는 달까지 좌우로 넘겨야 한다. → 요청 ①이 가리키는 지점.
+- **"오늘" 버튼은 어디에도 없다** — MonthNavigator·팝업 모두. → 요청 ②.
+
+### 1.5 부수 확인 `[측정]`
+
+- `Icons.today` 는 이미 `period_selector.dart:138`·`date_range_filter.dart:59` 에서 쓰인다
+  → **신규 아이콘 코드포인트 없음. 아이콘 폰트 subset 변화 없음**
+  (`reference_flutter_icon_font_cache` 리스크 해당 없음).
+- `MonthNavigator` 전용 테스트는 **없다**. `test/core/widgets/` 에 `period_selector_test.dart`
+  등 12개가 있으나 월 네비게이터는 미커버.
+- 소스 스캔 가드 테스트 선례 다수(`ledger_view_param_wiring_test.dart`,
+  `dashboard_widget_registry_guard_test.dart` 등) → 같은 패턴을 따른다.
 
 ---
 
-## 3. 영향 범위와 리스크
+## 2. 하네스 게이트와 구조적 수정 (필수)
 
-- **회귀 범위가 넓다** — MonthNavigator 는 13개 페이지가 쓴다. 겉모습·탭 흐름이 모두 바뀐다.
-  착수 시 각 페이지의 기존 위젯 테스트 유무를 먼저 전수 확인하고, 없는 페이지는
-  MonthNavigator 자체 위젯 테스트로 대체 커버한다.
-- **월 선택 기본화의 부작용** — 지금은 팝업에서 일까지 고를 수 있다고 기대하는 사용자가 있을 수
-  있다. 거래 목록(일 선택 사용처)은 그대로 유지하므로 실사용 영향은 없을 것으로 본다.
-- **홈 레이아웃 변화** — Step 3 에서 글자 크기·정렬이 달라질 수 있다. 파라미터화로 흡수한다.
-- 하네스 태그: `navigation_state`(월 상태 이동) + `ui_pattern`. 착수 전 `pre-change-audit.sh`
-  재실행 필요. 2026-08-10 회차에서 도입한 `ledgerLocation` 이 이미 구조적 수정을 이행했으므로
-  게이트는 그 이력을 근거로 처리한다.
+`pre-change-audit.sh . navigation_state` → **🚫 STRUCTURAL_FIX_REQUIRED (LOCKED)**, 인시던트 4건.
+
+- 2026-04-14 예산 3월 → 카드 선택 → 4월 거래 표시
+- 2026-04-15 홈/예산 월 이동 후 거래 이동 시 현재 월로 리셋
+- 2026-04-15 월 이동 시 카드 요약이 홈/예산에서 stale
+- 2026-08-10 홈 대시보드에 위젯 추가 → CI 전부 통과·배포까지 갔는데 **죽은 화면이라 미노출**
+
+앞 3건의 구조적 이행은 2026-08-10 회차의 `ledgerLocation()`(required year/month → 컴파일 에러)이
+이미 담당한다. **이번 회차가 추가로 이행할 구조 항목은 4번째 인시던트 축**이다 —
+"공용 월 UI 를 고쳤는데 어떤 화면에는 반영되지 않는다 / 죽은 화면에 반영한다".
+
+### 구조 항목 S1 — 자체 월 헤더 금지 (소스 스캔 가드)
+
+`Icons.chevron_left` 와 `changeMonth(` 를 **동시에** 가진 파일은 `month_navigator.dart` 하나여야
+한다. 현재 위반 후보는 `dashboard_page.dart` 1건뿐 `[측정]`.
+
+- 이 파일은 **"미라우팅인 동안만" 예외**로 허용한다. 가드가 `app_router.dart` 를 함께 읽어
+  `/home` 이 여전히 redirect 인지 확인하고, redirect 가 사라지면(=홈을 되살리면) **테스트가 실패**한다.
+  → 홈 복원 시 `_MonthHeader` → `MonthNavigator` 이행이 강제된다.
+- 이 예외 방식이 "죽은 코드를 지금 삭제" 보다 나은 이유: 홈 복원 여부가 미결이고, 삭제하면
+  `dashboard_widget_registry_guard_test.dart`·`home_config_page` 까지 연쇄 정리가 필요해
+  이번 요청의 범위를 벗어난다.
+
+### 구조 항목 S2 — 월 피커 단일 소스
+
+`showMonthYearPickerDialog` 를 직접 호출하는 파일은 `month_navigator.dart` 하나여야 한다.
+(월 이동 UI 가 다시 페이지별로 갈라지는 것을 막는다.)
+
+### 구조 항목 S3 — 도달성 고정 (2026-08-10 인시던트 직결)
+
+§1.2 의 **9개 호스트 목록을 테스트에 상수로 박는다.** 각 항목에 대해
+① 그 파일이 `MonthNavigator(` 를 포함하고 ② `app_router.dart` 가 그 페이지를 참조하는지 검사.
+동시에 §1.2 의 "렌더되지 않는 3곳" 은 목록에서 제외돼 있음을 주석으로 명시 —
+다음 사람이 "13곳에 반영됐다" 고 착각하지 못하게 한다.
+
+### 구조 항목 S4 — MonthNavigator 위젯 테스트 신설
+
+`test/core/widgets/month_navigator_test.dart` — 지금까지 0건이라 회귀 감지가 없었다.
+9개 호스트 페이지에 개별 테스트를 다는 대신, 공용 위젯 자체를 커버해 9곳을 동시에 방어한다.
+
+> 게이트 해제는 이 문서를 근거로
+> `acknowledge-gate.sh budget-book docs/sessions/2026-08-10_3_month-navigator_plan.md` 로 처리한다.
 
 ---
 
-## 4. 사용자 검증 시나리오 (착수 후)
+## 3. 설계
 
-- A1. 거래 상단 `2026년 8월` 을 누르면 **월 그리드**가 먼저 뜬다
-- A2. 헤더의 연도를 누르면 **연도 그리드** → 연도 선택 → 그 연도 12개월 → 달 선택 2탭으로 이동
+### Step 1 — 신규 `showMonthYearPickerDialog` (`core/widgets/month_year_picker_dialog.dart`)
+
+반환값:
+
+- `MonthPickerResult { int year; int month; int? day; }` — `day == null` 이면 월까지만 고른 것.
+  거래 목록이 "사용자가 실제로 일을 골랐을 때만 스크롤" 을 구분할 수 있어야 하므로
+  `DateTime` 단일 타입으로 뭉개지 않는다(1일 반환과 구분 불가해진다).
+
+단계(`_Stage`): `year` → `month` → `day`
+
+- **월 그리드**: 3×4, `1월`~`12월`. 선택 달 filled, 오늘이 속한 달 테두리, 범위 밖 비활성.
+  탭 = 즉시 확정(확인 버튼 없음 — 탭 수 최소화가 요청 취지).
+- **연도 그리드**: 헤더의 `2026년` 을 탭하면 진입. 3열, 좌우 화살표로 12년 페이징.
+  연도 탭 → 월 그리드로 복귀.
+- **일 그리드**: `allowDaySelection: true` 일 때만. `CalendarDatePicker` 재사용 +
+  상단에 "월 선택으로" 되돌아가기.
+- **진입 단계 규칙** (2026-08-11 사용자 결정):
+  - `allowDaySelection: false` (호스트 8곳) → **월 그리드로 진입**. 달 선택이 1탭이 된다.
+  - `allowDaySelection: true` (거래 목록) → **일 그리드로 진입**(= 기존 첫 화면 그대로).
+    헤더 `2026년 8월 ▾` 탭 → 월 그리드 → 헤더 `2026년 ▾` 탭 → 연도 그리드로 *올라간다*.
+  - 탭 수 검산 `[추론]`: 거래 탭 기준 달 이동 2탭·일 선택 2탭으로 **어느 쪽도 퇴보가 없다**.
+    먼 달 이동만 "좌우 화살표 N회" 에서 "3탭 고정" 으로 개선된다.
+  - 기각안: 거래 탭도 월 그리드 진입 — 달 이동은 1탭이 되지만 같은 달 안의 일 스크롤이
+    2탭 → 3탭으로 퇴보한다. 사용자가 퇴보 없는 쪽을 선택했다.
+- `firstDate`/`lastDate` 기본값은 기존과 동일(2020 ~ 2030-12-31).
+- **기존 `showCalendarPickerDialog` 는 변경 없음** (§1.3 — 17개 호출부).
+
+### Step 2 — `MonthNavigator` 배선
+
+```
+final res = await showMonthYearPickerDialog(
+  context: context,
+  initialYear: displayYear, initialMonth: displayMonth,
+  allowDaySelection: onDatePicked != null,
+);
+if (res == null || !context.mounted) return;
+if (res.day != null) onDatePicked!(DateTime(res.year, res.month, res.day!));
+handleChange((year: res.year, month: res.month));
+```
+
+호출부 9곳 모두 **시그니처 변경 없음** — `onDatePicked` 유무로 동작이 갈린다.
+
+### Step 3 — "오늘" 버튼
+
+- 위치: `>` **오른쪽**. 좌측에 같은 폭(48) 투명 스페이서를 넣어 가운데 텍스트의 대칭을 유지한다.
+  폭 검산: 아이콘 4칸(48×4=192) + 날짜 텍스트(~90) ≒ 282 < 360(모바일 최소 폭) → overflow 없음 `[추론: 48dp IconButton 기본 폭 × 4 + titleMedium '2026년 8월' 실측 근사]`.
+- 표시 중인 달이 이번 달이면 **비활성**(`onPressed: null`).
+- 동작: `handleChange((year: now.year, month: now.month))` — 기존 월 변경 경로를 그대로 탄다.
+  새 동기화 경로를 만들지 않으므로 `MonthSyncHandler`·페이지별 `onMonthChanged` 가 자동 적용된다.
+- 아이콘 `Icons.today`(기존 사용 중), 툴팁 `'이번 달로'`.
+
+### Step 4 — 가드/테스트 (§2 이행)
+
+- `test/core/widgets/month_navigator_single_source_guard_test.dart` — S1·S2·S3
+- `test/core/widgets/month_navigator_test.dart` — S4
+  - 오늘 버튼: 이번 달이면 비활성 / 다른 달이면 활성 + 탭 시 MonthCubit 이 이번 달로
+  - 날짜 탭 → 피커 오픈, 월 선택 시 `onMonthChanged` 호출·`onDatePicked` **미호출**
+  - `onDatePicked` 를 준 경우 일 선택이 `onDatePicked` 로 전달
+- `test/core/widgets/month_year_picker_dialog_test.dart` — 단계 전환(월→연→월), 범위 밖 비활성
+
+---
+
+## 4. 영향 범위와 리스크
+
+- **회귀 범위 9개 호스트.** 그중 개별 위젯 테스트가 있는 페이지는 `statistics_page_test.dart` 뿐인데
+  그건 렌더 안 되는 호출부다 → 실질 커버 0. **공용 위젯 테스트(S4)로 대체 커버**한다.
+- **월 그리드 기본 진입의 부작용**: 8개 호스트는 원래 일을 고를 이유가 없다(연/월만 사용) → 영향 없음.
+  일 선택이 실제로 쓰이는 거래 목록은 진입 단계를 일 그리드로 유지해 퇴보를 막는다.
+- **아이콘 폰트**: 신규 코드포인트 없음 → 캐시 리스크 없음(§1.5).
+- **홈 대시보드**: 이번 변경으로 달라지지 않는다(미라우팅). S1 가드가 되살아날 때를 대비한다.
+
+---
+
+## 5. 검증 게이트
+
+로컬 CI 4종 + 배포 전 1종:
+
+1. `flutter analyze --no-fatal-infos --no-congratulate` 전체 — 신규 지적 0
+2. `flutter test` — 기존 894건 + 신규 통과
+3. `./gradlew test` (BE 무변경이나 게이트 유지)
+4. `flutter build web --release`
+5. **번들 문자열 확인** — 산출물에서 `이번 달로`(툴팁)와 월 그리드 고유 문자열을 찾는다.
+   한글은 번들에서 `\uXXXX` 이스케이프되므로 **escaped 형태로 대조**한다
+   (`reference_live_bundle_string_verification`). 2026-08-10 인시던트의 재발 방지 게이트.
+
+## 6. 사용자 검증 시나리오 (배포 후)
+
+- A1. **분석·자산·이체 등**에서 `2026년 8월` 을 누르면 **월 그리드**가 먼저 뜬다
+- A2. 헤더의 `2026년` 을 누르면 연도 그리드 → 연도 선택 → 12개월 → 달 선택
 - A3. 2024년 3월처럼 먼 달도 좌우 스와이프 없이 도달한다
+- A4. **거래 탭**은 기존처럼 **일 달력이 먼저** 뜨고, 헤더를 누르면 월 → 연도로 올라간다
 - B1. `>` 오른쪽 **오늘** 버튼으로 어디서든 이번 달로 즉시 복귀
-- B2. 이미 이번 달이면 그 버튼이 비활성
-- C1. 홈 대시보드에서도 날짜를 눌러 같은 피커가 열리고, 오늘 버튼이 있다
-- C2. 홈에서 달을 바꾸면 거래·예산 탭도 같은 달로 따라온다(기존 동작 유지)
-- D1. 거래 목록에서 특정 **일**을 고르면 그 날짜로 스크롤되는 기존 동작이 그대로다
+- B2. 이미 이번 달이면 그 버튼이 비활성(회색)
+- C1. 거래 목록에서 특정 **일**을 고르면 그 날짜로 스크롤되는 기존 동작이 그대로다
+- C2. 어느 화면에서 달을 바꾸든 다른 탭도 같은 달로 따라온다(기존 동작 유지)
 
 ---
 
-## 5. 범위 밖
+## 7. 미해결 사항
+
+- **9개 호스트 중 UI 진입점이 실제로 존재하는지는 라우팅 등록까지만 확인했다** `[측정: 라우트 등록]`
+  / 각 화면으로 가는 메뉴·버튼 전수는 미확인 `[미확인]`. 이번 변경은 어느 쪽이든 회귀를 만들지
+  않으므로(공용 위젯 개선) 착수 조건은 아니다. 확인 주체: 사용자 라이브 검증 A1.
+- **`statistics_page`·`budget_list_page` 의 `showMonthNavigator` 죽은 분기 정리** — 이번 범위 밖.
+  홈 복원 여부와 함께 별도 회차에서 판단한다.
+- **S1 가드는 휴리스틱이다** `[추론: `Icons.chevron_left` + `changeMonth(` 동시 보유로 탐지]`.
+  누군가 `Icons.arrow_back_ios` 같은 다른 아이콘으로 자체 월 헤더를 만들면 탐지하지 못한다
+  `[미확인: 실효 커버리지]`. 완전한 컴파일 타임 강제는 불가능한 형태(위젯 구성 자유도)이므로,
+  탐지 누락이 실제로 발생하면 그때 아이콘 후보를 가드에 추가한다.
+- **거래 탭의 드릴업 발견 가능성** — 헤더 `2026년 8월 ▾` 이 눌린다는 것을 사용자가 알아채는지는
+  `[미확인]`. `▾` 표식으로 어포던스를 준다. 라이브 검증 A4 에서 판정.
+
+## 8. 범위 밖
 
 - 기간(범위) 선택 — 이번 요청은 단일 월 이동이다
 - 주간 예산 화면의 주차 네비게이션
+- 홈 대시보드 복원 / 죽은 코드 삭제

--- a/frontend/lib/core/widgets/month_navigator.dart
+++ b/frontend/lib/core/widgets/month_navigator.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:intl/intl.dart';
 import 'package:budget_book/core/bloc/month_cubit.dart';
-import 'package:budget_book/core/widgets/calendar_picker_dialog.dart';
+import 'package:budget_book/core/widgets/month_year_picker_dialog.dart';
 
 /// Shared month navigation widget.
 ///
@@ -12,6 +12,13 @@ import 'package:budget_book/core/widgets/calendar_picker_dialog.dart';
 ///
 /// `onMonthChanged` 콜백은 기본적으로 MonthCubit.changeMonth()만 호출하면
 /// 됨 (MonthSyncHandler가 관련 BLoC reload 자동 처리).
+///
+/// ## 이 위젯이 월 이동 UI 의 유일한 진입점이다 (2026-08-11)
+///
+/// 페이지가 자체 월 헤더를 만들면 여기 개선이 그 화면에만 빠진다 — 실제로
+/// 홈 대시보드가 그랬다(`_MonthHeader`, 눌러도 팝업이 없음). 하네스 `navigation_state`
+/// 4회 재발의 한 축이라 `month_navigator_single_source_guard_test.dart` 가
+/// "자체 월 헤더 금지" 를 소스 스캔으로 막는다.
 class MonthNavigator extends StatelessWidget {
   /// 표시할 연도. 미지정 시 MonthCubit.state.year 사용.
   final int? year;
@@ -23,6 +30,9 @@ class MonthNavigator extends StatelessWidget {
   final ValueChanged<({int year, int month})>? onMonthChanged;
 
   /// 사용자가 특정 날짜(일)를 선택했을 때 호출. null이면 year/month만 사용.
+  ///
+  /// 이 콜백을 주면 피커가 **일 그리드로 진입**한다(기존 사용감 유지). 주지 않으면
+  /// **월 그리드로 진입**해 달 선택이 1탭으로 끝난다. 실제 사용처는 거래 목록 1곳뿐이다.
   final ValueChanged<DateTime>? onDatePicked;
 
   const MonthNavigator({
@@ -52,11 +62,17 @@ class MonthNavigator extends StatelessWidget {
     final dateStr =
         DateFormat('yyyy년 M월').format(DateTime(displayYear, displayMonth));
 
+    final now = DateTime.now();
+    final isCurrentMonth = displayYear == now.year && displayMonth == now.month;
+
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
       child: Row(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
+          // "오늘" 버튼이 오른쪽 끝에 붙으므로, 같은 폭을 왼쪽에 비워 가운데 날짜의
+          // 좌우 대칭을 유지한다.
+          const SizedBox(width: 48),
           IconButton(
             icon: const Icon(Icons.chevron_left),
             onPressed: () {
@@ -67,26 +83,33 @@ class MonthNavigator extends StatelessWidget {
             },
             tooltip: '이전 달',
           ),
-          TextButton(
-            onPressed: () async {
-              final picked = await showCalendarPickerDialog(
-                context: context,
-                initialDate: DateTime(displayYear, displayMonth),
-                firstDate: DateTime(2020),
-                lastDate: DateTime(2030, 12, 31),
-              );
-              if (picked != null && context.mounted) {
-                if (onDatePicked != null) {
-                  onDatePicked!(picked);
+          // 고정 폭 4칸(스페이서 + 화살표 2 + 오늘) 192 를 빼면 좁은 화면·큰 글꼴 배율에서
+          // 여유가 많지 않다. 넘치면 잘라서 표시한다.
+          Flexible(
+            child: TextButton(
+              onPressed: () async {
+                final picked = await showMonthYearPickerDialog(
+                  context: context,
+                  initialYear: displayYear,
+                  initialMonth: displayMonth,
+                  firstDate: DateTime(2020),
+                  lastDate: DateTime(2030, 12, 31),
+                  allowDaySelection: onDatePicked != null,
+                );
+                if (picked == null || !context.mounted) return;
+                if (picked.day != null) {
+                  onDatePicked!(picked.date);
                 }
                 handleChange((year: picked.year, month: picked.month));
-              }
-            },
-            child: Text(
-              dateStr,
-              style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                    fontWeight: FontWeight.bold,
-                  ),
+              },
+              child: Text(
+                dateStr,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.bold,
+                    ),
+              ),
             ),
           ),
           IconButton(
@@ -98,6 +121,14 @@ class MonthNavigator extends StatelessWidget {
               handleChange(next);
             },
             tooltip: '다음 달',
+          ),
+          IconButton(
+            icon: const Icon(Icons.today),
+            // 이번 달을 보고 있으면 누를 이유가 없다 — 비활성으로 상태를 드러낸다.
+            onPressed: isCurrentMonth
+                ? null
+                : () => handleChange((year: now.year, month: now.month)),
+            tooltip: '이번 달로',
           ),
         ],
       ),

--- a/frontend/lib/core/widgets/month_year_picker_dialog.dart
+++ b/frontend/lib/core/widgets/month_year_picker_dialog.dart
@@ -1,0 +1,450 @@
+/// Year → month → day drill-down picker used by `MonthNavigator`.
+///
+/// ## 왜 별도 다이얼로그인가 (2026-08-11)
+///
+/// 기존 `showCalendarPickerDialog` 의 `CalendarDatePicker` 는 연도 목록은 열리지만
+/// **월 그리드가 없다** — 연도를 고르면 그 연도의 *같은 달* 일 그리드로 돌아오고,
+/// 원하는 달까지 좌우로 넘겨야 한다. 그게 사용자가 지적한 결손 지점이다.
+///
+/// 그렇다고 `showCalendarPickerDialog` 를 고칠 수는 없다. 호출부 18곳 중 **17곳이
+/// "특정 날짜 입력"이 본질**(거래·이체·보험·지출계획·카드정산 폼, 기간 필터 5곳, 포켓 시트 2곳)
+/// 이라 월 우선으로 바꾸면 그쪽이 전부 퇴보한다. 그래서 월 이동 전용 피커를 따로 둔다.
+///
+/// **이 파일의 함수를 직접 호출하는 파일은 `month_navigator.dart` 하나여야 한다** —
+/// 월 이동 UI 가 다시 페이지별로 갈라지는 것을 `month_navigator_single_source_guard_test.dart`
+/// 가 막는다(하네스 `navigation_state`, 4회 재발).
+library;
+
+import 'package:flutter/material.dart';
+
+/// 사용자가 피커에서 고른 값.
+///
+/// [day] 가 null 이면 **월까지만** 고른 것이다. 호출부가 "사용자가 실제로 일을 골랐는지"
+/// 를 구분해야 하므로(거래 목록은 그때만 해당 날짜로 스크롤한다) `DateTime` 하나로
+/// 뭉개지 않는다 — 1일 선택과 월 선택이 구별되지 않기 때문이다.
+class MonthPickerResult {
+  final int year;
+  final int month;
+  final int? day;
+
+  const MonthPickerResult({
+    required this.year,
+    required this.month,
+    this.day,
+  });
+
+  DateTime get date => DateTime(year, month, day ?? 1);
+}
+
+/// 연/월(선택적으로 일) 드릴다운 피커를 띄운다.
+///
+/// [allowDaySelection] 이 true 면 **일 그리드로 진입**하고(기존 사용감 유지),
+/// 헤더를 눌러 월 → 연도로 올라갈 수 있다. false 면 **월 그리드로 진입**해
+/// 달 선택이 1탭으로 끝난다.
+Future<MonthPickerResult?> showMonthYearPickerDialog({
+  required BuildContext context,
+  required int initialYear,
+  required int initialMonth,
+  DateTime? firstDate,
+  DateTime? lastDate,
+  bool allowDaySelection = false,
+}) {
+  return showDialog<MonthPickerResult>(
+    context: context,
+    builder: (ctx) => _MonthYearPickerDialog(
+      initialYear: initialYear,
+      initialMonth: initialMonth,
+      firstDate: firstDate ?? DateTime(2020),
+      lastDate: lastDate ?? DateTime(2030, 12, 31),
+      allowDaySelection: allowDaySelection,
+    ),
+  );
+}
+
+enum _PickerStage { year, month, day }
+
+/// 연도 그리드 한 페이지에 담는 연도 수 (3열 × 4행).
+const int _yearsPerPage = 12;
+
+class _MonthYearPickerDialog extends StatefulWidget {
+  final int initialYear;
+  final int initialMonth;
+  final DateTime firstDate;
+  final DateTime lastDate;
+  final bool allowDaySelection;
+
+  const _MonthYearPickerDialog({
+    required this.initialYear,
+    required this.initialMonth,
+    required this.firstDate,
+    required this.lastDate,
+    required this.allowDaySelection,
+  });
+
+  @override
+  State<_MonthYearPickerDialog> createState() => _MonthYearPickerDialogState();
+}
+
+class _MonthYearPickerDialogState extends State<_MonthYearPickerDialog> {
+  late _PickerStage _stage;
+
+  /// 현재 화면이 다루는 연/월. 일 그리드에서는 표시 중인 달이기도 하다.
+  late int _year;
+  late int _month;
+
+  /// 연도 그리드가 보여주는 12년 묶음의 첫 연도.
+  late int _yearPageStart;
+
+  /// 일 그리드에서 사용자가 마지막으로 고른 날짜.
+  late DateTime _selectedDay;
+
+  @override
+  void initState() {
+    super.initState();
+    _year = widget.initialYear;
+    _month = widget.initialMonth;
+    _selectedDay =
+        _clampToRange(DateTime(widget.initialYear, widget.initialMonth));
+    _yearPageStart = _pageStartFor(_year);
+    _stage = widget.allowDaySelection ? _PickerStage.day : _PickerStage.month;
+  }
+
+  int get _firstYear => widget.firstDate.year;
+  int get _lastYear => widget.lastDate.year;
+
+  int _pageStartFor(int year) =>
+      _firstYear + ((year - _firstYear) ~/ _yearsPerPage) * _yearsPerPage;
+
+  DateTime _clampToRange(DateTime d) {
+    if (d.isBefore(widget.firstDate)) return widget.firstDate;
+    if (d.isAfter(widget.lastDate)) return widget.lastDate;
+    return d;
+  }
+
+  bool _isMonthEnabled(int year, int month) {
+    final monthStart = DateTime(year, month);
+    final monthEnd = DateTime(year, month + 1, 0);
+    return !monthEnd.isBefore(widget.firstDate) &&
+        !monthStart.isAfter(widget.lastDate);
+  }
+
+  void _pickMonth(int year, int month) {
+    if (widget.allowDaySelection) {
+      setState(() {
+        _year = year;
+        _month = month;
+        _selectedDay = _clampToRange(DateTime(year, month));
+        _stage = _PickerStage.day;
+      });
+      return;
+    }
+    Navigator.pop(context, MonthPickerResult(year: year, month: month));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Dialog(
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 360),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            _buildTitleBar(context),
+            switch (_stage) {
+              _PickerStage.year => _buildYearStage(context),
+              _PickerStage.month => _buildMonthStage(context),
+              _PickerStage.day => _buildDayStage(context),
+            },
+          ],
+        ),
+      ),
+    );
+  }
+
+  String get _title => switch (_stage) {
+        _PickerStage.year => '연도 선택',
+        _PickerStage.month => '월 선택',
+        _PickerStage.day => '날짜 선택',
+      };
+
+  Widget _buildTitleBar(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(20, 16, 8, 0),
+      child: Row(
+        children: [
+          Text(
+            _title,
+            style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
+          ),
+          const Spacer(),
+          IconButton(
+            icon: const Icon(Icons.close, size: 20),
+            onPressed: () => Navigator.pop(context),
+            tooltip: '닫기',
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// `‹ 라벨 ›` 헤더. 가운데 라벨은 상위 단계로 올라가는 버튼이다.
+  Widget _buildStageHeader({
+    required String label,
+    required VoidCallback? onPrev,
+    required VoidCallback? onNext,
+    required VoidCallback? onLabelTap,
+  }) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 8),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          IconButton(
+            icon: const Icon(Icons.chevron_left),
+            onPressed: onPrev,
+            tooltip: '이전',
+          ),
+          Expanded(
+            child: TextButton(
+              onPressed: onLabelTap,
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Flexible(
+                    child: Text(
+                      label,
+                      overflow: TextOverflow.ellipsis,
+                      style: Theme.of(context)
+                          .textTheme
+                          .titleMedium
+                          ?.copyWith(fontWeight: FontWeight.bold),
+                    ),
+                  ),
+                  if (onLabelTap != null)
+                    const Icon(Icons.arrow_drop_down, size: 20),
+                ],
+              ),
+            ),
+          ),
+          IconButton(
+            icon: const Icon(Icons.chevron_right),
+            onPressed: onNext,
+            tooltip: '다음',
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildYearStage(BuildContext context) {
+    final pageEnd = _yearPageStart + _yearsPerPage - 1;
+    final years = [
+      for (var y = _yearPageStart; y <= pageEnd; y++)
+        if (y >= _firstYear && y <= _lastYear) y,
+    ];
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        _buildStageHeader(
+          label: '$_yearPageStart – $pageEnd',
+          onPrev: _yearPageStart - _yearsPerPage >= _firstYear
+              ? () => setState(() => _yearPageStart -= _yearsPerPage)
+              : null,
+          onNext: _yearPageStart + _yearsPerPage <= _lastYear
+              ? () => setState(() => _yearPageStart += _yearsPerPage)
+              : null,
+          // 연도가 최상위 단계라 더 올라갈 곳이 없다.
+          onLabelTap: null,
+        ),
+        _buildGrid(
+          context,
+          columns: 3,
+          items: [
+            for (final y in years)
+              _GridCell(
+                label: '$y년',
+                selected: y == _year,
+                outlined: y == DateTime.now().year,
+                onTap: () => setState(() {
+                  _year = y;
+                  _stage = _PickerStage.month;
+                }),
+              ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  Widget _buildMonthStage(BuildContext context) {
+    final now = DateTime.now();
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        _buildStageHeader(
+          label: '$_year년',
+          onPrev:
+              _year - 1 >= _firstYear ? () => setState(() => _year -= 1) : null,
+          onNext:
+              _year + 1 <= _lastYear ? () => setState(() => _year += 1) : null,
+          onLabelTap: () => setState(() {
+            _yearPageStart = _pageStartFor(_year);
+            _stage = _PickerStage.year;
+          }),
+        ),
+        _buildGrid(
+          context,
+          columns: 3,
+          items: [
+            for (var m = 1; m <= 12; m++)
+              _GridCell(
+                label: '$m월',
+                selected:
+                    _year == widget.initialYear && m == widget.initialMonth,
+                outlined: _year == now.year && m == now.month,
+                onTap: _isMonthEnabled(_year, m)
+                    ? () => _pickMonth(_year, m)
+                    : null,
+              ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  Widget _buildDayStage(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Align(
+          alignment: Alignment.centerLeft,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 12),
+            child: TextButton.icon(
+              icon: const Icon(Icons.chevron_left, size: 20),
+              label: const Text('월 선택으로'),
+              onPressed: () => setState(() => _stage = _PickerStage.month),
+            ),
+          ),
+        ),
+        CalendarDatePicker(
+          // 월 그리드에서 다른 달을 고르고 돌아오면 그 달로 다시 그려야 한다.
+          key: ValueKey('$_year-$_month'),
+          initialDate: _selectedDay,
+          firstDate: widget.firstDate,
+          lastDate: widget.lastDate,
+          onDateChanged: (d) => _selectedDay = d,
+        ),
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 0, 16, 12),
+          child: SizedBox(
+            width: double.infinity,
+            child: FilledButton(
+              onPressed: () => Navigator.pop(
+                context,
+                MonthPickerResult(
+                  year: _selectedDay.year,
+                  month: _selectedDay.month,
+                  day: _selectedDay.day,
+                ),
+              ),
+              child: const Text('선택'),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildGrid(
+    BuildContext context, {
+    required int columns,
+    required List<_GridCell> items,
+  }) {
+    final rows = <Widget>[];
+    for (var i = 0; i < items.length; i += columns) {
+      final slice = items.sublist(
+        i,
+        (i + columns) > items.length ? items.length : i + columns,
+      );
+      rows.add(Row(
+        children: [
+          for (final cell in slice) Expanded(child: cell),
+          // 마지막 줄이 덜 찼을 때 칸 폭을 유지한다.
+          for (var pad = slice.length; pad < columns; pad++)
+            const Expanded(child: SizedBox.shrink()),
+        ],
+      ));
+    }
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(12, 4, 12, 16),
+      child: Column(mainAxisSize: MainAxisSize.min, children: rows),
+    );
+  }
+}
+
+/// 연도/월 그리드의 한 칸.
+class _GridCell extends StatelessWidget {
+  final String label;
+
+  /// 현재 보고 있는 값 — 채워진 배경으로 표시.
+  final bool selected;
+
+  /// 오늘이 속한 값 — 테두리로 표시.
+  final bool outlined;
+
+  final VoidCallback? onTap;
+
+  const _GridCell({
+    required this.label,
+    required this.selected,
+    required this.outlined,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    final disabled = onTap == null;
+
+    final Color fg;
+    if (disabled) {
+      fg = scheme.onSurface.withValues(alpha: 0.38);
+    } else if (selected) {
+      fg = scheme.onPrimary;
+    } else {
+      fg = scheme.onSurface;
+    }
+
+    return Padding(
+      padding: const EdgeInsets.all(4),
+      child: Material(
+        color: selected ? scheme.primary : Colors.transparent,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(10),
+          side: outlined && !selected
+              ? BorderSide(color: scheme.primary, width: 1.5)
+              : BorderSide.none,
+        ),
+        clipBehavior: Clip.antiAlias,
+        child: InkWell(
+          onTap: onTap,
+          child: SizedBox(
+            height: 44,
+            child: Center(
+              child: Text(
+                label,
+                style: TextStyle(
+                  color: fg,
+                  fontWeight: selected ? FontWeight.bold : FontWeight.normal,
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/test/core/widgets/month_navigator_single_source_guard_test.dart
+++ b/frontend/test/core/widgets/month_navigator_single_source_guard_test.dart
@@ -1,0 +1,158 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// 월 이동 UI 단일 소스 + 도달성 가드.
+///
+/// ## 왜 필요한가 (하네스 `navigation_state` — 4회 재발)
+///
+/// - 2026-04-14 예산 3월 → 카드 선택 → 4월 거래 표시
+/// - 2026-04-15 홈/예산 월 이동 후 거래 이동 시 현재 월로 리셋
+/// - 2026-04-15 월 이동 시 카드 요약이 홈/예산에서 stale
+/// - 2026-08-10 홈 대시보드에 위젯을 추가해 CI·배포까지 통과했는데 **죽은 화면이라 미노출**
+///
+/// 앞 3건의 구조적 이행은 `ledgerLocation()`(required year/month → 컴파일 에러)이 담당한다.
+/// 이 파일은 **4번째 축**을 막는다 — "공용 월 UI 를 고쳤는데 어떤 화면에는 반영되지 않는다 /
+/// 반영한 화면이 사용자에게 도달하지 않는다".
+void main() {
+  String read(String path) => File(path).readAsStringSync();
+
+  final router = read('lib/core/router/app_router.dart');
+
+  /// MonthNavigator 가 **실제로 렌더되는** 호스트 (2026-08-11 측정).
+  ///
+  /// 여기 없는 호출부 3곳은 파라미터로 꺼져 있어 화면에 나오지 않는다 —
+  /// `statistics_page.dart:68` 과 `budget_list_page.dart:269/566` 은
+  /// `if (showMonthNavigator …)` 안에 있고, 유일한 사용처인 `analysis_page` 가
+  /// `showMonthNavigator: false` 로 넘긴다(`/budgets`·`/statistics` 는 분석 탭으로 redirect).
+  /// **"13곳에 반영됐다" 고 세지 말 것.**
+  const hosts = <String, String>{
+    'lib/features/transaction/presentation/pages/transaction_list_page.dart':
+        'TransactionListPage',
+    'lib/features/analysis/presentation/pages/analysis_page.dart': 'AnalysisPage',
+    'lib/features/transfer/presentation/pages/transfer_list_page.dart':
+        'TransferListPage',
+    'lib/features/payment_method/presentation/pages/payment_method_page.dart':
+        'PaymentMethodPage',
+    'lib/features/settings/presentation/pages/asset_management_page.dart':
+        'AssetManagementPage',
+    'lib/features/weekly_budget/presentation/pages/weekly_budget_page.dart':
+        'WeeklyBudgetPage',
+    'lib/features/weekly_budget/presentation/pages/weekly_settlement_page.dart':
+        'WeeklySettlementPage',
+    'lib/features/report/presentation/pages/report_page.dart': 'ReportPage',
+    'lib/features/spending_plan/presentation/pages/spending_plan_list_page.dart':
+        'SpendingPlanListPage',
+  };
+
+  group('S3 — 도달성 고정', () {
+    hosts.forEach((path, pageClass) {
+      test('$pageClass 은 MonthNavigator 를 쓰고 라우터에 등록돼 있다', () {
+        expect(
+          read(path).contains('MonthNavigator('),
+          isTrue,
+          reason: '$path 에서 MonthNavigator 가 사라졌다. 이 화면만 월 이동 개선에서 '
+              '빠지게 된다 — 호스트 목록을 고치든 위젯을 되돌리든 결정이 필요하다.',
+        );
+        expect(
+          router.contains(pageClass),
+          isTrue,
+          reason: '$pageClass 이 app_router 에서 사라졌다. 라우팅되지 않는 화면에 '
+              '기능을 얹으면 사용자에게 도달하지 않는다(2026-08-10 인시던트).',
+        );
+      });
+    });
+
+    test('분석 탭은 예산/통계의 자체 MonthNavigator 를 꺼둔 채 감싼다', () {
+      // 이 전제가 깨지면 분석 탭에 월 네비게이터가 두 개 나온다.
+      final analysis =
+          read('lib/features/analysis/presentation/pages/analysis_page.dart');
+      expect('showMonthNavigator: false'.allMatches(analysis).length, 2);
+    });
+  });
+
+  group('S1 — 자체 월 헤더 금지', () {
+    test('월 헤더를 직접 만드는 파일은 month_navigator.dart 하나뿐이다', () {
+      final offenders = <String>[];
+      for (final entity in Directory('lib').listSync(recursive: true)) {
+        if (entity is! File || !entity.path.endsWith('.dart')) continue;
+        final src = entity.readAsStringSync();
+        // 좌우 화살표 + 월 상태 변경을 한 파일이 동시에 갖고 있으면 자체 월 헤더다.
+        if (src.contains('Icons.chevron_left') && src.contains('changeMonth(')) {
+          offenders.add(entity.path.replaceAll(r'\', '/'));
+        }
+      }
+
+      const allowed = 'lib/core/widgets/month_navigator.dart';
+      // 홈 대시보드는 **미라우팅인 동안만** 예외다. 아래 테스트가 그 전제를 지킨다.
+      const deadExemption =
+          'lib/features/home/presentation/pages/dashboard_page.dart';
+
+      expect(
+        offenders.toSet().difference({allowed, deadExemption}),
+        isEmpty,
+        reason: '자체 월 헤더가 새로 생겼다. 월 네비게이터 개선(피커·오늘 버튼)이 '
+            '그 화면에만 빠진다 — MonthNavigator 를 쓰라.',
+      );
+    });
+
+    test('홈 예외는 홈이 미라우팅일 때만 유효하다', () {
+      // `/home` 이 redirect 인 동안 dashboard_page 는 사용자에게 도달하지 않으므로
+      // 자체 `_MonthHeader` 를 남겨둬도 무해하다. 홈을 되살리는 순간 이 테스트가 깨지고,
+      // MonthNavigator 이행이 강제된다.
+      final idx = router.indexOf("path: '/home'");
+      expect(idx, greaterThan(-1), reason: "'/home' 라우트 자체가 사라졌다.");
+      final block = router.substring(idx, idx + 200);
+      expect(
+        block.contains('redirect:'),
+        isTrue,
+        reason: '홈이 실제 화면으로 되살아났다. dashboard_page 의 `_MonthHeader` 를 '
+            'MonthNavigator 로 이행하고 이 예외를 제거하라 — 지금 상태로 두면 홈만 '
+            '월 피커·오늘 버튼이 없다.',
+      );
+    });
+  });
+
+  group('S2 — 월 피커 단일 소스', () {
+    test('showMonthYearPickerDialog 호출부는 month_navigator.dart 하나뿐이다', () {
+      final callers = <String>[];
+      for (final entity in Directory('lib').listSync(recursive: true)) {
+        if (entity is! File || !entity.path.endsWith('.dart')) continue;
+        final path = entity.path.replaceAll(r'\', '/');
+        if (path.endsWith('month_year_picker_dialog.dart')) continue; // 정의부
+        if (entity.readAsStringSync().contains('showMonthYearPickerDialog(')) {
+          callers.add(path);
+        }
+      }
+      expect(callers, ['lib/core/widgets/month_navigator.dart']);
+    });
+
+    test('일 선택이 본질인 호출부는 기존 showCalendarPickerDialog 를 계속 쓴다', () {
+      // 거래·이체·보험·지출계획·카드정산 폼과 기간 필터 등 17곳. 월 우선 피커로
+      // 갈아끼우면 그쪽이 퇴보한다.
+      final formPicker = read(
+        'lib/features/transaction/presentation/pages/transaction_form_page.dart',
+      );
+      expect(formPicker.contains('showCalendarPickerDialog('), isTrue);
+      expect(formPicker.contains('showMonthYearPickerDialog('), isFalse);
+    });
+  });
+
+  group('요청 산출물이 위젯에 남아 있다', () {
+    final navigator = read('lib/core/widgets/month_navigator.dart');
+
+    test('월 피커로 연결돼 있다', () {
+      expect(navigator.contains('showMonthYearPickerDialog('), isTrue);
+      expect(
+        navigator.contains('allowDaySelection: onDatePicked != null'),
+        isTrue,
+        reason: '거래 목록만 일 그리드로 진입한다는 규칙이 사라졌다.',
+      );
+    });
+
+    test('"오늘" 버튼이 있다', () {
+      expect(navigator.contains('Icons.today'), isTrue);
+      expect(navigator.contains("'이번 달로'"), isTrue);
+    });
+  });
+}

--- a/frontend/test/core/widgets/month_navigator_test.dart
+++ b/frontend/test/core/widgets/month_navigator_test.dart
@@ -1,0 +1,191 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:budget_book/core/bloc/month_cubit.dart';
+import 'package:budget_book/core/widgets/month_navigator.dart';
+
+/// MonthNavigator 위젯 테스트.
+///
+/// 이 위젯은 렌더되는 화면 9곳이 공유하는데 2026-08-11 까지 전용 테스트가 **0건**이었다.
+/// 페이지마다 테스트를 다는 대신 공용 위젯을 커버해 9곳을 한 번에 방어한다.
+void main() {
+  Widget host({
+    int? year,
+    int? month,
+    required MonthCubit cubit,
+    ValueChanged<({int year, int month})>? onMonthChanged,
+    ValueChanged<DateTime>? onDatePicked,
+  }) {
+    return MaterialApp(
+      home: BlocProvider.value(
+        value: cubit,
+        child: Scaffold(
+          body: MonthNavigator(
+            year: year,
+            month: month,
+            onMonthChanged: onMonthChanged,
+            onDatePicked: onDatePicked,
+          ),
+        ),
+      ),
+    );
+  }
+
+  IconButton todayButton(WidgetTester tester) => tester.widget<IconButton>(
+        find.ancestor(
+          of: find.byIcon(Icons.today),
+          matching: find.byType(IconButton),
+        ),
+      );
+
+  group('"오늘" 버튼', () {
+    testWidgets('이번 달을 보고 있으면 비활성', (tester) async {
+      final now = DateTime.now();
+      final cubit = MonthCubit();
+      await tester.pumpWidget(
+        host(year: now.year, month: now.month, cubit: cubit),
+      );
+
+      expect(todayButton(tester).onPressed, isNull);
+    });
+
+    testWidgets('다른 달을 보고 있으면 활성이고, 누르면 이번 달로 돌아온다', (tester) async {
+      final cubit = MonthCubit();
+      ({int year, int month})? changed;
+      await tester.pumpWidget(host(
+        year: 2020,
+        month: 3,
+        cubit: cubit,
+        onMonthChanged: (m) => changed = m,
+      ));
+
+      expect(todayButton(tester).onPressed, isNotNull);
+
+      await tester.tap(find.byIcon(Icons.today));
+      await tester.pumpAndSettle();
+
+      final now = DateTime.now();
+      expect(changed, (year: now.year, month: now.month));
+    });
+
+    testWidgets('콜백이 없으면 MonthCubit 을 이번 달로 바꾼다', (tester) async {
+      final cubit = MonthCubit();
+      cubit.changeMonth(2020, 3);
+      await tester.pumpWidget(host(cubit: cubit));
+
+      await tester.tap(find.byIcon(Icons.today));
+      await tester.pumpAndSettle();
+
+      final now = DateTime.now();
+      expect(cubit.state.year, now.year);
+      expect(cubit.state.month, now.month);
+    });
+  });
+
+  group('피커 진입 단계', () {
+    testWidgets('onDatePicked 가 없으면 월 그리드로 진입한다', (tester) async {
+      final cubit = MonthCubit();
+      await tester.pumpWidget(host(year: 2026, month: 8, cubit: cubit));
+
+      await tester.tap(find.text('2026년 8월'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('월 선택'), findsOneWidget);
+      expect(find.text('2026년'), findsOneWidget);
+      expect(find.text('3월'), findsOneWidget);
+    });
+
+    testWidgets('onDatePicked 가 있으면 일 그리드로 진입한다 (거래 목록)', (tester) async {
+      final cubit = MonthCubit();
+      await tester.pumpWidget(host(
+        year: 2026,
+        month: 8,
+        cubit: cubit,
+        onDatePicked: (_) {},
+      ));
+
+      await tester.tap(find.text('2026년 8월'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('날짜 선택'), findsOneWidget);
+      expect(find.text('월 선택으로'), findsOneWidget);
+    });
+  });
+
+  group('선택 결과 전달', () {
+    testWidgets('월만 고르면 onMonthChanged 만 호출되고 onDatePicked 는 호출되지 않는다',
+        (tester) async {
+      final cubit = MonthCubit();
+      ({int year, int month})? changed;
+      DateTime? datePicked;
+      await tester.pumpWidget(host(
+        year: 2026,
+        month: 8,
+        cubit: cubit,
+        onMonthChanged: (m) => changed = m,
+        onDatePicked: null,
+      ));
+
+      await tester.tap(find.text('2026년 8월'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('3월'));
+      await tester.pumpAndSettle();
+
+      expect(changed, (year: 2026, month: 3));
+      expect(datePicked, isNull);
+    });
+
+    testWidgets('일까지 고르면 onDatePicked 와 onMonthChanged 가 모두 호출된다',
+        (tester) async {
+      final cubit = MonthCubit();
+      ({int year, int month})? changed;
+      DateTime? datePicked;
+      await tester.pumpWidget(host(
+        year: 2026,
+        month: 8,
+        cubit: cubit,
+        onMonthChanged: (m) => changed = m,
+        onDatePicked: (d) => datePicked = d,
+      ));
+
+      await tester.tap(find.text('2026년 8월'));
+      await tester.pumpAndSettle();
+      // 일 그리드로 진입해 있다 — 15일 선택 후 확정.
+      await tester.tap(find.text('15'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('선택'));
+      await tester.pumpAndSettle();
+
+      expect(datePicked, DateTime(2026, 8, 15));
+      expect(changed, (year: 2026, month: 8));
+    });
+  });
+
+  group('좌우 화살표', () {
+    testWidgets('연말/연초를 넘어간다', (tester) async {
+      final cubit = MonthCubit();
+      ({int year, int month})? changed;
+      await tester.pumpWidget(host(
+        year: 2026,
+        month: 12,
+        cubit: cubit,
+        onMonthChanged: (m) => changed = m,
+      ));
+
+      await tester.tap(find.byIcon(Icons.chevron_right));
+      await tester.pumpAndSettle();
+      expect(changed, (year: 2027, month: 1));
+
+      await tester.pumpWidget(host(
+        year: 2026,
+        month: 1,
+        cubit: cubit,
+        onMonthChanged: (m) => changed = m,
+      ));
+      await tester.tap(find.byIcon(Icons.chevron_left));
+      await tester.pumpAndSettle();
+      expect(changed, (year: 2025, month: 12));
+    });
+  });
+}

--- a/frontend/test/core/widgets/month_year_picker_dialog_test.dart
+++ b/frontend/test/core/widgets/month_year_picker_dialog_test.dart
@@ -1,0 +1,146 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:budget_book/core/widgets/month_year_picker_dialog.dart';
+
+void main() {
+  /// 다이얼로그를 띄운다. 닫힐 때의 반환값은 [sink] 로 흘려보낸다
+  /// (다이얼로그가 열려 있는 동안에는 `await` 이 끝나지 않으므로 리턴값으로 받을 수 없다).
+  Future<void> open(
+    WidgetTester tester, {
+    int initialYear = 2026,
+    int initialMonth = 8,
+    DateTime? firstDate,
+    DateTime? lastDate,
+    bool allowDaySelection = false,
+    void Function(MonthPickerResult?)? sink,
+  }) async {
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: Builder(
+          builder: (context) => ElevatedButton(
+            onPressed: () async {
+              final result = await showMonthYearPickerDialog(
+                context: context,
+                initialYear: initialYear,
+                initialMonth: initialMonth,
+                firstDate: firstDate,
+                lastDate: lastDate,
+                allowDaySelection: allowDaySelection,
+              );
+              sink?.call(result);
+            },
+            child: const Text('open'),
+          ),
+        ),
+      ),
+    ));
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('월 그리드로 진입하고 달을 고르면 즉시 닫힌다', (tester) async {
+    MonthPickerResult? result;
+    await open(tester, sink: (r) => result = r);
+
+    expect(find.text('월 선택'), findsOneWidget);
+    expect(find.text('1월'), findsOneWidget);
+    expect(find.text('12월'), findsOneWidget);
+
+    await tester.tap(find.text('5월'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('월 선택'), findsNothing); // 확인 버튼 없이 1탭으로 확정
+    expect(result?.year, 2026);
+    expect(result?.month, 5);
+    expect(result?.day, isNull, reason: '월까지만 골랐으므로 day 는 비어 있어야 한다.');
+  });
+
+  testWidgets('헤더를 누르면 연도 그리드로 올라가고, 연도를 고르면 월 그리드로 내려온다',
+      (tester) async {
+    await open(tester);
+
+    await tester.tap(find.text('2026년'));
+    await tester.pumpAndSettle();
+    expect(find.text('연도 선택'), findsOneWidget);
+    expect(find.text('2024년'), findsOneWidget);
+
+    await tester.tap(find.text('2024년'));
+    await tester.pumpAndSettle();
+    expect(find.text('월 선택'), findsOneWidget);
+    expect(find.text('2024년'), findsOneWidget); // 헤더가 고른 연도를 반영
+  });
+
+  testWidgets('연도 좌우 화살표로 표시 연도를 바꾼다', (tester) async {
+    await open(tester);
+
+    await tester.tap(find.byIcon(Icons.chevron_right));
+    await tester.pumpAndSettle();
+    expect(find.text('2027년'), findsOneWidget);
+
+    await tester.tap(find.byIcon(Icons.chevron_left));
+    await tester.pumpAndSettle();
+    expect(find.text('2026년'), findsOneWidget);
+  });
+
+  testWidgets('범위 밖의 달은 비활성이라 눌러도 닫히지 않는다', (tester) async {
+    await open(
+      tester,
+      initialYear: 2026,
+      initialMonth: 8,
+      firstDate: DateTime(2026, 6),
+      lastDate: DateTime(2026, 9, 30),
+    );
+
+    await tester.tap(find.text('2월'));
+    await tester.pumpAndSettle();
+    expect(find.text('월 선택'), findsOneWidget); // 여전히 열려 있다
+
+    await tester.tap(find.text('7월'));
+    await tester.pumpAndSettle();
+    expect(find.text('월 선택'), findsNothing);
+  });
+
+  testWidgets('범위를 벗어나는 연도 이동 화살표는 비활성', (tester) async {
+    await open(
+      tester,
+      firstDate: DateTime(2026),
+      lastDate: DateTime(2026, 12, 31),
+    );
+
+    final prev = tester.widget<IconButton>(find.ancestor(
+      of: find.byIcon(Icons.chevron_left),
+      matching: find.byType(IconButton),
+    ));
+    expect(prev.onPressed, isNull);
+  });
+
+  group('allowDaySelection', () {
+    testWidgets('일 그리드로 진입하고, 월 선택으로 올라갔다가 다시 내려올 수 있다',
+        (tester) async {
+      MonthPickerResult? result;
+      await open(tester, allowDaySelection: true, sink: (r) => result = r);
+
+      expect(find.text('날짜 선택'), findsOneWidget);
+
+      await tester.tap(find.text('월 선택으로'));
+      await tester.pumpAndSettle();
+      expect(find.text('월 선택'), findsOneWidget);
+
+      // 다른 달을 고르면 닫히지 않고 그 달의 일 그리드로 내려간다.
+      await tester.tap(find.text('4월'));
+      await tester.pumpAndSettle();
+      expect(find.text('날짜 선택'), findsOneWidget);
+
+      // 달력이 실제로 4월을 그리고 있는지는 고른 날짜로 확인한다
+      // (테스트 환경은 로케일 델리게이트가 없어 헤더가 영문으로 나온다).
+      await tester.tap(find.text('10'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('선택'));
+      await tester.pumpAndSettle();
+      expect(result?.year, 2026);
+      expect(result?.month, 4);
+      expect(result?.day, 10);
+    });
+  });
+}


### PR DESCRIPTION
## 요청

`< yyyy년 mm월 >` 의 달력 팝업에서 **연도별 보기 → 연도 내 달 선택**이 편했으면 좋겠고,
**"오늘로 가는 버튼"** 이 적절한 위치에 있으면 좋겠다. (사용자, 2026-08-10)

## 결손 지점

`CalendarDatePicker` 는 연도 목록은 열리지만 **월 그리드가 없다** — 연도를 골라도 그 연도의
*같은 달* 일 그리드로 돌아오고, 원하는 달까지 좌우로 넘겨야 한다. "오늘" 버튼은 네비게이터·팝업
어디에도 없었다.

## 변경

- **`core/widgets/month_year_picker_dialog.dart` 신설** — 연도 ↔ 월 ↔ 일 3단 드릴다운.
  `MonthPickerResult.day` 가 null 이면 "월까지만 골랐다" 는 신호다. `DateTime` 하나로 뭉갰다면
  1일 선택과 구별되지 않아 거래 목록이 매번 스크롤했을 것이다.
- **기존 `showCalendarPickerDialog` 는 무변경** — 호출부 18곳 중 **17곳이 "날짜 입력"이 본질**
  (거래·이체·보험·지출계획·카드정산 폼, 기간 필터 5곳, 포켓 시트 2곳). 월 우선으로 바꾸면 퇴보한다.
- **진입 단계** — 거래 목록(`onDatePicked` 사용)은 기존대로 일 달력, 나머지 8곳은 월 그리드.
  어느 쪽도 탭 수 퇴보가 없다.
- **"오늘" 버튼** — `>` 오른쪽. 이번 달이면 비활성. `Icons.today` 는 이미 쓰이던 아이콘이라
  **새 코드포인트가 없다**(폰트 subset 변화 없음). 기존 월 변경 경로를 그대로 타므로
  `MonthSyncHandler` 가 그대로 처리한다.

## 구조적 수정 (하네스 `navigation_state` — 4회 재발, STRUCTURAL_FIX_REQUIRED)

- **S1 자체 월 헤더 금지** — `Icons.chevron_left` + `changeMonth(` 를 동시에 가진 파일은
  `month_navigator.dart` 하나여야 한다. 홈 `dashboard_page` 는 **미라우팅인 동안만 예외**이고,
  `/home` 이 redirect 가 아니게 되면 테스트가 깨져 `MonthNavigator` 이행을 강제한다.
- **S2 월 피커 단일 소스** — `showMonthYearPickerDialog` 직접 호출은 `month_navigator.dart` 만.
- **S3 도달성 고정** — 렌더되는 호스트 **9곳**을 목록으로 박고 라우터 등록까지 검사
  (2026-08-10 "죽은 화면에 배포" 인시던트 직결).
- **S4 `MonthNavigator` 위젯 테스트 신설** — 그동안 0건이라 회귀 감지가 없었다.

### 측정으로 바로잡은 것

기존 기획서의 "사용처 13개 페이지" 는 틀렸다. `statistics_page:68` 과
`budget_list_page:269/566` 은 `if (showMonthNavigator …)` 안에 있고 유일한 사용처인
`analysis_page` 가 `false` 로 넘긴다 → **화면에 나오지 않는 죽은 분기**. 실제 호스트는 9곳이다.

## 게이트

- `flutter analyze --no-fatal-infos --no-congratulate` — 신규 지적 0 (기존 info 3건만)
- `flutter test` — **924** (기존 894 + 신규 30)
- `./gradlew test` — BUILD SUCCESSFUL (BE 무변경)
- `flutter build web --release` — ✅
- **번들 문자열 확인** — `이번 달로` 1 · `월 선택으로` 1 · `연도 선택` 2 · `월 선택` 2 ·
  `날짜 선택` 2. 신규 UI 가 트리셰이킹되지 않았다.
  (⚠ dart2js 는 한글을 **소문자** hex 로 이스케이프한다 — 대문자로만 grep 하면 0건 오탐)

## 배포 후 사용자 검증

- A1. 분석·자산·이체 등에서 `2026년 8월` 을 누르면 **월 그리드**가 먼저 뜬다
- A2. 헤더 `2026년` → 연도 그리드 → 연도 → 12개월 → 달 선택
- A3. 2024년 3월처럼 먼 달도 좌우 스와이프 없이 도달
- A4. **거래 탭**은 기존처럼 일 달력이 먼저, `월 선택으로` 로 올라간다
- B1/B2. `>` 오른쪽 **오늘** 버튼으로 이번 달 복귀 / 이미 이번 달이면 비활성
- C1. 거래 목록에서 일을 고르면 그 날짜로 스크롤되는 기존 동작 유지
- C2. 어느 화면에서 달을 바꾸든 다른 탭도 따라온다

정본: `docs/sessions/2026-08-10_3_month-navigator_plan.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)