### PR TITLE
fix(ledger): 합계와 행이 같은 집합을 세도록 이체 판정을 서버 단일 지점으로 통합

### DIFF
--- a/backend/src/main/kotlin/com/budgetbook/common/filter/LedgerFilterAxis.kt
+++ b/backend/src/main/kotlin/com/budgetbook/common/filter/LedgerFilterAxis.kt
@@ -1,0 +1,63 @@
+package com.budgetbook.common.filter
+
+/**
+ * 장부 필터(`CommonFilterParams`)의 **축 1개 = enum 1개** 대응.
+ *
+ * ## 왜 이 enum 이 있는가 (2026-08-12, filter_propagation 4회 재발 후 구조적 봉인)
+ *
+ * 장부 목록은 거래(`transactions`)와 이체(`transfers`) 두 테이블을 합쳐 보여준다.
+ * 필터 축이 추가될 때마다 **한쪽 스트림에서만 축이 누락**되는 사고가 반복됐다:
+ *  - 이체에 `needsReviewOnly` / 카테고리 / 포켓 / 금액이 미적용
+ *  - 결제수단은 복수 선택인데 첫 1개만 적용
+ *  - 합계는 이체를 빼는데 목록에는 이체가 남음 ("합계 ≠ 행")
+ *
+ * 그래서 축을 enum 으로 열거하고 [com.budgetbook.transfer.service.TransferGating.handling] 이
+ * `when` 을 **exhaustive** 로 처리한다. 축을 추가하면 그 `when` 이 **컴파일 실패**하므로
+ * "이체에서 이 축을 어떻게 다루는지" 를 선언하지 않고는 빌드가 되지 않는다.
+ *
+ * [propertyName] 은 `CommonFilterParams` 의 프로퍼티명과 1:1 이어야 하며,
+ * `LedgerFilterAxisGuardTest` 가 리플렉션으로 그 대응을 고정한다.
+ */
+enum class LedgerFilterAxis(val propertyName: String) {
+    DATE_FROM("dateFrom"),
+    DATE_TO("dateTo"),
+    YEAR("year"),
+    MONTH("month"),
+    CATEGORY_ID("categoryId"),
+    PAYMENT_METHOD_ID("paymentMethodId"),
+    POCKET_ID("pocketId"),
+    CATEGORY_IDS("categoryIds"),
+    CATEGORY_GROUP_IDS("categoryGroupIds"),
+    PAYMENT_METHOD_IDS("paymentMethodIds"),
+    POCKET_IDS("pocketIds"),
+    AMOUNT_MIN("amountMin"),
+    AMOUNT_MAX("amountMax"),
+    KEYWORD("keyword"),
+    VISIBILITY("visibility"),
+    TYPE("type"),
+    TRANSACTION_TYPES("transactionTypes"),
+    STATUS("status"),
+    NEEDS_REVIEW_ONLY("needsReviewOnly"),
+    RECONCILED("reconciled"),
+}
+
+/**
+ * 각 축을 **이체 스트림**에서 어떻게 다루는지의 분류.
+ *
+ * 이체(`Transfer`)에는 카테고리 / 포켓 / needsReview / visibility 필드가 없다.
+ * 그런 축이 켜지면 이체는 논리적으로 매칭 불가이므로 전량 제외가 정답이다
+ * (과거에는 필터를 무시하고 그대로 노출해서 "거래는 맞는데 이체만 남는" 비대칭을 만들었다).
+ */
+enum class TransferAxisHandling {
+    /** 이체에도 그대로 적용된다 (기간·결제수단·금액·검색어·정산 여부). */
+    APPLIES,
+
+    /** 이체에 없는 축 → 활성 시 이체를 **전량 제외**한다. */
+    EXCLUDES_WHOLESALE,
+
+    /** 집계·조회 **범위**를 결정하는 축. 거래·이체·합계가 같은 범위를 본다. */
+    RANGE,
+
+    /** 장부 게이팅과 무관한 축 (다른 화면 전용). */
+    IRRELEVANT,
+}

--- a/backend/src/main/kotlin/com/budgetbook/common/filter/LedgerTypeSelection.kt
+++ b/backend/src/main/kotlin/com/budgetbook/common/filter/LedgerTypeSelection.kt
@@ -1,0 +1,75 @@
+package com.budgetbook.common.filter
+
+import com.budgetbook.common.exception.BusinessException
+import com.budgetbook.transaction.domain.TransactionType
+
+/**
+ * `transactionTypes` 파싱의 **단일 진입점**.
+ *
+ * ## `TRANSFER` 는 이제 계약 값이다 (2026-08-12)
+ *
+ * 장부의 타입 칩은 지출 / 수입 / **이체** 3종이다. 그런데 `TRANSFER` 는 `TransactionType`
+ * 이 아니어서, 예전에는 FE 가 전송 직전에 `TRANSFER` 를 **잘라내고** 보냈다. 그 결과:
+ *  - 서버는 "타입 필터 없음" 으로 해석해 거래 전체를 세고,
+ *  - FE 가 클라이언트에서 다시 타입 게이팅을 했다 → 판정이 두 곳 = drift 원인.
+ *
+ * 이제 FE 는 `TRANSFER` 를 **그대로 보내고**, 서버가 두 스트림 모두를 판정한다.
+ *  - 거래: [transactionTypes] 로 필터. 선택에 거래 타입이 하나도 없으면 [matchesNoTransaction]
+ *    = true → 거래는 **0건**이어야 한다("이체만 보기").
+ *  - 이체: [includesTransfer] 가 false 면 이체를 전량 제외
+ *    ([com.budgetbook.transfer.service.TransferGating]).
+ *
+ * 유효하지 않은 값(예: `FOO`)은 여전히 `VALIDATION_ERROR` 다.
+ */
+data class LedgerTypeSelection(
+    /** 선택된 거래 타입. 빈 Set 이고 [hasSelection] 이면 "거래 없음" 을 뜻한다. */
+    val transactionTypes: Set<TransactionType>,
+    /** 선택에 `TRANSFER` 가 포함됐는지. */
+    val includesTransfer: Boolean,
+    /** 타입 필터가 하나라도 켜져 있는지. false = 전체(필터 없음). */
+    val hasSelection: Boolean,
+) {
+    /** 타입 필터는 켜졌지만 거래 타입이 하나도 없다 → 거래는 0건이 정답. */
+    val matchesNoTransaction: Boolean
+        get() = hasSelection && transactionTypes.isEmpty()
+
+    /** 이체를 노출해야 하는지. 필터 없음 = 전체 노출. */
+    val includesTransfers: Boolean
+        get() = !hasSelection || includesTransfer
+
+    companion object {
+        /** FE 의사-타입. `TransactionType` 에는 없고 이체 스트림을 가리킨다. */
+        const val TRANSFER = "TRANSFER"
+
+        fun parse(rawTypes: List<String>?): LedgerTypeSelection {
+            val raw = rawTypes?.filter { it.isNotBlank() }?.map { it.trim().uppercase() } ?: emptyList()
+            if (raw.isEmpty()) {
+                return LedgerTypeSelection(
+                    transactionTypes = emptySet(),
+                    includesTransfer = false,
+                    hasSelection = false,
+                )
+            }
+            val txTypes = mutableSetOf<TransactionType>()
+            var transfer = false
+            for (value in raw) {
+                if (value == TRANSFER) {
+                    transfer = true
+                    continue
+                }
+                txTypes.add(
+                    try {
+                        TransactionType.valueOf(value)
+                    } catch (e: IllegalArgumentException) {
+                        throw BusinessException("VALIDATION_ERROR", "Invalid transaction type: $value")
+                    }
+                )
+            }
+            return LedgerTypeSelection(
+                transactionTypes = txTypes,
+                includesTransfer = transfer,
+                hasSelection = true,
+            )
+        }
+    }
+}

--- a/backend/src/main/kotlin/com/budgetbook/statistics/controller/StatisticsController.kt
+++ b/backend/src/main/kotlin/com/budgetbook/statistics/controller/StatisticsController.kt
@@ -37,25 +37,9 @@ class StatisticsController(
         @RequestParam @Min(1) @Max(12) month: Int,
         @ModelAttribute filter: CommonFilterParams
     ): ApiResponse<StatisticsSummaryResponse> {
-        // 회차 8 — 모든 필터 전달 (FE client-side fold 제거 / 합계 정확성)
-        return ApiResponse.ok(statisticsService.getMonthlySummary(
-            userId = userId, year = year, month = month,
-            visibility = filter.visibility ?: "ALL",
-            dateFrom = filter.dateFrom, dateTo = filter.dateTo,
-            categoryId = filter.categoryId,
-            paymentMethodId = filter.paymentMethodId,
-            pocketId = filter.pocketId,
-            categoryIds = filter.categoryIds,
-            categoryGroupIds = filter.categoryGroupIds,
-            paymentMethodIds = filter.paymentMethodIds,
-            pocketIds = filter.pocketIds,
-            amountMin = filter.amountMin,
-            amountMax = filter.amountMax,
-            keyword = filter.keyword,
-            transactionTypes = filter.transactionTypes ?: emptyList(),
-            // 2026-07-27 — 목록과 동일 필터로 합계 계산 (합계 ≠ 행 불일치 fix).
-            needsReviewOnly = filter.needsReviewOnly
-        ))
+        // 2026-08-12 — 필터는 VO 를 **통째로** 넘긴다.
+        // 필드를 하나씩 나열하면 새 축이 추가될 때 조용히 누락된다(4회 재발 원인).
+        return ApiResponse.ok(statisticsService.getMonthlySummary(userId, year, month, filter))
     }
 
     @GetMapping("/by-category")
@@ -106,19 +90,7 @@ class StatisticsController(
         @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) dateTo: LocalDate,
         @ModelAttribute filter: CommonFilterParams
     ): ApiResponse<PeriodSummaryResponse> {
-        return ApiResponse.ok(statisticsService.getPeriodSummary(
-            userId = userId,
-            dateFrom = dateFrom,
-            dateTo = dateTo,
-            visibility = filter.visibility ?: "ALL",
-            categoryId = filter.categoryId,
-            paymentMethodId = filter.paymentMethodId,
-            pocketId = filter.pocketId,
-            // PR-C2 다중/그룹 필터 전달 (하위 Service 에서 합집합으로 처리)
-            categoryIds = filter.categoryIds,
-            categoryGroupIds = filter.categoryGroupIds,
-            paymentMethodIds = filter.paymentMethodIds,
-            pocketIds = filter.pocketIds
-        ))
+        // 필터 VO 통째로 전달 (getMonthlySummary 와 동일 규칙).
+        return ApiResponse.ok(statisticsService.getPeriodSummary(userId, dateFrom, dateTo, filter))
     }
 }

--- a/backend/src/main/kotlin/com/budgetbook/statistics/dto/StatisticsDtos.kt
+++ b/backend/src/main/kotlin/com/budgetbook/statistics/dto/StatisticsDtos.kt
@@ -12,7 +12,15 @@ data class StatisticsSummaryResponse(
      */
     val totalTransfer: Long,
     val balance: Long,
-    val transactionCount: Int
+    val transactionCount: Int,
+    /**
+     * 2026-08-12 신규 — 이 합계에 **집계된 이체 건수** (`CARD_SETTLEMENT` 제외).
+     *
+     * 합계와 목록이 같은 집합을 세는지 대조하기 위한 관측 값이다.
+     * 합계는 서버가 전 범위를 세고 목록은 페이지 단위로 오므로, 클라이언트는 로드가
+     * 끝난 뒤에만 이 값과 행 수를 비교해야 한다.
+     */
+    val transferCount: Int = 0
 )
 
 data class CategoryStatisticsResponse(

--- a/backend/src/main/kotlin/com/budgetbook/statistics/service/ExpenseCalculator.kt
+++ b/backend/src/main/kotlin/com/budgetbook/statistics/service/ExpenseCalculator.kt
@@ -1,12 +1,35 @@
 package com.budgetbook.statistics.service
 
+import com.budgetbook.common.dto.CommonFilterParams
 import com.budgetbook.transaction.domain.TransactionType
 import com.budgetbook.transaction.repository.TransactionRepository
+import com.budgetbook.transfer.domain.Transfer
+import com.budgetbook.transfer.domain.TransferKind
 import com.budgetbook.transfer.domain.TransferKinds
 import com.budgetbook.transfer.repository.TransferRepository
+import com.budgetbook.transfer.service.TransferGating
 import org.springframework.stereotype.Component
 import java.time.LocalDate
 import java.util.UUID
+
+/**
+ * 이체 집계 결과의 kind 별 버킷.
+ *
+ * - [income] : `INCOME_TRANSFER` 합 (수입 총액에 더한다)
+ * - [expense]: `EXPENSE_TRANSFER` 합 (지출 총액에 더한다)
+ * - [generic]: `GENERIC` 합 (합계바의 "이체" 칸 전용, 수입/지출과 disjoint)
+ * - [count]  : 집계에 포함된 이체 건수 (`CARD_SETTLEMENT` 제외)
+ */
+data class TransferBuckets(
+    val income: Long,
+    val expense: Long,
+    val generic: Long,
+    val count: Int,
+) {
+    companion object {
+        val EMPTY = TransferBuckets(income = 0L, expense = 0L, generic = 0L, count = 0)
+    }
+}
 
 /**
  * Phase 22 S1 — 통계 집계의 단일 진입점.
@@ -82,6 +105,67 @@ class ExpenseCalculator(
             .sumAmountBySourceByKind(coupleId, from, to, TransferKinds.TRANSFER_ONLY)
             .sumOf { it[1] as Long }
     }
+
+    /**
+     * 장부 필터를 적용한 이체 집계.
+     *
+     * ## 왜 여기 있는가 (2026-08-12)
+     *
+     * 예전에는 통계 서비스가 "필터가 하나라도 켜지면 이체를 전량 제외"(`totalTransfer = 0`)
+     * 했다. 그런데 목록에는 이체 행이 남아서 합계와 행이 다른 집합을 셌다.
+     * 이제 **이체 목록 조회와 같은 판정**([TransferGating])으로 집계한다 —
+     * `TransferService.listTransfers` 와 이 함수가 같은 spec 을 쓰므로 한쪽만 어긋날 수 없다.
+     *
+     * 주의: `filter.reconciled` 는 여기서 적용하지 않는다(스냅샷 테이블 조회가 필요).
+     * 장부 합계바의 필터 VO 에는 정산 축이 없어 현재 도달하지 않는 경로다 —
+     * 정산 필터를 합계에 쓰려면 `ReconciliationLookup` 을 함께 주입해야 한다.
+     */
+    fun transferBuckets(
+        coupleId: UUID,
+        from: LocalDate,
+        to: LocalDate,
+        filter: CommonFilterParams,
+    ): TransferBuckets {
+        if (TransferGating.excludedWholesale(filter)) return TransferBuckets.EMPTY
+        val transfers = transferRepository.findAll(TransferGating.spec(coupleId, filter, from, to))
+        return bucketsOf(transfers)
+    }
+
+    /**
+     * kind 별 버킷 분류. 집계식은 클래스 KDoc 과 동일하며 FE `LedgerSummary` 규칙과 일치한다.
+     * `CARD_SETTLEMENT` 는 모든 버킷에서 제외된다(원본 EXPENSE 로 이미 집계됨).
+     */
+    fun bucketsOf(transfers: List<Transfer>): TransferBuckets {
+        var income = 0L
+        var expense = 0L
+        var generic = 0L
+        var counted = 0
+        for (transfer in transfers) {
+            when (transfer.kind) {
+                TransferKind.CARD_SETTLEMENT -> continue
+                TransferKind.EXPENSE_TRANSFER -> expense += transfer.amount
+                TransferKind.INCOME_TRANSFER -> income += transfer.amount
+                TransferKind.GENERIC -> generic += transfer.amount
+            }
+            counted++
+        }
+        return TransferBuckets(income = income, expense = expense, generic = generic, count = counted)
+    }
+
+    /**
+     * **거래만** 의 타입별 합계 (이체 미포함).
+     *
+     * 이체를 [transferBuckets] 로 따로 집계하는 호출부는 이 함수를 써야 한다 —
+     * [totalIncome]/[totalExpense] 는 이체를 포함하므로 함께 쓰면 **이중 계산**이 된다.
+     */
+    fun transactionOnlyTotal(
+        coupleId: UUID,
+        from: LocalDate,
+        to: LocalDate,
+        type: TransactionType,
+        userId: UUID,
+        visibility: String = "ALL",
+    ): Long = sumTransactionByType(coupleId, from, to, type, userId, visibility)
 
     // --- 내부 헬퍼 ---
 

--- a/backend/src/main/kotlin/com/budgetbook/statistics/service/StatisticsService.kt
+++ b/backend/src/main/kotlin/com/budgetbook/statistics/service/StatisticsService.kt
@@ -3,7 +3,9 @@ package com.budgetbook.statistics.service
 import com.budgetbook.budget.domain.BudgetPeriod
 import com.budgetbook.budget.repository.MonthlyBudgetRepository
 import com.budgetbook.category.repository.CategoryRepository
+import com.budgetbook.common.dto.CommonFilterParams
 import com.budgetbook.common.exception.BusinessException
+import com.budgetbook.common.filter.LedgerTypeSelection
 import com.budgetbook.couple.service.CoupleResolver
 import com.budgetbook.common.service.CoupleAwareService
 import com.budgetbook.spendingplan.repository.SpendingPlanRepository
@@ -15,6 +17,7 @@ import com.budgetbook.statistics.dto.MonthlyTrendResponse
 import com.budgetbook.statistics.dto.PaymentMethodSpending
 import com.budgetbook.statistics.dto.PeriodSummaryResponse
 import com.budgetbook.statistics.dto.StatisticsSummaryResponse
+import com.budgetbook.transaction.domain.Transaction
 import com.budgetbook.transaction.domain.TransactionType
 import com.budgetbook.transaction.dto.CategorySummary
 import com.budgetbook.transaction.repository.TransactionRepository
@@ -49,130 +52,139 @@ class StatisticsService(
     }
 
     @Transactional(readOnly = true)
+    /**
+     * 장부 합계바가 쓰는 월/기간 합계.
+     *
+     * ## 2026-08-12 — `hasContentFilters` 분기를 **제거**했다
+     *
+     * 이전에는 두 갈래였다:
+     *  - 필터 없음 → `ExpenseCalculator` (이체 **포함**)
+     *  - 필터 있음 → 거래만 집계 + `totalTransfer = 0` (이체 **제외**)
+     *
+     * 같은 화면의 합계가 필터 유무에 따라 다른 규칙을 쓴 것이 "합계 ≠ 행" 의 원인이었다.
+     * 이제 경로가 하나다 — 거래는 spec, 이체는 [ExpenseCalculator.transferBuckets]
+     * (= 이체 목록 조회와 **동일한** `TransferGating` 판정).
+     * 분기가 없으므로 한쪽만 규칙을 어기는 재발이 구조적으로 불가능하다.
+     *
+     * 필터는 VO 하나로 받는다 — 필드 수동 나열은 누락 4회 재발의 원인이었다.
+     */
     fun getMonthlySummary(
         userId: UUID,
         year: Int,
         month: Int,
-        visibility: String = "ALL",
-        dateFrom: LocalDate? = null,
-        dateTo: LocalDate? = null,
-        // 회차 8 — 모든 필터 지원 (period-summary 패턴 차용). client-side fold 부정확 회귀 fix.
-        categoryId: UUID? = null,
-        paymentMethodId: UUID? = null,
-        pocketId: UUID? = null,
-        categoryIds: List<UUID> = emptyList(),
-        categoryGroupIds: List<UUID> = emptyList(),
-        paymentMethodIds: List<UUID> = emptyList(),
-        pocketIds: List<UUID> = emptyList(),
-        amountMin: Long? = null,
-        amountMax: Long? = null,
-        keyword: String? = null,
-        transactionTypes: List<String> = emptyList(),
-        // 2026-07-27 — 거래 목록에만 적용되고 summary 에는 누락돼 있던 필터.
-        // 목록은 needs_review 만 보여주는데 합계는 전체였다 → "합계 ≠ 보이는 행".
-        needsReviewOnly: Boolean? = null
+        filter: CommonFilterParams = CommonFilterParams()
     ): StatisticsSummaryResponse {
         val couple = getActiveCouple(userId)
-        val visFilter = validateVisibility(visibility)
+        val visFilter = validateVisibility(filter.visibility ?: "ALL")
         val yearMonth = YearMonth.of(year, month)
-        val startDate = dateFrom ?: yearMonth.atDay(1)
-        val endDate = dateTo ?: yearMonth.atEndOfMonth()
+        // dateFrom/dateTo 가 있으면 월을 덮어쓴다 — 거래 목록·이체 목록과 같은 범위 규칙.
+        val startDate = filter.dateFrom ?: yearMonth.atDay(1)
+        val endDate = filter.dateTo ?: yearMonth.atEndOfMonth()
 
-        // PR-C2 + 회차 8: 단수+복수 병합, 그룹 펼치기
-        val effectiveCategoryIds = categoryIds.toMutableSet().also { set ->
-            categoryId?.let { set.add(it) }
-            if (categoryGroupIds.isNotEmpty()) {
-                set.addAll(categoryRepository.findByGroupIdIn(categoryGroupIds).map { it.id })
-            }
-        }
-        val effectivePaymentMethodIds = paymentMethodIds.toMutableSet().also { set ->
-            paymentMethodId?.let { set.add(it) }
-        }
-        val effectivePocketIds = pocketIds.toMutableSet().also { set ->
-            pocketId?.let { set.add(it) }
-        }
-        val effectiveTypes = transactionTypes.mapNotNull {
-            try { TransactionType.valueOf(it) } catch (_: IllegalArgumentException) { null }
-        }.toSet()
+        val scope = resolveTransactionScope(couple.id, userId, visFilter, filter, startDate, endDate)
+        val buckets = expenseCalculator.transferBuckets(couple.id, startDate, endDate, filter)
 
-        val hasContentFilters = effectiveCategoryIds.isNotEmpty() ||
-            effectivePaymentMethodIds.isNotEmpty() ||
-            effectivePocketIds.isNotEmpty() ||
-            amountMin != null ||
-            amountMax != null ||
-            !keyword.isNullOrBlank() ||
-            effectiveTypes.isNotEmpty() ||
-            needsReviewOnly == true
-
-        val totalIncome: Long
-        val totalExpense: Long
-        val totalTransfer: Long
-        val transactionCount: Int
-
-        if (hasContentFilters) {
-            // 회차 8 — 모든 필터 지원: Specifications-based query 로 정확한 합계 계산.
-            val incomeSpec = TransactionSpecifications.withFilters(
-                coupleId = couple.id, startDate = startDate, endDate = endDate,
-                type = TransactionType.INCOME, categoryId = null, keyword = keyword,
-                paymentMethodId = null, pocketId = null,
-                amountMin = amountMin, amountMax = amountMax, userId = userId,
-                visibility = visFilter,
-                categoryIds = effectiveCategoryIds,
-                paymentMethodIds = effectivePaymentMethodIds,
-                pocketIds = effectivePocketIds,
-                needsReviewOnly = needsReviewOnly
-            )
-            val expenseSpec = TransactionSpecifications.withFilters(
-                coupleId = couple.id, startDate = startDate, endDate = endDate,
-                type = TransactionType.EXPENSE, categoryId = null, keyword = keyword,
-                paymentMethodId = null, pocketId = null,
-                amountMin = amountMin, amountMax = amountMax, userId = userId,
-                visibility = visFilter,
-                categoryIds = effectiveCategoryIds,
-                paymentMethodIds = effectivePaymentMethodIds,
-                pocketIds = effectivePocketIds,
-                needsReviewOnly = needsReviewOnly
-            )
-
-            val incomeTransactions = transactionRepository.findAll(incomeSpec)
-            val expenseTransactions = transactionRepository.findAll(expenseSpec)
-
-            // transactionTypes 필터 — INCOME/EXPENSE 만 받음 (TRANSFER 는 별도, ADJUSTMENT 통계 제외)
-            val includeIncome = effectiveTypes.isEmpty() || effectiveTypes.contains(TransactionType.INCOME)
-            val includeExpense = effectiveTypes.isEmpty() || effectiveTypes.contains(TransactionType.EXPENSE)
-
-            totalIncome = if (includeIncome) incomeTransactions.sumOf { it.amount } else 0L
-            totalExpense = if (includeExpense) expenseTransactions.sumOf { it.amount } else 0L
-            // Transfer 는 카테고리/결제수단/포켓 없으므로 필터 활성 시 제외
-            totalTransfer = 0L
-            transactionCount = (if (includeIncome) incomeTransactions.size else 0) +
-                (if (includeExpense) expenseTransactions.size else 0)
-        } else {
-            // No content filters: ExpenseCalculator 일원화 (Phase 22 S1).
-            val results = transactionRepository.sumByTypeForCouple(couple.id, startDate, endDate, userId, visFilter)
-            var count = 0
-            for (row in results) {
-                val type = row[0] as TransactionType
-                val rowCount = (row[2] as Long).toInt()
-                if (type == TransactionType.INCOME || type == TransactionType.EXPENSE) {
-                    count += rowCount
-                }
-            }
-            transactionCount = count
-            totalIncome = expenseCalculator.totalIncome(couple.id, startDate, endDate, userId, visFilter)
-            totalExpense = expenseCalculator.totalExpense(couple.id, startDate, endDate, userId, visFilter)
-            totalTransfer = expenseCalculator.totalTransfer(couple.id, startDate, endDate)
-        }
+        val totalIncome = scope.incomeTotal + buckets.income
+        val totalExpense = scope.expenseTotal + buckets.expense
 
         return StatisticsSummaryResponse(
             yearMonth = yearMonth.toString(),
             totalIncome = totalIncome,
             totalExpense = totalExpense,
-            totalTransfer = totalTransfer,
+            totalTransfer = buckets.generic,
             balance = totalIncome - totalExpense,
-            transactionCount = transactionCount
+            transactionCount = scope.transactionCount,
+            transferCount = buckets.count
         )
     }
+
+    /**
+     * 거래 쪽 집계 — 타입 선택([LedgerTypeSelection])을 반영한 spec 조회.
+     *
+     * `ADJUSTMENT` 는 통계 범주 밖이므로 INCOME/EXPENSE 만 조회한다(잔액 전용).
+     * 타입 필터가 켜졌는데 거래 타입이 하나도 없으면("이체만 보기") 거래는 0건이 정답이다.
+     */
+    private fun resolveTransactionScope(
+        coupleId: UUID,
+        userId: UUID,
+        visFilter: String?,
+        filter: CommonFilterParams,
+        startDate: LocalDate,
+        endDate: LocalDate,
+    ): TransactionScope {
+        val effectiveCategoryIds = filter.categoryIds.toMutableSet().also { set ->
+            filter.categoryId?.let { set.add(it) }
+            if (filter.categoryGroupIds.isNotEmpty()) {
+                set.addAll(categoryRepository.findByGroupIdIn(filter.categoryGroupIds).map { it.id })
+            }
+        }
+        val effectivePaymentMethodIds = filter.paymentMethodIds.toMutableSet().also { set ->
+            filter.paymentMethodId?.let { set.add(it) }
+        }
+        val effectivePocketIds = filter.pocketIds.toMutableSet().also { set ->
+            filter.pocketId?.let { set.add(it) }
+        }
+
+        val selection = LedgerTypeSelection.parse(filter.transactionTypes)
+        // 단수 `type` 은 `transactionTypes` 가 비어 있을 때만 의미가 있다(FE toQueryParams 우선순위와 일치).
+        val singularType = if (!selection.hasSelection) {
+            filter.type?.let {
+                try { TransactionType.valueOf(it) } catch (_: IllegalArgumentException) {
+                    throw BusinessException("VALIDATION_ERROR", "Invalid transaction type: ${filter.type}")
+                }
+            }
+        } else null
+
+        val selectedTypes: Set<TransactionType> = when {
+            selection.hasSelection -> selection.transactionTypes
+            singularType != null -> setOf(singularType)
+            else -> emptySet()
+        }
+        // ADJUSTMENT 는 통계 범주 밖이다(잔액 전용) → 집계 대상은 INCOME/EXPENSE 뿐.
+        val statisticalTypes = setOf(TransactionType.INCOME, TransactionType.EXPENSE)
+        // 주의: "타입 필터 없음"(전체)과 "타입 필터가 거래를 하나도 고르지 않음"(이체만 보기)은
+        // 다르다. 후자를 전체로 착각하면 이체만 보기에서 거래 합계가 그대로 남는다.
+        val hasTypeFilter = selection.hasSelection || singularType != null
+        val queryTypes =
+            if (!hasTypeFilter) statisticalTypes else selectedTypes intersect statisticalTypes
+
+        // "이체만 보기" — 집계 대상 거래 타입이 하나도 없으면 조회 자체를 생략한다.
+        if (queryTypes.isEmpty()) return TransactionScope(0L, 0L, 0)
+
+        // 한 번의 조회로 가져와 타입별로 접는다 (타입마다 쿼리하면 왕복이 2배).
+        val transactions = transactionRepository.findAll(
+            TransactionSpecifications.withFilters(
+                coupleId = coupleId, startDate = startDate, endDate = endDate,
+                type = null, categoryId = null, keyword = filter.keyword,
+                paymentMethodId = null, pocketId = null,
+                amountMin = filter.amountMin, amountMax = filter.amountMax, userId = userId,
+                visibility = visFilter,
+                categoryIds = effectiveCategoryIds,
+                paymentMethodIds = effectivePaymentMethodIds,
+                pocketIds = effectivePocketIds,
+                types = queryTypes,
+                needsReviewOnly = filter.needsReviewOnly
+            )
+        )
+
+        return TransactionScope(
+            incomeTotal = transactions.filter { it.type == TransactionType.INCOME }.sumOf { it.amount },
+            expenseTotal = transactions.filter { it.type == TransactionType.EXPENSE }.sumOf { it.amount },
+            transactionCount = transactions.size,
+            transactions = transactions,
+        )
+    }
+
+    /**
+     * 거래 집계 결과. [transactions] 를 함께 들고 있어 카테고리 분해 같은 파생 계산이
+     * **같은 행 집합**을 쓰도록 한다(다시 조회하면 두 값이 어긋날 수 있다).
+     */
+    private data class TransactionScope(
+        val incomeTotal: Long,
+        val expenseTotal: Long,
+        val transactionCount: Int,
+        val transactions: List<Transaction> = emptyList(),
+    )
 
     @Transactional(readOnly = true)
     fun getCategoryBreakdown(userId: UUID, year: Int, month: Int, type: String?, visibility: String = "ALL", dateFrom: LocalDate? = null, dateTo: LocalDate? = null): List<CategoryStatisticsResponse> {
@@ -338,72 +350,43 @@ class StatisticsService(
         userId: UUID,
         dateFrom: LocalDate,
         dateTo: LocalDate,
-        visibility: String = "ALL",
-        categoryId: UUID? = null,
-        paymentMethodId: UUID? = null,
-        pocketId: UUID? = null,
-        // PR-C2 다중/그룹 필터. 단수 필드와 합쳐 Set 으로 전달됨.
-        categoryIds: List<UUID> = emptyList(),
-        categoryGroupIds: List<UUID> = emptyList(),
-        paymentMethodIds: List<UUID> = emptyList(),
-        pocketIds: List<UUID> = emptyList()
+        filter: CommonFilterParams = CommonFilterParams()
     ): PeriodSummaryResponse {
         val couple = getActiveCouple(userId)
-        val visFilter = validateVisibility(visibility)
+        val visFilter = validateVisibility(filter.visibility ?: "ALL")
 
         // PR-C2: 단수 + 복수 병합, 그룹 펼치기
-        val effectiveCategoryIds = categoryIds.toMutableSet().also { set ->
-            categoryId?.let { set.add(it) }
-            if (categoryGroupIds.isNotEmpty()) {
-                set.addAll(categoryRepository.findByGroupIdIn(categoryGroupIds).map { it.id })
+        val effectiveCategoryIds = filter.categoryIds.toMutableSet().also { set ->
+            filter.categoryId?.let { set.add(it) }
+            if (filter.categoryGroupIds.isNotEmpty()) {
+                set.addAll(categoryRepository.findByGroupIdIn(filter.categoryGroupIds).map { it.id })
             }
         }
-        val effectivePaymentMethodIds = paymentMethodIds.toMutableSet().also { set ->
-            paymentMethodId?.let { set.add(it) }
+        val effectivePaymentMethodIds = filter.paymentMethodIds.toMutableSet().also { set ->
+            filter.paymentMethodId?.let { set.add(it) }
         }
-        val effectivePocketIds = pocketIds.toMutableSet().also { set ->
-            pocketId?.let { set.add(it) }
+        val effectivePocketIds = filter.pocketIds.toMutableSet().also { set ->
+            filter.pocketId?.let { set.add(it) }
         }
         val hasFilters = effectiveCategoryIds.isNotEmpty() ||
             effectivePaymentMethodIds.isNotEmpty() ||
             effectivePocketIds.isNotEmpty()
 
-        var totalIncome: Long
-        var totalExpense: Long
-        var totalTransfer = 0L
+        // 2026-08-12 — 이체는 필터 유무와 무관하게 **같은 판정**으로 집계한다.
+        // (이전: 필터가 켜지면 totalTransfer = 0 → 합계가 목록과 다른 집합을 셌다)
+        val transferBuckets = expenseCalculator.transferBuckets(couple.id, dateFrom, dateTo, filter)
+
+        // 거래 집계는 getMonthlySummary 와 **같은 헬퍼**를 쓴다 — 두 엔드포인트가 다른 기전을
+        // 쓰면 같은 기간의 수치가 갈라진다(회귀 가드: "consistency between ..." 테스트).
+        val scope = resolveTransactionScope(couple.id, userId, visFilter, filter, dateFrom, dateTo)
+        var totalIncome: Long = scope.incomeTotal
+        var totalExpense: Long = scope.expenseTotal
         val byCategory: List<CategorySpending>
 
         if (hasFilters) {
-            // Use Specifications-based query when filters are applied
-            val incomeSpec = TransactionSpecifications.withFilters(
-                coupleId = couple.id, startDate = dateFrom, endDate = dateTo,
-                type = TransactionType.INCOME, categoryId = null, keyword = null,
-                paymentMethodId = null, pocketId = null,
-                amountMin = null, amountMax = null, userId = userId,
-                categoryIds = effectiveCategoryIds,
-                paymentMethodIds = effectivePaymentMethodIds,
-                pocketIds = effectivePocketIds
-            )
-            val expenseSpec = TransactionSpecifications.withFilters(
-                coupleId = couple.id, startDate = dateFrom, endDate = dateTo,
-                type = TransactionType.EXPENSE, categoryId = null, keyword = null,
-                paymentMethodId = null, pocketId = null,
-                amountMin = null, amountMax = null, userId = userId,
-                categoryIds = effectiveCategoryIds,
-                paymentMethodIds = effectivePaymentMethodIds,
-                pocketIds = effectivePocketIds
-            )
-
-            val incomeTransactions = transactionRepository.findAll(incomeSpec)
-            val expenseTransactions = transactionRepository.findAll(expenseSpec)
-
-            totalIncome = incomeTransactions.sumOf { it.amount }
-            totalExpense = expenseTransactions.sumOf { it.amount }
-            // Transfer 는 카테고리/결제수단/포켓 필드가 없으므로 필터 활성 시 집계에서 제외됨.
-            // totalTransfer 도 0 유지.
-
-            // byCategory from filtered expense transactions
-            byCategory = expenseTransactions
+            // byCategory 는 **합계와 같은 행 집합**에서 파생한다(다시 조회하면 어긋날 수 있다).
+            byCategory = scope.transactions
+                .filter { it.type == TransactionType.EXPENSE }
                 .filter { it.category != null }
                 .groupBy { it.category!!.id }
                 .map { (_, txns) ->
@@ -434,11 +417,8 @@ class StatisticsService(
                     }
                 }
         } else {
-            // No filters: ExpenseCalculator 로 일원화 (Phase 22 S1).
-            totalIncome = expenseCalculator.totalIncome(couple.id, dateFrom, dateTo, userId, visFilter)
-            totalExpense = expenseCalculator.totalExpense(couple.id, dateFrom, dateTo, userId, visFilter)
-            totalTransfer = expenseCalculator.totalTransfer(couple.id, dateFrom, dateTo)
-
+            // 합계는 위 scope 가 이미 계산했다. 여기서는 카테고리 분해만 집계 쿼리로 얻는다
+            // (총액을 다시 계산하면 두 값이 갈라진다 — 그것이 이번 회차의 근본 원인이었다).
             val categoryResults = transactionRepository.sumByCategoryForCouple(
                 couple.id, dateFrom, dateTo, TransactionType.EXPENSE, userId, visFilter
             )
@@ -473,6 +453,10 @@ class StatisticsService(
                 }
             }
         }
+
+        // 이체 버킷을 거래 합계에 더한다 — 두 분기 공통(규칙이 갈라지지 않게 여기 한 곳에서).
+        totalIncome += transferBuckets.income
+        totalExpense += transferBuckets.expense
 
         // 3. byBudget — find budgets covering this period
         val yearMonths = generateYearMonths(dateFrom, dateTo)
@@ -597,7 +581,7 @@ class StatisticsService(
             dateTo = dateTo.toString(),
             totalIncome = totalIncome,
             totalExpense = totalExpense,
-            totalTransfer = totalTransfer,
+            totalTransfer = transferBuckets.generic,
             balance = totalIncome - totalExpense,
             byCategory = byCategory,
             byBudget = byBudget,

--- a/backend/src/main/kotlin/com/budgetbook/transaction/service/TransactionService.kt
+++ b/backend/src/main/kotlin/com/budgetbook/transaction/service/TransactionService.kt
@@ -4,6 +4,7 @@ import com.budgetbook.auth.repository.UserRepository
 import com.budgetbook.category.repository.CategoryRepository
 import com.budgetbook.common.entity.Visibility
 import com.budgetbook.common.exception.BusinessException
+import com.budgetbook.common.filter.LedgerTypeSelection
 import com.budgetbook.common.exception.ForbiddenException
 import com.budgetbook.common.exception.NotFoundException
 import com.budgetbook.common.security.OwnershipValidator
@@ -118,17 +119,11 @@ class TransactionService(
             endDate = yearMonth.atEndOfMonth()
         }
 
-        // Phase 22 T10: 다중 타입 우선 파싱.
-        // 각 원소는 EXPENSE/INCOME/ADJUSTMENT 여야 하며, 그 외(예: FE-only TRANSFER) 는 400.
-        val effectiveTransactionTypes: Set<TransactionType> = transactionTypes
-            ?.filter { it.isNotBlank() }
-            ?.map { raw ->
-                try { TransactionType.valueOf(raw) } catch (e: IllegalArgumentException) {
-                    throw BusinessException("VALIDATION_ERROR", "Invalid transaction type: $raw")
-                }
-            }
-            ?.toSet()
-            ?: emptySet()
+        // Phase 22 T10 + 2026-08-12: 타입 파싱은 `LedgerTypeSelection` 단일 진입점.
+        // `TRANSFER` 는 이제 유효한 계약 값이다(이체 스트림 지시자) — 예전처럼 400 이 아니다.
+        // FE 가 전송 직전에 TRANSFER 를 잘라내던 관례를 없애 서버가 두 스트림을 모두 판정한다.
+        val typeSelection = LedgerTypeSelection.parse(transactionTypes)
+        val effectiveTransactionTypes: Set<TransactionType> = typeSelection.transactionTypes
 
         // 단수 `type` 파싱 — `transactionTypes` 가 비어있을 때만 의미 있음.
         val transactionType = type?.let {
@@ -181,6 +176,21 @@ class TransactionService(
             needsReviewOnly == true ||
             // legacy JPQL 경로는 정산 서브쿼리를 모른다 → Spec 경로로 강제.
             reconciled != null
+
+        // "이체만 보기" — 타입 필터가 켜졌는데 거래 타입이 하나도 없으면 거래는 0건이 정답이다.
+        // (예전에는 FE 가 TRANSFER 를 잘라 보내 서버가 "필터 없음" 으로 해석해 거래 전체를
+        //  반환하고, FE 가 클라이언트에서 다시 걸렀다 → 판정 2곳 = "합계 ≠ 행" 의 한 갈래)
+        if (typeSelection.matchesNoTransaction) {
+            return PageResponse(
+                content = emptyList(),
+                page = page,
+                size = pageSize,
+                totalElements = 0,
+                totalPages = 0,
+                first = true,
+                last = true
+            )
+        }
 
         val result = if (hasExtendedFilters) {
             // 단수 categoryId 는 Set 에 이미 합쳐졌으므로 Spec 에는 Set 만 전달 (중복 조건 방지).

--- a/backend/src/main/kotlin/com/budgetbook/transfer/controller/TransferController.kt
+++ b/backend/src/main/kotlin/com/budgetbook/transfer/controller/TransferController.kt
@@ -1,6 +1,7 @@
 package com.budgetbook.transfer.controller
 
 import com.budgetbook.common.dto.ApiResponse
+import com.budgetbook.common.dto.CommonFilterParams
 import com.budgetbook.common.ratelimit.RateLimit
 import com.budgetbook.common.security.AuthUser
 import com.budgetbook.transaction.dto.ConvertToTransactionRequest
@@ -17,6 +18,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.ModelAttribute
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
@@ -93,15 +95,20 @@ class TransferController(
         return ApiResponse.ok(result)
     }
 
+    /**
+     * 이체 목록.
+     *
+     * 2026-08-12 — 장부 필터를 그대로 받는다(`@ModelAttribute CommonFilterParams`).
+     * `year`/`month` 는 계속 동작하고(하위호환), `dateFrom`/`dateTo` 가 있으면 그쪽이 우선한다
+     * — 거래 목록·통계 합계와 **같은 범위 규칙**(`getEffectiveDateRange`).
+     * 축별 판정은 `TransferGating` 단일 지점.
+     */
     @GetMapping
     fun listTransfers(
         @AuthUser userId: UUID,
-        @RequestParam year: Int,
-        @RequestParam month: Int,
-        // V65 — 정산 필터. 거래 목록(`GET /transactions?reconciled=`) 과 동일 의미.
-        @RequestParam(required = false) reconciled: Boolean? = null
+        @ModelAttribute filter: CommonFilterParams
     ): ApiResponse<List<TransferResponse>> {
-        return ApiResponse.ok(transferService.listTransfers(userId, year, month, reconciled))
+        return ApiResponse.ok(transferService.listTransfers(userId, filter))
     }
 
     @GetMapping("/{id}")

--- a/backend/src/main/kotlin/com/budgetbook/transfer/repository/TransferRepository.kt
+++ b/backend/src/main/kotlin/com/budgetbook/transfer/repository/TransferRepository.kt
@@ -3,12 +3,17 @@ package com.budgetbook.transfer.repository
 import com.budgetbook.transfer.domain.Transfer
 import com.budgetbook.transfer.domain.TransferKind
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import java.time.LocalDate
 import java.util.UUID
 
-interface TransferRepository : JpaRepository<Transfer, UUID> {
+/**
+ * `JpaSpecificationExecutor` — 2026-08-12. 장부 필터를 이체에도 적용하기 위해 추가.
+ * 조건 조립은 반드시 `TransferGating.spec()` 을 거친다(목록·집계 단일 판정).
+ */
+interface TransferRepository : JpaRepository<Transfer, UUID>, JpaSpecificationExecutor<Transfer> {
 
     fun findByCoupleIdAndTransferDateBetweenOrderByTransferDateDesc(
         coupleId: UUID,

--- a/backend/src/main/kotlin/com/budgetbook/transfer/service/TransferGating.kt
+++ b/backend/src/main/kotlin/com/budgetbook/transfer/service/TransferGating.kt
@@ -1,0 +1,151 @@
+package com.budgetbook.transfer.service
+
+import com.budgetbook.common.dto.CommonFilterParams
+import com.budgetbook.common.filter.LedgerFilterAxis
+import com.budgetbook.common.filter.LedgerTypeSelection
+import com.budgetbook.common.filter.TransferAxisHandling
+import com.budgetbook.paymentmethod.domain.PaymentMethod
+import com.budgetbook.transfer.domain.Transfer
+import jakarta.persistence.criteria.Predicate
+import org.springframework.data.jpa.domain.Specification
+import java.time.LocalDate
+import java.util.UUID
+
+/**
+ * 장부 필터를 **이체 스트림**에 적용하는 단일 판정 지점.
+ *
+ * ## 이 파일이 유일한 판정이다
+ *
+ * 이체 **목록 조회**([spec])와 이체 **집계**(`ExpenseCalculator.transferBuckets`)가
+ * 같은 함수를 쓴다. 한쪽만 고치는 것이 구조적으로 불가능하다 —
+ * 그것이 "합계 ≠ 행" 불일치의 재발 메커니즘이었다.
+ *
+ * 과거에는 같은 판정이 FE `ledger_gating.dart` 에도 있었다(총 2곳).
+ * 2026-08-12 회차에서 판정을 서버로 모으고 FE 는 서버 결과를 그대로 소비한다.
+ *
+ * 축을 추가하면 [handling] 의 `when` 이 컴파일 실패한다 → 분류 선언을 강제한다.
+ */
+object TransferGating {
+
+    /**
+     * 축별 처리 분류. **exhaustive `when`** — 축이 늘면 여기서 컴파일이 막힌다.
+     *
+     * 이 함수는 문서이자 게이트다. 실제 판정은 [excludedWholesale] 과 [spec] 이 수행하며,
+     * `TransferGatingAxisTest` 가 둘의 분류 일치를 검증한다.
+     */
+    fun handling(axis: LedgerFilterAxis): TransferAxisHandling = when (axis) {
+        // 범위 — 거래·이체·합계가 같은 기간을 본다.
+        LedgerFilterAxis.DATE_FROM,
+        LedgerFilterAxis.DATE_TO,
+        LedgerFilterAxis.YEAR,
+        LedgerFilterAxis.MONTH -> TransferAxisHandling.RANGE
+
+        // 이체에도 적용되는 축.
+        LedgerFilterAxis.PAYMENT_METHOD_ID,
+        LedgerFilterAxis.PAYMENT_METHOD_IDS,
+        LedgerFilterAxis.AMOUNT_MIN,
+        LedgerFilterAxis.AMOUNT_MAX,
+        LedgerFilterAxis.KEYWORD,
+        LedgerFilterAxis.RECONCILED -> TransferAxisHandling.APPLIES
+
+        // 이체에 없는 축 → 활성 시 전량 제외.
+        // (VISIBILITY 는 'PRIVATE' 일 때만, TRANSACTION_TYPES 는 TRANSFER 미포함일 때만)
+        LedgerFilterAxis.CATEGORY_ID,
+        LedgerFilterAxis.CATEGORY_IDS,
+        LedgerFilterAxis.CATEGORY_GROUP_IDS,
+        LedgerFilterAxis.POCKET_ID,
+        LedgerFilterAxis.POCKET_IDS,
+        LedgerFilterAxis.NEEDS_REVIEW_ONLY,
+        LedgerFilterAxis.VISIBILITY,
+        LedgerFilterAxis.TYPE,
+        LedgerFilterAxis.TRANSACTION_TYPES -> TransferAxisHandling.EXCLUDES_WHOLESALE
+
+        // 장부 게이팅과 무관 (지출계획 등 다른 화면 전용).
+        LedgerFilterAxis.STATUS -> TransferAxisHandling.IRRELEVANT
+    }
+
+    /**
+     * 이체에 **존재하지 않는 축**이 활성이면 이체는 매칭 불가 → 전량 제외.
+     *
+     * `Transfer` 에는 category / pocket / needsReview / visibility 필드가 없다.
+     */
+    fun excludedWholesale(filter: CommonFilterParams): Boolean {
+        // 축: needsReviewOnly — 이체엔 "확인/입력 필요" 개념이 없다.
+        if (filter.needsReviewOnly == true) return true
+        // 축: category (단수·복수·그룹) — 이체엔 카테고리가 없다.
+        if (filter.categoryId != null ||
+            filter.categoryIds.isNotEmpty() ||
+            filter.categoryGroupIds.isNotEmpty()
+        ) {
+            return true
+        }
+        // 축: pocket (단수·복수) — 이체엔 포켓이 없다(포켓 이체는 별도 기능).
+        if (filter.pocketId != null || filter.pocketIds.isNotEmpty()) return true
+        // 축: visibility — 이체엔 visibility 가 없어 전부 "공유" 취급. 개인 필터에서는 숨긴다.
+        //     개인 자산(ASSET-PRIVATE) 도입 시 source/dest 자산의 visibility 로 파생하도록 여기를 고친다.
+        if (filter.visibility?.uppercase() == "PRIVATE") return true
+        // 축: type (단수) — 거래 타입 전용 필터. 이체는 대상이 아니다.
+        if (filter.type != null) return true
+        // 축: transactionTypes — 선택에 TRANSFER 가 없으면 이체 제외 (빈 선택 = 전체).
+        if (!LedgerTypeSelection.parse(filter.transactionTypes).includesTransfers) return true
+        return false
+    }
+
+    /**
+     * 이체에 적용 가능한 축의 쿼리 조건.
+     *
+     * [from]/[to] 는 호출부가 해석한 **실효 범위**다
+     * (`CommonFilterParams.getEffectiveDateRange()` 와 같은 규칙이어야 한다).
+     *
+     * `reconciled` 는 스냅샷 조회가 필요해 여기서 다루지 않는다 —
+     * 호출부가 `ReconciliationLookup` 으로 후처리한다([reconciledMatches]).
+     */
+    fun spec(coupleId: UUID, filter: CommonFilterParams, from: LocalDate, to: LocalDate): Specification<Transfer> =
+        Specification { root, _, cb ->
+            val predicates = mutableListOf<Predicate>()
+
+            predicates += cb.equal(root.get<Any>("couple").get<UUID>("id"), coupleId)
+            predicates += cb.between(root.get("transferDate"), from, to)
+
+            // 축: paymentMethodId / paymentMethodIds — 출금·입금 **어느 쪽이든** OR 매칭.
+            // (과거 FE 는 복수 선택인데 첫 1개만 적용했다)
+            val pmIds = filter.paymentMethodIds.toMutableSet().also { set ->
+                filter.paymentMethodId?.let { set.add(it) }
+            }
+            if (pmIds.isNotEmpty()) {
+                val source = root.get<PaymentMethod>("sourcePaymentMethod").get<UUID>("id")
+                val destination = root.get<PaymentMethod>("destinationPaymentMethod").get<UUID>("id")
+                predicates += cb.or(source.`in`(pmIds), destination.`in`(pmIds))
+            }
+
+            // 축: amountMin / amountMax.
+            filter.amountMin?.let { predicates += cb.greaterThanOrEqualTo(root.get("amount"), it) }
+            filter.amountMax?.let { predicates += cb.lessThanOrEqualTo(root.get("amount"), it) }
+
+            // 축: keyword — 설명 + 출금/입금 결제수단명 (FE 판정과 동일한 필드 집합).
+            val keyword = filter.keyword?.trim()
+            if (!keyword.isNullOrEmpty()) {
+                val pattern = "%${keyword.lowercase()}%"
+                val sourceName = root.join<Transfer, PaymentMethod>("sourcePaymentMethod").get<String>("name")
+                val destinationName =
+                    root.join<Transfer, PaymentMethod>("destinationPaymentMethod").get<String>("name")
+                predicates += cb.or(
+                    cb.like(cb.lower(root.get("description")), pattern),
+                    cb.like(cb.lower(sourceName), pattern),
+                    cb.like(cb.lower(destinationName), pattern),
+                )
+            }
+
+            cb.and(*predicates.toTypedArray())
+        }
+
+    /**
+     * 축: reconciled — 정산 스냅샷 유무 판정. 스냅샷은 별도 테이블이라 쿼리 후처리한다.
+     * `null` = 전체 / `true` = 기록된 것만 / `false` = 미기록만.
+     */
+    fun reconciledMatches(reconciled: Boolean?, hasSnapshot: Boolean): Boolean = when (reconciled) {
+        null -> true
+        true -> hasSnapshot
+        false -> !hasSnapshot
+    }
+}

--- a/backend/src/main/kotlin/com/budgetbook/transfer/service/TransferService.kt
+++ b/backend/src/main/kotlin/com/budgetbook/transfer/service/TransferService.kt
@@ -1,6 +1,7 @@
 package com.budgetbook.transfer.service
 
 import com.budgetbook.auth.repository.UserRepository
+import com.budgetbook.common.dto.CommonFilterParams
 import com.budgetbook.common.exception.BusinessException
 import com.budgetbook.common.exception.NotFoundException
 import com.budgetbook.common.security.OwnershipValidator
@@ -87,36 +88,44 @@ class TransferService(
         return saved.toResponse()
     }
 
-    @Transactional(readOnly = true)
     /**
-     * 월 이체 목록.
+     * 이체 목록.
      *
-     * [reconciled] 는 거래 목록과 **동일한 의미** 의 정산 필터다 (false=미기록만, true=기록만,
-     * null=전체). 장부 목록은 거래+이체 병합이므로 한쪽 스트림만 필터를 지원하면
-     * "이체만 계속 남아 보이는" drift 가 난다 — 두 엔드포인트를 항상 같이 확장할 것.
+     * `filter.reconciled` 는 거래 목록과 **동일한 의미** 의 정산 필터다
+     * (false=미기록만, true=기록만, null=전체). 장부 목록은 거래+이체 병합이므로
+     * 한쪽 스트림만 필터를 지원하면 "이체만 계속 남아 보이는" drift 가 난다 —
+     * 두 엔드포인트를 항상 같이 확장할 것.
+     *
+     * ## 2026-08-12 — 범위·필터를 장부와 일치시킨다
+     *
+     * 이전에는 `year`/`month` 만 받아 **항상 한 달**을 반환했다. 장부(거래 목록)는
+     * `dateFrom`/`dateTo` 가 월을 덮어쓰는데 이체만 월에 갇혀 있어서, 기간 필터가 월을
+     * 넘으면 **이체 행이 통째로 누락**됐다(측정: 범위 내 이체 금액의 77%).
+     *
+     * 이제 범위는 `CommonFilterParams.getEffectiveDateRange()` 단일 규칙을 따르고,
+     * 나머지 축은 [TransferGating] 이 판정한다 — 이체 **집계**와 같은 함수다.
      */
-    fun listTransfers(
-        userId: UUID,
-        year: Int,
-        month: Int,
-        reconciled: Boolean? = null
-    ): List<TransferResponse> {
+    @Transactional(readOnly = true)
+    fun listTransfers(userId: UUID, filter: CommonFilterParams): List<TransferResponse> {
         val couple = getActiveCouple(userId)
-        val yearMonth = YearMonth.of(year, month)
-        val startDate = yearMonth.atDay(1)
-        val endDate = yearMonth.atEndOfMonth()
+        val (startDate, endDate) = filter.getEffectiveDateRange()
+            ?: throw BusinessException(
+                "VALIDATION_ERROR",
+                "Either dateFrom/dateTo or year/month is required."
+            )
 
-        val transfers = transferRepository.findByCoupleIdAndTransferDateBetweenOrderByTransferDateDesc(
-            couple.id, startDate, endDate
-        )
+        // 이체에 없는 축이 켜져 있으면 이체는 논리적으로 매칭 불가 → 조회 자체를 생략.
+        if (TransferGating.excludedWholesale(filter)) return emptyList()
+
+        val transfers = transferRepository
+            .findAll(TransferGating.spec(couple.id, filter, startDate, endDate))
+            .sortedByDescending { it.transferDate }
+
         // 정산 ref 를 한 번에 벌크 조회 (항목당 조회 = N+1 금지).
         val refs = reconciliationLookup.refsForTransfers(transfers.map { it.id })
-        val filtered = when (reconciled) {
-            null -> transfers
-            true -> transfers.filter { refs.containsKey(it.id) }
-            false -> transfers.filter { !refs.containsKey(it.id) }
-        }
-        return filtered.map { it.toResponse(refs[it.id]) }
+        return transfers
+            .filter { TransferGating.reconciledMatches(filter.reconciled, refs.containsKey(it.id)) }
+            .map { it.toResponse(refs[it.id]) }
     }
 
     @Transactional(readOnly = true)

--- a/backend/src/test/kotlin/com/budgetbook/common/filter/LedgerFilterAxisGuardTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/common/filter/LedgerFilterAxisGuardTest.kt
@@ -1,0 +1,61 @@
+package com.budgetbook.common.filter
+
+import com.budgetbook.common.dto.CommonFilterParams
+import com.budgetbook.transfer.service.TransferGating
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * **축 가드** — 장부 필터에 필드를 추가하면 이 테스트가 실패한다.
+ *
+ * 왜: 필터 축이 늘 때 한쪽 스트림(거래/이체)에서만 축이 누락되는 사고가 4회 반복됐다.
+ * 컴파일 단계에서는 [TransferGating.handling] 의 exhaustive `when` 이 막고,
+ * 여기서는 **enum 과 VO 프로퍼티의 1:1 대응**을 막는다. 둘 중 하나만으로는
+ * "enum 에 추가하고 VO 는 안 고침"(또는 반대)을 못 잡는다.
+ *
+ * 실패했다면 순서는 이렇다:
+ *  1. `CommonFilterParams` 에 추가한 필드에 대응하는 [LedgerFilterAxis] 항목을 추가
+ *  2. [TransferGating.handling] 에서 그 축을 어떻게 다룰지 선언 (컴파일이 강제)
+ *  3. 이체에 적용되는 축이면 `TransferGating.spec`(또는 `excludedWholesale`)에 판정 추가
+ *  4. `TransferService.listTransfers` 와 합계가 같은 판정을 쓰는지 확인
+ *     (같은 함수를 쓰므로 자동이지만, 새 축이 후처리라면 양쪽에 넣어야 한다)
+ */
+class LedgerFilterAxisGuardTest : FunSpec({
+
+    // Kotlin data class 의 프로퍼티는 private 필드로 컴파일된다. 합성 필드는 제외.
+    val voPropertyNames = CommonFilterParams::class.java.declaredFields
+        .filterNot { it.isSynthetic }
+        .map { it.name }
+        .toSet()
+
+    test("every LedgerFilterAxis maps to a real CommonFilterParams property") {
+        val unknown = LedgerFilterAxis.entries
+            .map { it.propertyName }
+            .filterNot { it in voPropertyNames }
+
+        unknown.shouldBeEmpty()
+    }
+
+    test("every CommonFilterParams property has a LedgerFilterAxis") {
+        val covered = LedgerFilterAxis.entries.map { it.propertyName }.toSet()
+        val uncovered = voPropertyNames - covered
+
+        // 실패 시: 위 KDoc 의 1~4 순서를 따르라.
+        uncovered.shouldBeEmpty()
+    }
+
+    test("axis count matches property count (1:1, no duplicates)") {
+        LedgerFilterAxis.entries.size shouldBe voPropertyNames.size
+        LedgerFilterAxis.entries.map { it.propertyName }.toSet().size shouldBe LedgerFilterAxis.entries.size
+    }
+
+    test("every axis declares how transfers handle it") {
+        // handling 은 exhaustive when 이라 컴파일이 이미 강제한다.
+        // 여기서는 호출이 예외 없이 끝나는지(= 모든 항목이 분류됐는지)를 확인한다.
+        LedgerFilterAxis.entries.forEach { axis ->
+            TransferGating.handling(axis) shouldNotBe null
+        }
+    }
+})

--- a/backend/src/test/kotlin/com/budgetbook/common/filter/LedgerTypeSelectionTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/common/filter/LedgerTypeSelectionTest.kt
@@ -1,0 +1,68 @@
+package com.budgetbook.common.filter
+
+import com.budgetbook.common.exception.BusinessException
+import com.budgetbook.transaction.domain.TransactionType
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * 타입 선택 파싱 규칙.
+ *
+ * 핵심은 세 상태를 구분하는 것이다:
+ *  - 필터 없음(전체)
+ *  - 거래 타입이 선택됨
+ *  - 필터는 켜졌으나 거래 타입이 하나도 없음("이체만 보기") → 거래는 0건
+ *
+ * 마지막 상태를 "필터 없음" 과 혼동하면 이체만 보기에서 거래 합계가 그대로 남는다
+ * (구현 중 실제로 한 번 발생 — 회귀 가드).
+ */
+class LedgerTypeSelectionTest : FunSpec({
+
+    test("null and empty mean no filter") {
+        listOf(null, emptyList(), listOf("", "  ")).forEach { raw ->
+            val selection = LedgerTypeSelection.parse(raw)
+            selection.hasSelection shouldBe false
+            selection.matchesNoTransaction shouldBe false
+            selection.includesTransfers shouldBe true
+        }
+    }
+
+    test("TRANSFER alone selects no transaction type but keeps transfers") {
+        val selection = LedgerTypeSelection.parse(listOf("TRANSFER"))
+
+        selection.hasSelection shouldBe true
+        selection.transactionTypes shouldBe emptySet()
+        selection.matchesNoTransaction shouldBe true
+        selection.includesTransfers shouldBe true
+    }
+
+    test("EXPENSE alone excludes transfers") {
+        val selection = LedgerTypeSelection.parse(listOf("EXPENSE"))
+
+        selection.transactionTypes shouldBe setOf(TransactionType.EXPENSE)
+        selection.matchesNoTransaction shouldBe false
+        selection.includesTransfers shouldBe false
+    }
+
+    test("EXPENSE + TRANSFER keeps both streams") {
+        val selection = LedgerTypeSelection.parse(listOf("EXPENSE", "TRANSFER"))
+
+        selection.transactionTypes shouldBe setOf(TransactionType.EXPENSE)
+        selection.includesTransfers shouldBe true
+        selection.matchesNoTransaction shouldBe false
+    }
+
+    test("values are case-insensitive and trimmed") {
+        val selection = LedgerTypeSelection.parse(listOf(" expense ", "transfer"))
+
+        selection.transactionTypes shouldBe setOf(TransactionType.EXPENSE)
+        selection.includesTransfers shouldBe true
+    }
+
+    test("an unknown value is still a validation error") {
+        shouldThrow<BusinessException> {
+            LedgerTypeSelection.parse(listOf("EXPENSE", "BOGUS"))
+        }.code shouldBe "VALIDATION_ERROR"
+    }
+})

--- a/backend/src/test/kotlin/com/budgetbook/statistics/controller/StatisticsControllerTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/statistics/controller/StatisticsControllerTest.kt
@@ -34,9 +34,9 @@ class StatisticsControllerTest : FunSpec({
             balance = 1800000,
             transactionCount = 45
         )
-        every { statisticsService.getMonthlySummary(testUserId, 2026, 3, "ALL", null, null) } returns summary
-
         val filter = CommonFilterParams()
+        every { statisticsService.getMonthlySummary(testUserId, 2026, 3, filter) } returns summary
+
         val result = controller.getMonthlySummary(testUserId, 2026, 3, filter)
 
         result.success shouldBe true
@@ -50,13 +50,13 @@ class StatisticsControllerTest : FunSpec({
     test("getMonthlySummary passes visibility SHARED to service") {
 
         val summary = StatisticsSummaryResponse("2026-03", 1000000, 500000, 0, 500000, 10)
-        every { statisticsService.getMonthlySummary(testUserId, 2026, 3, "SHARED", null, null) } returns summary
-
         val filter = CommonFilterParams(visibility = "SHARED")
+        every { statisticsService.getMonthlySummary(testUserId, 2026, 3, filter) } returns summary
+
         val result = controller.getMonthlySummary(testUserId, 2026, 3, filter)
 
         result.success shouldBe true
-        verify { statisticsService.getMonthlySummary(testUserId, 2026, 3, "SHARED", null, null) }
+        verify { statisticsService.getMonthlySummary(testUserId, 2026, 3, filter) }
     }
 
     // 2026-07-27 회귀 가드 — 거래 목록에는 needsReviewOnly 가 적용되는데 summary 에는
@@ -65,36 +65,49 @@ class StatisticsControllerTest : FunSpec({
     test("getMonthlySummary passes needsReviewOnly to service") {
 
         val summary = StatisticsSummaryResponse("2026-03", 0, 30000, 0, -30000, 2)
-        every {
-            statisticsService.getMonthlySummary(
-                userId = testUserId, year = 2026, month = 3, visibility = "ALL",
-                dateFrom = null, dateTo = null, needsReviewOnly = true
-            )
-        } returns summary
-
         val filter = CommonFilterParams(needsReviewOnly = true)
+        every { statisticsService.getMonthlySummary(testUserId, 2026, 3, filter) } returns summary
+
         val result = controller.getMonthlySummary(testUserId, 2026, 3, filter)
 
         result.success shouldBe true
         result.data!!.totalExpense shouldBe 30000
-        verify {
-            statisticsService.getMonthlySummary(
-                userId = testUserId, year = 2026, month = 3, visibility = "ALL",
-                dateFrom = null, dateTo = null, needsReviewOnly = true
-            )
-        }
+        verify { statisticsService.getMonthlySummary(testUserId, 2026, 3, filter) }
     }
 
     test("getMonthlySummary passes visibility PRIVATE to service") {
 
         val summary = StatisticsSummaryResponse("2026-03", 200000, 100000, 0, 100000, 5)
-        every { statisticsService.getMonthlySummary(testUserId, 2026, 3, "PRIVATE", null, null) } returns summary
-
         val filter = CommonFilterParams(visibility = "PRIVATE")
+        every { statisticsService.getMonthlySummary(testUserId, 2026, 3, filter) } returns summary
+
         val result = controller.getMonthlySummary(testUserId, 2026, 3, filter)
 
         result.success shouldBe true
-        verify { statisticsService.getMonthlySummary(testUserId, 2026, 3, "PRIVATE", null, null) }
+        verify { statisticsService.getMonthlySummary(testUserId, 2026, 3, filter) }
+    }
+
+    // 2026-08-12 구조 가드 — 컨트롤러가 필터 VO 를 **통째로** 넘기는지 고정한다.
+    // 필드를 하나씩 나열하던 시절에는 새 축이 추가될 때마다 summary 쪽에서만 조용히
+    // 누락됐다(4회 재발). 아래처럼 여러 축을 채운 VO 가 그대로 전달돼야 한다.
+    test("getMonthlySummary forwards the whole filter VO (no field enumeration)") {
+
+        val summary = StatisticsSummaryResponse("2026-03", 0, 0, 0, 0, 0)
+        val filter = CommonFilterParams(
+            dateFrom = LocalDate.of(2026, 6, 15),
+            dateTo = LocalDate.of(2026, 8, 5),
+            paymentMethodIds = listOf(UUID.randomUUID(), UUID.randomUUID()),
+            amountMin = 10_000,
+            amountMax = 500_000,
+            keyword = "커피",
+            transactionTypes = listOf("EXPENSE", "TRANSFER"),
+            needsReviewOnly = null,
+        )
+        every { statisticsService.getMonthlySummary(testUserId, 2026, 3, filter) } returns summary
+
+        controller.getMonthlySummary(testUserId, 2026, 3, filter).success shouldBe true
+
+        verify { statisticsService.getMonthlySummary(testUserId, 2026, 3, filter) }
     }
 
     test("getCategoryBreakdown returns category statistics with default visibility") {
@@ -218,11 +231,10 @@ class StatisticsControllerTest : FunSpec({
             byPaymentMethod = emptyList(),
             byDate = emptyList()
         )
-        every {
-            statisticsService.getPeriodSummary(testUserId, dateFrom, dateTo, "ALL", null, null, null)
-        } returns summary
-
         val filter = CommonFilterParams()
+        every {
+            statisticsService.getPeriodSummary(testUserId, dateFrom, dateTo, filter)
+        } returns summary
         val result = controller.getPeriodSummary(testUserId, dateFrom, dateTo, filter)
 
         result.success shouldBe true
@@ -246,15 +258,14 @@ class StatisticsControllerTest : FunSpec({
             byPaymentMethod = emptyList(),
             byDate = emptyList()
         )
-        every {
-            statisticsService.getPeriodSummary(testUserId, dateFrom, dateTo, "SHARED", null, null, null)
-        } returns summary
-
         val filter = CommonFilterParams(visibility = "SHARED")
+        every {
+            statisticsService.getPeriodSummary(testUserId, dateFrom, dateTo, filter)
+        } returns summary
         val result = controller.getPeriodSummary(testUserId, dateFrom, dateTo, filter)
 
         result.success shouldBe true
-        verify { statisticsService.getPeriodSummary(testUserId, dateFrom, dateTo, "SHARED", null, null, null) }
+        verify { statisticsService.getPeriodSummary(testUserId, dateFrom, dateTo, filter) }
     }
 
     test("getPeriodSummary passes categoryId filter to service") {
@@ -273,14 +284,13 @@ class StatisticsControllerTest : FunSpec({
             byPaymentMethod = emptyList(),
             byDate = emptyList()
         )
-        every {
-            statisticsService.getPeriodSummary(testUserId, dateFrom, dateTo, "ALL", catId, null, null)
-        } returns summary
-
         val filter = CommonFilterParams(categoryId = catId)
+        every {
+            statisticsService.getPeriodSummary(testUserId, dateFrom, dateTo, filter)
+        } returns summary
         val result = controller.getPeriodSummary(testUserId, dateFrom, dateTo, filter)
 
         result.success shouldBe true
-        verify { statisticsService.getPeriodSummary(testUserId, dateFrom, dateTo, "ALL", catId, null, null) }
+        verify { statisticsService.getPeriodSummary(testUserId, dateFrom, dateTo, filter) }
     }
 })

--- a/backend/src/test/kotlin/com/budgetbook/statistics/integration/LedgerSummaryRowContractIntegrationTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/statistics/integration/LedgerSummaryRowContractIntegrationTest.kt
@@ -1,0 +1,341 @@
+package com.budgetbook.statistics.integration
+
+import com.budgetbook.admin.integration.HighApiVersionDockerStrategy
+import com.budgetbook.common.dto.CommonFilterParams
+import com.budgetbook.statistics.service.StatisticsService
+import com.budgetbook.transaction.service.TransactionService
+import com.budgetbook.transfer.domain.TransferKind
+import com.budgetbook.transfer.service.TransferService
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.extensions.spring.SpringExtension
+import io.kotest.matchers.shouldBe
+import jakarta.persistence.EntityManager
+import jakarta.persistence.PersistenceContext
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.ApplicationContextInitializer
+import org.springframework.context.ConfigurableApplicationContext
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.support.TestPropertySourceUtils
+import org.springframework.transaction.PlatformTransactionManager
+import org.springframework.transaction.support.TransactionTemplate
+import org.testcontainers.containers.PostgreSQLContainer
+import java.time.LocalDate
+import java.util.UUID
+
+/**
+ * **"합계 = 행" 계약 테스트** (2026-08-12).
+ *
+ * 장부는 거래 목록 API + 이체 목록 API + 합계 API 세 개를 한 화면에 합쳐 보여준다.
+ * 같은 필터를 줬을 때 **합계가 목록 행의 합과 같아야** 한다. 이 불변식이 4회 깨졌고
+ * (축 누락 → 이체 전량 노출 → 필터 시 이체 전량 제외 → 기간 필터에서 이체 월 고착),
+ * 매번 "한쪽만 고치는" 패치로 끝나 재발했다.
+ *
+ * 그래서 이 테스트는 **세 API 를 실제 PostgreSQL 에 대고 함께 호출**해 축 조합마다
+ * 합계와 행을 대조한다. mock 으로는 Specification/JPQL 층이 검증되지 않아
+ * (`spec` 이 실제로 어떤 행을 고르는지) 이 계열 버그를 잡을 수 없다.
+ *
+ * 픽스처는 kind 4종과 타입 3종을 모두 섞고, **월을 넘는 기간**을 포함한다.
+ */
+@SpringBootTest
+@ActiveProfiles("integration-test")
+@ContextConfiguration(initializers = [LedgerSummaryRowContractIntegrationTest.DataSourceInitializer::class])
+class LedgerSummaryRowContractIntegrationTest(
+    private val statisticsService: StatisticsService,
+    private val transactionService: TransactionService,
+    private val transferService: TransferService,
+    @PersistenceContext private val em: EntityManager,
+    private val txManager: PlatformTransactionManager,
+) : FunSpec() {
+
+    override fun extensions() = listOf(SpringExtension)
+
+    companion object {
+        val postgres: PostgreSQLContainer<*> = PostgreSQLContainer("postgres:16-alpine")
+            .withDatabaseName("budgetbook_test")
+            .withUsername("test")
+            .withPassword("test")
+
+        init {
+            System.setProperty(
+                "testcontainers.docker.client.strategy",
+                HighApiVersionDockerStrategy::class.java.name
+            )
+            postgres.start()
+        }
+    }
+
+    class DataSourceInitializer : ApplicationContextInitializer<ConfigurableApplicationContext> {
+        override fun initialize(ctx: ConfigurableApplicationContext) {
+            TestPropertySourceUtils.addInlinedPropertiesToEnvironment(
+                ctx,
+                "spring.datasource.url=${postgres.jdbcUrl}",
+                "spring.datasource.username=${postgres.username}",
+                "spring.datasource.password=${postgres.password}",
+                "spring.datasource.driver-class-name=org.postgresql.Driver",
+                "spring.jpa.hibernate.ddl-auto=validate",
+                "spring.flyway.enabled=true",
+                "spring.flyway.baseline-on-migrate=true"
+            )
+        }
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────────────
+
+    private fun <T> inTx(action: () -> T): T = TransactionTemplate(txManager).execute { action() }!!
+
+    private fun insertUser(email: String): UUID {
+        val id = UUID.randomUUID()
+        em.createNativeQuery(
+            """INSERT INTO users (id, email, nickname, provider, provider_id, role, is_active, created_at, updated_at)
+               VALUES (:id, :email, 'Ledger', 'GOOGLE', :pid, 'USER', true, now(), now())"""
+        ).setParameter("id", id).setParameter("email", email)
+            .setParameter("pid", UUID.randomUUID().toString()).executeUpdate()
+        return id
+    }
+
+    private fun insertSelfCouple(userId: UUID): UUID {
+        val id = UUID.randomUUID()
+        em.createNativeQuery(
+            """INSERT INTO couples (id, user1_id, user2_id, status, is_self, created_at, updated_at)
+               VALUES (:id, :userId, null, 'ACTIVE', true, now(), now())"""
+        ).setParameter("id", id).setParameter("userId", userId).executeUpdate()
+        return id
+    }
+
+    private fun insertPaymentMethod(coupleId: UUID, name: String, type: String = "BANK"): UUID {
+        val id = UUID.randomUUID()
+        em.createNativeQuery(
+            """INSERT INTO payment_methods (id, couple_id, name, type, is_active, is_default, display_order, created_at, updated_at)
+               VALUES (:id, :coupleId, :name, :type, true, false, 0, now(), now())"""
+        ).setParameter("id", id).setParameter("coupleId", coupleId)
+            .setParameter("name", name).setParameter("type", type).executeUpdate()
+        return id
+    }
+
+    private fun insertTransaction(
+        coupleId: UUID,
+        authorId: UUID,
+        paymentMethodId: UUID?,
+        type: String,
+        amount: Long,
+        date: LocalDate,
+        description: String = "거래",
+    ): UUID {
+        val id = UUID.randomUUID()
+        em.createNativeQuery(
+            """INSERT INTO transactions
+               (id, couple_id, author_id, payment_method_id, type, amount, description,
+                transaction_date, visibility, needs_review, created_at, updated_at)
+               VALUES (:id, :coupleId, :authorId, :pm, :type, :amount, :description,
+                       :date, 'SHARED', false, now(), now())"""
+        ).setParameter("id", id).setParameter("coupleId", coupleId).setParameter("authorId", authorId)
+            .setParameter("pm", paymentMethodId).setParameter("type", type)
+            .setParameter("amount", amount).setParameter("description", description)
+            .setParameter("date", date).executeUpdate()
+        return id
+    }
+
+    private fun insertTransfer(
+        coupleId: UUID,
+        authorId: UUID,
+        sourceId: UUID,
+        destinationId: UUID,
+        amount: Long,
+        date: LocalDate,
+        kind: String,
+        description: String = "이체",
+    ): UUID {
+        val id = UUID.randomUUID()
+        em.createNativeQuery(
+            """INSERT INTO transfers
+               (id, couple_id, author_id, source_payment_method_id, destination_payment_method_id,
+                amount, description, transfer_date, kind, is_card_settlement, created_at, updated_at)
+               VALUES (:id, :coupleId, :authorId, :src, :dst, :amount, :description,
+                       :date, :kind, :isSettlement, now(), now())"""
+        ).setParameter("id", id).setParameter("coupleId", coupleId).setParameter("authorId", authorId)
+            .setParameter("src", sourceId).setParameter("dst", destinationId)
+            .setParameter("amount", amount).setParameter("description", description)
+            .setParameter("date", date).setParameter("kind", kind)
+            .setParameter("isSettlement", kind == "CARD_SETTLEMENT")
+            .executeUpdate()
+        return id
+    }
+
+    /**
+     * 목록 두 개(거래/이체)를 합계와 같은 규칙으로 접어 "행의 합" 을 만든다.
+     * FE `LedgerSummary` 와 BE `ExpenseCalculator` 의 집계식을 그대로 따른다:
+     * ADJUSTMENT·CARD_SETTLEMENT 는 어느 버킷에도 넣지 않는다.
+     */
+    private data class RowTotals(val income: Long, val expense: Long, val transfer: Long)
+
+    private fun rowTotals(userId: UUID, filter: CommonFilterParams, year: Int, month: Int): RowTotals {
+        val transactions = transactionService.listTransactions(
+            userId = userId, year = year, month = month, type = filter.type,
+            categoryId = filter.categoryId, keyword = filter.keyword,
+            paymentMethodId = filter.paymentMethodId, pocketId = filter.pocketId,
+            amountMin = filter.amountMin, amountMax = filter.amountMax,
+            dateFrom = filter.dateFrom, dateTo = filter.dateTo,
+            visibility = filter.visibility, page = 0, size = 500,
+            categoryIds = filter.categoryIds, categoryGroupIds = filter.categoryGroupIds,
+            paymentMethodIds = filter.paymentMethodIds, pocketIds = filter.pocketIds,
+            transactionTypes = filter.transactionTypes,
+            needsReviewOnly = filter.needsReviewOnly,
+        ).content
+        // 이체 목록은 범위를 VO 에서 읽는다. FE 도 같은 쿼리스트링에 year/month 를 실어 보내므로
+        // 여기서 채워 넣는 것이 실제 호출과 동일하다(dateFrom/dateTo 가 있으면 그쪽이 우선).
+        val transfers = transferService.listTransfers(
+            userId,
+            filter.copy(year = filter.year ?: year, month = filter.month ?: month)
+        )
+
+        var income = transactions.filter { it.type == "INCOME" }.sumOf { it.amount }
+        var expense = transactions.filter { it.type == "EXPENSE" }.sumOf { it.amount }
+        var transfer = 0L
+        for (t in transfers) {
+            when (t.kind) {
+                TransferKind.EXPENSE_TRANSFER -> expense += t.amount
+                TransferKind.INCOME_TRANSFER -> income += t.amount
+                TransferKind.GENERIC -> transfer += t.amount
+                TransferKind.CARD_SETTLEMENT -> Unit // 원본 EXPENSE 로 이미 집계됨
+            }
+        }
+        return RowTotals(income, expense, transfer)
+    }
+
+    init {
+        lateinit var userId: UUID
+        lateinit var bankId: UUID
+        lateinit var savingsId: UUID
+        lateinit var cardId: UUID
+
+        beforeSpec {
+            inTx {
+                userId = insertUser("ledger-contract-${UUID.randomUUID()}@test.com")
+                val coupleId = insertSelfCouple(userId)
+                bankId = insertPaymentMethod(coupleId, "주계좌")
+                savingsId = insertPaymentMethod(coupleId, "저축통장")
+                cardId = insertPaymentMethod(coupleId, "신용카드", "CREDIT")
+
+                // 7월 — 기준 월
+                insertTransaction(coupleId, userId, bankId, "EXPENSE", 30_000, LocalDate.of(2026, 7, 5), "커피 정기결제")
+                insertTransaction(coupleId, userId, cardId, "EXPENSE", 120_000, LocalDate.of(2026, 7, 10), "마트")
+                insertTransaction(coupleId, userId, bankId, "INCOME", 2_000_000, LocalDate.of(2026, 7, 25), "급여")
+                // ADJUSTMENT — 통계 범주 밖(잔액 전용). 합계 어느 칸에도 들어가지 않아야 한다.
+                insertTransaction(coupleId, userId, bankId, "ADJUSTMENT", 5_000, LocalDate.of(2026, 7, 26), "잔액 조정")
+
+                insertTransfer(coupleId, userId, bankId, savingsId, 500_000, LocalDate.of(2026, 7, 12), "GENERIC")
+                insertTransfer(coupleId, userId, bankId, savingsId, 80_000, LocalDate.of(2026, 7, 18), "EXPENSE_TRANSFER")
+                insertTransfer(coupleId, userId, savingsId, bankId, 60_000, LocalDate.of(2026, 7, 20), "INCOME_TRANSFER")
+                insertTransfer(coupleId, userId, bankId, cardId, 120_000, LocalDate.of(2026, 7, 28), "CARD_SETTLEMENT")
+
+                // 6월 — 기간 필터가 월을 넘을 때만 보여야 하는 데이터
+                insertTransaction(coupleId, userId, bankId, "EXPENSE", 40_000, LocalDate.of(2026, 6, 20), "6월 지출")
+                insertTransfer(coupleId, userId, bankId, savingsId, 300_000, LocalDate.of(2026, 6, 22), "GENERIC")
+            }
+        }
+
+        /** 축 조합마다 (합계 == 행의 합) 을 확인한다. */
+        fun assertSummaryMatchesRows(label: String, filter: CommonFilterParams) {
+            test("summary equals rows — $label") {
+                val summary = statisticsService.getMonthlySummary(userId, 2026, 7, filter)
+                val rows = rowTotals(userId, filter, 2026, 7)
+
+                summary.totalIncome shouldBe rows.income
+                summary.totalExpense shouldBe rows.expense
+                summary.totalTransfer shouldBe rows.transfer
+            }
+        }
+
+        assertSummaryMatchesRows("no filter", CommonFilterParams())
+        assertSummaryMatchesRows(
+            "amount range",
+            CommonFilterParams(amountMin = 50_000, amountMax = 600_000)
+        )
+        assertSummaryMatchesRows("keyword", CommonFilterParams(keyword = "커피"))
+        assertSummaryMatchesRows("needsReviewOnly", CommonFilterParams(needsReviewOnly = true))
+        assertSummaryMatchesRows("visibility SHARED", CommonFilterParams(visibility = "SHARED"))
+        assertSummaryMatchesRows("visibility PRIVATE", CommonFilterParams(visibility = "PRIVATE"))
+        assertSummaryMatchesRows(
+            "types EXPENSE only",
+            CommonFilterParams(transactionTypes = listOf("EXPENSE"))
+        )
+        assertSummaryMatchesRows(
+            "types TRANSFER only",
+            CommonFilterParams(transactionTypes = listOf("TRANSFER"))
+        )
+        assertSummaryMatchesRows(
+            "types EXPENSE + TRANSFER",
+            CommonFilterParams(transactionTypes = listOf("EXPENSE", "TRANSFER"))
+        )
+        assertSummaryMatchesRows(
+            "date range inside the month",
+            CommonFilterParams(dateFrom = LocalDate.of(2026, 7, 10), dateTo = LocalDate.of(2026, 7, 20))
+        )
+        // 이번 회차의 본체 — 기간이 월을 넘어가는 경우.
+        assertSummaryMatchesRows(
+            "date range spanning two months",
+            CommonFilterParams(dateFrom = LocalDate.of(2026, 6, 15), dateTo = LocalDate.of(2026, 7, 31))
+        )
+
+        // ── 절대값 회귀 가드 ────────────────────────────────────────────────────
+        // 위 대조만으로는 "둘 다 똑같이 틀린" 경우를 못 잡는다. 기대값을 못박는다.
+
+        test("no filter — absolute totals follow the kind rules") {
+            val summary = statisticsService.getMonthlySummary(userId, 2026, 7, CommonFilterParams())
+
+            // 지출 = 30,000 + 120,000 거래 + 80,000 EXPENSE_TRANSFER (CARD_SETTLEMENT 제외)
+            summary.totalExpense shouldBe 230_000L
+            // 수입 = 2,000,000 급여 + 60,000 INCOME_TRANSFER
+            summary.totalIncome shouldBe 2_060_000L
+            // 이체 칸 = GENERIC 만
+            summary.totalTransfer shouldBe 500_000L
+            // ADJUSTMENT 는 어느 칸에도 없다 → 거래 건수는 INCOME/EXPENSE 3건
+            summary.transactionCount shouldBe 3
+            // CARD_SETTLEMENT 는 집계 건수에서도 빠진다 → 이체 3건
+            summary.transferCount shouldBe 3
+        }
+
+        test("date range spanning two months includes the other month's transfers") {
+            val filter = CommonFilterParams(
+                dateFrom = LocalDate.of(2026, 6, 15),
+                dateTo = LocalDate.of(2026, 7, 31),
+            )
+            val summary = statisticsService.getMonthlySummary(userId, 2026, 7, filter)
+            val transfers = transferService.listTransfers(userId, filter)
+
+            // 6월 GENERIC 300,000 + 7월 GENERIC 500,000. 이체가 월에 갇혀 있던 버그가 있으면
+            // 여기서 500,000 만 나온다(= 이번 회차가 고친 것).
+            summary.totalTransfer shouldBe 800_000L
+            transfers.count { it.kind == TransferKind.GENERIC } shouldBe 2
+            // 지출 = 6월 40,000 + 7월 30,000 + 120,000 + EXPENSE_TRANSFER 80,000
+            summary.totalExpense shouldBe 270_000L
+        }
+
+        test("a filter axis absent from transfers hides transfers from BOTH sides") {
+            // 포켓 필터는 이체에 없는 축 → 목록에도 합계에도 이체가 없어야 한다.
+            val filter = CommonFilterParams(pocketIds = listOf(UUID.randomUUID()))
+
+            val summary = statisticsService.getMonthlySummary(userId, 2026, 7, filter)
+            val transfers = transferService.listTransfers(userId, filter.copy(year = 2026, month = 7))
+
+            transfers.size shouldBe 0
+            summary.totalTransfer shouldBe 0L
+            summary.transferCount shouldBe 0
+        }
+
+        test("payment method filter matches transfers on either leg") {
+            // 저축통장은 GENERIC(출금 bank→savings)·EXPENSE_TRANSFER(→savings)·
+            // INCOME_TRANSFER(savings→bank) 세 건에 걸린다.
+            val filter = CommonFilterParams(paymentMethodIds = listOf(savingsId))
+
+            val summary = statisticsService.getMonthlySummary(userId, 2026, 7, filter)
+            val rows = rowTotals(userId, filter, 2026, 7)
+
+            summary.totalTransfer shouldBe rows.transfer
+            summary.totalExpense shouldBe rows.expense
+            summary.totalIncome shouldBe rows.income
+            summary.totalTransfer shouldBe 500_000L
+        }
+    }
+}

--- a/backend/src/test/kotlin/com/budgetbook/statistics/service/StatisticsServiceTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/statistics/service/StatisticsServiceTest.kt
@@ -4,15 +4,22 @@ import com.budgetbook.auth.domain.AuthProvider
 import com.budgetbook.auth.domain.User
 import com.budgetbook.budget.repository.MonthlyBudgetRepository
 import com.budgetbook.category.repository.CategoryRepository
+import com.budgetbook.common.dto.CommonFilterParams
 import com.budgetbook.common.exception.BusinessException
 import com.budgetbook.common.exception.NotFoundException
 import com.budgetbook.couple.domain.Couple
 import com.budgetbook.couple.domain.CoupleStatus
 import com.budgetbook.couple.service.CoupleResolver
+import com.budgetbook.paymentmethod.domain.PaymentMethod
+import com.budgetbook.paymentmethod.domain.PaymentMethodType
 import com.budgetbook.spendingplan.repository.SpendingPlanRepository
+import com.budgetbook.transaction.domain.Transaction
 import com.budgetbook.transaction.domain.TransactionType
 import com.budgetbook.transaction.repository.TransactionRepository
+import com.budgetbook.transfer.domain.Transfer
+import com.budgetbook.transfer.domain.TransferKind
 import com.budgetbook.transfer.repository.TransferRepository
+import org.springframework.data.jpa.domain.Specification
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.BehaviorSpec
@@ -51,6 +58,7 @@ class StatisticsServiceTest : BehaviorSpec({
     val user1 = User(email = "u1@test.com", nickname = "U1", provider = AuthProvider.GOOGLE, providerId = "g1")
     val user2 = User(email = "u2@test.com", nickname = "U2", provider = AuthProvider.KAKAO, providerId = "k2")
     val couple = Couple(user1 = user1, user2 = user2, status = CoupleStatus.ACTIVE)
+    val fixturePaymentMethod = PaymentMethod(couple = couple, name = "주계좌", type = PaymentMethodType.BANK)
 
     // Default: no transfers (individual tests can override)
     // Phase 22: kind 기반 쿼리로 전환. 기존 ExcludingSettlement 계열은 deprecated 지만 호환을 위해 유지.
@@ -58,24 +66,39 @@ class StatisticsServiceTest : BehaviorSpec({
     every { transferRepository.sumAmountByDestinationExcludingSettlement(any(), any(), any()) } returns emptyList()
     every { transferRepository.sumAmountBySourceByKind(any(), any(), any(), any()) } returns emptyList()
     every { transferRepository.sumAmountByDestinationByKind(any(), any(), any(), any()) } returns emptyList()
+    // 2026-08-12 — 합계는 거래·이체 모두 spec 조회를 탄다. 기본은 "결과 없음".
+    every { transactionRepository.findAll(any<Specification<Transaction>>()) } returns emptyList()
+    every { transferRepository.findAll(any<Specification<Transfer>>()) } returns emptyList()
+
+    fun txOf(type: TransactionType, amount: Long, date: LocalDate = LocalDate.of(2026, 3, 15)) =
+        Transaction(
+            couple = couple, author = user1, type = type, amount = amount,
+            description = "fixture", transactionDate = date
+        )
+
+    fun transferOf(kind: TransferKind, amount: Long, date: LocalDate = LocalDate.of(2026, 3, 15)) =
+        Transfer(
+            couple = couple, author = user1,
+            sourcePaymentMethod = fixturePaymentMethod, destinationPaymentMethod = fixturePaymentMethod,
+            amount = amount, description = "fixture", transferDate = date, kind = kind
+        )
 
     // --- getMonthlySummary ---
+    //
+    // 2026-08-12 — 합계는 **단일 경로**다. 이전에는 "필터 없으면 집계 SQL / 있으면 spec" 두
+    // 갈래였고 이체 포함 규칙이 갈래마다 달라 "합계 ≠ 행" 이 생겼다. 이제 거래는 항상
+    // spec 1회 조회 후 타입별 fold, 이체는 항상 TransferGating 판정으로 집계한다.
 
     Given("a user in an active couple for monthly summary") {
         every { coupleResolver.getActiveCouple(user1.id) } returns couple
 
         When("there are income and expense transactions with default visibility") {
             every {
-                transactionRepository.sumByTypeForCouple(
-                    couple.id,
-                    LocalDate.of(2026, 3, 1),
-                    LocalDate.of(2026, 3, 31),
-                    any(),
-                    "ALL"
-                )
+                transactionRepository.findAll(any<Specification<Transaction>>())
             } returns listOf(
-                arrayOf(TransactionType.INCOME, 5000000L, 10L),
-                arrayOf(TransactionType.EXPENSE, 3200000L, 35L)
+                txOf(TransactionType.INCOME, 5_000_000L),
+                txOf(TransactionType.EXPENSE, 2_000_000L),
+                txOf(TransactionType.EXPENSE, 1_200_000L),
             )
 
             val result = service.getMonthlySummary(user1.id, 2026, 3)
@@ -85,72 +108,175 @@ class StatisticsServiceTest : BehaviorSpec({
                 result.totalIncome shouldBe 5000000L
                 result.totalExpense shouldBe 3200000L
                 result.balance shouldBe 1800000L
-                result.transactionCount shouldBe 45
+                result.transactionCount shouldBe 3
+            }
+
+            Then("counts no transfers when there are none") {
+                result.totalTransfer shouldBe 0L
+                result.transferCount shouldBe 0
+            }
+        }
+
+        When("transfers of every kind exist in the month") {
+            every {
+                transactionRepository.findAll(any<Specification<Transaction>>())
+            } returns listOf(txOf(TransactionType.EXPENSE, 1_000_000L))
+            every {
+                transferRepository.findAll(any<Specification<Transfer>>())
+            } returns listOf(
+                transferOf(TransferKind.EXPENSE_TRANSFER, 300_000L),
+                transferOf(TransferKind.INCOME_TRANSFER, 200_000L),
+                transferOf(TransferKind.GENERIC, 500_000L),
+                transferOf(TransferKind.CARD_SETTLEMENT, 900_000L),
+            )
+
+            val result = service.getMonthlySummary(user1.id, 2026, 3)
+
+            // 집계식은 ExpenseCalculator KDoc + FE LedgerSummary 와 동일해야 한다.
+            Then("EXPENSE_TRANSFER lands in expense and INCOME_TRANSFER in income") {
+                result.totalExpense shouldBe 1_300_000L
+                result.totalIncome shouldBe 200_000L
+            }
+
+            Then("GENERIC is the transfer bucket and CARD_SETTLEMENT is excluded everywhere") {
+                result.totalTransfer shouldBe 500_000L
+                // CARD_SETTLEMENT 는 어느 버킷에도 없고 건수에도 세지 않는다.
+                result.transferCount shouldBe 3
+            }
+        }
+
+        // 이번 회차의 핵심 회귀 가드 — 필터가 켜져도 이체가 합계에서 사라지지 않는다.
+        // (이전: hasContentFilters == true → totalTransfer = 0 + 이체 legs 누락)
+        When("a content filter that keeps transfers is active (amount range)") {
+            every {
+                transactionRepository.findAll(any<Specification<Transaction>>())
+            } returns listOf(txOf(TransactionType.EXPENSE, 50_000L))
+            every {
+                transferRepository.findAll(any<Specification<Transfer>>())
+            } returns listOf(
+                transferOf(TransferKind.EXPENSE_TRANSFER, 80_000L),
+                transferOf(TransferKind.GENERIC, 90_000L),
+            )
+
+            val result = service.getMonthlySummary(
+                user1.id, 2026, 3, CommonFilterParams(amountMin = 10_000, amountMax = 100_000)
+            )
+
+            Then("transfers still count toward the totals") {
+                result.totalExpense shouldBe 130_000L
+                result.totalTransfer shouldBe 90_000L
+            }
+        }
+
+        // 이체에 없는 축이 켜지면 이체는 조회조차 하지 않는다 (목록도 같은 판정 → 양쪽이 함께 사라진다).
+        When("a filter axis absent from transfers is active (category)") {
+            every {
+                transactionRepository.findAll(any<Specification<Transaction>>())
+            } returns listOf(txOf(TransactionType.EXPENSE, 70_000L))
+            // 이체 stub 은 비어있지 않다 — 그래도 합계에 잡히지 않아야 전량 제외가 증명된다.
+            every {
+                transferRepository.findAll(any<Specification<Transfer>>())
+            } returns listOf(transferOf(TransferKind.GENERIC, 55_000L))
+            every { categoryRepository.findByGroupIdIn(any()) } returns emptyList()
+
+            val result = service.getMonthlySummary(
+                user1.id, 2026, 3, CommonFilterParams(categoryId = UUID.randomUUID())
+            )
+
+            Then("transfers are excluded wholesale") {
+                result.totalExpense shouldBe 70_000L
+                result.totalTransfer shouldBe 0L
+                result.transferCount shouldBe 0
+            }
+        }
+
+        // "이체만 보기" — 거래는 0건이어야 한다. 예전에는 FE 가 TRANSFER 를 잘라 보내
+        // 서버가 "필터 없음" 으로 해석해 거래 전체를 합계에 넣었다.
+        When("only TRANSFER is selected") {
+            // 거래 조회가 **일어나도** 결과에 반영되지 않아야 한다는 것이 아니라,
+            // 애초에 거래를 세지 않는다는 것이 정답이다. 그래서 stub 은 일부러 비어있지 않다 —
+            // 합계가 0 이면 거래 경로를 타지 않았다는 증거다.
+            every {
+                transactionRepository.findAll(any<Specification<Transaction>>())
+            } returns listOf(txOf(TransactionType.EXPENSE, 999_000L))
+            every {
+                transferRepository.findAll(any<Specification<Transfer>>())
+            } returns listOf(transferOf(TransferKind.GENERIC, 400_000L))
+
+            val result = service.getMonthlySummary(
+                user1.id, 2026, 3, CommonFilterParams(transactionTypes = listOf("TRANSFER"))
+            )
+
+            Then("transactions are not counted and only the transfer bucket is filled") {
+                result.totalIncome shouldBe 0L
+                result.totalExpense shouldBe 0L
+                result.transactionCount shouldBe 0
+                result.totalTransfer shouldBe 400_000L
+            }
+        }
+
+        When("EXPENSE and TRANSFER are selected together") {
+            every {
+                transactionRepository.findAll(any<Specification<Transaction>>())
+            } returns listOf(txOf(TransactionType.EXPENSE, 60_000L))
+            every {
+                transferRepository.findAll(any<Specification<Transfer>>())
+            } returns listOf(transferOf(TransferKind.GENERIC, 30_000L))
+
+            val result = service.getMonthlySummary(
+                user1.id, 2026, 3,
+                CommonFilterParams(transactionTypes = listOf("EXPENSE", "TRANSFER"))
+            )
+
+            Then("both streams contribute") {
+                result.totalExpense shouldBe 60_000L
+                result.totalTransfer shouldBe 30_000L
             }
         }
 
         When("visibility is SHARED") {
             every {
-                transactionRepository.sumByTypeForCouple(
-                    couple.id,
-                    LocalDate.of(2026, 3, 1),
-                    LocalDate.of(2026, 3, 31),
-                    any(),
-                    "SHARED"
-                )
+                transactionRepository.findAll(any<Specification<Transaction>>())
             } returns listOf(
-                arrayOf(TransactionType.INCOME, 3000000L, 6L),
-                arrayOf(TransactionType.EXPENSE, 2000000L, 20L)
+                txOf(TransactionType.INCOME, 3_000_000L),
+                txOf(TransactionType.EXPENSE, 2_000_000L),
             )
 
-            val result = service.getMonthlySummary(user1.id, 2026, 3, "SHARED")
+            val result = service.getMonthlySummary(user1.id, 2026, 3, CommonFilterParams(visibility = "SHARED"))
 
+            // visibility 자체가 spec 에 실려 나가는지는 mock 으로 확인할 수 없다
+            // (Specification 내부는 들여다볼 수 없다) → 실 DB 계약 테스트가 담당한다:
+            // LedgerSummaryRowContractIntegrationTest.
             Then("returns shared-only summary") {
                 result.totalIncome shouldBe 3000000L
                 result.totalExpense shouldBe 2000000L
-                result.transactionCount shouldBe 26
-            }
-
-            Then("passes SHARED to repository") {
-                verify {
-                    transactionRepository.sumByTypeForCouple(
-                        couple.id, any(), any(), any(), "SHARED"
-                    )
-                }
+                result.transactionCount shouldBe 2
             }
         }
 
         When("visibility is PRIVATE") {
             every {
-                transactionRepository.sumByTypeForCouple(
-                    couple.id,
-                    LocalDate.of(2026, 3, 1),
-                    LocalDate.of(2026, 3, 31),
-                    any(),
-                    "PRIVATE"
-                )
-            } returns listOf(
-                arrayOf(TransactionType.EXPENSE, 500000L, 5L)
-            )
+                transactionRepository.findAll(any<Specification<Transaction>>())
+            } returns listOf(txOf(TransactionType.EXPENSE, 500_000L))
 
-            val result = service.getMonthlySummary(user1.id, 2026, 3, "PRIVATE")
+            val result = service.getMonthlySummary(user1.id, 2026, 3, CommonFilterParams(visibility = "PRIVATE"))
 
             Then("returns private-only summary") {
                 result.totalIncome shouldBe 0L
                 result.totalExpense shouldBe 500000L
-                result.transactionCount shouldBe 5
+                result.transactionCount shouldBe 1
+            }
+
+            // 이체엔 visibility 가 없다 → 개인 필터에서는 이체를 노출하지 않는다.
+            Then("transfers are excluded for the PRIVATE view") {
+                result.totalTransfer shouldBe 0L
+                result.transferCount shouldBe 0
             }
         }
 
         When("there are no transactions") {
             every {
-                transactionRepository.sumByTypeForCouple(
-                    couple.id,
-                    LocalDate.of(2026, 1, 1),
-                    LocalDate.of(2026, 1, 31),
-                    any(),
-                    "ALL"
-                )
+                transactionRepository.findAll(any<Specification<Transaction>>())
             } returns emptyList()
 
             val result = service.getMonthlySummary(user1.id, 2026, 1)
@@ -167,7 +293,7 @@ class StatisticsServiceTest : BehaviorSpec({
         When("invalid visibility is provided") {
             Then("throws BusinessException") {
                 shouldThrow<BusinessException> {
-                    service.getMonthlySummary(user1.id, 2026, 3, "INVALID")
+                    service.getMonthlySummary(user1.id, 2026, 3, CommonFilterParams(visibility = "INVALID"))
                 }.code shouldBe "VALIDATION_ERROR"
             }
         }
@@ -399,14 +525,10 @@ class StatisticsServiceTest : BehaviorSpec({
             val customEnd = LocalDate.of(2026, 3, 20)
 
             every {
-                transactionRepository.sumByTypeForCouple(
-                    couple.id, customStart, customEnd, any(), "ALL"
-                )
-            } returns listOf(
-                arrayOf(TransactionType.EXPENSE, 500000L, 5L)
-            )
+                transactionRepository.findAll(any<Specification<Transaction>>())
+            } returns List(5) { txOf(TransactionType.EXPENSE, 100_000L, customStart) }
 
-            val result = service.getMonthlySummary(user1.id, 2026, 3, "ALL", customStart, customEnd)
+            val result = service.getMonthlySummary(user1.id, 2026, 3, CommonFilterParams(dateFrom = customStart, dateTo = customEnd))
 
             Then("uses the custom date range instead of full month") {
                 result.totalExpense shouldBe 500000L
@@ -416,17 +538,12 @@ class StatisticsServiceTest : BehaviorSpec({
 
         When("only dateFrom is provided, dateTo defaults to end of month") {
             val customStart = LocalDate.of(2026, 3, 15)
-            val monthEnd = LocalDate.of(2026, 3, 31)
 
             every {
-                transactionRepository.sumByTypeForCouple(
-                    couple.id, customStart, monthEnd, any(), "ALL"
-                )
-            } returns listOf(
-                arrayOf(TransactionType.INCOME, 300000L, 3L)
-            )
+                transactionRepository.findAll(any<Specification<Transaction>>())
+            } returns listOf(txOf(TransactionType.INCOME, 300_000L, customStart))
 
-            val result = service.getMonthlySummary(user1.id, 2026, 3, "ALL", customStart, null)
+            val result = service.getMonthlySummary(user1.id, 2026, 3, CommonFilterParams(dateFrom = customStart))
 
             Then("uses dateFrom with month end as dateTo") {
                 result.totalIncome shouldBe 300000L
@@ -473,12 +590,12 @@ class StatisticsServiceTest : BehaviorSpec({
         val catId2 = UUID.randomUUID()
 
         When("requesting period summary with data") {
-            // sumByTypeForCouple
+            // 2026-08-12 — 총액은 getMonthlySummary 와 같은 spec 경로에서 나온다.
             every {
-                transactionRepository.sumByTypeForCouple(couple.id, dateFrom, dateTo, any(), "ALL")
+                transactionRepository.findAll(any<Specification<Transaction>>())
             } returns listOf(
-                arrayOf(TransactionType.INCOME, 5000000L, 10L),
-                arrayOf(TransactionType.EXPENSE, 3200000L, 35L)
+                txOf(TransactionType.INCOME, 5_000_000L, dateFrom),
+                txOf(TransactionType.EXPENSE, 3_200_000L, dateFrom),
             )
 
             // sumByCategoryForCouple
@@ -586,7 +703,7 @@ class StatisticsServiceTest : BehaviorSpec({
         When("invalid visibility is provided for period summary") {
             Then("throws BusinessException") {
                 shouldThrow<BusinessException> {
-                    service.getPeriodSummary(user1.id, dateFrom, dateTo, "INVALID")
+                    service.getPeriodSummary(user1.id, dateFrom, dateTo, CommonFilterParams(visibility = "INVALID"))
                 }.code shouldBe "VALIDATION_ERROR"
             }
         }
@@ -603,10 +720,10 @@ class StatisticsServiceTest : BehaviorSpec({
         When("transfers exist in the period") {
             // Transaction totals
             every {
-                transactionRepository.sumByTypeForCouple(couple.id, dateFrom, dateTo, any(), "ALL")
+                transactionRepository.findAll(any<Specification<Transaction>>())
             } returns listOf(
-                arrayOf(TransactionType.INCOME, 5000000L, 10L),
-                arrayOf(TransactionType.EXPENSE, 3000000L, 30L)
+                txOf(TransactionType.INCOME, 5_000_000L, dateFrom),
+                txOf(TransactionType.EXPENSE, 3_000_000L, dateFrom),
             )
             every {
                 transactionRepository.sumByCategoryForCouple(couple.id, dateFrom, dateTo, TransactionType.EXPENSE, any(), "ALL")
@@ -623,26 +740,14 @@ class StatisticsServiceTest : BehaviorSpec({
                 transactionRepository.dailySummaryForCouple(couple.id, dateFrom, dateTo, any(), "ALL")
             } returns emptyList()
 
-            // Phase 22: kind 기반. EXPENSE_TRANSFER=200000 OUT, INCOME_TRANSFER=100000 IN, GENERIC=없음.
-            val pmId = UUID.randomUUID()
+            // 2026-08-12 — 이체 집계는 kind 별 쿼리 대신 `TransferGating.spec` 1회 조회 + fold.
+            // (이체 목록 조회와 같은 판정을 쓰기 위한 통일. EXPENSE_TRANSFER=200000, INCOME_TRANSFER=100000)
             every {
-                transferRepository.sumAmountBySourceByKind(
-                    couple.id, dateFrom, dateTo,
-                    com.budgetbook.transfer.domain.TransferKinds.EXPENSE_AFFECTING
-                )
-            } returns listOf(arrayOf<Any>(pmId, 200000L))
-            every {
-                transferRepository.sumAmountByDestinationByKind(
-                    couple.id, dateFrom, dateTo,
-                    com.budgetbook.transfer.domain.TransferKinds.INCOME_AFFECTING
-                )
-            } returns listOf(arrayOf<Any>(pmId, 100000L))
-            every {
-                transferRepository.sumAmountBySourceByKind(
-                    couple.id, dateFrom, dateTo,
-                    com.budgetbook.transfer.domain.TransferKinds.TRANSFER_ONLY
-                )
-            } returns emptyList()
+                transferRepository.findAll(any<Specification<Transfer>>())
+            } returns listOf(
+                transferOf(TransferKind.EXPENSE_TRANSFER, 200_000L, dateFrom),
+                transferOf(TransferKind.INCOME_TRANSFER, 100_000L, dateFrom),
+            )
 
             val result = service.getPeriodSummary(user1.id, dateFrom, dateTo)
 
@@ -670,12 +775,12 @@ class StatisticsServiceTest : BehaviorSpec({
         val pmId = UUID.randomUUID()
 
         When("same period data is queried via both endpoints") {
-            // Same transaction data for both
+            // Same transaction data for both — 이제 두 엔드포인트가 같은 spec 경로를 탄다.
             every {
-                transactionRepository.sumByTypeForCouple(couple.id, dateFrom, dateTo, any(), "ALL")
+                transactionRepository.findAll(any<Specification<Transaction>>())
             } returns listOf(
-                arrayOf(TransactionType.INCOME, 4000000L, 8L),
-                arrayOf(TransactionType.EXPENSE, 2500000L, 20L)
+                txOf(TransactionType.INCOME, 4_000_000L, dateFrom),
+                txOf(TransactionType.EXPENSE, 2_500_000L, dateFrom),
             )
 
             // Transfers
@@ -702,7 +807,7 @@ class StatisticsServiceTest : BehaviorSpec({
                 transactionRepository.dailySummaryForCouple(couple.id, dateFrom, dateTo, any(), "ALL")
             } returns emptyList()
 
-            val summaryResult = service.getMonthlySummary(user1.id, 2026, 4, "ALL", dateFrom, dateTo)
+            val summaryResult = service.getMonthlySummary(user1.id, 2026, 4, CommonFilterParams(dateFrom = dateFrom, dateTo = dateTo))
             val periodResult = service.getPeriodSummary(user1.id, dateFrom, dateTo)
 
             Then("totalIncome matches between summary and period-summary") {
@@ -735,17 +840,17 @@ class StatisticsServiceTest : BehaviorSpec({
             } returns emptyList()
 
             val result = service.getMonthlySummary(
-                userId = user1.id, year = 2026, month = 3, needsReviewOnly = true
+                userId = user1.id, year = 2026, month = 3,
+                filter = CommonFilterParams(needsReviewOnly = true)
             )
 
             Then("uses the filtered Specification path so totals match the visible rows") {
                 result.totalIncome shouldBe 0L
                 result.totalExpense shouldBe 0L
                 result.transactionCount shouldBe 0
-                verify(exactly = 2) {
-                    transactionRepository.findAll(
-                        any<org.springframework.data.jpa.domain.Specification<com.budgetbook.transaction.domain.Transaction>>()
-                    )
+                // 2026-08-12 — 타입별 2회 조회를 1회 + fold 로 바꿨다.
+                verify(atLeast = 1) {
+                    transactionRepository.findAll(any<Specification<Transaction>>())
                 }
             }
         }
@@ -780,8 +885,8 @@ class StatisticsServiceTest : BehaviorSpec({
             } returns emptyList()
 
             val result = service.getPeriodSummary(
-                user1.id, dateFrom, dateTo, "ALL",
-                categoryId = filterCategoryId
+                user1.id, dateFrom, dateTo,
+                CommonFilterParams(categoryId = filterCategoryId)
             )
 
             Then("uses Specifications-based query (returns filtered data)") {

--- a/backend/src/test/kotlin/com/budgetbook/transaction/service/TransactionServiceTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/transaction/service/TransactionServiceTest.kt
@@ -29,6 +29,7 @@ import com.budgetbook.transfer.repository.TransferRepository
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
@@ -918,21 +919,62 @@ class TransactionServiceTest : BehaviorSpec({
         }
     }
 
-    Given("transactionTypes contains FE-only TRANSFER value") {
+    // 2026-08-12 계약 변경 — `TRANSFER` 는 **유효한 값**이 됐다.
+    //
+    // 이전에는 400 이었고, 그래서 FE 가 전송 직전에 TRANSFER 를 잘라냈다. 그 결과 서버는
+    // "타입 필터 없음" 으로 해석해 거래 전체를 반환하고 FE 가 클라이언트에서 다시 걸렀다 —
+    // 판정이 두 곳에 있어 합계와 행이 다른 집합을 세는 원인이 됐다.
+    // 이제 서버가 두 스트림을 모두 판정한다: TRANSFER 단독이면 거래는 0건.
+    Given("transactionTypes contains the TRANSFER ledger value") {
         every { coupleResolver.getActiveCouple(user1.id) } returns couple
 
         When("listTransactions is called with transactionTypes=[TRANSFER]") {
-            Then("throws BusinessException with VALIDATION_ERROR (TRANSFER 는 FE 의사-타입)") {
-                val ex = shouldThrow<com.budgetbook.common.exception.BusinessException> {
-                    service.listTransactions(
-                        userId = user1.id, year = 2024, month = 1, type = null, categoryId = null,
-                        keyword = null, paymentMethodId = null, pocketId = null,
-                        amountMin = null, amountMax = null, dateFrom = null, dateTo = null,
-                        visibility = null, page = 0, size = 20,
-                        transactionTypes = listOf("TRANSFER")
+            Then("returns an empty page instead of throwing (거래 타입이 하나도 선택되지 않음)") {
+                val result = service.listTransactions(
+                    userId = user1.id, year = 2024, month = 1, type = null, categoryId = null,
+                    keyword = null, paymentMethodId = null, pocketId = null,
+                    amountMin = null, amountMax = null, dateFrom = null, dateTo = null,
+                    visibility = null, page = 0, size = 20,
+                    transactionTypes = listOf("TRANSFER")
+                )
+
+                result.content.shouldBeEmpty()
+                result.totalElements shouldBe 0
+                result.last shouldBe true
+                // 조회 자체를 하지 않는다 (repository 를 태우면 mock 이 예외를 던져 실패).
+                verify(exactly = 0) {
+                    transactionRepository.findAll(
+                        any<org.springframework.data.jpa.domain.Specification<Transaction>>(),
+                        any<org.springframework.data.domain.Pageable>()
                     )
                 }
-                ex.code shouldBe "VALIDATION_ERROR"
+            }
+        }
+
+        When("listTransactions is called with transactionTypes=[EXPENSE, TRANSFER]") {
+            Then("filters transactions to EXPENSE only (이체는 이체 스트림이 담당)") {
+                every {
+                    transactionRepository.findAll(
+                        any<org.springframework.data.jpa.domain.Specification<Transaction>>(),
+                        any<org.springframework.data.domain.Pageable>()
+                    )
+                } returns org.springframework.data.domain.PageImpl(emptyList())
+
+                val result = service.listTransactions(
+                    userId = user1.id, year = 2024, month = 1, type = null, categoryId = null,
+                    keyword = null, paymentMethodId = null, pocketId = null,
+                    amountMin = null, amountMax = null, dateFrom = null, dateTo = null,
+                    visibility = null, page = 0, size = 20,
+                    transactionTypes = listOf("EXPENSE", "TRANSFER")
+                )
+
+                result.content.shouldBeEmpty()
+                verify(exactly = 1) {
+                    transactionRepository.findAll(
+                        any<org.springframework.data.jpa.domain.Specification<Transaction>>(),
+                        any<org.springframework.data.domain.Pageable>()
+                    )
+                }
             }
         }
 

--- a/backend/src/test/kotlin/com/budgetbook/transfer/controller/TransferControllerTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/transfer/controller/TransferControllerTest.kt
@@ -1,5 +1,6 @@
 package com.budgetbook.transfer.controller
 
+import com.budgetbook.common.dto.CommonFilterParams
 import com.budgetbook.couple.dto.UserSummary
 import com.budgetbook.transfer.dto.CreateTransferRequest
 import com.budgetbook.transfer.dto.PaymentMethodSummary
@@ -57,9 +58,10 @@ class TransferControllerTest : FunSpec({
 
     test("listTransfers returns transfer list") {
         val transfers = listOf(sampleTransferResponse())
-        every { transferService.listTransfers(testUserId, 2026, 3) } returns transfers
+        val filter = CommonFilterParams(year = 2026, month = 3)
+        every { transferService.listTransfers(testUserId, filter) } returns transfers
 
-        val result = controller.listTransfers(testUserId, 2026, 3)
+        val result = controller.listTransfers(testUserId, filter)
 
         result.success shouldBe true
         result.data!!.size shouldBe 1

--- a/backend/src/test/kotlin/com/budgetbook/transfer/service/TransferGatingTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/transfer/service/TransferGatingTest.kt
@@ -1,0 +1,83 @@
+package com.budgetbook.transfer.service
+
+import com.budgetbook.common.dto.CommonFilterParams
+import com.budgetbook.common.filter.LedgerFilterAxis
+import com.budgetbook.common.filter.TransferAxisHandling
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.util.UUID
+
+/**
+ * 이체 게이팅 단일 판정의 규칙 고정.
+ *
+ * 여기서 검증하는 것은 "**어떤 축이 이체를 전량 제외하는가**" 다.
+ * 쿼리 조건([TransferGating.spec])이 실제로 어떤 행을 고르는지는 mock 으로 확인할 수 없어
+ * `LedgerSummaryRowContractIntegrationTest` 가 실 PostgreSQL 로 담당한다.
+ */
+class TransferGatingTest : FunSpec({
+
+    test("no filter keeps transfers") {
+        TransferGating.excludedWholesale(CommonFilterParams()) shouldBe false
+    }
+
+    test("axes that transfers do not have exclude them wholesale") {
+        // 이체엔 카테고리·포켓·needsReview·visibility 필드가 없다 → 매칭 불가 = 전량 제외.
+        listOf(
+            "categoryId" to CommonFilterParams(categoryId = UUID.randomUUID()),
+            "categoryIds" to CommonFilterParams(categoryIds = listOf(UUID.randomUUID())),
+            "categoryGroupIds" to CommonFilterParams(categoryGroupIds = listOf(UUID.randomUUID())),
+            "pocketId" to CommonFilterParams(pocketId = UUID.randomUUID()),
+            "pocketIds" to CommonFilterParams(pocketIds = listOf(UUID.randomUUID())),
+            "needsReviewOnly" to CommonFilterParams(needsReviewOnly = true),
+            "visibility=PRIVATE" to CommonFilterParams(visibility = "PRIVATE"),
+            "singular type" to CommonFilterParams(type = "EXPENSE"),
+            "types without TRANSFER" to CommonFilterParams(transactionTypes = listOf("EXPENSE")),
+        ).forEach { (axis, filter) ->
+            withClue("axis=$axis should exclude transfers") {
+                TransferGating.excludedWholesale(filter) shouldBe true
+            }
+        }
+    }
+
+    test("axes that apply to transfers keep them") {
+        listOf(
+            "amount range" to CommonFilterParams(amountMin = 1_000, amountMax = 2_000),
+            "payment methods" to CommonFilterParams(paymentMethodIds = listOf(UUID.randomUUID())),
+            "keyword" to CommonFilterParams(keyword = "커피"),
+            "date range" to CommonFilterParams(year = 2026, month = 7),
+            "visibility=SHARED" to CommonFilterParams(visibility = "SHARED"),
+            "visibility=ALL" to CommonFilterParams(visibility = "ALL"),
+            "needsReviewOnly=false" to CommonFilterParams(needsReviewOnly = false),
+            "types with TRANSFER" to CommonFilterParams(transactionTypes = listOf("EXPENSE", "TRANSFER")),
+            "TRANSFER only" to CommonFilterParams(transactionTypes = listOf("TRANSFER")),
+        ).forEach { (axis, filter) ->
+            withClue("axis=$axis should keep transfers") {
+                TransferGating.excludedWholesale(filter) shouldBe false
+            }
+        }
+    }
+
+    test("reconciled matching follows the three-state rule") {
+        TransferGating.reconciledMatches(null, hasSnapshot = true) shouldBe true
+        TransferGating.reconciledMatches(null, hasSnapshot = false) shouldBe true
+        TransferGating.reconciledMatches(true, hasSnapshot = true) shouldBe true
+        TransferGating.reconciledMatches(true, hasSnapshot = false) shouldBe false
+        TransferGating.reconciledMatches(false, hasSnapshot = false) shouldBe true
+        TransferGating.reconciledMatches(false, hasSnapshot = true) shouldBe false
+    }
+
+    test("the axis classification agrees with excludedWholesale") {
+        // 분류(문서)와 실제 판정(코드)이 갈라지면 다음 사람이 문서를 믿고 틀린다.
+        val wholesaleAxes = LedgerFilterAxis.entries
+            .filter { TransferGating.handling(it) == TransferAxisHandling.EXCLUDES_WHOLESALE }
+            .map { it.propertyName }
+            .toSet()
+
+        wholesaleAxes shouldBe setOf(
+            "categoryId", "categoryIds", "categoryGroupIds",
+            "pocketId", "pocketIds",
+            "needsReviewOnly", "visibility", "type", "transactionTypes",
+        )
+    }
+})

--- a/backend/src/test/kotlin/com/budgetbook/transfer/service/TransferServiceTest.kt
+++ b/backend/src/test/kotlin/com/budgetbook/transfer/service/TransferServiceTest.kt
@@ -4,6 +4,7 @@ import com.budgetbook.auth.domain.AuthProvider
 import com.budgetbook.auth.domain.User
 import com.budgetbook.auth.repository.UserRepository
 import com.budgetbook.common.dto.PatchValue
+import com.budgetbook.common.dto.CommonFilterParams
 import com.budgetbook.common.exception.BusinessException
 import com.budgetbook.common.exception.NotFoundException
 import com.budgetbook.couple.domain.Couple
@@ -229,13 +230,13 @@ class TransferServiceTest : BehaviorSpec({
             amount = 100000, description = "ATM", transferDate = LocalDate.of(2026, 3, 15)
         )
         every {
-            transferRepository.findByCoupleIdAndTransferDateBetweenOrderByTransferDateDesc(
-                couple.id, LocalDate.of(2026, 3, 1), LocalDate.of(2026, 3, 31)
+            transferRepository.findAll(
+                any<org.springframework.data.jpa.domain.Specification<Transfer>>()
             )
         } returns listOf(transfer)
 
         When("listing transfers for March 2026") {
-            val result = service.listTransfers(user1.id, 2026, 3)
+            val result = service.listTransfers(user1.id, CommonFilterParams(year = 2026, month = 3))
 
             Then("returns the transfer list") {
                 result.size shouldBe 1

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -9,16 +9,24 @@
 ## 1. 현재 상태 (한눈에)
 
 <!-- HNS:STATE -->
-- **단계**: **"연/월 피커 단일 화면 통합 + 스피너"** 회차 — PR #296 → 배포 →
-  **사용자 라이브 검증 통과 = 완료**(2026-08-11, 타임라인 34)
-- **상태**: **열린 작업 없음.** 다음 회차(합계 ≠ 행 잔존 불일치)는 아래 §3 에 착수 지점까지
-  고정돼 있다 — **분석부터** 시작한다
-- **회차 경계**: 다음 회차는 **`/clear` 후 새 세션**에서 시작한다
-- **이번 회차 교훈**: UI 개선이 프레임워크 위젯 위에 얹히면 어포던스가 둘로 갈라진다.
-  완료 기준은 "경로 추가"가 아니라 **"경쟁 경로 0개"** — 제어 불가하면 위젯을 교체한다
+- **단계**: **"합계 ≠ 행 불일치"** 회차 — **구현 완료 · 로컬 CI 5종 통과**
+  (2026-08-13, 타임라인 37). 커밋/PR 진행 중
+- **상태**: 승인 완료 → 구현 완료. 남은 것은 커밋 → PR → 원격 CI → 머지 → 배포 →
+  **사용자 라이브 검증**(기획서 §8 A1~A11)
+- **정본 문서**: 분석 `docs/sessions/2026-08-12_1_summary-row-mismatch_analysis.md` /
+  기획 `docs/sessions/2026-08-12_2_summary-row-mismatch_plan.md`
+- **확정된 판정**: Q1 합계에 **이체 포함**(필터 경로를 고친다) / Q2 **기간 장부**(이체도 범위 로드) /
+  Q3 행 유지 + **"합계 제외" 배지**
+- **하네스 게이트**: `filter_propagation` STRUCTURAL_FIX_REQUIRED → **acknowledge 완료(편집 허용)**.
+  근거 = 기획서 §2 S1~S8
+- ⚠ **착수 지점 전제 정정(측정)**: `StatisticsService.kt:147`(필터 시 `totalTransfer=0`)은
+  **표시되지 않는 죽은 값**이고, 수입/지출 불일치는 실 DB 에 0건인 `EXPENSE_TRANSFER`/
+  `INCOME_TRANSFER` 가 있어야 발현한다 → **현재 발현 중인 결함은 F1**:
+  기간 필터가 월을 넘으면 이체 스트림만 월에 갇혀 **범위 내 이체 금액 77% 누락**
+- **근본 원인**: 행 집합과 합계 집합이 같은 소스에서 나오지 않는다(서버=거래·범위 전체 /
+  클라=이체·포커스 월). `gateLedger` 는 축 누락을 봉인했고 남은 구멍은 **범위·소스 불일치**
+- **이번 회차 교훈(직전)**: 완료 기준은 "경로 추가"가 아니라 **"경쟁 경로 0개"**
   (메모리 `reference_framework_owned_affordance`)
-- **확정된 설계**: 왼쪽 연도 **휠 스피너** + 오른쪽 12개월 그리드(한 화면, 단계 전환 0회) /
-  일 선택은 **자체 일 그리드**로 교체해 `CalendarDatePicker` 를 피커에서 제거
 - ⚠ **이 앱에 홈 대시보드 화면은 없다** — `/home` → `/transactions` redirect,
   `DashboardPage` 는 미라우팅(죽은 코드), 탭 4개(거래·분석·자산·더보기).
   설정의 "홈 화면 구성" 도 고아 항목이다. **홈 위젯 전제의 계획·후보는 전부 무효**
@@ -559,34 +567,125 @@
    - **회차 경계**: 여기서 멈춘다. 다음 회차는 `/clear` 후 새 세션에서 **분석부터** 시작
      (메모리 `feedback_round_boundary_clear`)
 
+35. **2026-08-12** — 새 회차 **"합계 ≠ 행 잔존 불일치" 분석 완료**(기획 전, 코드 변경 0줄).
+   **착수 지점의 전제가 측정으로 정정됐다.**
+   - 산출물: `docs/sessions/2026-08-12_1_summary-row-mismatch_analysis.md`
+   - 하네스 감사: `pre-change-audit.sh . filter_propagation amount_calculation` →
+     `filter_propagation` **STRUCTURAL_FIX_REQUIRED**(과거 3건, 게이트 LOCKED).
+     기획서에 구조적 수정 포함 후 `acknowledge-gate.sh` 로 해제
+   - **전제 정정**: §3 에 적혀 있던 근거 `StatisticsService.kt:147`(필터 활성 시 `totalTransfer=0`)은
+     **FE 어디에서도 표시되지 않는 죽은 값**이었다 — 장부 합계바의 이체 칸은 클라 계산
+     (`LedgerSummary.from`)이고 분석 탭은 이체 칸을 그리지 않는다(grep 측정).
+     수입/지출이 갈라지려면 `EXPENSE_TRANSFER`/`INCOME_TRANSFER` 이체가 필요한데 실 DB **0건**
+   - 실 DB 측정: 이체 kind = `GENERIC` 22 / `CARD_SETTLEMENT` 8 / EXPENSE·INCOME_TRANSFER **0** ·
+     거래 type = EXPENSE 542 / INCOME 31 / **ADJUSTMENT 17** · 월 최대 거래 **119건**(페이지 200 미달)
+   - **실제 발현 중인 결함(F1)**: 기간 필터가 포커스 월을 넘으면 **이체 스트림만 월에 갇힌다** —
+     `LoadTransfers({year, month})` 는 월 단위(`transfer_event.dart:15`)인데 거래 목록과 서버 합계는
+     `dateFrom/dateTo` 가 월을 완전히 덮어쓴다(`TransactionService.kt:109~118`,
+     `StatisticsService.kt:78~79`)며 행 빌더는 월로 다시 자르지 않는다.
+     표본(2026-06-15~08-05, 포커스 8월): 거래 192건 전량 노출 vs 이체는 8월 2건만 →
+     범위 내 이체 금액의 **77%(3,385,139원) 누락**.
+     `reference_transaction_merged_transfer_stream_drift` 의 5번째 변형 —
+     이번엔 축 누락이 아니라 **스트림의 로드 범위 불일치**
+   - 함께 확인된 잠재/표시 결함: F2 필터 경로의 이체 전량 제외(도달 가능, 이체 폼에서 kind 선택 가능) ·
+     F3 ADJUSTMENT 17건·CARD_SETTLEMENT 8건이 행에는 보이나 합계 어느 칸에도 없음
+     (합계바 잔액이 `LedgerSummary.balance` 를 안 쓴다) · F4 페이지네이션(월 단위 미발현, 여유 8건)
+   - 근본 원인 한 문장: **행 집합과 합계 집합이 같은 소스에서 나오지 않는다** — 합계는
+     서버(거래·범위 전체) + 클라(이체·포커스 월)를 한 줄에 섞고, 이체 로드 범위(월)가 필터 범위와 다르다
+   - 구조적 수정 방향(안 A 권장): S1 BE `hasContentFilters` 분기 제거(이체도 필터 축 집계) ·
+     S2 `LoadTransfers({required dateFrom, dateTo})` 로 컴파일 강제 · S3 합계 응답에 집계 건수 ·
+     S4 합계바 혼합 소스 금지 소스검사 가드 · S5 `StatisticsServiceTest` 의 kind×필터 케이스 0건 보강
+   - **다음 단계는 사용자 판정 3건**(분석서 §5): Q1 합계에 이체 포함 여부(포함으로 판정, 반증 조건 명시) ·
+     Q2 기간 필터가 월을 넘을 때 화면 정체성 · Q3 ADJUSTMENT/CARD_SETTLEMENT 행 배지 여부
+
+36. **2026-08-12** — 판정 3건 확정 + **기획 완료**(승인 대기). 코드 변경 0줄.
+   - 사용자 판정: **Q1 = 합계에 이체 포함**(필터 경로를 고친다) / **Q2 = 기간 장부**(이체도 범위 로드) /
+     **Q3 = 행 유지 + "합계 제외" 배지**
+   - 산출물: `docs/sessions/2026-08-12_2_summary-row-mismatch_plan.md`
+   - **게이트 해제 완료**: `acknowledge-gate.sh budget-book <plan>` → 편집 허용
+     (근거 = 기획서 §2 S1~S8 구조적 수정)
+   - 구조적 수정 설계: S1 BE `LedgerFilter` VO + `LedgerFilterAxis` enum(`when` exhaustive =
+     축 추가 시 **컴파일 실패**) + 리플렉션 가드 · S2 `TransferGating` 단일 판정을 **이체 목록
+     쿼리와 이체 집계가 공유** · S3 합계의 `hasContentFilters` 분기 **제거**(`totalTransfer=0`
+     하드코딩 삭제) · S4 장부 전용 `LedgerTransfersCubit` 분리 · S5 합계바 서버 단일 소스 +
+     FE 이체 축 판정 제거 · S6 합계 제외 배지 · S7 api-spec 선행 갱신 · S8 "합계=행" 계약 통합테스트
+   - **사이드이펙트 감사(측정)**: `TransferBloc` 은 **6곳이 공유하는 lazy singleton**
+     (장부 · 이체 목록 · 카드정산 · 정산 뷰 · 거래 폼 · month_sync/sync_event) →
+     장부에 필터를 주입하면 나머지가 오염된다 → **장부 전용 Cubit 분리로 차단**(S4).
+     이 감사 없이 진행했으면 5개 화면이 필터된 이체만 보게 됐다
+   - **금액 표시 위치 전수 조사(측정)**: `totalIncome|totalExpense|totalTransfer` 참조 26파일 확인 →
+     영향 7곳(합계바 계열) / 무영향 확인 근거 병기. 분석 탭·리포트는 **이체 칸을 그리지 않음**
+     (grep 0건) → 분석서 §6 미해결 1건 해소. `reconciliation_view.dart:729` 는 정산 스냅샷 별개 소스
+   - **자체 총괄 검토에서 잡은 누락 2건**: ① `docs/api-spec.md:1773` 이 summary 의 필터 파라미터를
+     3개만 문서화(구현은 12개+) + `:42` 가 이번에 바꿀 규칙("필터 시 totalTransfer 항상 0")을
+     규범으로 못박아 둠 → S7 로 선행 갱신 ② Spring `@ModelAttribute` + Kotlin 기본값 +
+     `List<UUID>` 바인딩 리스크 → 구현 첫 단계에 컨트롤러 슬라이스 테스트로 선검증
+   - DB 마이그레이션 없음(스키마 변경 0건)
+
+37. **2026-08-13** — 승인 후 **구현 완료 · 로컬 CI 5종 전부 통과**. 커밋/PR 전.
+   - 사용자 승인: "기획대로 한 PR" (기획서 §7 순서 그대로)
+   - **BE 구조 수정**:
+     - 신설 `common/filter/LedgerFilterAxis.kt` — 축 20개 enum + `TransferAxisHandling`.
+       `TransferGating.handling` 의 **exhaustive when** 이 축 추가 시 컴파일을 막는다
+     - 신설 `common/filter/LedgerTypeSelection.kt` — `transactionTypes` 파싱 단일 진입점.
+       **`TRANSFER` 가 계약 값으로 승격**(이전엔 400). "필터 없음"과 "거래 타입 0개 선택"을 구분
+     - 신설 `transfer/service/TransferGating.kt` — 이체 판정 단일 지점.
+       `excludedWholesale` + `spec` 을 **목록 조회와 집계가 공유**
+     - `StatisticsService.getMonthlySummary` 의 `hasContentFilters` **분기 제거** →
+       `totalTransfer = 0L` 하드코딩 삭제. `getPeriodSummary` 도 같은 헬퍼(`resolveTransactionScope`)로 통일
+     - `ExpenseCalculator.transferBuckets/bucketsOf` 추가(kind 별 버킷) ·
+       `TransferRepository` 에 `JpaSpecificationExecutor` · 응답에 `transferCount`
+     - 컨트롤러의 **필드 수동 나열 제거** — 필터 VO 통째로 전달
+   - **FE 구조 수정**:
+     - 신설 `LedgerTransfersCubit` — 장부 전용 이체 소스. 공유 `TransferBloc`(소비자 6곳)은
+       손대지 않아 이체 목록·카드정산·정산 뷰·거래 폼 무영향. DI·month_sync·sync_event 배선
+     - `ledger_gating.dart` 에서 **이체 축 판정 삭제**(서버 신뢰) — 판정 2곳이 재발 메커니즘이었다
+     - 합계바 3칸 전부 **서버 단일 소스**(`serverTotalTransfer` 신설). 클라 `LedgerSummary` 는
+       러닝밸런스 전용으로 축소. `toQueryParams` 가 `TRANSFER` 를 그대로 전송
+     - 신설 `ledger_totals_exclusion.dart` + `ExcludedFromTotalsBadge` — ADJUSTMENT·카드정산 행에
+       "합계 제외" 배지(판정은 단일 헬퍼 경유)
+   - **계약 문서 선행 갱신**: `docs/api-spec.md` — summary 필터 파라미터 12개+ 문서화 ·
+     `:42` 의 "필터 시 totalTransfer 항상 0" **규범 폐기 명시** · List Transfers 범위·필터 ·
+     `TRANSFER` 계약 값 절 신설
+   - **구현 중 테스트가 잡은 실제 버그 1건**: "타입 필터 없음"과 "타입 필터가 거래를 하나도
+     고르지 않음"(이체만 보기)을 혼동해 이체만 보기에서 거래 합계가 남았다 →
+     `hasTypeFilter` 로 분리. `LedgerTypeSelectionTest` 가 회귀 가드
+   - **신설 테스트**: `LedgerSummaryRowContractIntegrationTest`(실 PostgreSQL, 축 조합 15건 —
+     **합계 = 행** 대조 + 절대값 고정) · `LedgerFilterAxisGuardTest`(리플렉션 1:1) ·
+     `TransferGatingTest` · `LedgerTypeSelectionTest` · `ledger_transfers_cubit_test.dart` ·
+     `ledger_gating_test.dart` 재작성(FE 이체 판정 재도입 금지 + 장부의 `TransferBloc` 사용 금지 가드)
+   - **로컬 CI 5종**: analyze 신규 0건(잔여 3건은 미변경 테스트 파일 기존 info) /
+     `flutter test` **936건** / `./gradlew clean test` 통과 /
+     `flutter build web --release` 통과 / **번들 문자열 확인** — `합계 제외` 1건,
+     배지 툴팁 2건 존재
+   - **측정 방법 보강**: 번들 문자열 확인에서 한글은 `\uXXXX` 지만 **Latin-1 범위(`·` 등)는
+     `\xNN`** 로 인코딩된다. 처음 `·` 포함 문구가 0건으로 나와 대조군 실험으로 방법 결함을 찾았다
+     (메모리 `reference_live_bundle_string_verification` 보강 대상)
+
 ## 3. 다음 단계
 
 <!-- HNS:NEXT -->
-- **현재 상태**: 연/월 피커 통합 회차 **라이브 검증 통과 = 완료**(타임라인 34). **열린 작업 없음.**
-- **회차 경계 규칙**: 회차가 끝나면 종결 기록 + 착수 지점 고정까지만 하고 **멈춘다**.
-  다음 회차는 **반드시 `/clear` 후 새 세션에서 시작**한다 — 같은 세션에서 이어서 착수 금지
-  (메모리 `feedback_round_boundary_clear`)
+- **현재 상태**: "합계 ≠ 행" 회차 **기획 완료 → 승인 대기**(타임라인 36).
+  기획서 `docs/sessions/2026-08-12_2_summary-row-mismatch_plan.md`
+- 선행 작업은 모두 끝났다: 하네스 감사 + 게이트 acknowledge / 판정 3건 확정 /
+  `TransferBloc` 공유 6곳 사이드이펙트 감사 / 금액 표시 26파일 전수 조사 / api-spec drift 2건 확인
 
-### 다음 회차 — **합계 ≠ 행 잔존 불일치** (착수 지점 고정, **분석부터**)
+### 승인 후 순서 (기획서 §7, 고정)
 
-대기열에서 이걸 먼저 잡는 이유: 사용자 눈에 **숫자가 틀려 보이는** 유일한 항목이고
-범위가 작다(BE 위주). 나머지는 기능 추가·인프라라 급하지 않다.
-정본 기획서는 새로 쓴다 → `docs/sessions/YYYY-MM-DD_N_summary-row-mismatch_plan.md`
-
-- **증상**: 금액/기간/결제수단 필터만 켜면 **상단 합계와 아래 행이 서로 다른 집합**을 센다.
-  BE summary 는 이체를 빼는데(`StatisticsService.kt:147`) FE 목록에는 이체 행이 남는다
-- **첫 명령**: `bash ~/.claude/harness/scripts/pre-change-audit.sh . filter_propagation amount_calculation`
-  → 그 다음 `StatisticsService.kt` 의 summary 쿼리와 `ledger_gating.dart` 판정을 **나란히** 읽는다
-- **이미 알려진 지형 (재조사 불필요)**:
-  - 거래 목록은 **거래 + 이체 FE 병합** 스트림이다. 집계/필터를 한쪽에만 넣으면 drift 한다
-    (메모리 `reference_transaction_merged_transfer_stream_drift` — 이 프로젝트 최대 재발원)
-  - 이체 게이팅의 단일 진입점은 `lib/features/transaction/presentation/utils/ledger_gating.dart`.
-    새 판정은 반드시 여기를 먼저 거친다(필드 수 가드가 강제)
-  - 필터는 VO 하나로 관통해야 한다 — 필드 수동 나열은 4회 재발원
-    (메모리 `feedback_filter_vo_single_source`, `reference_month_move_filter_drop`)
-- **분석 시 정할 것**: 정답이 "합계도 이체를 포함" 인지 "목록도 이체를 제외" 인지.
-  **어느 쪽이든 20곳 표시 위치 전수 확인**이 전제다(메모리 `feedback_financial_consistency`).
-  판정 기준을 기획서에 사전에 못 박고 시작한다
+1. 계약 커밋 0 — `docs/api-spec.md` 갱신(summary 필터 파라미터 12개+ 미문서화 · `:42` 의
+   "필터 시 totalTransfer 항상 0" 규범 정정 · List Transfers 의 범위·필터 파라미터). **구현보다 먼저**
+2. BE 커밋 1 — `LedgerFilter` VO + `LedgerFilterAxis` enum + `TransferGating` + 리플렉션 가드 +
+   컨트롤러 바인딩 슬라이스 테스트(Spring `@ModelAttribute` + Kotlin 기본값 리스크 선검증)
+3. BE 커밋 2 — 합계 `hasContentFilters` 분기 제거(`getMonthlySummary` · `getPeriodSummary`) +
+   이체 목록 필터 파라미터 + "합계 = 행" 계약 통합테스트(Testcontainers, 축 조합 매트릭스)
+4. FE 커밋 3 — 장부 전용 `LedgerTransfersCubit` + 배선(month_sync · sync_event) +
+   `gateLedger` 이체 축 판정 제거 + 가드 재작성(FE 재도입 금지 · 장부의 `TransferBloc` 참조 금지)
+5. FE 커밋 4 — 합계바 서버 단일 소스 + "합계 제외" 배지(단일 헬퍼 경유)
+6. 로컬 CI 5종(analyze 전체 / flutter test / gradlew test / build web / 번들 문자열) → PR →
+   원격 CI → 머지 → 배포 → 기획서 §8 A1~A11 라이브 검증 요청
+- DB 마이그레이션 없음(스키마 변경 0건)
+- **라이브 검증 핵심(A1)**: 기간 `2026-06-15~2026-08-05` → 6·7월 이체 행이 보이고 이체 합계가
+  1,008,648원 → 4,393,787원 수준으로 오른다(수정 전 77% 누락)
 
 ### 그 다음 대기열 (착수 순서 아님)
 

--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -39,7 +39,35 @@ Transfers now carry a semantic classification `kind` that controls how they flow
 
 - `totalTransfer: Long` — sum of `TransferKind.GENERIC` transfers for the period. Always present. Disjoint from `totalIncome`/`totalExpense`.
 
-`PeriodSummaryResponse` (period-summary endpoint) also adds `totalTransfer`. When category/payment-method/pocket filters are active, `totalTransfer` is always `0` (transfers are not subject to those filters).
+`PeriodSummaryResponse` (period-summary endpoint) also adds `totalTransfer`.
+
+> **Changed 2026-08-12 — transfers are now aggregated under every filter.**
+> The previous rule ("when category/payment-method/pocket filters are active, `totalTransfer`
+> is always `0`") is **obsolete**. It made the summary count a different set than the rows the
+> client displays ("합계 ≠ 행"): the ledger list keeps transfer rows for amount / payment-method /
+> keyword filters, while the summary dropped them.
+>
+> The rule is now uniform for both the list and the summary (single source: `TransferGating`):
+> - Axes that exist on a transfer (date range, payment method — either leg, amount range,
+>   keyword over description + both payment-method names) are **applied**.
+> - Axes that do not exist on a transfer (category, category group, pocket, `needsReviewOnly`,
+>   `visibility=PRIVATE`, singular `type`, `transactionTypes` without `TRANSFER`) **exclude
+>   transfers entirely** — they cannot match, so both the rows and the summary drop them.
+> - `CARD_SETTLEMENT` is excluded from every bucket (already counted via the original expense);
+>   `ADJUSTMENT` transactions stay out of all statistics.
+
+### transactionTypes and the `TRANSFER` value
+
+`transactionTypes` accepts `EXPENSE | INCOME | ADJUSTMENT | TRANSFER`.
+
+> **Changed 2026-08-12.** `TRANSFER` used to be a client-only pseudo-type that the client
+> stripped before sending, which made the server read "no type filter" and return every
+> transaction while the client re-filtered locally — two places deciding the same thing.
+> Clients now send `TRANSFER` as-is and the server gates both streams:
+> - `transactionTypes=TRANSFER` alone → transactions are **empty**, transfers are returned.
+> - `transactionTypes=EXPENSE&transactionTypes=TRANSFER` → expense transactions + transfers.
+> - The singular `type` parameter stays transaction-only; sending `type=TRANSFER` is a
+>   `VALIDATION_ERROR`.
 
 ### TransactionType.ADJUSTMENT (new)
 
@@ -1780,6 +1808,20 @@ Returns total income, total expense, balance, and transaction count for a given 
 | `year`       | `integer` | Yes      | —       | Target year (e.g., `2026`)                                        |
 | `month`      | `integer` | Yes      | —       | Target month (1–12)                                               |
 | `visibility` | `string`  | No       | `ALL`   | `SHARED`, `PRIVATE`, or `ALL` (SHARED + caller's own PRIVATE). Determines which transactions are included in the summary totals. |
+| `dateFrom`   | `date`    | No       | —       | Overrides the month when present (same rule as `GET /transactions`) |
+| `dateTo`     | `date`    | No       | —       | Overrides the month when present                                   |
+| `categoryId` / `categoryIds` / `categoryGroupIds` | `uuid` | No | — | Category filters. Group ids are expanded to their categories server-side |
+| `paymentMethodId` / `paymentMethodIds` | `uuid` | No | — | Payment-method filters (repeatable) |
+| `pocketId` / `pocketIds` | `uuid` | No | — | Pocket filters (repeatable) |
+| `amountMin` / `amountMax` | `integer` | No | — | Amount range |
+| `keyword`    | `string`  | No       | —       | Description search |
+| `type` / `transactionTypes` | `string` | No | — | `EXPENSE`, `INCOME`, `ADJUSTMENT`, `TRANSFER` (see below) |
+| `needsReviewOnly` | `boolean` | No  | —       | `true` → only transactions flagged as needing review |
+
+> **The summary takes the same filter set as the list.** The client sends one filter object to
+> both endpoints; sending a subset here is what produced the "합계 ≠ 행" defects (documented
+> 2026-07-27 and 2026-08-12). Transfers are aggregated under the rules in
+> [Statistics additions](#statistics-additions).
 
 **Response `200 OK`**: `ApiResponse<StatisticsSummaryResponse>`
 
@@ -3373,7 +3415,7 @@ Records money moved between payment methods (e.g., bank account to cash withdraw
 
 ### 2. List Transfers
 
-Returns transfers for the couple filtered by month.
+Returns transfers for the couple in a date range, optionally narrowed by the ledger filter.
 
 | Item        | Value                    |
 |:------------|:-------------------------|
@@ -3385,8 +3427,23 @@ Returns transfers for the couple filtered by month.
 
 | Parameter | Type      | Required | Description                             |
 |:----------|:----------|:--------:|:----------------------------------------|
-| `year`    | `integer` | Yes      | Year (e.g., `2026`)                     |
-| `month`   | `integer` | Yes      | Month 1–12 (e.g., `3`)                  |
+| `year`    | `integer` | Cond.    | Year (e.g., `2026`). Required unless `dateFrom`/`dateTo` is given |
+| `month`   | `integer` | Cond.    | Month 1–12 (e.g., `3`)                  |
+| `dateFrom` | `date`   | No       | **Overrides `year`/`month`** — same range rule as `GET /transactions` and `GET /statistics/summary` |
+| `dateTo`  | `date`    | No       | Overrides `year`/`month`                |
+| `reconciled` | `boolean` | No    | `false` = unrecorded only, `true` = recorded only, omitted = all |
+| `paymentMethodId` / `paymentMethodIds` | `uuid` | No | Matches a transfer if **either leg** (source or destination) is in the set |
+| `amountMin` / `amountMax` | `integer` | No | Amount range |
+| `keyword` | `string`  | No       | Matches description or either payment-method name |
+| `categoryId` / `categoryIds` / `categoryGroupIds` / `pocketId` / `pocketIds` / `needsReviewOnly` / `visibility=PRIVATE` / `type` / `transactionTypes` without `TRANSFER` | — | No | Axes a transfer does not have → **returns an empty list** (a transfer cannot match them) |
+
+> **Changed 2026-08-12 — the range is no longer locked to one month.** The ledger list merges
+> transactions and transfers; transactions honoured `dateFrom`/`dateTo` while transfers were
+> always a single month, so a range spanning two months silently dropped transfer rows
+> (measured: 77% of the transfer amount in the range). `year`/`month` still work unchanged.
+>
+> Filtering uses the same `TransferGating` rules as the summary endpoint, so
+> `GET /transfers` + `GET /transactions` always sum to `GET /statistics/summary`.
 
 **Response `200 OK`**: `ApiResponse<List<TransferResponse>>`
 

--- a/docs/sessions/2026-08-12_1_summary-row-mismatch_analysis.md
+++ b/docs/sessions/2026-08-12_1_summary-row-mismatch_analysis.md
@@ -1,0 +1,192 @@
+# 합계 ≠ 행 잔존 불일치 — 분석 (2026-08-12)
+
+> 회차: "합계 ≠ 행 잔존 불일치" · 단계: **분석 (기획 전)** · 코드 변경 0줄
+> 근거 등급 표기: `[측정]` 직접 실행·관측 / `[1차]` 코드·공식 문서 / `[추론]` 유도(과정 병기) / `[미확인]`
+> 하네스 게이트: `filter_propagation` **STRUCTURAL_FIX_REQUIRED** (LOCKED) — 기획서에 구조적 수정 포함 필수
+
+---
+
+## 0. 한 줄 결론
+
+착수 지점에 적혀 있던 전제("금액/기간/결제수단 필터만 켜면 상단 합계와 아래 행이 서로 다른 집합을
+센다", 근거 `StatisticsService.kt:147`)는 **수입/지출 축에서는 현재 발현하지 않는다** —
+그 코드가 만드는 `totalTransfer = 0` 은 **어느 화면에도 표시되지 않는 값**이고, 수입/지출이
+갈라지려면 실 DB 에 0건인 이체 kind 가 필요하다. 대신 **기간 필터가 포커스 월을 넘어가는 순간
+이체 행이 통째로 누락되는 결함**이 지금 발현 중이다(측정: 범위 내 이체 금액의 **77% 누락**).
+
+---
+
+## 1. 측정 기록 (hard evidence)
+
+실 DB (`ssh tiggle` → `db_postgres_bb`, 2026-08-12):
+
+- 이체 kind 분포 `[측정]`: `GENERIC` 22건 / 17,835,887원, `CARD_SETTLEMENT` 8건 / 6,539,921원,
+  **`EXPENSE_TRANSFER` 0건, `INCOME_TRANSFER` 0건**
+- 거래 type 분포 `[측정]`: `EXPENSE` 542건, `INCOME` 31건, **`ADJUSTMENT` 17건**
+- 월별 거래 최대 건수 `[측정]`: 119건 (2026-06 / 2026-03) — **페이지 크기 200 미달**
+- `needs_review` 1건 / `visibility='PRIVATE'` 87건 `[측정]`
+
+교차 검증용 범위 표본 `[측정]` — 2026-06-15 ~ 2026-08-05:
+
+- 거래 192건 (06월 63 / 07월 118 / 08월 11)
+- 이체 `GENERIC` 11건 4,393,787원 (06월 1 / 07월 8 / 08월 2), `CARD_SETTLEMENT` 3건
+
+---
+
+## 2. 지형 (코드 근거)
+
+합계바 한 줄이 **서로 다른 세 소스**를 섞는다 `[1차]` — `transaction_list_page.dart:797~836`:
+
+- 수입·지출: **서버값 우선** (`state.serverTotalIncome/Expense`, BE `/statistics/summary`)
+- 이체: **클라 계산** (`LedgerSummary.from(visibleTransfers)`)
+- 잔액: `displayIncome - displayExpense` (ADJUSTMENT 미반영)
+
+행 집합은 `gateLedger()` 결과 `[1차]` — `ledger_gating.dart:60~86`. 거래는 BE 가 좁힌 결과에
+타입 게이팅만 추가, 이체는 FE 가 16축 전수 판정.
+
+집계 규칙 정본은 BE `ExpenseCalculator` `[1차]` — `ExpenseCalculator.kt:36~82`:
+지출 = EXPENSE 거래 + `EXPENSE_TRANSFER` 이체, 수입 = INCOME 거래 + `INCOME_TRANSFER` 이체,
+이체 = `GENERIC`, ADJUSTMENT·CARD_SETTLEMENT 는 전량 제외. FE `LedgerSummary` 규칙과 **동일** `[1차]`.
+
+---
+
+## 3. 원인 분해 — 발현 중 / 잠재 구분
+
+### F1. 기간 필터가 월을 넘으면 이체 스트림만 월에 갇힌다 — **발현 중 (이번 회차의 본체)**
+
+근거 `[1차]`:
+
+- 이체 로드는 **월 단위 고정**: `LoadTransfers({required year, required month})`
+  (`transfer_event.dart:15`), 호출 1곳 `transaction_list_page.dart:280`
+- 거래 목록은 `dateFrom/dateTo` 가 **월을 완전히 덮어쓴다**: 지정 시 범위 전체,
+  미지정 축은 `2000-01-01`~`2099-12-31` (`TransactionService.kt:109~118`)
+- 서버 합계도 동일하게 월을 덮어쓴다 (`StatisticsService.kt:78~79`)
+- 행 빌더는 포커스 월로 **다시 자르지 않는다** — `_buildGroupedList` 는 받은 리스트를
+  날짜 그룹으로만 묶는다 (`transaction_list_page.dart:951~965`, 주석에 "Server already
+  filters transactions by dateFrom/dateTo")
+
+발현 계산 `[추론: §1 범위 표본 + 위 코드 경로를 조합]` — 2026-06-15~2026-08-05 범위를 걸고
+8월을 보고 있을 때:
+
+- 거래 행: 192건 전량 노출(200 미달이라 페이지 1회로 완주)
+- 이체 행: **8월 GENERIC 2건 1,008,648원만** — 06·07월 GENERIC 9건 3,385,139원 +
+  CARD_SETTLEMENT 3건이 행에서 사라짐 → 범위 내 이체 금액의 **77% 누락**
+- 이체 칸도 같은 리스트를 세므로 함께 과소 표시
+- 수입/지출 합계는 서버·행 모두 범위 전체라 **일치** → 사용자 눈에는 "6월 거래는 보이는데
+  6월 이체만 없다" + "이체 합계가 너무 작다"
+
+이것이 메모리 `reference_transaction_merged_transfer_stream_drift` 의 5번째 변형이다 —
+이번에는 **필터 축이 아니라 스트림의 로드 범위**가 갈라졌다.
+
+### F2. 필터 활성 시 BE 합계가 이체를 전량 제외 — **잠재 (데이터 0건, 도달 가능)**
+
+근거 `[1차]` — `StatisticsService.kt:98~149`: `hasContentFilters`(카테고리·결제수단·포켓·금액·
+검색어·타입·needsReview 중 하나) 가 참이면 Specifications 로 **거래만** 집계하고
+`totalTransfer = 0L` 하드코딩. 거짓이면 `ExpenseCalculator` 로 **이체 포함**.
+즉 규칙을 어기는 것은 필터 경로 한쪽뿐이다.
+
+발현 조건 두 개가 모두 필요하다:
+
+1. 이체를 전량 제외하지 않는 축이 켜짐 — 금액·결제수단·검색어, 또는 타입에서 TRANSFER 와
+   지출/수입을 함께 선택 (`ledger_gating.dart:93~110` 기준: 카테고리·포켓·needsReview·
+   개인 visibility 는 이체를 전량 제외하므로 양쪽이 함께 이체를 뺀다 = 불일치 없음)
+2. `EXPENSE_TRANSFER` / `INCOME_TRANSFER` 이체가 존재 — **실 DB 0건** `[측정]`
+
+→ 현재 미발현. 그러나 이체 폼에서 사용자가 직접 kind 를 고를 수 있어(자동 추천은 GENERIC 고정,
+사용자 override 가능 — `transfer_form_page.dart:41~47, 96~103, 234`) **"이체로 기록된 지출"을
+한 건 넣는 순간 발현**한다. `[1차]`
+
+부수 확인 `[측정: grep]`: `totalTransfer = 0L` 이 만드는 값은 **FE 어디에서도 쓰이지 않는다** —
+`totalTransfer` 를 읽는 FE 코드는 `ledger_summary.dart`(클라 계산) 뿐이고, 장부 합계바는 클라값,
+분석 탭은 이체 칸을 아예 그리지 않는다. **착수 지점이 근거로 든 `StatisticsService.kt:147` 은
+표시되지 않는 죽은 값이었다** — 이 회차의 전제를 여기서 정정한다.
+
+### F3. 합계 어느 칸에도 안 들어가는 행 — **발현 중 (설계 의도, 표시 문제)**
+
+- `ADJUSTMENT` 17건 `[측정]`: 행에는 부호 있는 금액으로 렌더링됨
+  (`transaction_list_tile.dart:29~34, 144`). BE 통계는 전량 제외
+  (`ExpenseCalculator.kt:88~97`), FE `LedgerSummary` 는 `balance` 에만 반영하지만
+  합계바 잔액은 `displayIncome - displayExpense` 로 계산해 **그 balance 를 쓰지 않는다**
+  (`transaction_list_page.dart:834`) → ADJUSTMENT 는 화면 어디에도 안 잡힌다
+- `CARD_SETTLEMENT` 이체 8건 `[측정]`: `gateLedger` 는 kind 를 보지 않아 행에 남지만
+  모든 버킷에서 제외 `[1차]`
+
+의도된 규칙이지만(원본 EXPENSE 로 이미 집계 / 잔액 전용) **행에 그 사실이 표시되지 않으면
+사용자에게는 "합계에서 빠진 행"** 이다. 판정이 필요한 항목.
+
+### F4. 페이지네이션 — **잠재 (여유 8건)**
+
+행은 page 0 / 200건, 서버 합계는 범위 전체 `[1차]` (`transaction_bloc.dart:67, 88~94`).
+월 최대 119건이라 월 단위로는 미발현이나 `[측정]`, 기간 필터로 범위를 넓히면 도달한다
+(§1 표본이 이미 192건). 자동 LoadMore 가 있어 최종적으로는 채워지지만
+**로드 완주 전 합계 > 행** 구간이 존재한다.
+
+---
+
+## 4. 근본 원인 (한 문장)
+
+행 집합과 합계 집합이 **같은 소스에서 나오지 않는다**: 합계는 서버(거래 전용·범위 전체)와
+클라(이체·포커스 월 한정)를 한 줄에 섞고, 이체 스트림의 로드 범위(월)는 필터의 범위(임의 기간)와
+다르다. `gateLedger` 가 봉인한 것은 "축의 누락"이었고, 남은 구멍은 **"범위와 소스의 불일치"** 다.
+
+---
+
+## 5. 구조적 수정 방향 (게이트 대응) — 사전 판정 기준 포함
+
+게이트가 패치 수정을 불허하므로, 두 안 중 하나를 택해 컴파일/테스트 수준으로 강제한다.
+
+### 안 A (권장) — 서버 단일 집계 + 이체 로드 범위를 필터에 종속
+
+- **S1**: BE 합계에서 `hasContentFilters` 분기를 **없앤다**. 이체 집계도 필터 축을 받는
+  단일 함수(`ExpenseCalculator` 확장)로 통일해 두 경로가 같은 코드를 타게 한다 —
+  `totalTransfer = 0L` 하드코딩 삭제. (분기 제거 = 재발 불가, 패치가 아니라 구조)
+- **S2**: 이체 로드를 **기간 기반**으로 바꾼다 — `LoadTransfers({required dateFrom, required dateTo})`.
+  `required` 라 호출부가 월만 넘기면 컴파일이 실패한다(`ledgerLocation` 선례와 동일한 강제).
+- **S3**: BE 합계 응답에 **집계에 포함된 건수**(거래/이체/제외)를 실어 FE 가 표시 행 수와
+  대조 가능하게 한다 → 위젯 테스트가 "합계 = 행" 을 골든으로 고정.
+- **S4**: 합계바가 서버·클라 혼합 소스를 쓰면 실패하는 소스 검사 가드
+  (인라인 게이팅 재도입 검사 테스트의 선례를 그대로 확장).
+- **S5**: BE 테스트 공백 메우기 — `StatisticsServiceTest` 에 `totalTransfer`/필터 조합 케이스가
+  **0건** `[측정: grep]`. kind × 필터 축 매트릭스를 Kotest 로 고정.
+
+### 안 B (비권장) — 클라 단일 집계
+
+모든 행을 완주 로드한 뒤 `LedgerSummary` 로만 계산. 범위가 넓어질수록 라운드트립·정확도 비용이
+커지고 F4 를 악화시킨다. 200건 초과 달의 페이지 UI(대기열 1번)와도 충돌.
+
+### 결정 항목 — "무엇이 나오면 어느 쪽" (사후 합리화 방지)
+
+- **Q1. 합계에 이체를 포함하는가?** → 포함이 정답으로 **판정한다**. 근거: 무필터 경로·
+  `getMonthlyTrend`·`ReconciliationAggregator`·FE `LedgerSummary` 가 **전부 이미 포함 규칙**이고
+  어기는 곳은 필터 경로 하나뿐이다 `[1차]`. **반증 조건**: 사용자가 "필터를 걸면 이체는 빼는 게
+  맞다"고 판단하면, 그때는 **행에서도 이체를 제외하고 이체 칸도 숨겨야** 한다 — 한쪽만 바꾸면
+  같은 불일치가 방향만 바꿔 남는다.
+- **Q2. 기간 필터가 월을 넘을 때 이 화면의 정체성은?** "기간 장부"로 판정하면 S2(이체도 범위 로드)가
+  정답. "월 장부"로 판정하면 **기간 필터를 월 안으로 제약**하거나 월 밖 데이터를 거래 쪽에서도
+  잘라야 한다. 어느 쪽이든 거래·이체·합계 세 곳이 같은 범위를 봐야 한다.
+- **Q3. ADJUSTMENT / CARD_SETTLEMENT 행을 계속 보여주는가?** 보여주면 "합계 제외" 배지를 붙인다.
+  안 보여주면 잔액 흐름 추적이 끊긴다 → 배지 쪽을 권장.
+
+---
+
+## 6. 미해결 사항 (본문에 섞지 않고 격리)
+
+- **20곳 표시 위치 전수 조사 미실시** `[미확인]` — 금액 표시 지점 전수(메모리
+  `feedback_financial_consistency`)는 기획 단계에서 `scope-auditor` 관점으로 수행해야 한다.
+  현재 확인한 소비 지점은 장부 합계바·달력뷰·러닝밸런스·정산 뷰 4곳뿐.
+- **분석 탭(PeriodSummary)의 필터 경로** `[미확인]` — `getPeriodSummary` 도 같은
+  `hasContentFilters` 패턴(`StatisticsService.kt:373, 402~403, 440`)을 갖지만, 화면이 어떤
+  필드를 그리는지 전수 확인하지 않았다. 확인 주체: 기획 단계, 수단: `period_summary` 위젯 grep.
+- **사용자 원 보고의 존재 여부** `[미확인]` — 이 증상은 2026-08-10 **자체 코드 검토**에서
+  파생된 항목이다(대장 타임라인 16 "미해결로 남긴 것"). 사용자가 실제로 목격한 화면·필터 조합이
+  있다면 F1 인지 F3 인지 특정이 달라진다. 확인 주체: 사용자.
+- **`EXPENSE_TRANSFER` 를 실제로 쓸 계획인지** `[미확인]` — 쓰지 않는다면 F2 의 우선순위는
+  낮아지고(가드 테스트만), 쓴다면 F1 과 함께 한 PR 로 묶어야 한다. 확인 주체: 사용자.
+
+---
+
+## 7. 다음 단계
+
+1. §5 Q1~Q3 판정 (사용자) → 2. 기획서 승격
+   `docs/sessions/2026-08-12_2_summary-row-mismatch_plan.md` 에 S1~S5 구조적 수정 명시 →
+   3. `acknowledge-gate.sh budget-book <plan_path>` 로 게이트 해제 → 4. 승인 후 구현

--- a/docs/sessions/2026-08-12_2_summary-row-mismatch_plan.md
+++ b/docs/sessions/2026-08-12_2_summary-row-mismatch_plan.md
@@ -1,0 +1,244 @@
+# 합계 ≠ 행 불일치 — 기획서 (2026-08-12)
+
+> 분석 정본: `docs/sessions/2026-08-12_1_summary-row-mismatch_analysis.md`
+> 근거 등급: `[측정]` 직접 실행·관측 / `[1차]` 코드·문서 / `[추론]` 유도(과정 병기) / `[미확인]`
+> 하네스 게이트: `filter_propagation` **STRUCTURAL_FIX_REQUIRED** — 본 문서 §2 가 해제 근거
+> 상태: **승인 대기** (코드 변경 0줄)
+
+---
+
+## 0. 확정된 판정 (사용자, 2026-08-12)
+
+- **Q1 = 합계에 이체를 포함한다.** 필터 경로를 고친다. 근거: 무필터 경로·`getMonthlyTrend`·
+  `ReconciliationAggregator`·FE `LedgerSummary` 가 이미 전부 포함 규칙이고, 어기는 곳은
+  BE 필터 경로 하나뿐이다 `[1차]`
+- **Q2 = 기간 장부다.** 거래·이체·합계 셋이 모두 `dateFrom~dateTo` 를 본다. 이체도 범위로 로드
+- **Q3 = 행은 유지하고 "합계 제외" 배지를 붙인다.** ADJUSTMENT 17건 · CARD_SETTLEMENT 이체 8건 `[측정]`
+
+---
+
+## 1. 목표 / 비목표
+
+목표
+
+1. 기간 필터가 월을 넘어도 **이체 행이 누락되지 않는다** (F1 — 현재 77% 누락 `[측정]`)
+2. 필터가 켜져도 **합계가 이체를 포함**한다 (F2 — 잠재, `EXPENSE_TRANSFER` 첫 등록 시 발현)
+3. 행 집합과 합계 집합이 **같은 판정·같은 범위**에서 나온다 (근본 원인 제거)
+4. 합계에서 제외되는 행은 화면에 그 사실이 표시된다 (F3)
+
+비목표 (이번 회차에서 하지 않는다)
+
+- 거래+이체를 서버가 하나의 병합 리스트로 주는 API 신설 — 진짜 최종형이지만 계약 대변경.
+  §6 에 향후 항목으로 남긴다
+- 200건 초과 페이지 UI (F4) — 대기열 1번 항목. 이번 변경으로 악화되지 않는지만 확인
+- 개인 자산(ASSET-PRIVATE) 도입 — 대기열 2번
+
+---
+
+## 2. 구조적 수정 설계 (게이트 해제 근거)
+
+게이트가 패치를 불허하는 이유는 같은 판정이 **두 곳**에 존재해 왔다는 것이다.
+현재도 이체 판정은 FE `ledger_gating.dart` 에만 있고 BE 합계는 "필터 있으면 이체 제외"라는
+**다른 규칙**을 쓴다. 판정을 BE 한 곳으로 모으고, 목록 쿼리와 집계가 **같은 함수**를 타게 한다.
+
+### S1. BE — `LedgerFilter` VO + 축 enum (컴파일 강제)
+
+- 신설 `common/filter/LedgerFilter.kt` — 장부 필터의 모든 축을 담는 data class.
+  컨트롤러 3곳(거래 목록 · 이체 목록 · 통계 합계)이 개별 `@RequestParam` 나열 대신 이 VO 로 받는다
+- 신설 `enum class LedgerFilterAxis` — 축 1개 = enum 1개. `TransferGating` 이 `when(axis)` 를
+  **exhaustive** 로 처리하므로 **축을 추가하면 컴파일이 실패**한다
+- 리플렉션 가드 테스트: `LedgerFilter` 의 프로퍼티 수 == `LedgerFilterAxis` 항목 수.
+  둘의 대응이 깨지면 테스트 실패 (FE `kUnifiedFilterAxisCount` 선례를 BE 로 이식)
+
+### S2. BE — `TransferGating` 단일 판정, 목록과 집계가 공유
+
+- 신설 `transfer/service/TransferGating.kt`:
+  - `excludedWholesale(f): Boolean` — 이체에 없는 축이 켜지면 전량 제외
+    (needsReviewOnly / categoryIds·categoryGroupIds / pocketIds / visibility=PRIVATE /
+    transactionTypes 에 TRANSFER 미포함). FE `ledger_gating.dart:93~110` 의 규칙을 그대로 이관
+  - `spec(f, coupleId): Specification<Transfer>` — 적용 가능한 축
+    (기간 / 결제수단 출금·입금 OR / 금액범위 / 검색어 = 설명 + 출금·입금 결제수단명)
+- **이체 목록 조회와 이체 집계가 이 두 함수를 함께 쓴다.** 한쪽만 고치는 것이 구조적으로 불가능해진다
+
+### S3. BE — 합계에서 `hasContentFilters` 분기 제거
+
+- `StatisticsService.getMonthlySummary` 의 이중 분기(`StatisticsService.kt:98~165`)를 없앤다.
+  항상 "거래 spec 집계 + 이체 spec 집계(kind 별 버킷)".
+  `totalTransfer = 0L` 하드코딩 삭제 — 분기 자체가 사라지므로 재발 지점이 없다
+- kind 규칙은 `ExpenseCalculator` 의 기존 정의를 그대로 따른다 `[1차]`:
+  EXPENSE_TRANSFER→지출 / INCOME_TRANSFER→수입 / GENERIC→이체 칸 / CARD_SETTLEMENT→전량 제외 /
+  ADJUSTMENT→통계 제외
+- `getPeriodSummary` 의 동일 패턴(`StatisticsService.kt:373, 402~403, 440`)도 같은 함수로 통일
+
+### S4. FE — 장부 전용 이체 소스 분리 (사이드이펙트 차단)
+
+`TransferBloc` 은 **6개 소비자가 공유하는 lazy singleton** 이다 `[측정, §3]`.
+여기에 장부의 필터·범위를 주입하면 이체 목록·카드정산·정산 뷰·거래 폼이 오염된다.
+
+- 신설 `features/transaction/presentation/bloc/ledger_transfers_cubit.dart` — 장부 전용.
+  `load({required String dateFrom, required String dateTo, required TransactionFilter filter})`.
+  `required` 라 월만 넘기는 호출은 **컴파일이 실패**한다
+- 공유 `TransferBloc` 과 `LoadTransfers(year, month)` 는 **손대지 않는다** → 다른 5개 소비자 무영향
+- `transaction_list_page.dart` 는 `TransferBloc` 참조를 버리고 이 Cubit 을 소비.
+  소스 검사 가드 테스트: 장부 페이지에 `TransferBloc` 참조가 재등장하면 실패
+- 배선: `MonthSyncHandler`(월 이동) · `SyncEventHandler`(WebSocket) 에 새 Cubit 등록.
+  `registerLazySingleton` 사용 (SyncEventHandler 가 참조하는 BLoC 규칙)
+
+### S5. FE — 합계바를 서버 단일 소스로, 게이팅은 서버 신뢰
+
+- 합계바 3칸(수입·지출·이체) 전부 서버값. 서버/클라 혼합(`transaction_list_page.dart:811~822`)을 제거
+- `gateLedger` 에서 **이체 축 판정을 삭제**한다(서버가 이미 좁힌 결과를 받으므로).
+  파일은 거래 pseudo-type 게이팅과 `resolveLedgerKeyword` 만 남긴다.
+  가드 테스트를 "FE 에 이체 축 판정이 재도입되면 실패" 로 재작성
+- 클라 `LedgerSummary` 는 **러닝밸런스 전용**으로 축소(행 순서 누적 계산은 여전히 FE 몫)
+
+### S6. FE — 합계 제외 배지 (Q3)
+
+- `transaction_list_tile.dart`(ADJUSTMENT) · 이체 타일(CARD_SETTLEMENT)에 "합계 제외" 배지.
+  문구는 한국어, 규칙 판정은 단일 헬퍼(`isExcludedFromTotals(item)`)를 거친다 — 두 타일이 각자
+  판정하면 그게 다음 drift 다
+
+### S7. 계약 문서 선행 갱신 (프로젝트 필수 규칙)
+
+`.claude/domains/contracts.md` — "API 변경: `docs/api-spec.md` 먼저 수정 → 구현".
+자체 검토에서 **기존 문서 drift 2건**을 발견했다 `[측정]`:
+
+- `docs/api-spec.md:1773` 의 Monthly Summary 는 쿼리 파라미터를 `year`·`month`·`visibility`
+  **3개만** 문서화하고 있다. 실제 구현은 회차 8 에서 카테고리·결제수단·포켓·금액·검색어·타입·
+  needsReview 까지 받는다(`StatisticsService.kt:52~73`) → **문서가 이미 뒤처져 있다**
+- `docs/api-spec.md:42` 는 이번에 바꿀 동작을 규범으로 적어두었다 —
+  "When category/payment-method/pocket filters are active, `totalTransfer` is always `0`".
+  이 문장을 고치지 않으면 다음 사람이 옛 규칙으로 되돌린다
+
+갱신 항목: Monthly Summary·Period Summary 의 전체 필터 파라미터 · 이체 포함 집계 규칙 ·
+List Transfers 의 `dateFrom`/`dateTo` + 필터 파라미터(기존 `year`/`month` 는 하위호환 유지) ·
+응답의 집계 건수 필드. **구현보다 먼저 커밋한다.**
+
+### S8. 계약 테스트 — "합계 = 행" 을 게이트로 고정
+
+- BE 통합 테스트(Testcontainers, 실 PG): 축 조합 매트릭스마다 **목록 API 합 == 합계 API** 를 검증.
+  mock 으로는 spec/쿼리 층이 검증되지 않는다(메모리 `reference_card_settlement_flush_ordering` 교훈)
+- 현재 `StatisticsServiceTest` 에 `totalTransfer`·필터 조합 케이스가 **0건** `[측정: grep]` → 신설
+- 대상 조합: 무필터 / 금액 / 결제수단(복수) / 검색어 / 기간(월 내부·월 초과) / 타입(TRANSFER 단독·혼합) /
+  카테고리 / 포켓 / needsReview / 개인. 각 조합에서 이체 kind 4종을 섞은 픽스처
+
+---
+
+## 3. 사이드이펙트 감사 — `TransferBloc` 공유 소비자 전수 `[측정]`
+
+S4 가 필요한 이유. 아래 6곳이 같은 싱글톤 상태를 본다:
+
+1. `transaction_list_page.dart:280, 763~765` — 장부 (이번에 분리 대상)
+2. `transfer_list_page.dart:27~68` — 이체 목록 화면
+3. `card_settlement_page.dart:253` — 카드정산 (월 일치 목적으로 LoadTransfers 재발행)
+4. `reconciliation_view.dart:150` — 정산 뷰
+5. `transaction_form_page.dart:707~711, 1358` — 거래 폼(카드 결제 후보)
+6. `core/bloc/month_sync_handler.dart:94` · `core/websocket/sync_event_handler.dart:201` — 전역 재조회
+
+판정: 장부만 별도 Cubit 으로 떼어내면 1번 외에는 코드 변경이 없다. 2~5 는 기존 월 단위 계약을 유지.
+
+---
+
+## 4. 금액 표시 위치 전수 조사 `[측정]` (메모리 `feedback_financial_consistency`)
+
+`totalIncome|totalExpense|totalTransfer` 를 참조하는 파일 26개를 전수 확인했다.
+이번 변경의 영향 판정:
+
+**영향 있음 (직접 수정)**
+
+- `transaction/presentation/pages/transaction_list_page.dart` — 합계바 소스 통일 (S5)
+- `transaction/presentation/widgets/month_summary_bar.dart` — 3칸 서버값 수용
+- `transaction/presentation/bloc/transaction_bloc.dart` · `transaction_state.dart` — 서버 총계 필드
+- `transaction/presentation/utils/running_balance.dart` — 클라 집계 잔존 범위 확인
+- `statistics/domain/entities/ledger_summary.dart` — 러닝밸런스 전용으로 축소
+- `statistics/data/models/statistics_summary_model.dart` · `entities/statistics_summary.dart` —
+  응답에 집계 건수 추가 시 확장
+
+**영향 없음 (측정 근거 병기)**
+
+- `reconciliation_view.dart:729` 의 `totalTransfer` 는 **정산 스냅샷** 값으로 별개 소스
+- `statistics/presentation/*`(summary_tab · monthly_trend_tab · year_comparison_tab ·
+  period_summary_page) 는 **이체 칸을 그리지 않는다** `[측정: grep 결과 0건]` —
+  분석 탭에서 서버 `totalTransfer` 는 표시되지 않는다(분석서 §6 미해결 항목 해소)
+- `report/*` · `pocket/*` · `home/dashboard_page.dart` — 후자는 미라우팅 죽은 코드
+  (메모리 `reference_dead_home_dashboard`)
+- `features/transfer/domain/entities/transfer.dart` — 엔티티 정의
+
+단, `getPeriodSummary` 를 S3 로 함께 고치면 분석 탭의 수입·지출 값이 바뀔 수 있다
+(이체 포함으로) → §8 라이브 검증에 항목으로 넣는다.
+
+---
+
+## 5. 게이트 계획
+
+로컬 CI 4종 + 1 (대장 §1 기준)
+
+1. `flutter analyze --no-fatal-infos --no-congratulate` 전체 경로 — 신규 0건
+   (부분 경로 금지, 메모리 `feedback_full_flutter_analyze`)
+2. `flutter test` — 기존 894건 + 신규(가드 재작성 · Cubit · 배지 · 계약)
+3. `./gradlew test` — 신규 계약 테스트 포함
+4. `flutter build web --release`
+5. 배포 후 번들 문자열 확인 — 신규 배지 문구가 트리셰이킹되지 않았는지
+   (한글은 `\uXXXX` 이스케이프 대조, 메모리 `reference_live_bundle_string_verification`)
+
+게이트 해제: `bash ~/.claude/harness/scripts/acknowledge-gate.sh budget-book docs/sessions/2026-08-12_2_summary-row-mismatch_plan.md`
+
+---
+
+## 6. 리스크 · 미해결
+
+- **PR 규모** — BE(VO·게이팅·합계 통합·계약 테스트) + FE(Cubit 분리·게이팅 이관·합계바·배지)로
+  크다. §7 에서 커밋을 3단으로 쪼개 롤백 지점을 만든다. 한 PR 로 가는 이유는 중간 상태가
+  "행은 범위, 합계는 월" 처럼 더 어긋나기 때문
+- **배포 순서** `[추론: 파라미터 하위호환성으로 유도]` — 새 쿼리 파라미터는 구 BE 가 무시하고,
+  구 FE 는 새 파라미터를 보내지 않는다 → BE·FE 어느 쪽이 먼저 떠도 안전
+- **Spring 파라미터 바인딩** `[미확인]` — `LedgerFilter` 를 `@ModelAttribute` 생성자 바인딩으로
+  받을 때 Kotlin 기본값 + `List<UUID>`(반복 쿼리 파라미터) 조합이 그대로 바인딩되는지 확인이
+  필요하다. 실패하면 대안은 VO 를 유지하면서 컨트롤러에서 명시 팩토리(`LedgerFilter.from(...)`)로
+  조립하는 것 — **축 강제(S1 enum + 리플렉션 가드)는 어느 쪽이든 유지된다**.
+  확인 수단: 컨트롤러 슬라이스 테스트를 구현 첫 단계에서 먼저 작성
+- **FE 이체 datasource 확장** `[1차]` — `LedgerTransfersCubit` 이 쓸 조회는 기존 이체
+  repository/datasource 에 **옵셔널 파라미터 추가**로 처리한다(기존 월 단위 호출부 무영향).
+  필터 직렬화는 `TransactionFilter.toQueryParams()` 단일 경로를 재사용 —
+  새 직렬화 함수를 만들면 그것이 다음 drift 다
+- **MODE B(단일 자산 필터) 이체 leg 의미** `[미확인]` — 현재 클라가 pmFilter 기준으로 leg 1회만
+  더한다. 서버 spec 이 이미 그 이체를 좁히므로 동등할 것으로 보이나(추론), 구현 시 자산 모드
+  화면에서 수치 대조가 필요하다. 확인 수단: MODE B 위젯 테스트 + 라이브 자산 필터 확인
+- **검색 반응성** `[미확인]` — 이체 게이팅이 서버로 가면 검색어 입력 시 이체도 왕복을 탄다.
+  거래는 이미 그렇게 동작하므로 체감 저하는 없을 것으로 보나(추론), 라이브에서 확인
+- **사용자 원 보고 부재** `[미확인]` — F1 은 코드·DB 측정으로 확정했지만 사용자가 이 증상을
+  화면에서 목격한 기록은 없다. 라이브 검증에서 재현 시나리오(§8 A1)로 확인한다
+- 거래+이체 서버 병합 리스트 API — 최종형. 이번 비목표, 향후 후보
+
+---
+
+## 7. 작업 순서 (승인 후)
+
+1. 계약 커밋 0 — `docs/api-spec.md` 갱신 (S7). 구현보다 먼저
+2. BE 커밋 1 — `LedgerFilter` + `LedgerFilterAxis` + `TransferGating` + 리플렉션 가드 +
+   컨트롤러 바인딩 슬라이스 테스트(§6 리스크 선검증)
+3. BE 커밋 2 — 합계 분기 제거(`getMonthlySummary` · `getPeriodSummary`) + 이체 목록 필터 파라미터 +
+   계약 통합 테스트(S8)
+4. FE 커밋 3 — `LedgerTransfersCubit` + 장부 배선 + `gateLedger` 축 판정 제거 + 가드 재작성
+5. FE 커밋 4 — 합계바 서버 단일 소스 + 배지(S6)
+6. 로컬 CI 5종 → PR → 원격 CI → 머지 → 배포 → §8 라이브 검증 요청
+7. DB 마이그레이션 **없음** (스키마 변경 0건 — 집계·조회 경로만 변경)
+
+---
+
+## 8. 라이브 검증 체크리스트 (사용자 확인용)
+
+- **A1 (F1 핵심)**: 기간을 `2026-06-15 ~ 2026-08-05` 로 걸고 장부를 본다 →
+  6월·7월 **이체 행이 보이고**(GENERIC 9건 + 카드정산 3건 `[측정]`), 이체 합계가
+  4,393,787원 수준으로 오른다. 수정 전에는 8월 2건 1,008,648원만 보였다
+- **A2**: 같은 기간에서 상단 합계와 화면 행의 합이 일치한다(수입·지출·이체 3칸)
+- **A3**: 결제수단 여러 개 선택 → 이체가 두 결제수단 어느 쪽이든 걸리면 행에 남고 합계에도 반영
+- **A4**: 금액 범위 필터 → 이체도 같은 기준으로 걸러지고 합계가 행과 일치
+- **A5**: 검색어 → 이체는 설명·출금/입금 결제수단명으로 매칭
+- **A6**: 카테고리 / 포켓 / 확인 필요만 / 개인 → 이체는 행과 합계에서 **함께** 사라진다
+- **A7**: 타입에서 "이체" 단독 → 거래 행 0건, 수입·지출 0원, 이체 칸만 표시
+- **A8**: 타입에서 "지출 + 이체" → 지출 거래와 이체가 함께 보이고 합계가 둘을 반영
+- **A9 (F3)**: 잔액 수정(ADJUSTMENT) 행과 카드정산 이체 행에 "합계 제외" 배지가 보인다
+- **A10**: 이체 목록 화면 · 카드정산 화면 · 정산 뷰 · 거래 폼(카드 결제 후보)이 이전과 동일하게
+  동작한다 (S4 사이드이펙트 없음 확인)
+- **A11**: 분석 탭 수입·지출 수치 — 필터를 걸었을 때 값이 장부와 같은 규칙으로 나온다

--- a/frontend/lib/core/bloc/month_sync_handler.dart
+++ b/frontend/lib/core/bloc/month_sync_handler.dart
@@ -19,6 +19,7 @@ import 'package:budget_book/features/statistics/presentation/bloc/statistics_blo
 import 'package:budget_book/features/statistics/presentation/bloc/statistics_event.dart';
 import 'package:budget_book/features/transaction/presentation/bloc/transaction_bloc.dart';
 import 'package:budget_book/features/transaction/presentation/bloc/transaction_event.dart';
+import 'package:budget_book/features/transaction/presentation/bloc/ledger_transfers_cubit.dart';
 import 'package:budget_book/features/transfer/presentation/bloc/transfer_bloc.dart';
 import 'package:budget_book/features/transfer/presentation/bloc/transfer_event.dart';
 import 'package:budget_book/features/weekly_budget/presentation/bloc/weekly_budget_bloc.dart';
@@ -89,9 +90,20 @@ class MonthSyncHandler extends StatelessWidget {
       ));
     } catch (_) {}
 
-    // Transfer list
+    // Transfer list (공유 싱글톤 — 이체 목록 화면 등)
     try {
       getIt<TransferBloc>().add(LoadTransfers(year: year, month: month));
+    } catch (_) {}
+
+    // 장부 전용 이체 소스 — 장부의 필터를 유지한 채 새 월로 재조회한다.
+    // (공유 TransferBloc 과 달리 필터가 실려 있으므로 반드시 별도로 갱신해야 한다)
+    try {
+      final txnBloc = getIt<TransactionBloc>();
+      getIt<LedgerTransfersCubit>().load(
+        year: year,
+        month: month,
+        filter: txnBloc.currentFilter.copyWith(clearDateRange: true),
+      );
     } catch (_) {}
 
     // Statistics (all tabs)

--- a/frontend/lib/core/di/injection.dart
+++ b/frontend/lib/core/di/injection.dart
@@ -61,6 +61,7 @@ import 'package:budget_book/features/pocket/presentation/bloc/pocket_transfer_bl
 import 'package:budget_book/features/transfer/data/datasources/transfer_remote_datasource.dart';
 import 'package:budget_book/features/transfer/data/repositories/transfer_repository_impl.dart';
 import 'package:budget_book/features/transfer/domain/repositories/transfer_repository.dart';
+import 'package:budget_book/features/transaction/presentation/bloc/ledger_transfers_cubit.dart';
 import 'package:budget_book/features/transfer/presentation/bloc/transfer_bloc.dart';
 import 'package:budget_book/features/home/presentation/bloc/dashboard_bloc.dart';
 import 'package:budget_book/core/websocket/websocket_service.dart';
@@ -350,6 +351,14 @@ Future<void> configureDependencies() async {
     () => TransferBloc(
         transferRepository: getIt<TransferRepository>()),
     dispose: (bloc) => bloc.close(),
+  );
+  // 장부 전용 이체 소스 (2026-08-12). 공유 TransferBloc 에 장부 필터를 주입하면
+  // 이체 목록·카드정산·정산 뷰·거래 폼이 함께 오염되므로 분리했다.
+  // SyncEventHandler·MonthSyncHandler 가 참조하므로 registerLazySingleton (프로젝트 규칙).
+  getIt.registerLazySingleton<LedgerTransfersCubit>(
+    () => LedgerTransfersCubit(
+        transferRepository: getIt<TransferRepository>()),
+    dispose: (cubit) => cubit.close(),
   );
 
   // Reconciliation feature (정산 스냅샷) — V65

--- a/frontend/lib/core/router/app_router.dart
+++ b/frontend/lib/core/router/app_router.dart
@@ -62,6 +62,7 @@ import 'package:budget_book/features/pocket/presentation/bloc/pocket_transfer_ev
 import 'package:budget_book/features/pocket/presentation/pages/pocket_page.dart';
 import 'package:budget_book/features/pocket/presentation/pages/distribute_wizard_page.dart';
 import 'package:budget_book/features/pocket/presentation/pages/pocket_transfer_page.dart';
+import 'package:budget_book/features/transaction/presentation/bloc/ledger_transfers_cubit.dart';
 import 'package:budget_book/features/transfer/presentation/bloc/transfer_bloc.dart';
 import 'package:budget_book/features/transfer/presentation/bloc/transfer_event.dart';
 import 'package:budget_book/features/transfer/presentation/bloc/transfer_state.dart';
@@ -412,10 +413,25 @@ GoRouter createAppRouter(AuthBloc authBloc) => GoRouter(
                   final tm = int.tryParse(monthParam ?? '') ?? now.month;
                   transferBloc.add(LoadTransfers(year: ty, month: tm));
                 }
+                // 장부 전용 이체 소스 부트스트랩 (2026-08-12). 장부는 공유 TransferBloc 이
+                // 아니라 이 Cubit 을 소비하므로, 첫 진입/새로고침에서 여기서 깨워야 한다
+                // (누락 시 이체 행이 아예 뜨지 않는다).
+                final ledgerTransfers = getIt<LedgerTransfersCubit>();
+                if (ledgerTransfers.state.transfers.isEmpty) {
+                  final now = DateTime.now();
+                  final ty = int.tryParse(yearParam ?? '') ?? now.year;
+                  final tm = int.tryParse(monthParam ?? '') ?? now.month;
+                  ledgerTransfers.load(
+                    year: ty,
+                    month: tm,
+                    filter: bloc.currentFilter,
+                  );
+                }
                 return MultiBlocProvider(
                   providers: [
                     BlocProvider<TransactionBloc>.value(value: getIt<TransactionBloc>()),
                     BlocProvider<TransferBloc>.value(value: transferBloc),
+                    BlocProvider<LedgerTransfersCubit>.value(value: ledgerTransfers),
                   ],
                   child: TransactionListPage(
                     initialPaymentMethodId: paymentMethodId,

--- a/frontend/lib/core/websocket/sync_event_handler.dart
+++ b/frontend/lib/core/websocket/sync_event_handler.dart
@@ -18,6 +18,7 @@ import 'package:budget_book/features/pocket/presentation/bloc/pocket_transfer_bl
 import 'package:budget_book/features/pocket/presentation/bloc/pocket_transfer_event.dart';
 import 'package:budget_book/features/home/presentation/bloc/dashboard_bloc.dart';
 import 'package:budget_book/features/home/presentation/bloc/dashboard_event.dart';
+import 'package:budget_book/features/transaction/presentation/bloc/ledger_transfers_cubit.dart';
 import 'package:budget_book/features/transfer/presentation/bloc/transfer_bloc.dart';
 import 'package:budget_book/features/transfer/presentation/bloc/transfer_event.dart';
 import 'package:budget_book/features/statistics/presentation/bloc/statistics_bloc.dart';
@@ -200,6 +201,8 @@ class SyncEventHandler {
       final monthState = _getIt<MonthCubit>().state;
       final bloc = _getIt<TransferBloc>();
       bloc.add(LoadTransfers(year: monthState.year, month: monthState.month));
+      // 장부 전용 이체 소스도 같은 필터로 재조회한다 (분리된 소스라 따로 깨워야 한다).
+      _getIt<LedgerTransfersCubit>().reload();
       _logger.d('Dispatched LoadTransfers refresh');
     } catch (e) {
       _logger.e('Failed to refresh transfers: $e');

--- a/frontend/lib/core/widgets/excluded_from_totals_badge.dart
+++ b/frontend/lib/core/widgets/excluded_from_totals_badge.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+
+import 'package:budget_book/features/transaction/presentation/utils/ledger_totals_exclusion.dart';
+
+/// "합계 제외" 배지 — **모든 노출 지점의 단일 소스**.
+///
+/// 목록에는 보이지만 상단 합계의 어느 칸에도 들어가지 않는 행에 붙인다
+/// (잔액 수정 = 통계 범주 밖 / 카드 정산 이체 = 원본 지출로 이미 집계).
+/// 표시가 없으면 사용자에게는 "합계가 틀린" 것으로 보인다.
+///
+/// 판정은 `ledger_totals_exclusion.dart` 가 단독으로 갖는다 — 타일이 직접
+/// `isAdjustment`/`kind` 를 보고 배지를 그리면 규칙이 갈라진다.
+class ExcludedFromTotalsBadge extends StatelessWidget {
+  /// 왜 제외되는지 (툴팁). `ledger_totals_exclusion.dart` 의 상수를 쓴다.
+  final String reason;
+
+  const ExcludedFromTotalsBadge({super.key, required this.reason});
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    return Tooltip(
+      message: reason,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+        decoration: BoxDecoration(
+          color: scheme.surfaceContainerHighest.withValues(alpha: 0.8),
+          borderRadius: BorderRadius.circular(4),
+          border: Border.all(
+            color: scheme.outlineVariant.withValues(alpha: 0.8),
+          ),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Icons.functions,
+              size: 11,
+              color: scheme.onSurfaceVariant,
+            ),
+            const SizedBox(width: 3),
+            Text(
+              kExcludedFromTotalsLabel,
+              style: TextStyle(
+                fontSize: 10,
+                fontWeight: FontWeight.w600,
+                color: scheme.onSurfaceVariant,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/lib/features/statistics/data/models/statistics_summary_model.dart
+++ b/frontend/lib/features/statistics/data/models/statistics_summary_model.dart
@@ -5,8 +5,10 @@ class StatisticsSummaryModel extends StatisticsSummary {
     required super.yearMonth,
     required super.totalIncome,
     required super.totalExpense,
+    super.totalTransfer,
     required super.balance,
     required super.transactionCount,
+    super.transferCount,
   });
 
   factory StatisticsSummaryModel.fromJson(Map<String, dynamic> json) {
@@ -14,8 +16,11 @@ class StatisticsSummaryModel extends StatisticsSummary {
       yearMonth: json['yearMonth'] as String,
       totalIncome: json['totalIncome'] as int,
       totalExpense: json['totalExpense'] as int,
+      // 구 서버 호환 — 필드가 없으면 0.
+      totalTransfer: json['totalTransfer'] as int? ?? 0,
       balance: json['balance'] as int,
       transactionCount: json['transactionCount'] as int,
+      transferCount: json['transferCount'] as int? ?? 0,
     );
   }
 }

--- a/frontend/lib/features/statistics/domain/entities/statistics_summary.dart
+++ b/frontend/lib/features/statistics/domain/entities/statistics_summary.dart
@@ -4,18 +4,38 @@ class StatisticsSummary extends Equatable {
   final String yearMonth;
   final int totalIncome;
   final int totalExpense;
+
+  /// 순수 내부 이체(`TransferKind.GENERIC`) 합계. 수입/지출과 disjoint.
+  ///
+  /// 2026-08-12 신규 — 이전에는 이 값이 응답에 있어도 FE 엔티티에 없어서 장부의
+  /// "이체" 칸을 클라이언트가 따로 계산했다. 그 계산은 포커스 월의 이체만 봐서
+  /// 기간 필터가 월을 넘으면 과소 표시됐다.
+  final int totalTransfer;
+
   final int balance;
   final int transactionCount;
+
+  /// 이 합계에 집계된 이체 건수(`CARD_SETTLEMENT` 제외). 합계와 행 대조용.
+  final int transferCount;
 
   const StatisticsSummary({
     required this.yearMonth,
     required this.totalIncome,
     required this.totalExpense,
+    this.totalTransfer = 0,
     required this.balance,
     required this.transactionCount,
+    this.transferCount = 0,
   });
 
   @override
-  List<Object?> get props =>
-      [yearMonth, totalIncome, totalExpense, balance, transactionCount];
+  List<Object?> get props => [
+        yearMonth,
+        totalIncome,
+        totalExpense,
+        totalTransfer,
+        balance,
+        transactionCount,
+        transferCount,
+      ];
 }

--- a/frontend/lib/features/transaction/domain/entities/transaction_filter.dart
+++ b/frontend/lib/features/transaction/domain/entities/transaction_filter.dart
@@ -256,24 +256,27 @@ extension UnifiedFilterStateToTransactionFilter on UnifiedFilterState {
 /// `pocketIds`)도 함께 직렬화한다. Dio ListFormat.multi 기준으로
 /// `?categoryIds=a&categoryIds=b` 형식으로 전달되어 Spring `@RequestParam List<UUID>` 와 호환.
 ///
-/// Phase 22: 'TRANSFER' is a FE-only pseudo-type — it is NOT sent to BE
-/// `/transactions` (which knows only EXPENSE/INCOME/ADJUSTMENT). The FE
-/// merges /transfers results client-side when 'TRANSFER' is in the set.
+/// 2026-08-12 — 'TRANSFER' 는 이제 **서버로 그대로 전송**한다.
+///
+/// 이전에는 FE 전용 의사-타입이라 전송 직전에 잘라냈다. 그러면 서버는 "타입 필터 없음" 으로
+/// 해석해 거래 전체를 세고, FE 가 클라이언트에서 다시 걸렀다 — 판정이 두 곳에 생겨
+/// 합계와 행이 다른 집합을 세는 원인이 됐다. 이제 서버가 두 스트림을 모두 판정한다
+/// (`LedgerTypeSelection`): TRANSFER 단독이면 거래 0건, 이체는 노출.
 extension TransactionFilterQueryParams on TransactionFilter {
   Map<String, dynamic> toQueryParams() {
     final params = <String, dynamic>{};
 
     // Multi-select wins over legacy singular `type`.
-    // Strip TRANSFER (FE-only pseudo-type) before sending.
-    final beTypes = transactionTypes
-        .where((t) => t == 'EXPENSE' || t == 'INCOME' || t == 'ADJUSTMENT')
-        .toList();
-    if (beTypes.isNotEmpty) {
-      params['transactionTypes'] = beTypes;
-      // Also send `type` for single-value backward compatibility with any
-      // BE endpoint not yet updated.
-      if (beTypes.length == 1) {
-        params['type'] = beTypes.first;
+    // TRANSFER 포함해 그대로 보낸다 — 서버가 거래/이체 양쪽 판정에 쓴다.
+    if (transactionTypes.isNotEmpty) {
+      params['transactionTypes'] = transactionTypes.toList();
+      // 단수 `type` 은 **거래 타입 1개**일 때만 함께 보낸다(구 BE 호환).
+      // TRANSFER 는 거래 타입이 아니므로 여기로 보내면 400 이다.
+      final txTypes = transactionTypes
+          .where((t) => t == 'EXPENSE' || t == 'INCOME' || t == 'ADJUSTMENT')
+          .toList();
+      if (transactionTypes.length == 1 && txTypes.length == 1) {
+        params['type'] = txTypes.first;
       }
     } else if (type != null) {
       params['type'] = type;

--- a/frontend/lib/features/transaction/presentation/bloc/ledger_transfers_cubit.dart
+++ b/frontend/lib/features/transaction/presentation/bloc/ledger_transfers_cubit.dart
@@ -1,0 +1,116 @@
+import 'package:equatable/equatable.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import 'package:budget_book/features/transaction/domain/entities/transaction_filter.dart';
+import 'package:budget_book/features/transfer/domain/entities/transfer.dart';
+import 'package:budget_book/features/transfer/domain/repositories/transfer_repository.dart';
+
+/// 장부(거래 목록 화면) **전용** 이체 소스.
+///
+/// ## 왜 공유 `TransferBloc` 을 쓰지 않는가 (2026-08-12)
+///
+/// `TransferBloc` 은 lazy singleton 이고 **6곳이 같은 상태를 본다**:
+/// 장부 · 이체 목록 화면 · 카드정산 화면 · 정산 뷰 · 거래 폼(카드 결제 후보) ·
+/// 월 동기화/WebSocket 재조회. 장부의 필터(카테고리·금액·검색어…)를 그 싱글톤에
+/// 밀어넣으면 나머지 5곳이 **필터된 이체만** 보게 된다.
+///
+/// 그래서 장부만 자기 소스를 갖는다. 공유 `TransferBloc` 과 `LoadTransfers(year, month)` 는
+/// 그대로 두므로 다른 화면은 영향이 없다.
+///
+/// ## 범위 규칙
+///
+/// [load] 는 `dateFrom`/`dateTo` 를 **필수**로 받는다. 이체가 월 단위로 고정돼 있고
+/// 거래·합계는 기간을 따르던 비대칭이 "기간 필터를 걸면 이체 행이 사라지는" 결함의
+/// 원인이었다(측정: 범위 내 이체 금액의 77% 누락). `required` 라 월만 넘기는 호출은
+/// 컴파일이 막는다.
+///
+/// 필터 판정은 **서버**가 한다(`TransferGating`) — FE 에 이체 축 판정을 다시 만들면
+/// 판정이 두 곳이 되어 같은 사고가 재발한다.
+class LedgerTransfersCubit extends Cubit<LedgerTransfersState> {
+  final TransferRepository transferRepository;
+
+  LedgerTransfersCubit({required this.transferRepository})
+      : super(const LedgerTransfersState.initial());
+
+  /// 마지막 요청을 기억해 동기화 이벤트(월 이동·WebSocket)에서 재조회한다.
+  int? _year;
+  int? _month;
+  TransactionFilter _filter = TransactionFilter.empty;
+
+  /// 늦게 도착한 응답이 최신 요청을 덮어쓰지 않게 하는 순번.
+  int _requestSeq = 0;
+
+  Future<void> load({
+    required int year,
+    required int month,
+    required TransactionFilter filter,
+  }) async {
+    _year = year;
+    _month = month;
+    _filter = filter;
+
+    final seq = ++_requestSeq;
+    // 이미 목록이 있으면 스피너로 비우지 않는다(필터 조작 중 깜빡임 방지).
+    if (state.transfers.isEmpty) {
+      emit(state.copyWith(isLoading: true, clearError: true));
+    }
+
+    final result = await transferRepository.getTransfers(
+      year: year,
+      month: month,
+      filter: filter,
+    );
+
+    // 뒤늦은 응답 폐기.
+    if (seq != _requestSeq) return;
+
+    result.fold(
+      (failure) => emit(state.copyWith(isLoading: false, error: failure.message)),
+      (transfers) => emit(
+        LedgerTransfersState(transfers: transfers, isLoading: false),
+      ),
+    );
+  }
+
+  /// 월 이동·실시간 동기화 후 **같은 필터로** 다시 읽는다.
+  /// 아직 한 번도 로드하지 않았으면 아무 것도 하지 않는다(화면이 뜨면 스스로 로드한다).
+  Future<void> reload() async {
+    final year = _year;
+    final month = _month;
+    if (year == null || month == null) return;
+    await load(year: year, month: month, filter: _filter);
+  }
+}
+
+class LedgerTransfersState extends Equatable {
+  final List<Transfer> transfers;
+  final bool isLoading;
+  final String? error;
+
+  const LedgerTransfersState({
+    required this.transfers,
+    this.isLoading = false,
+    this.error,
+  });
+
+  const LedgerTransfersState.initial()
+      : transfers = const [],
+        isLoading = false,
+        error = null;
+
+  LedgerTransfersState copyWith({
+    List<Transfer>? transfers,
+    bool? isLoading,
+    String? error,
+    bool clearError = false,
+  }) {
+    return LedgerTransfersState(
+      transfers: transfers ?? this.transfers,
+      isLoading: isLoading ?? this.isLoading,
+      error: clearError ? null : (error ?? this.error),
+    );
+  }
+
+  @override
+  List<Object?> get props => [transfers, isLoading, error];
+}

--- a/frontend/lib/features/transaction/presentation/bloc/transaction_bloc.dart
+++ b/frontend/lib/features/transaction/presentation/bloc/transaction_bloc.dart
@@ -95,6 +95,8 @@ class TransactionBloc extends Bloc<TransactionEvent, TransactionState> {
 
       int? serverIncome;
       int? serverExpense;
+      int? serverTransfer;
+      int? serverTransferCount;
 
       if (statisticsRepository != null) {
         final results = await Future.wait([
@@ -112,6 +114,9 @@ class TransactionBloc extends Bloc<TransactionEvent, TransactionState> {
         summaryResult.fold((_) {}, (s) {
           serverIncome = (s as dynamic).totalIncome as int;
           serverExpense = (s as dynamic).totalExpense as int;
+          // 2026-08-12 — 이체 합계도 서버값을 쓴다(클라 계산은 월에 갇혀 있었다).
+          serverTransfer = (s as dynamic).totalTransfer as int;
+          serverTransferCount = (s as dynamic).transferCount as int;
         });
         txnResult.fold(
           (failure) => emit(TransactionError((failure as dynamic).message as String)),
@@ -124,6 +129,8 @@ class TransactionBloc extends Bloc<TransactionEvent, TransactionState> {
             currentPage: 0,
             serverTotalIncome: serverIncome,
             serverTotalExpense: serverExpense,
+            serverTotalTransfer: serverTransfer,
+            serverTransferCount: serverTransferCount,
             scrollToDate: event.scrollToDate,
             dateFrom: event.dateFrom,
             dateTo: event.dateTo,
@@ -178,6 +185,8 @@ class TransactionBloc extends Bloc<TransactionEvent, TransactionState> {
         isLoadingMore: true,
         serverTotalIncome: currentState.serverTotalIncome,
         serverTotalExpense: currentState.serverTotalExpense,
+        serverTotalTransfer: currentState.serverTotalTransfer,
+        serverTransferCount: currentState.serverTransferCount,
         // 포커싱 의도 보존: 추가 페이지를 붙이는 동안에도 scrollToDate 가 살아 있어야
         // UI 가 대상 날짜 등장 시 포커싱하고, 부재 시 다음 페이지를 계속 요청한다.
         scrollToDate: currentState.scrollToDate,
@@ -207,6 +216,8 @@ class TransactionBloc extends Bloc<TransactionEvent, TransactionState> {
             operationError: failure.message,
             serverTotalIncome: currentState.serverTotalIncome,
             serverTotalExpense: currentState.serverTotalExpense,
+            serverTotalTransfer: currentState.serverTotalTransfer,
+            serverTransferCount: currentState.serverTransferCount,
             scrollToDate: currentState.scrollToDate,
             dateFrom: currentState.dateFrom,
             dateTo: currentState.dateTo,
@@ -226,6 +237,8 @@ class TransactionBloc extends Bloc<TransactionEvent, TransactionState> {
             currentPage: nextPage,
             serverTotalIncome: currentState.serverTotalIncome,
             serverTotalExpense: currentState.serverTotalExpense,
+            serverTotalTransfer: currentState.serverTotalTransfer,
+            serverTransferCount: currentState.serverTransferCount,
             scrollToDate: currentState.scrollToDate,
             dateFrom: currentState.dateFrom,
             dateTo: currentState.dateTo,
@@ -244,6 +257,8 @@ class TransactionBloc extends Bloc<TransactionEvent, TransactionState> {
         operationError: '예기치 않은 오류가 발생했습니다',
         serverTotalIncome: currentState.serverTotalIncome,
         serverTotalExpense: currentState.serverTotalExpense,
+        serverTotalTransfer: currentState.serverTotalTransfer,
+        serverTransferCount: currentState.serverTransferCount,
         scrollToDate: currentState.scrollToDate,
         dateFrom: currentState.dateFrom,
         dateTo: currentState.dateTo,

--- a/frontend/lib/features/transaction/presentation/bloc/transaction_state.dart
+++ b/frontend/lib/features/transaction/presentation/bloc/transaction_state.dart
@@ -29,6 +29,13 @@ class TransactionLoaded extends TransactionState {
   final int? serverTotalIncome;
   final int? serverTotalExpense;
 
+  /// 서버가 계산한 이체(GENERIC) 합계. 2026-08-12 — 이전에는 이 값이 없어서 장부의
+  /// "이체" 칸을 클라이언트가 포커스 월의 이체로만 계산했다(기간 필터에서 과소 표시).
+  final int? serverTotalTransfer;
+
+  /// 서버 합계에 포함된 이체 건수. 합계 ↔ 행 대조용 관측 값.
+  final int? serverTransferCount;
+
   final String? scrollToDate;
   final String? dateFrom;
   final String? dateTo;
@@ -46,6 +53,8 @@ class TransactionLoaded extends TransactionState {
     this.scrollToDate,
     this.serverTotalIncome,
     this.serverTotalExpense,
+    this.serverTotalTransfer,
+    this.serverTransferCount,
     this.dateFrom,
     this.dateTo,
   });
@@ -76,7 +85,7 @@ class TransactionLoaded extends TransactionState {
 
   @override
   List<Object?> get props =>
-      [transactions, year, month, totalElements, hasMore, currentPage, isLoadingMore, operationError, operationSuccess, scrollToDate, serverTotalIncome, serverTotalExpense, dateFrom, dateTo];
+      [transactions, year, month, totalElements, hasMore, currentPage, isLoadingMore, operationError, operationSuccess, scrollToDate, serverTotalIncome, serverTotalExpense, serverTotalTransfer, serverTransferCount, dateFrom, dateTo];
 }
 
 class TransactionError extends TransactionState {

--- a/frontend/lib/features/transaction/presentation/pages/transaction_list_page.dart
+++ b/frontend/lib/features/transaction/presentation/pages/transaction_list_page.dart
@@ -25,9 +25,7 @@ import 'package:budget_book/features/transaction/presentation/widgets/transactio
 import 'package:budget_book/features/transaction/presentation/widgets/transfer_list_tile.dart';
 import 'package:budget_book/features/card_settlement/presentation/card_settlement_route.dart';
 import 'package:budget_book/features/transfer/domain/entities/transfer.dart';
-import 'package:budget_book/features/transfer/presentation/bloc/transfer_bloc.dart';
-import 'package:budget_book/features/transfer/presentation/bloc/transfer_event.dart';
-import 'package:budget_book/features/transfer/presentation/bloc/transfer_state.dart';
+import 'package:budget_book/features/transaction/presentation/bloc/ledger_transfers_cubit.dart';
 import 'package:budget_book/core/widgets/balance_adjustment_sheet.dart';
 import 'package:budget_book/core/widgets/calendar_picker_dialog.dart';
 import 'package:budget_book/core/widgets/error_widget.dart';
@@ -272,12 +270,21 @@ class _TransactionListPageState extends State<TransactionListPage> {
         _searchController.text.trim().isEmpty ? null : _searchController.text.trim();
 
     // UI 필터 → 도메인 VO 변환은 toTransactionFilter 단일 경로 (필드 나열 금지).
+    final filter = _filterState.toTransactionFilter(keywordOverride: keyword);
     context.read<TransactionBloc>().add(LoadTransactions.fromFilter(
           year,
           month,
-          _filterState.toTransactionFilter(keywordOverride: keyword),
+          filter,
         ));
-    context.read<TransferBloc>().add(LoadTransfers(year: year, month: month));
+    // 2026-08-12 — 이체도 **같은 필터 VO** 로 서버에서 좁힌다.
+    // 공유 TransferBloc 이 아니라 장부 전용 Cubit 을 쓴다(다른 화면 오염 방지).
+    // 필터에 dateFrom/dateTo 가 있으면 서버가 월 대신 그 범위를 본다 → 기간 필터가
+    // 월을 넘어도 이체 행이 누락되지 않는다.
+    getIt<LedgerTransfersCubit>().load(
+      year: year,
+      month: month,
+      filter: filter,
+    );
   }
 
   /// 회차 1 (2026-05-26) — 거래 추가 진입 URL 단일 조립.
@@ -760,21 +767,19 @@ class _TransactionListPageState extends State<TransactionListPage> {
         ),
         // Summary bar + Transaction list (both need transfers)
         Expanded(
-          child: BlocBuilder<TransferBloc, TransferState>(
+          child: BlocBuilder<LedgerTransfersCubit, LedgerTransfersState>(
             builder: (context, transferState) {
-              final transfers = transferState is TransferLoaded
-                  ? transferState.transfers
-                  : <Transfer>[];
+              final transfers = transferState.transfers;
 
-              // CHANGE 2 / 2026-08-10 구조적 수정 — SINGLE gating step shared by
-              // calendar + list + summary + running-balance so all of them
-              // consume the SAME lists.
+              // 2026-08-12 구조적 수정 — 이체 판정은 **서버**가 한다.
               //
-              // 이체 게이팅을 여기서 인라인으로 나열하지 않는다. 필터 축이 늘 때마다
-              // 이체 스트림에서만 축이 누락되는 사고가 4회 반복됐다(확인 필요/카테고리/
-              // 포켓/금액 누락, 결제수단은 first 1개만 적용). 판정은 전부
-              // `ledger_gating.dart` 의 gateLedger 안에 있고, 필터 VO 에 필드가
-              // 추가되면 필드 수 가드 테스트가 실패해 갱신을 강제한다.
+              // 이전에는 FE `gateLedger` 가 이체 축을 전수 판정했고, BE 합계는 "필터가
+              // 있으면 이체 제외" 라는 **다른 규칙**을 썼다. 판정이 두 곳이면 한쪽만
+              // 고쳐지고 다시 어긋난다(4회 재발). 이제 목록 API·합계 API 가 같은
+              // `TransferGating` 을 쓰고, FE 는 받은 결과를 그대로 소비한다.
+              //
+              // 남은 FE 게이팅은 거래 쪽 타입 표시뿐이다(서버가 이미 좁혔지만,
+              // 응답 대기 중 옛 목록이 잠깐 보이는 것을 막는다).
               final gated = gateLedger(
                 transactions: state.filteredTransactions,
                 transfers: transfers,
@@ -784,42 +789,37 @@ class _TransactionListPageState extends State<TransactionListPage> {
               final visibleTransactions = gated.transactions;
               final visibleTransfers = gated.transfers;
 
-              final types = _filterState.transactionTypes;
               // 결제수단 1개 필터 시에만 의미가 있는 자산 모드 판정용(MODE B).
               final filterPmId = _filterState.paymentMethodIds.length == 1
                   ? _filterState.paymentMethodIds.first
                   : null;
 
-              // S2: single aggregation entry point via LedgerSummary.from
-              // kind/type branching lives inside the factory, including
-              // CARD_SETTLEMENT exclusion (supersedes PR-A heuristic).
-              // Fed the SAME gated lists so the summary matches the rows.
-              final summary = LedgerSummary.from(
+              // 2026-08-12 — 합계바는 **서버 단일 소스**다.
+              //
+              // 이전에는 한 줄 안에서 소스를 섞었다: 수입/지출은 서버값, 이체는 클라
+              // 계산(`LedgerSummary`), 그리고 이체는 포커스 월에만 갇혀 있었다.
+              // 지금은 세 칸 모두 서버가 같은 필터·같은 범위로 계산한 값이고,
+              // 목록 API 도 같은 판정을 쓰므로 합계와 행이 같은 집합을 센다.
+              //
+              // 클라 집계(`LedgerSummary`)는 **러닝밸런스/자산 모드 전용**으로 남는다
+              // (행 순서대로 누적하는 계산은 서버가 대신할 수 없다).
+              final clientSummary = LedgerSummary.from(
                 txs: visibleTransactions,
                 tfs: visibleTransfers,
                 pmFilter: filterPmId,
               );
 
-              // 회차 8 — BE getSummary 가 모든 필터 지원하도록 확장됨.
-              // 모든 케이스에서 BE 가 계산한 정확한 합계(state.totalIncome/Expense) 사용.
-              // server total 미수신 시 (statisticsRepository 미주입) 만 client fallback.
-              //
-              // Gate income/expense display by type: for a TRANSFER-only
-              // selection the BE strips TRANSFER → no type filter is sent → the
-              // server totals still contain all income/expense. Zero them so
-              // the summary matches the (empty) transaction rows.
+              // 서버 총계 미수신(statisticsRepository 미주입 = 테스트 경로) 시에만
+              // 클라 집계로 대체한다.
               final hasServerTotals = state.serverTotalIncome != null;
-              final gateIncome = types.isEmpty || types.contains('INCOME');
-              final gateExpense = types.isEmpty || types.contains('EXPENSE');
-              final displayIncome = !gateIncome
-                  ? 0
-                  : (hasServerTotals ? state.totalIncome : summary.totalIncome);
-              final displayExpense = !gateExpense
-                  ? 0
-                  : (hasServerTotals
-                      ? state.totalExpense
-                      : summary.totalExpense);
-              final displayTransfer = summary.totalTransfer;
+              final displayIncome =
+                  hasServerTotals ? state.totalIncome : clientSummary.totalIncome;
+              final displayExpense = hasServerTotals
+                  ? state.totalExpense
+                  : clientSummary.totalExpense;
+              final displayTransfer = hasServerTotals
+                  ? (state.serverTotalTransfer ?? 0)
+                  : clientSummary.totalTransfer;
 
               // CHANGE 3/4 — MODE B when exactly one non-credit asset is
               // filtered. singleAssetPmId is null otherwise (→ MODE A).

--- a/frontend/lib/features/transaction/presentation/utils/ledger_gating.dart
+++ b/frontend/lib/features/transaction/presentation/utils/ledger_gating.dart
@@ -1,22 +1,22 @@
-// 장부(거래 + 이체 병합 뷰)의 **단일 게이팅 진입점**.
+// 장부(거래 + 이체 병합 뷰)의 표시용 게이팅.
 //
-// 배경 (2026-08-10, 4회째 재발):
-//   거래 목록은 `TransactionBloc`(거래) 과 `TransferBloc`(이체) 를 FE 에서 병합한다.
-//   거래 쪽 필터는 `UnifiedFilterState.toTransactionFilter()` 라는 VO 단일 변환기로
-//   BE 까지 관통하지만, **이체 쪽 게이팅은 페이지 안에 인라인으로 필드를 나열**하고
-//   있었다. 그래서 새 필터가 추가될 때마다 이체 스트림에서만 축이 누락됐다:
-//     - `needsReviewOnly`(확인/입력 필요만) 켜도 이체가 그대로 노출
-//     - 카테고리/포켓 필터를 걸어도 이체가 그대로 노출
-//     - 금액범위가 이체에 미적용
-//     - 결제수단은 복수 선택인데 `paymentMethodIds.first` 1개만 적용
+// ## 이력 — 판정이 두 곳이었다는 것이 문제였다
 //
-// 구조적 수정:
-//   1) 이 파일이 **유일한** 게이팅 지점이다. 페이지는 `gateLedger()` 결과만 소비하고
-//      (목록/달력/합계바/러닝밸런스가 같은 리스트를 본다) 이체를 직접 거르지 않는다.
-//   2) `UnifiedFilterState` 의 **모든 축**을 아래 `_transferMatches` 에서 명시적으로
-//      분류한다 — "이체에 적용 / 이체에 없는 축이라 전량 제외 / 게이팅과 무관".
-//   3) `kUnifiedFilterAxisCount` 가드: 필터 VO 에 필드가 추가되면 테스트가 실패해
-//      이 파일을 갱신하지 않고는 CI 를 통과할 수 없다.
+// 거래 목록은 `TransactionBloc`(거래) 과 이체 목록을 FE 에서 병합한다.
+// 2026-08-10 회차에서 **이체 축 판정을 이 파일로 모아** 인라인 나열을 없앴다
+// (needsReviewOnly/카테고리/포켓/금액 누락, 결제수단 `.first` 1개만 적용).
+//
+// 그런데 BE 합계는 여전히 **다른 규칙**을 썼다 — "필터가 하나라도 켜지면 이체를 전량
+// 제외"(`totalTransfer = 0`). 그래서 같은 화면에서 합계와 행이 다른 집합을 셌고,
+// 기간 필터가 월을 넘으면 이체 행이 통째로 빠졌다(측정: 범위 내 이체 금액 77% 누락).
+//
+// ## 2026-08-12 — 이체 판정은 **서버**로 옮겼다
+//
+// 이체 목록 API 와 합계 API 가 같은 `TransferGating`(BE) 을 쓴다. 목록 쿼리와 집계가
+// 같은 함수를 타므로 한쪽만 어긋날 수 없다. FE 는 받은 이체를 **그대로 표시**한다.
+//
+// 이 파일에 이체 축 판정을 다시 넣지 마라 — 그러면 판정이 또 두 곳이 되고,
+// `ledger_gating_test.dart` 의 가드가 실패한다.
 //
 // 관련 메모리: reference_transaction_merged_transfer_stream_drift,
 //              feedback_filter_vo_single_source, reference_month_move_filter_drop
@@ -27,15 +27,18 @@ import 'package:budget_book/features/transfer/domain/entities/transfer.dart';
 /// `UnifiedFilterState` 의 축(=필드) 개수.
 ///
 /// 필터 VO 에 필드를 추가/삭제하면 `ledger_gating_test.dart` 가 실패한다.
-/// **먼저** 아래 `_transferMatches` 에 그 축의 이체 판정을 명시한 뒤 이 값을 갱신하라.
-/// (새 필터가 이체 스트림에서만 조용히 누락되던 사고의 구조적 봉인)
+/// 그때 확인할 것은 **서버**다:
+///   1. `CommonFilterParams` 에 그 축이 있는가
+///   2. `LedgerFilterAxis` 에 항목을 추가했는가 (BE 리플렉션 가드가 강제)
+///   3. `TransferGating` 이 그 축을 어떻게 다루는지 선언했는가 (exhaustive when 이 강제)
+/// 그런 다음 이 값을 갱신하라.
 const int kUnifiedFilterAxisCount = 16;
 
-/// 실효 검색어 결정 규칙 — FE 게이팅과 BE 전송이 **같은 규칙**을 쓰도록 한 곳에 둔다.
+/// 실효 검색어 결정 규칙 — FE 표시와 BE 전송이 **같은 규칙**을 쓰도록 한 곳에 둔다.
 ///
 /// `toTransactionFilter(keywordOverride:)` 는 override 가 null 이면 VO 의 keyword 로
 /// 되돌아간다. 화면이 빈 검색창(`''`)을 넘길 때 FE 만 "검색어 없음"으로 판단하면
-/// 서버가 좁힌 거래 목록과 FE 가 남긴 이체가 어긋난다(합계 ≠ 행 계열).
+/// 서버가 좁힌 목록과 화면 표시가 어긋난다.
 String resolveLedgerKeyword(UnifiedFilterState filter, String? override) {
   final o = override?.trim() ?? '';
   if (o.isNotEmpty) return o;
@@ -50,13 +53,12 @@ class GatedLedger {
   const GatedLedger({required this.transactions, required this.transfers});
 }
 
-/// 필터 상태를 거래·이체 두 스트림에 **동일한 기준**으로 적용한다.
+/// 서버가 좁힌 두 스트림을 표시용으로 정리한다.
 ///
-/// - [transactions] 는 BE 가 이미 좁힌 결과다. 여기서는 BE 가 알지 못하는
-///   FE 전용 pseudo-type(`TRANSFER`) 때문에 타입 게이팅만 추가로 건다.
-/// - [transfers] 는 월 단위 원본이므로 모든 축을 FE 에서 판정한다.
-/// - [keyword] 는 검색창처럼 VO 밖에 있는 키워드 주입용
-///   (`toTransactionFilter(keywordOverride:)` 와 같은 관례).
+/// - [transactions] 는 BE 가 이미 필터·타입까지 좁힌 결과다. 여기서 타입 게이팅을
+///   한 번 더 하는 이유는 **응답 대기 중 옛 목록이 잠깐 보이는 것**을 막기 위한
+///   과도기 방어뿐이다(서버 판정과 같은 규칙이므로 결과를 바꾸지 않는다).
+/// - [transfers] 는 서버가 이미 축 전수를 판정했다 → **손대지 않는다**.
 GatedLedger gateLedger({
   required List<Transaction> transactions,
   required List<Transfer> transfers,
@@ -65,98 +67,14 @@ GatedLedger gateLedger({
 }) {
   final types = filter.transactionTypes;
 
-  // 거래: 클라 타입 게이팅. TRANSFER 는 거래 타입이 아니므로 TRANSFER 단독 선택은
-  // 거래 0건이 된다(BE 에는 TRANSFER 가 전달되지 않아 서버가 좁히지 못한다).
+  // 거래: 타입 표시 게이팅. TRANSFER 는 거래 타입이 아니므로 TRANSFER 단독 선택은
+  // 거래 0건이 된다(서버도 같은 판정을 한다 — `LedgerTypeSelection`).
   final gatedTransactions = types.isEmpty
       ? transactions
       : transactions.where((t) => types.contains(t.type)).toList();
 
-  // 이체: 축 전수 판정.
-  final effectiveKeyword = resolveLedgerKeyword(filter, keyword).toLowerCase();
-  final gatedTransfers = _transfersExcludedWholesale(filter)
-      ? const <Transfer>[]
-      : transfers
-          .where((t) => _transferMatches(t, filter, effectiveKeyword))
-          .toList();
-
   return GatedLedger(
     transactions: gatedTransactions,
-    transfers: gatedTransfers,
+    transfers: transfers,
   );
 }
-
-/// 이체 엔티티에 **존재하지 않는 축**이 활성이면 이체는 논리적으로 매칭 불가 →
-/// 전량 제외한다. (필터를 무시하고 노출하던 것이 버그였다)
-///
-/// `Transfer` 에는 `needsReview` / category / pocket 필드가 없다
-/// (`features/transfer/domain/entities/transfer.dart`).
-bool _transfersExcludedWholesale(UnifiedFilterState f) {
-  // 축: needsReviewOnly — 이체엔 "확인/입력 필요" 개념이 없다.
-  if (f.needsReviewOnly) return true;
-  // 축: categoryIds / categoryGroupIds — 이체엔 카테고리가 없다.
-  if (f.categoryIds.isNotEmpty || f.categoryGroupIds.isNotEmpty) return true;
-  // 축: pocketIds — 이체엔 포켓이 없다(포켓 이체는 별도 기능).
-  if (f.pocketIds.isNotEmpty) return true;
-  // 축: visibility — 이체엔 visibility 가 없어 현재 전부 "공유" 취급.
-  //     개인(PRIVATE) 필터에서는 숨긴다. 개인 자산(ASSET-PRIVATE) 도입 시
-  //     source/dest 자산의 visibility 로 파생하도록 여기를 고친다.
-  if (f.visibility == 'PRIVATE') return true;
-  // 축: transactionTypes — TRANSFER 미포함 선택이면 이체 제외(빈 셋 = 전체).
-  if (f.transactionTypes.isNotEmpty &&
-      !f.transactionTypes.contains('TRANSFER')) {
-    return true;
-  }
-  return false;
-}
-
-/// 이체에 **실제로 적용 가능한 축**의 행 단위 판정.
-///
-/// 나머지 축의 처리는 아래 주석이 전부다 — 축을 추가하면 반드시 여기(또는
-/// [_transfersExcludedWholesale])에 분류를 남긴다.
-///   - dateRangeLabel / categoryName / paymentMethodName: 표시 전용 라벨, 게이팅 무관
-///   - status: 장부 필터바에 노출되지 않는 축(지출계획 등 타 화면 전용), 게이팅 무관
-bool _transferMatches(
-  Transfer t,
-  UnifiedFilterState f,
-  String keywordLower,
-) {
-  // 축: dateFrom / dateTo — transferDate 는 'yyyy-MM-dd' 문자열이라 사전식 비교가 안전.
-  if (f.dateFrom != null && t.transferDate.compareTo(_ymd(f.dateFrom!)) < 0) {
-    return false;
-  }
-  if (f.dateTo != null && t.transferDate.compareTo(_ymd(f.dateTo!)) > 0) {
-    return false;
-  }
-
-  // 축: paymentMethodIds — **복수 선택 전체**를 OR 매칭 (출금/입금 어느 쪽이든).
-  //     기존에는 `.first` 만 봐서 2개 이상 선택 시 나머지가 무시됐다.
-  if (f.paymentMethodIds.isNotEmpty) {
-    final hit = f.paymentMethodIds.contains(t.sourcePaymentMethod.id) ||
-        f.paymentMethodIds.contains(t.destinationPaymentMethod.id);
-    if (!hit) return false;
-  }
-
-  // 축: amountMin / amountMax — 이체 금액도 금액범위 필터를 따른다.
-  if (f.amountMin != null && t.amount < f.amountMin!) return false;
-  if (f.amountMax != null && t.amount > f.amountMax!) return false;
-
-  // 축: keyword — 설명 + 출금/입금 결제수단명.
-  if (keywordLower.isNotEmpty) {
-    final desc = t.description?.toLowerCase() ?? '';
-    final src = t.sourcePaymentMethod.name.toLowerCase();
-    final dst = t.destinationPaymentMethod.name.toLowerCase();
-    if (!desc.contains(keywordLower) &&
-        !src.contains(keywordLower) &&
-        !dst.contains(keywordLower)) {
-      return false;
-    }
-  }
-
-  return true;
-}
-
-/// DateTime → 'yyyy-MM-dd' (intl 의존 없이 순수 함수 유지).
-String _ymd(DateTime d) =>
-    '${d.year.toString().padLeft(4, '0')}-'
-    '${d.month.toString().padLeft(2, '0')}-'
-    '${d.day.toString().padLeft(2, '0')}';

--- a/frontend/lib/features/transaction/presentation/utils/ledger_totals_exclusion.dart
+++ b/frontend/lib/features/transaction/presentation/utils/ledger_totals_exclusion.dart
@@ -1,0 +1,30 @@
+import 'package:budget_book/features/transaction/domain/entities/transaction.dart';
+import 'package:budget_book/features/transfer/domain/entities/transfer.dart';
+
+/// 합계에서 제외되는 행의 **단일 판정**.
+///
+/// ## 왜 필요한가 (2026-08-12)
+///
+/// 두 종류의 행은 목록에 보이지만 상단 합계의 어느 칸에도 들어가지 않는다:
+///  - `ADJUSTMENT`(잔액 수정): 통계 범주 밖 — 잔액만 움직인다
+///  - `CARD_SETTLEMENT`(카드 정산 이체): 원본 지출 거래로 이미 집계됨 (이중 계산 방지)
+///
+/// 규칙 자체는 의도된 것이지만, 행에 아무 표시가 없으면 사용자에게는
+/// **"합계에서 빠진 행"** 으로 보인다(실측: 잔액 수정 17건 · 카드정산 8건).
+/// 그래서 행에 배지를 붙인다.
+///
+/// 판정을 타일마다 각자 하면 그것이 다음 drift 다 — 두 타일이 이 함수만 쓴다.
+/// 집계식 정본은 `LedgerSummary`(FE) 와 `ExpenseCalculator`(BE) 이며,
+/// 이 함수는 그 규칙의 "제외" 쪽을 그대로 반영한다.
+bool isTransactionExcludedFromTotals(Transaction transaction) =>
+    transaction.isAdjustment;
+
+bool isTransferExcludedFromTotals(Transfer transfer) =>
+    transfer.kind == TransferKind.cardSettlement;
+
+/// 배지 문구 — 두 종류가 같은 이유로 제외되는 것은 아니라서 사유를 구분한다.
+const String kExcludedFromTotalsLabel = '합계 제외';
+
+/// 배지 툴팁 — 왜 제외되는지 한 줄로 설명한다.
+const String kAdjustmentExclusionReason = '잔액 수정은 수입·지출 합계에 포함되지 않습니다';
+const String kCardSettlementExclusionReason = '카드 정산은 원본 지출로 이미 집계되었습니다';

--- a/frontend/lib/features/transaction/presentation/widgets/transaction_list_tile.dart
+++ b/frontend/lib/features/transaction/presentation/widgets/transaction_list_tile.dart
@@ -1,5 +1,7 @@
 import 'package:budget_book/core/utils/currency_formatter.dart';
+import 'package:budget_book/core/widgets/excluded_from_totals_badge.dart';
 import 'package:budget_book/core/widgets/reconciled_badge.dart';
+import 'package:budget_book/features/transaction/presentation/utils/ledger_totals_exclusion.dart';
 import 'package:budget_book/core/utils/couple_mode.dart';
 import 'package:budget_book/core/utils/dialog_helpers.dart';
 import 'package:flutter/material.dart';
@@ -139,6 +141,14 @@ class TransactionListTile extends StatelessWidget {
             // V65 — 정산 완료 배지 (공통 위젯 ReconciledBadge 단일 소스).
             if (transaction.isReconciled) ...[
               ReconciledBadge(seq: transaction.reconciliationSeq),
+              const SizedBox(width: 6),
+            ],
+            // 2026-08-12 — 합계에 안 잡히는 행임을 행에서 바로 보여준다.
+            // 판정은 ledger_totals_exclusion 단일 헬퍼 경유(타일이 직접 판단하지 않는다).
+            if (isTransactionExcludedFromTotals(transaction)) ...[
+              const ExcludedFromTotalsBadge(
+                reason: kAdjustmentExclusionReason,
+              ),
               const SizedBox(width: 6),
             ],
             if (isAdjustment) ...[

--- a/frontend/lib/features/transaction/presentation/widgets/transfer_list_tile.dart
+++ b/frontend/lib/features/transaction/presentation/widgets/transfer_list_tile.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:budget_book/core/utils/currency_formatter.dart';
+import 'package:budget_book/core/widgets/excluded_from_totals_badge.dart';
 import 'package:budget_book/core/widgets/reconciled_badge.dart';
+import 'package:budget_book/features/transaction/presentation/utils/ledger_totals_exclusion.dart';
 import 'package:budget_book/features/transfer/domain/entities/transfer.dart';
 
 /// A list tile for displaying a transfer in the unified transaction list.
@@ -63,6 +65,14 @@ class TransferListTile extends StatelessWidget {
           // V65 — 거래 타일과 **동일한** 배지 (두 스트림 표시 일치).
           if (transfer.isReconciled) ...[
             ReconciledBadge(seq: transfer.reconciliationSeq),
+            const SizedBox(width: 6),
+          ],
+          // 2026-08-12 — 카드 정산 이체는 원본 지출로 이미 집계돼 합계에 안 잡힌다.
+          // 판정은 ledger_totals_exclusion 단일 헬퍼 경유.
+          if (isTransferExcludedFromTotals(transfer)) ...[
+            const ExcludedFromTotalsBadge(
+              reason: kCardSettlementExclusionReason,
+            ),
             const SizedBox(width: 6),
           ],
           Expanded(

--- a/frontend/lib/features/transfer/data/datasources/transfer_remote_datasource.dart
+++ b/frontend/lib/features/transfer/data/datasources/transfer_remote_datasource.dart
@@ -1,13 +1,18 @@
 import 'package:budget_book/core/network/api_client.dart';
 import 'package:budget_book/core/constants/api_endpoints.dart';
 import 'package:budget_book/features/transaction/data/models/transaction_model.dart';
+import 'package:budget_book/features/transaction/domain/entities/transaction_filter.dart';
 import 'package:budget_book/features/transfer/data/models/transfer_model.dart';
 
 abstract class TransferRemoteDataSource {
+  /// [filter] 를 주면 장부 필터가 서버에서 적용된다 (2026-08-12).
+  /// 직렬화는 `TransactionFilter.toQueryParams()` **단일 경로**를 재사용한다 —
+  /// 이체용 직렬화를 따로 만들면 그것이 다음 drift 다.
   Future<List<TransferModel>> getTransfers({
     required int year,
     required int month,
     bool? reconciled,
+    TransactionFilter? filter,
   });
   Future<TransferModel> getTransfer(String id);
   Future<TransferModel> createTransfer(Map<String, dynamic> data);
@@ -34,12 +39,15 @@ class TransferRemoteDataSourceImpl implements TransferRemoteDataSource {
     required int year,
     required int month,
     bool? reconciled,
+    TransactionFilter? filter,
   }) async {
     final response = await apiClient.dio.get(
       ApiEndpoints.transfers,
       queryParameters: {
         'year': year,
         'month': month,
+        // 장부 필터 (있으면). dateFrom/dateTo 가 실리면 서버가 year/month 대신 그 범위를 쓴다.
+        ...?filter?.toQueryParams(),
         // V65 — false 도 의미가 있다("미기록만"). null 일 때만 생략.
         if (reconciled != null) 'reconciled': reconciled,
       },

--- a/frontend/lib/features/transfer/data/repositories/transfer_repository_impl.dart
+++ b/frontend/lib/features/transfer/data/repositories/transfer_repository_impl.dart
@@ -3,6 +3,7 @@ import 'package:dio/dio.dart';
 import 'package:budget_book/core/error/failure.dart';
 import 'package:budget_book/core/error/dio_error_mapper.dart';
 import 'package:budget_book/features/transaction/domain/entities/transaction.dart';
+import 'package:budget_book/features/transaction/domain/entities/transaction_filter.dart';
 import 'package:budget_book/features/transfer/data/datasources/transfer_remote_datasource.dart';
 import 'package:budget_book/features/transfer/domain/entities/transfer.dart';
 import 'package:budget_book/features/transfer/domain/repositories/transfer_repository.dart';
@@ -17,12 +18,14 @@ class TransferRepositoryImpl implements TransferRepository {
     required int year,
     required int month,
     bool? reconciled,
+    TransactionFilter? filter,
   }) async {
     try {
       final result = await remoteDataSource.getTransfers(
         year: year,
         month: month,
         reconciled: reconciled,
+        filter: filter,
       );
       return Right(result);
     } on DioException catch (e) {

--- a/frontend/lib/features/transfer/domain/repositories/transfer_repository.dart
+++ b/frontend/lib/features/transfer/domain/repositories/transfer_repository.dart
@@ -1,16 +1,23 @@
 import 'package:dartz/dartz.dart';
 import 'package:budget_book/core/error/failure.dart';
 import 'package:budget_book/features/transaction/domain/entities/transaction.dart';
+import 'package:budget_book/features/transaction/domain/entities/transaction_filter.dart';
 import 'package:budget_book/features/transfer/domain/entities/transfer.dart';
 
 abstract class TransferRepository {
   /// [reconciled] — V65 정산 필터. 거래 목록(`reconciled` 쿼리)과 **동일한 의미**:
   /// false=미기록만, true=기록만, null=전체. 장부는 거래+이체 병합 뷰이므로 한쪽 스트림만
   /// 필터를 지원하면 "이체만 계속 남아 보이는" drift 가 난다 → 항상 함께 확장한다.
+  /// 이체 목록.
+  ///
+  /// [filter] 를 주면 장부 필터가 **서버에서** 적용된다(2026-08-12). `dateFrom`/`dateTo` 가
+  /// 있으면 `year`/`month` 를 덮어쓴다 — 거래 목록·합계와 같은 범위 규칙이다.
+  /// 필터를 주지 않는 호출부(이체 목록 화면·카드정산 등)는 기존 월 단위 동작을 유지한다.
   Future<Either<Failure, List<Transfer>>> getTransfers({
     required int year,
     required int month,
     bool? reconciled,
+    TransactionFilter? filter,
   });
 
   Future<Either<Failure, Transfer>> getTransfer(String id);

--- a/frontend/test/features/transaction/domain/entities/transaction_filter_test.dart
+++ b/frontend/test/features/transaction/domain/entities/transaction_filter_test.dart
@@ -80,13 +80,18 @@ void main() {
         expect(params.containsKey('type'), isFalse);
       });
 
-      test('TRANSFER pseudo-type is stripped before hitting BE', () {
+      // 2026-08-12 계약 변경 — TRANSFER 를 **그대로 보낸다**.
+      // 예전에는 잘라 보냈고, 그래서 서버가 "타입 필터 없음" 으로 해석해 거래 전체를
+      // 세고 FE 가 다시 걸렀다(판정 2곳 → "합계 ≠ 행"). 이제 서버가 두 스트림을 판정한다.
+      test('TRANSFER is sent to BE so the server can gate both streams', () {
         const f = TransactionFilter(
           transactionTypes: {'EXPENSE', 'TRANSFER'},
         );
         final params = f.toQueryParams();
         final list = (params['transactionTypes'] as List).cast<String>();
-        expect(list, equals(<String>['EXPENSE']));
+        expect(list, containsAll(<String>['EXPENSE', 'TRANSFER']));
+        // 복수 선택이므로 단수 `type` 은 보내지 않는다.
+        expect(params.containsKey('type'), isFalse);
       });
 
       test('single-value multi sets both `transactionTypes` and legacy `type`',
@@ -100,10 +105,14 @@ void main() {
         );
       });
 
-      test('only TRANSFER (pseudo) → BE gets no type filter', () {
+      test('only TRANSFER → transactionTypes=[TRANSFER], no singular type', () {
         const f = TransactionFilter(transactionTypes: {'TRANSFER'});
         final params = f.toQueryParams();
-        expect(params.containsKey('transactionTypes'), isFalse);
+        expect(
+          (params['transactionTypes'] as List).cast<String>(),
+          equals(<String>['TRANSFER']),
+        );
+        // TRANSFER 는 거래 타입이 아니다 → 단수 `type` 으로 보내면 BE 가 400 을 낸다.
         expect(params.containsKey('type'), isFalse);
       });
 

--- a/frontend/test/features/transaction/presentation/bloc/ledger_transfers_cubit_test.dart
+++ b/frontend/test/features/transaction/presentation/bloc/ledger_transfers_cubit_test.dart
@@ -1,0 +1,150 @@
+import 'package:dartz/dartz.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:budget_book/core/error/failure.dart';
+import 'package:budget_book/features/transaction/domain/entities/transaction_filter.dart';
+import 'package:budget_book/features/transaction/presentation/bloc/ledger_transfers_cubit.dart';
+import 'package:budget_book/features/transaction/presentation/utils/ledger_totals_exclusion.dart';
+import 'package:budget_book/features/transaction/domain/entities/transaction_author.dart';
+import 'package:budget_book/features/transfer/domain/entities/transfer.dart';
+import 'package:budget_book/features/transfer/domain/repositories/transfer_repository.dart';
+
+/// 장부 전용 이체 소스.
+///
+/// 회귀 배경: 이체는 `LoadTransfers(year, month)` 로 **월 단위**만 조회했고 거래·합계는
+/// `dateFrom/dateTo` 를 따랐다. 그래서 기간 필터가 월을 넘으면 이체 행이 통째로 빠졌다
+/// (실측: 범위 내 이체 금액의 77% 누락). 이제 필터 VO 를 서버로 그대로 보낸다.
+class _FakeTransferRepository implements TransferRepository {
+  final List<Map<String, dynamic>> calls = [];
+  Either<Failure, List<Transfer>> result = const Right(<Transfer>[]);
+
+  @override
+  Future<Either<Failure, List<Transfer>>> getTransfers({
+    required int year,
+    required int month,
+    bool? reconciled,
+    TransactionFilter? filter,
+  }) async {
+    calls.add({
+      'year': year,
+      'month': month,
+      'reconciled': reconciled,
+      'filter': filter,
+    });
+    return result;
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError('${invocation.memberName} is not used in this test');
+}
+
+void main() {
+  const author = TransactionAuthor(id: 'u1', nickname: '나');
+
+  Transfer tf({String id = 'tf1', int amount = 5000}) => Transfer(
+        id: id,
+        coupleId: 'c1',
+        author: author,
+        sourcePaymentMethod:
+            const PaymentMethodRef(id: 'pm-bank', name: '국민은행', type: 'BANK'),
+        destinationPaymentMethod:
+            const PaymentMethodRef(id: 'pm-cash', name: '현금', type: 'CASH'),
+        amount: amount,
+        description: '생활비 이체',
+        transferDate: '2026-08-10',
+        createdAt: DateTime(2026, 8, 10),
+      );
+
+  test('필터 VO 를 통째로 서버에 전달한다 (필드 나열 금지)', () async {
+    final repo = _FakeTransferRepository();
+    final cubit = LedgerTransfersCubit(transferRepository: repo);
+    const filter = TransactionFilter(
+      amountMin: 10000,
+      dateFrom: '2026-06-15',
+      dateTo: '2026-08-05',
+      transactionTypes: {'EXPENSE', 'TRANSFER'},
+    );
+
+    await cubit.load(year: 2026, month: 8, filter: filter);
+
+    expect(repo.calls, hasLength(1));
+    // 필터가 그대로 실려야 한다 — 축을 골라 넘기면 새 축이 조용히 누락된다.
+    expect(repo.calls.single['filter'], same(filter));
+    expect(repo.calls.single['year'], 2026);
+    expect(repo.calls.single['month'], 8);
+  });
+
+  test('로드 성공 시 이체 목록을 상태에 담는다', () async {
+    final repo = _FakeTransferRepository()..result = Right([tf(), tf(id: 'tf2')]);
+    final cubit = LedgerTransfersCubit(transferRepository: repo);
+
+    await cubit.load(
+      year: 2026,
+      month: 8,
+      filter: TransactionFilter.empty,
+    );
+
+    expect(cubit.state.transfers, hasLength(2));
+    expect(cubit.state.isLoading, isFalse);
+    expect(cubit.state.error, isNull);
+  });
+
+  test('실패 시 에러를 담고 목록은 유지한다', () async {
+    final repo = _FakeTransferRepository()..result = Right([tf()]);
+    final cubit = LedgerTransfersCubit(transferRepository: repo);
+    await cubit.load(year: 2026, month: 8, filter: TransactionFilter.empty);
+
+    repo.result = const Left(ServerFailure('이체 목록을 불러오지 못했습니다'));
+    await cubit.load(year: 2026, month: 8, filter: TransactionFilter.empty);
+
+    expect(cubit.state.error, '이체 목록을 불러오지 못했습니다');
+    // 목록을 비우지 않는다 — 필터 조작 중 화면이 깜빡이는 것을 막는다.
+    expect(cubit.state.transfers, hasLength(1));
+  });
+
+  test('reload 는 마지막 필터·월을 그대로 다시 쓴다 (월 이동·WebSocket 동기화)', () async {
+    final repo = _FakeTransferRepository();
+    final cubit = LedgerTransfersCubit(transferRepository: repo);
+    const filter = TransactionFilter(keyword: '커피');
+
+    await cubit.load(year: 2026, month: 7, filter: filter);
+    await cubit.reload();
+
+    expect(repo.calls, hasLength(2));
+    expect(repo.calls.last['year'], 2026);
+    expect(repo.calls.last['month'], 7);
+    expect(repo.calls.last['filter'], same(filter));
+  });
+
+  test('한 번도 로드하지 않았으면 reload 는 아무 것도 하지 않는다', () async {
+    final repo = _FakeTransferRepository();
+    final cubit = LedgerTransfersCubit(transferRepository: repo);
+
+    await cubit.reload();
+
+    expect(repo.calls, isEmpty);
+  });
+
+  group('합계 제외 판정', () {
+    test('카드 정산 이체만 합계에서 제외된다', () {
+      final settlement = Transfer(
+        id: 'tf-settle',
+        coupleId: 'c1',
+        author: author,
+        sourcePaymentMethod:
+            const PaymentMethodRef(id: 'pm-bank', name: '국민은행', type: 'BANK'),
+        destinationPaymentMethod:
+            const PaymentMethodRef(id: 'pm-card', name: '신용카드', type: 'CREDIT'),
+        amount: 120000,
+        description: '카드 정산',
+        transferDate: '2026-08-28',
+        createdAt: DateTime(2026, 8, 28),
+        kind: TransferKind.cardSettlement,
+      );
+
+      expect(isTransferExcludedFromTotals(settlement), isTrue);
+      expect(isTransferExcludedFromTotals(tf()), isFalse);
+    });
+  });
+}

--- a/frontend/test/features/transaction/presentation/bloc/load_transactions_filter_coverage_test.dart
+++ b/frontend/test/features/transaction/presentation/bloc/load_transactions_filter_coverage_test.dart
@@ -205,11 +205,13 @@ void main() {
       );
     });
 
-    test('TRANSFER 의사-타입은 BE 로 보내지 않는다', () {
+    // 2026-08-12 계약 변경 — TRANSFER 는 서버가 이체 스트림을 판정하는 데 필요하다.
+    // 잘라 보내면 서버가 "타입 필터 없음" 으로 해석해 합계와 행이 갈라진다.
+    test('TRANSFER 도 BE 로 전달한다 (서버가 두 스트림을 판정한다)', () {
       final types =
           fullFilter.toQueryParams()['transactionTypes'] as List<dynamic>;
       expect(types, contains('EXPENSE'));
-      expect(types, isNot(contains('TRANSFER')));
+      expect(types, contains('TRANSFER'));
     });
   });
 }

--- a/frontend/test/features/transaction/presentation/utils/ledger_gating_test.dart
+++ b/frontend/test/features/transaction/presentation/utils/ledger_gating_test.dart
@@ -7,9 +7,17 @@ import 'package:budget_book/features/transaction/domain/entities/transaction_aut
 import 'package:budget_book/features/transfer/domain/entities/transfer.dart';
 import 'package:budget_book/features/transaction/presentation/utils/ledger_gating.dart';
 
-/// 2026-08-10 회귀 테스트 — "확인 필요 필터를 켰는데 이체가 보인다" (4회째 재발).
+/// 장부 게이팅 가드.
 ///
-/// 이체 스트림 게이팅이 필터 축을 수동 나열하다 축을 빠뜨리던 사고를 구조적으로 막는다.
+/// ## 2026-08-12 — 이체 판정은 서버로 옮겼다
+///
+/// 2026-08-10 회차는 이체 축 판정을 FE `ledger_gating.dart` 한 곳으로 모았다.
+/// 그런데 BE 합계는 "필터가 켜지면 이체 전량 제외" 라는 **다른 규칙**을 유지해서
+/// 합계와 행이 다른 집합을 셌고, 기간 필터가 월을 넘으면 이체 행이 통째로 빠졌다.
+///
+/// 그래서 판정을 **서버 한 곳**(`TransferGating`)으로 옮겼다. 이 테스트는 이제
+/// "FE 가 이체를 다시 판정하지 않는다" 를 고정한다 — 판정이 두 곳이 되는 순간
+/// 같은 사고가 재발하기 때문이다.
 void main() {
   const author = TransactionAuthor(id: 'u1', nickname: '나');
 
@@ -54,14 +62,13 @@ void main() {
       );
 
   group('필터 VO 축 가드', () {
-    test('UnifiedFilterState 필드 수가 바뀌면 이체 게이팅을 갱신해야 한다', () {
+    test('UnifiedFilterState 필드 수가 바뀌면 서버 판정을 갱신해야 한다', () {
       expect(
         const UnifiedFilterState().props.length,
         kUnifiedFilterAxisCount,
-        reason: 'UnifiedFilterState 에 필드가 추가/삭제되었다. '
-            'ledger_gating.dart 의 _transfersExcludedWholesale / _transferMatches 에 '
-            '그 축의 이체 판정을 명시한 뒤 kUnifiedFilterAxisCount 를 갱신하라. '
-            '(축 누락으로 이체가 필터를 무시하고 노출되던 사고의 재발 방지)',
+        reason: '필터 축이 바뀌었다. 서버를 먼저 갱신하라: '
+            'CommonFilterParams 필드 → LedgerFilterAxis 항목 → TransferGating.handling '
+            '(exhaustive when 이 컴파일로 강제). 그 다음 이 상수를 갱신한다.',
       );
     });
 
@@ -78,167 +85,96 @@ void main() {
         expect(
           src.contains(banned),
           isFalse,
-          reason: '이체 게이팅은 ledger_gating.dart 의 gateLedger 단일 진입점에서만 한다. '
+          reason: '이체 필터링은 서버(TransferGating)가 단독으로 한다. '
               '페이지에 "$banned" 형태의 인라인 필터링이 다시 들어왔다.',
+        );
+      }
+    });
+
+    // 장부는 공유 TransferBloc 을 쓰지 않는다 — 그 싱글톤에 장부 필터가 실리면
+    // 이체 목록 화면·카드정산·정산 뷰·거래 폼이 함께 오염된다(측정: 소비자 6곳).
+    test('거래 목록 페이지는 공유 TransferBloc 을 참조하지 않는다', () {
+      final src = File(
+        'lib/features/transaction/presentation/pages/transaction_list_page.dart',
+      ).readAsStringSync();
+
+      // 주석에서의 언급은 허용한다(왜 안 쓰는지 설명이 필요하다) — 실제 **사용**만 막는다.
+      for (final banned in [
+        'read<TransferBloc>',
+        'watch<TransferBloc>',
+        'getIt<TransferBloc>',
+        'BlocBuilder<TransferBloc',
+        'BlocProvider<TransferBloc',
+        'BlocListener<TransferBloc',
+      ]) {
+        expect(
+          src.contains(banned),
+          isFalse,
+          reason: '장부는 LedgerTransfersCubit(전용 소스)만 쓴다. 공유 TransferBloc 을 '
+              '다시 사용하면("$banned") 필터가 다른 5개 화면으로 새어나간다.',
+        );
+      }
+      expect(
+        src.contains('LedgerTransfersCubit'),
+        isTrue,
+        reason: '장부 전용 이체 소스가 사라졌다.',
+      );
+    });
+
+    // 이체 축 판정이 FE 로 되돌아오는 것을 막는다 (판정 2곳 = 재발 메커니즘).
+    test('ledger_gating.dart 에 이체 축 판정이 없다', () {
+      final src = File(
+        'lib/features/transaction/presentation/utils/ledger_gating.dart',
+      ).readAsStringSync();
+
+      for (final banned in [
+        '_transferMatches',
+        '_transffersExcludedWholesale',
+        '_transfersExcludedWholesale',
+        'transferDate.compareTo',
+        'f.amountMin',
+        'f.paymentMethodIds',
+        'f.needsReviewOnly',
+      ]) {
+        expect(
+          src.contains(banned),
+          isFalse,
+          reason: '이체 판정("$banned")이 FE 로 돌아왔다. 판정은 서버 TransferGating '
+              '한 곳이어야 한다 — 두 곳이 되면 "합계 ≠ 행" 이 재발한다.',
         );
       }
     });
   });
 
-  group('이체에 없는 축이 켜지면 이체는 전량 제외', () {
-    test('needsReviewOnly — 확인/입력 필요만 보기', () {
+  group('이체는 서버 결과를 그대로 통과시킨다', () {
+    test('이체에 없는 축이 켜져 있어도 FE 는 손대지 않는다 (서버가 이미 걸렀다)', () {
+      // 서버가 카테고리 필터에서 이체를 전량 제외했다면 애초에 빈 리스트가 온다.
+      // FE 가 또 판정하면 규칙이 두 곳이 되므로, 받은 것을 그대로 보여준다.
       final g = gateLedger(
         transactions: [tx()],
-        transfers: [tf()],
-        filter: const UnifiedFilterState(needsReviewOnly: true),
+        transfers: [tf(id: 'a'), tf(id: 'b')],
+        filter: const UnifiedFilterState(categoryIds: {'cat-1'}),
       );
-      expect(g.transfers, isEmpty);
-      expect(g.transactions, hasLength(1)); // 거래는 BE 가 이미 좁혔다
-    });
 
-    test('카테고리 / 카테고리 그룹', () {
-      expect(
-        gateLedger(
-          transactions: [tx()],
-          transfers: [tf()],
-          filter: const UnifiedFilterState(categoryIds: {'cat1'}),
-        ).transfers,
-        isEmpty,
-      );
-      expect(
-        gateLedger(
-          transactions: [tx()],
-          transfers: [tf()],
-          filter: const UnifiedFilterState(categoryGroupIds: {'g1'}),
-        ).transfers,
-        isEmpty,
-      );
-    });
-
-    test('포켓', () {
-      expect(
-        gateLedger(
-          transactions: [tx()],
-          transfers: [tf()],
-          filter: const UnifiedFilterState(pocketIds: {'p1'}),
-        ).transfers,
-        isEmpty,
-      );
-    });
-
-    test('개인(PRIVATE) 공개범위 — 이체는 현재 전부 공유 취급', () {
-      expect(
-        gateLedger(
-          transactions: [tx()],
-          transfers: [tf()],
-          filter: const UnifiedFilterState(visibility: 'PRIVATE'),
-        ).transfers,
-        isEmpty,
-      );
-      // 공유(SHARED) 는 이체를 숨기지 않는다.
-      expect(
-        gateLedger(
-          transactions: [tx()],
-          transfers: [tf()],
-          filter: const UnifiedFilterState(visibility: 'SHARED'),
-        ).transfers,
-        hasLength(1),
-      );
-    });
-
-    test('거래 유형에서 이체 미선택', () {
-      expect(
-        gateLedger(
-          transactions: [tx()],
-          transfers: [tf()],
-          filter: const UnifiedFilterState(transactionTypes: {'EXPENSE'}),
-        ).transfers,
-        isEmpty,
-      );
-    });
-  });
-
-  group('이체에 적용 가능한 축은 실제로 매칭', () {
-    test('금액 범위', () {
-      const filter = UnifiedFilterState(amountMin: 1000, amountMax: 3000);
-      final g = gateLedger(
-        transactions: const [],
-        transfers: [tf(id: 'in', amount: 2000), tf(id: 'out', amount: 9000)],
-        filter: filter,
-      );
-      expect(g.transfers.map((t) => t.id), ['in']);
-    });
-
-    test('결제수단 복수 선택 — 전부 OR 매칭 (first 1개만 보던 버그)', () {
-      const filter = UnifiedFilterState(paymentMethodIds: {'pm-a', 'pm-b'});
-      final g = gateLedger(
-        transactions: const [],
-        transfers: [
-          tf(id: 'a', srcId: 'pm-a', dstId: 'pm-z'),
-          tf(id: 'b', srcId: 'pm-z', dstId: 'pm-b'),
-          tf(id: 'c', srcId: 'pm-y', dstId: 'pm-z'),
-        ],
-        filter: filter,
-      );
       expect(g.transfers.map((t) => t.id), ['a', 'b']);
     });
 
-    test('기간', () {
-      final filter = UnifiedFilterState(
-        dateFrom: DateTime(2026, 8, 5),
-        dateTo: DateTime(2026, 8, 10),
-      );
+    test('금액·기간·검색어 축에서도 FE 는 이체를 재판정하지 않는다', () {
       final g = gateLedger(
         transactions: const [],
         transfers: [
-          tf(id: 'before', date: '2026-08-04'),
-          tf(id: 'inside', date: '2026-08-07'),
-          tf(id: 'edge', date: '2026-08-10'),
-          tf(id: 'after', date: '2026-08-11'),
+          tf(id: 'in', amount: 5000, date: '2026-08-10'),
+          // 서버가 걸렀어야 하는 값이라도 FE 는 그대로 통과시킨다.
+          tf(id: 'out', amount: 999999, date: '2026-01-01', description: '무관'),
         ],
-        filter: filter,
+        filter: const UnifiedFilterState(
+          amountMin: 1000,
+          amountMax: 9000,
+          keyword: '생활비',
+        ),
       );
-      expect(g.transfers.map((t) => t.id), ['inside', 'edge']);
-    });
 
-    test('검색어 — 설명 / 출금·입금 결제수단명', () {
-      final g = gateLedger(
-        transactions: const [],
-        transfers: [
-          tf(id: 'desc', description: '월세 이체'),
-          tf(id: 'pm', description: null),
-          tf(id: 'none', description: '기타'),
-        ],
-        filter: const UnifiedFilterState(),
-        keyword: '월세',
-      );
-      expect(g.transfers.map((t) => t.id), ['desc']);
-
-      final byPm = gateLedger(
-        transactions: const [],
-        transfers: [tf(id: 'pm')],
-        filter: const UnifiedFilterState(),
-        keyword: '국민',
-      );
-      expect(byPm.transfers, hasLength(1));
-    });
-
-    test('빈 검색창은 VO 의 keyword 로 되돌아간다 (BE 전송 규칙과 동일)', () {
-      // toTransactionFilter(keywordOverride: null) 이 filter.keyword 로 fallback 하므로
-      // FE 게이팅도 같은 규칙이어야 행/합계가 어긋나지 않는다.
-      expect(resolveLedgerKeyword(const UnifiedFilterState(keyword: '월세'), ''),
-          '월세');
-      expect(resolveLedgerKeyword(const UnifiedFilterState(keyword: '월세'), '커피'),
-          '커피');
-      expect(resolveLedgerKeyword(const UnifiedFilterState(), '  '), '');
-
-      final g = gateLedger(
-        transactions: const [],
-        transfers: [tf(id: 'hit', description: '월세 이체'), tf(id: 'miss')],
-        filter: const UnifiedFilterState(keyword: '월세'),
-        keyword: '',
-      );
-      expect(g.transfers.map((t) => t.id), ['hit']);
+      expect(g.transfers.map((t) => t.id), ['in', 'out']);
     });
   });
 
@@ -249,18 +185,53 @@ void main() {
         transfers: [tf()],
         filter: const UnifiedFilterState(transactionTypes: {'TRANSFER'}),
       );
+
       expect(g.transactions, isEmpty);
       expect(g.transfers, hasLength(1));
     });
 
     test('필터 없음 = 전부 통과', () {
       final g = gateLedger(
-        transactions: [tx()],
+        transactions: [tx(), tx(id: 'tx2', type: 'INCOME')],
         transfers: [tf()],
         filter: const UnifiedFilterState(),
       );
-      expect(g.transactions, hasLength(1));
+
+      expect(g.transactions, hasLength(2));
       expect(g.transfers, hasLength(1));
+    });
+
+    test('지출 + 이체 선택 시 지출 거래와 이체가 함께 남는다', () {
+      final g = gateLedger(
+        transactions: [tx(type: 'EXPENSE'), tx(id: 'tx2', type: 'INCOME')],
+        transfers: [tf()],
+        filter: const UnifiedFilterState(
+          transactionTypes: {'EXPENSE', 'TRANSFER'},
+        ),
+      );
+
+      expect(g.transactions.map((t) => t.type), ['EXPENSE']);
+      expect(g.transfers, hasLength(1));
+    });
+  });
+
+  group('실효 검색어 규칙', () {
+    test('빈 검색창은 VO 의 keyword 로 되돌아간다 (BE 전송 규칙과 동일)', () {
+      expect(
+        resolveLedgerKeyword(const UnifiedFilterState(keyword: '커피'), ''),
+        '커피',
+      );
+    });
+
+    test('검색창 입력이 VO 보다 우선한다', () {
+      expect(
+        resolveLedgerKeyword(const UnifiedFilterState(keyword: '커피'), '택시'),
+        '택시',
+      );
+    });
+
+    test('둘 다 없으면 빈 문자열', () {
+      expect(resolveLedgerKeyword(const UnifiedFilterState(), null), '');
     });
   });
 }


### PR DESCRIPTION
## 문제 (측정)

장부 화면은 **거래 목록 API + 이체 목록 API + 합계 API** 세 개를 합쳐 보여주는데, 세 API 가 서로 다른 규칙을 썼습니다.

- **기간 축 비대칭 (현재 발현 중)**: 이체는 `LoadTransfers(year, month)` 로 월 단위만 조회했고, 거래 목록과 서버 합계는 `dateFrom/dateTo` 가 월을 덮어썼습니다. 실 DB 측정(범위 2026-06-15~08-05, 8월 포커스): 거래 192건은 전량 노출되는데 이체는 8월 2건만 → **범위 내 이체 금액의 77%(3,385,139원) 누락**
- **필터 축 비대칭 (잠재, 도달 가능)**: BE 합계는 필터가 하나라도 켜지면 이체를 전량 제외(`totalTransfer = 0L`)했는데 FE 목록은 금액·결제수단·검색어 필터에서 이체 행을 유지했습니다. 이체 폼에서 "지출로 반영"(`EXPENSE_TRANSFER`) 을 한 건 고르는 순간 수입/지출 합계가 행과 갈라집니다
- 같은 합계바 안에서 소스가 섞여 있었습니다 — 수입/지출은 서버값, 이체는 클라 계산(포커스 월 한정)

근본 원인은 **행 집합과 합계 집합이 같은 소스에서 나오지 않는다**는 것입니다.

## 구조적 수정

하네스 감사에서 `filter_propagation` 이 **4회 재발 / STRUCTURAL_FIX_REQUIRED** 라 패치가 불허됐습니다.

- **`LedgerFilterAxis`** — 필터 축 20개를 enum 으로 열거. `TransferGating.handling` 의 exhaustive `when` 이 축 추가 시 **컴파일을 막고**, 리플렉션 가드가 VO 프로퍼티와 1:1 대응을 고정
- **`TransferGating`** — 이체 판정 단일 지점. **이체 목록 조회와 이체 집계가 같은 함수**를 씀 → 한쪽만 고치는 것이 구조적으로 불가능
- **`hasContentFilters` 분기 제거** — 필터 유무로 집계 규칙이 갈라지던 지점 자체를 없앰. `totalTransfer = 0L` 하드코딩 삭제. `getPeriodSummary` 도 같은 헬퍼로 통일
- **`LedgerTypeSelection`** — `TRANSFER` 를 계약 값으로 승격. 클라가 잘라 보내고 다시 거르던 이중 판정 제거
- **FE 이체 축 판정 삭제** — `ledger_gating.dart` 는 서버 결과를 그대로 소비
- **장부 전용 `LedgerTransfersCubit` 분리** — 공유 `TransferBloc` 은 소비자가 6곳(이체 목록·카드정산·정산 뷰·거래 폼·월 동기화)이라 장부 필터를 주입하면 5개 화면이 오염됩니다
- 합계바 3칸 전부 서버 단일 소스. 클라 집계는 러닝밸런스 전용으로 축소

## 표시 (사용자 판정)

`ADJUSTMENT` 17건 · 카드정산 이체 8건은 규칙상 합계에 안 잡히지만 행에는 보입니다 → **"합계 제외" 배지** 추가. 판정은 `ledger_totals_exclusion` 단일 헬퍼 경유.

## 게이트

- **`LedgerSummaryRowContractIntegrationTest`** — 실 PostgreSQL(Testcontainers)로 축 조합 15건에서 `합계 == 행의 합` 을 대조 + 절대값 고정. mock 은 Specification 층을 검증하지 못해 이 계열 버그를 잡을 수 없습니다
- 구현 중 이 테스트가 **실제 버그 1건**을 잡았습니다: "타입 필터 없음"과 "타입 필터가 거래를 하나도 고르지 않음"(이체만 보기)을 혼동해 이체만 보기에서 거래 합계가 남았습니다
- 로컬 CI 5종: analyze 신규 0 / `flutter test` **936** / `gradlew clean test` / `build web --release` / 번들 문자열 확인

## 계약

`docs/api-spec.md` 선행 갱신 — summary 의 필터 파라미터 12개+ 미문서화 보완, "필터 시 `totalTransfer` 항상 0" **규범 폐기 명시**, List Transfers 의 범위·필터, `TRANSFER` 계약 값 절 신설.

**DB 마이그레이션 없음** (스키마 변경 0건). 새 쿼리 파라미터는 하위호환이라 BE·FE 배포 순서 무관.

## 라이브 검증 (배포 후)

핵심: 기간을 `2026-06-15 ~ 2026-08-05` 로 걸면 6·7월 **이체 행이 보이고** 이체 합계가 1,008,648원 → 4,393,787원 수준으로 오릅니다. 전체 체크리스트는 `docs/sessions/2026-08-12_2_summary-row-mismatch_plan.md` §8 (A1~A11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)